### PR TITLE
qtbase: Do not modify QT_CONFIG_FLAGS

### DIFF
--- a/dynamic-layers/qt5-layer/recipes-qt/qt5/qtbase_%.bbappend
+++ b/dynamic-layers/qt5-layer/recipes-qt/qt5/qtbase_%.bbappend
@@ -30,8 +30,3 @@ PACKAGECONFIG_PLATFORM_imxgpu3d = " \
                                                        'eglfs', d), d)}"
 PACKAGECONFIG_PLATFORM_use-mainline-bsp = "${@bb.utils.contains('DISTRO_FEATURES', 'x11', '', 'eglfs', d)}"
 PACKAGECONFIG += "${PACKAGECONFIG_PLATFORM}"
-
-QT_CONFIG_FLAGS += \
-    "${@bb.utils.contains('DISTRO_FEATURES', 'wayland', '-qpa wayland', \
-        bb.utils.contains('DISTRO_FEATURES',     'x11',             '', \
-                                                          '-qpa eglfs', d), d)}"


### PR DESCRIPTION
* For distros enabling x11 and wayland it breaks X11 images (xfce/lxqt) for ALL
  machines
* It is a setting which can be done at runtime. E.g KDE plasma does so.
* Settings like these do NOT belong into BSP layers

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>