### PR TITLE
Add utp-com util

### DIFF
--- a/recipes-devtools/utp-com/utp-com/0001-Fix-Makefile-for-crosscompilation.patch
+++ b/recipes-devtools/utp-com/utp-com/0001-Fix-Makefile-for-crosscompilation.patch
@@ -1,0 +1,19 @@
+--- a/makefile
++++ b/makefile
+@@ -1,10 +1,12 @@
+-CC=gcc
+-CFLAGS=-I. -Wall -O2
+-DEPS=
++CC ?= gcc
++CFLAGS ?= -I. -Wall -O2
++LDFLAGS ?=
++DEPS ?=
++
+ OBJ=utp_com.o
+ 
+ %.o: %.c $(DEPS)
+ 	$(CC) -c -o $@ $< $(CFLAGS)
+ 
+ utp_com: $(OBJ)
+-	gcc -o $@ $^ $(CFLAGS)
++	$(CC) -o $@ $^ $(LDFLAGS)

--- a/recipes-devtools/utp-com/utp-com_git.bb
+++ b/recipes-devtools/utp-com/utp-com_git.bb
@@ -1,0 +1,28 @@
+DESCRIPTION = "Tool used to send commands to hardware via NXP's UTP protocol"
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=8264535c0c4e9c6c335635c4026a8022"
+
+DEPENDS = "sg3-utils"
+
+SRCREV = "7fe590fef812561cceb08aaa10b64e9bac8f542f"
+SRC_URI = " \
+    git://github.com/ixonos/utp_com;protocol=https \
+    file://0001-Fix-Makefile-for-crosscompilation.patch \
+"
+
+PV = "1.0+git${SRCPV}"
+
+S = "${WORKDIR}/git"
+
+do_configure[noexec] = "1"
+
+do_compile () {
+	oe_runmake
+}
+
+do_install () {
+    install -d -m 0755 ${D}${bindir}
+    install -m 0755 ${S}/utp_com ${D}${bindir}/utp_com
+}
+
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-support/sg3-utils/sg3-utils_%.bbappend
+++ b/recipes-support/sg3-utils/sg3-utils_%.bbappend
@@ -1,0 +1,1 @@
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
utp-com: Add recipe

This utility is used to send commands to the device
using the NXP's UTP protocol.

Signed-off-by: Vincent Prince <vincent.prince.fr@gmail.com>