### PR TITLE
libdrm: Add nobranch option

### DIFF
--- a/recipes-graphics/drm/libdrm_2.4.91.imx.bb
+++ b/recipes-graphics/drm/libdrm_2.4.91.imx.bb
@@ -10,7 +10,7 @@ LIC_FILES_CHKSUM = "file://xf86drm.c;beginline=9;endline=32;md5=c8a3b961af7667c5
 PROVIDES = "drm"
 DEPENDS = "libpthread-stubs libpciaccess"
 
-IMX_LIBDRM_SRC ?= "git://source.codeaurora.org/external/imx/libdrm-imx.git;protocol=https"
+IMX_LIBDRM_SRC ?= "git://source.codeaurora.org/external/imx/libdrm-imx.git;protocol=https;nobranch=1"
 IMX_LIBDRM_BRANCH = "libdrm-imx-2.4.91"
 SRC_URI = "${IMX_LIBDRM_SRC};branch=${IMX_LIBDRM_BRANCH} \
            file://installtests.patch \


### PR DESCRIPTION
The codeaurora repository doesn't provide a remote HEAD, which cause an
issue when bitbake try to verify the SHA1 of the commit id.
The nobranch option allow to bypass this behaviour and correctly
checkout the commit id.