### PR TITLE
usdpaa-apps: fix broken clean task

### DIFF
--- a/recipes-dpaa/usdpaa-apps/usdpaa-apps_git.bb
+++ b/recipes-dpaa/usdpaa-apps/usdpaa-apps_git.bb
@@ -66,3 +66,5 @@ FILES_${PN} += "/root/SOURCE_THIS /usr/etc/"
 
 COMPATIBLE_HOST_qoriq-ppc = ".*"
 COMPATIBLE_HOST ?= "(none)"
+
+CLEANBROKEN = "1"


### PR DESCRIPTION
usdpaa and usdpaa-apps depends on linux kernel and need to be
rebuilt after it. usdpaa-apps build system cannot complete
'make clean' target, so let bitbake handle clean task in order
to avoid need to manually clean usdpaa-apps recipe on every
kernel rebuild

Signed-off-by: Ivan Koveshnikov <ikoveshnik@gmail.com>