### PR TITLE
qe-ucode: Fix python indentation as per OE-Core style guidelines

### DIFF
--- a/recipes-bsp/qe-ucode/qe-ucode_git.bb
+++ b/recipes-bsp/qe-ucode/qe-ucode_git.bb
@@ -11,12 +11,12 @@ SRCREV= "57401f6dff6507055558eaa6838116baa8a2fd46"
 S = "${WORKDIR}/git"
 
 python () {
-	if not d.getVar("QE_UCODE", True):
-		PN = d.getVar("PN", True)
-		FILE = os.path.basename(d.getVar("FILE", True))
-		bb.debug(1, "To build %s, see %s for instructions on \
-			     setting up your qe-ucode" % (PN, FILE))
-		raise bb.parse.SkipRecipe("because QE_UCODE is not set")
+    if not d.getVar("QE_UCODE", True):
+        PN = d.getVar("PN", True)
+        FILE = os.path.basename(d.getVar("FILE", True))
+        bb.debug(1, "To build %s, see %s for instructions on \
+                     setting up your qe-ucode" % (PN, FILE))
+        raise bb.parse.SkipRecipe("because QE_UCODE is not set")
 }
 
 do_install () {


### PR DESCRIPTION
Fixes parsing warnings e.g.
qe-ucode_git.bb: python should use 4 spaces indentation, but found tabs in qe-ucode_git.bb, line 14

Signed-off-by: Khem Raj <raj.khem@gmail.com>