### PR TITLE
vpp-core: Pin to qoriq socs

### DIFF
--- a/recipes-extended/vpp-core/vpp-core.bb
+++ b/recipes-extended/vpp-core/vpp-core.bb
@@ -60,3 +60,6 @@ do_install_append() {
 
 
 BBCLASSEXTEND = "native nativesdk"
+
+COMPATIBLE_MACHINE_class-target = "(qoriq)"
+


### PR DESCRIPTION
It depends on dpdk which is also qoriq specific

Fixes
 ERROR: Nothing PROVIDES 'dpdk' (but /mnt/jenkins/workspace/yocto-world-glibc/sources/meta-freescale/recipes-extended/vpp-core/vpp-core.bb DEPENDS on or otherwise requires it)
03:58:38 dpdk was skipped: incompatible with machine qemumips (not in COMPATIBLE_MACHINE)

ERROR: Nothing RPROVIDES 'vpp-core' (but /mnt/jenkins/workspace/yocto-world-glibc/sources/meta-freescale/recipes-extended/vpp-core/vpp-core.bb RDEPENDS on or otherwise requires it)

Signed-off-by: Khem Raj <raj.khem@gmail.com>