### PR TITLE
u-boot.imx: Fix u-boot configuration for fsl distro

### DIFF
--- a/conf/machine/imx6qdlsabreauto.conf
+++ b/conf/machine/imx6qdlsabreauto.conf
@@ -33,10 +33,11 @@ KERNEL_DEVICETREE_use-mainline-bsp = " \
 "
 
 UBOOT_MACHINE ?= "mx6sabreauto_defconfig"
-UBOOT_MAKE_TARGET = "all"
-UBOOT_SUFFIX = "img"
-SPL_BINARY = "SPL"
-WKS_FILE = "imx-uboot-spl-bootpart.wks"
+
+UBOOT_MAKE_TARGET_fslc = "all"
+UBOOT_SUFFIX_fslc = "img"
+SPL_BINARY_fslc = "SPL"
+WKS_FILE_fslc = "imx-uboot-spl-bootpart.wks"
 
 SERIAL_CONSOLES = "115200;ttymxc3"
 

--- a/conf/machine/imx6qdlsabresd.conf
+++ b/conf/machine/imx6qdlsabresd.conf
@@ -33,10 +33,11 @@ KERNEL_DEVICETREE_use-mainline-bsp = " \
 "
 
 UBOOT_MACHINE ?= "mx6sabresd_defconfig"
-UBOOT_MAKE_TARGET = "all"
-UBOOT_SUFFIX = "img"
-SPL_BINARY = "SPL"
-WKS_FILE = "imx-uboot-spl-bootpart.wks"
+
+UBOOT_MAKE_TARGET_fslc = "all"
+UBOOT_SUFFIX_fslc = "img"
+SPL_BINARY_fslc = "SPL"
+WKS_FILE_fslc = "imx-uboot-spl-bootpart.wks"
 
 SERIAL_CONSOLES = "115200;ttymxc0"
 

--- a/conf/machine/imx6ulevk.conf
+++ b/conf/machine/imx6ulevk.conf
@@ -16,12 +16,13 @@ KERNEL_DEVICETREE = "imx6ul-14x14-evk.dtb imx6ul-14x14-evk-csi.dtb imx6ul-14x14-
                      imx6ul-14x14-evk-emmc.dtb "
 KERNEL_DEVICETREE_use-mainline-bsp = "imx6ul-14x14-evk.dtb"
 
-UBOOT_SUFFIX = "img"
-SPL_BINARY = "SPL"
-UBOOT_MAKE_TARGET = ""
+UBOOT_MAKE_TARGET_fslc = ""
+UBOOT_SUFFIX_fslc = "img"
+SPL_BINARY_fslc = "SPL"
+WKS_FILE_fslc = "imx-uboot-spl-bootpart.wks"
+
 UBOOT_CONFIG ??= "sd"
 UBOOT_CONFIG[sd] = "mx6ul_14x14_evk_config,sdcard"
 UBOOT_CONFIG[emmc] = "mx6ul_14x14_evk_emmc_config,sdcard"
 UBOOT_CONFIG[qspi1] = "mx6ul_14x14_evk_qspi1_config"
 UBOOT_CONFIG[mfgtool] = "mx6ul_14x14_evk_config"
-WKS_FILE = "imx-uboot-spl-bootpart.wks"


### PR DESCRIPTION
The fsl distro was broken for the following machine files
because they set u-boot configuration to fslc configuration:

- imx6qdlsabreauto
- imx6qdlsabresd
- imx6ulevk

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>