### PR TITLE
Fix whitespace separator in DEPENDS_append

### DIFF
--- a/recipes-bsp/u-boot/u-boot-imx_2017.03.bb
+++ b/recipes-bsp/u-boot/u-boot-imx_2017.03.bb
@@ -6,7 +6,7 @@ DESCRIPTION = "i.MX U-Boot suppporting i.MX reference boards."
 require recipes-bsp/u-boot/u-boot.inc
 
 PROVIDES += "u-boot"
-DEPENDS_append = "dtc-native"
+DEPENDS_append = " dtc-native"
 
 LICENSE = "GPLv2+"
 LIC_FILES_CHKSUM = "file://Licenses/gpl-2.0.txt;md5=b234ee4d69f5fce4486a80fdaf4a4263"


### PR DESCRIPTION
# Summary
When I run bitbake fsl-image-mfgtool-initramfs, I have an error>

`NOTE: Resolving any missing task queue dependencies
ERROR: Nothing PROVIDES 'python-nativedtc-native' (but /.../poky/meta-freescale/recipes-bsp/u-boot/u-boot-imx-mfgtool_2017.03.bb DEPENDS on or otherwise requires it). Close matches:
  python-pyparted-native
  python-pytest-native
  python-epydoc-native
`

https://www.yoctoproject.org/docs/1.6/bitbake-user-manual/bitbake-user-manual.html
3.1.8. Appending and Prepending (Overrid#e Style Syntax)
B_append = " additional data"

- [x] Bug fix (non-breaking)
