### PR TITLE
u-boot-imx: Fix filename at install

### DIFF
--- a/recipes-bsp/u-boot/u-boot-imx_2017.03.bb
+++ b/recipes-bsp/u-boot/u-boot-imx_2017.03.bb
@@ -35,7 +35,7 @@ do_deploy_append_mx8m() {
                     install -d ${DEPLOYDIR}/${BOOT_TOOLS}
                     install -m 0777 ${B}/${config}/arch/arm/dts/${UBOOT_DTB_NAME}  ${DEPLOYDIR}/${BOOT_TOOLS}
                     install -m 0777 ${B}/${config}/tools/mkimage  ${DEPLOYDIR}/${BOOT_TOOLS}/mkimage_uboot
-                    install -m 0777 ${B}/${config}/u-boot-nodtb.bin  ${DEPLOYDIR}/${BOOT_TOOLS}/u-boot-nodtb.bin-${MACHINE}-${UBOOT_CONFIG}
+                    install -m 0777 ${B}/${config}/u-boot-nodtb.bin  ${DEPLOYDIR}/${BOOT_TOOLS}/u-boot-nodtb.bin
                 fi
             done
             unset  j


### PR DESCRIPTION
Fix the error:

er/build/tmp/work/imx8mqevk-fslc-linux/imx-boot/0.2-r0/git/iMX8M
| cp: cannot stat '/media/daiane/TRIFORCE/yocto/master/build/tmp/deploy/images/imx8mqevk/imx-boot-tools/u-boot-nodtb.bin': No such file or directory
| WARNING: exit code 1 from a shell command.
| ERROR: Function failed: do_compile (log file is located at /media/daiane/TRIFORCE/yocto/master/build/tmp/work/imx8mqevk-fslc-linux/imx-boot/0.2-r0/temp/log.do_compile.27338)

Signed-off-by: Daiane Angolini <daiane.angolini@nxp.com>