### PR TITLE
wic:mx8: Fix the image creation

### DIFF
--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -301,7 +301,10 @@ WKS_FILE_DEPENDS ?= " \
     bmap-tools-native \
 "
 
+WKS_FILE_DEPENDS_mx8 += "imx-boot"
+
 SOC_DEFAULT_WKS_FILE ?= "imx-uboot-bootpart.wks"
+SOC_DEFAULT_WKS_FILE_mx8 ?= "imx-imx-boot-bootpart.wks"
 SOC_DEFAULT_WKS_FILE_mxs ?= "imx-uboot-mxs-bootpart.wks.in"
 
 WKS_FILE ?= "${SOC_DEFAULT_WKS_FILE}"

--- a/recipes-bsp/imx-mkimage/imx-boot_0.2.bb
+++ b/recipes-bsp/imx-mkimage/imx-boot_0.2.bb
@@ -180,7 +180,7 @@ do_deploy() {
         install -m 0644 ${S}/${BOOT_CONFIG_MACHINE}-${target} ${DEPLOYDIR}
     done
     cd ${DEPLOYDIR}
-    ln -sf ${BOOT_CONFIG_MACHINE}-${IMAGE_IMXBOOT_TARGET} ${BOOT_CONFIG_MACHINE}
+    ln -sf ${BOOT_CONFIG_MACHINE}-${IMAGE_IMXBOOT_TARGET} ${BOOT_NAME}
     cd -
 }
 addtask deploy before do_build after do_compile

--- a/wic/imx-imx-boot-bootpart.wks
+++ b/wic/imx-imx-boot-bootpart.wks
@@ -1,0 +1,20 @@
+# short-description: Create SD card image with a boot partition
+# long-description:
+# Create an image that can be written onto a SD card using dd for use
+# with i.MX SoC family
+# It uses u-boot + other binaries gathered together on imx-boot file
+#
+# The disk layout used is:
+#  - ---------- -------------- --------------
+# | | imx-boot |     boot     |    rootfs   |
+#  - ---------- -------------- --------------
+# ^ ^          ^              ^
+# | |          |              |
+# 0 33kiB    4MiB          16MiB + rootfs + IMAGE_EXTRA_SPACE (default 10MiB)
+#
+part u-boot --source rawcopy --sourceparams="file=imx-boot" --ondisk mmcblk --no-table --align 33
+part /boot --source bootimg-partition --ondisk mmcblk --fstype=vfat --label boot --active --align 4096 --size 16
+part / --source rootfs --ondisk mmcblk --fstype=ext4 --label root --align 4096
+
+bootloader --ptable msdos
+


### PR DESCRIPTION
imx8 family boards use u-boot as boot loader in addition to some other
binaries. The final bootloader binary is gathered by mkimage into a file
called imx-boot.

Add the wks file to create the wic image tailored for imx8 family.
Fix the symbolic link file create to point to imx-boot (so it works for
all the imx8 flavors).
Set the wks file as default for all imx8.

Signed-off-by: Daiane Angolini <daiane.angolini@nxp.com>