### PR TITLE
u-boot.imx: Add u-boot configuration for fsl

### DIFF
--- a/conf/machine/imx6qdlsabreauto.conf
+++ b/conf/machine/imx6qdlsabreauto.conf
@@ -33,6 +33,8 @@ KERNEL_DEVICETREE_use-mainline-bsp = " \
 "
 
 UBOOT_MACHINE ?= "mx6sabreauto_defconfig"
+
+# Use fslc u-boot by default. See also imx-base.inc.
 UBOOT_MAKE_TARGET = "all"
 UBOOT_SUFFIX = "img"
 SPL_BINARY = "SPL"

--- a/conf/machine/imx6qdlsabresd.conf
+++ b/conf/machine/imx6qdlsabresd.conf
@@ -33,6 +33,8 @@ KERNEL_DEVICETREE_use-mainline-bsp = " \
 "
 
 UBOOT_MACHINE ?= "mx6sabresd_defconfig"
+
+# Use fslc u-boot by default. See also imx-base.inc.
 UBOOT_MAKE_TARGET = "all"
 UBOOT_SUFFIX = "img"
 SPL_BINARY = "SPL"

--- a/conf/machine/imx6ulevk.conf
+++ b/conf/machine/imx6ulevk.conf
@@ -16,12 +16,14 @@ KERNEL_DEVICETREE = "imx6ul-14x14-evk.dtb imx6ul-14x14-evk-csi.dtb imx6ul-14x14-
                      imx6ul-14x14-evk-emmc.dtb "
 KERNEL_DEVICETREE_use-mainline-bsp = "imx6ul-14x14-evk.dtb"
 
+# Use fslc u-boot by default. See also imx-base.inc.
+UBOOT_MAKE_TARGET = ""
 UBOOT_SUFFIX = "img"
 SPL_BINARY = "SPL"
-UBOOT_MAKE_TARGET = ""
+WKS_FILE = "imx-uboot-spl-bootpart.wks"
+
 UBOOT_CONFIG ??= "sd"
 UBOOT_CONFIG[sd] = "mx6ul_14x14_evk_config,sdcard"
 UBOOT_CONFIG[emmc] = "mx6ul_14x14_evk_emmc_config,sdcard"
 UBOOT_CONFIG[qspi1] = "mx6ul_14x14_evk_qspi1_config"
 UBOOT_CONFIG[mfgtool] = "mx6ul_14x14_evk_config"
-WKS_FILE = "imx-uboot-spl-bootpart.wks"

--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -310,6 +310,14 @@ SOC_DEFAULT_WKS_FILE_mxs ?= "imx-uboot-mxs-bootpart.wks.in"
 
 WKS_FILE ?= "${SOC_DEFAULT_WKS_FILE}"
 
+# Certain machines override the default fsl u-boot with the
+# fslc u-boot. To restore the fsl u-boot, add use-fsl-bsp like this:
+#   MACHINEOVERRIDES_prepend_imx6ulevk = "use-fsl-bsp:"
+UBOOT_MAKE_TARGET_use-fsl-bsp = "u-boot.imx"
+UBOOT_SUFFIX_use-fsl-bsp = "imx"
+SPL_BINARY_use-fsl-bsp = ""
+WKS_FILE_use-fsl-bsp = "imx-uboot-bootpart.wks"
+
 SERIAL_CONSOLES = "115200;ttymxc0"
 SERIAL_CONSOLES_mxs = "115200;ttyAMA0"
 


### PR DESCRIPTION
The fsl distro was broken for the following machine files
because they set u-boot configuration to fslc configuration:

- imx6qdlsabreauto
- imx6qdlsabresd
- imx6ulevk

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>