### PR TITLE
conf/layer.conf: Drop sumo and thud support

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -8,7 +8,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 BBFILE_COLLECTIONS += "freescale-layer"
 BBFILE_PATTERN_freescale-layer := "^${LAYERDIR}/"
 BBFILE_PRIORITY_freescale-layer = "5"
-LAYERSERIES_COMPAT_freescale-layer = "sumo thud warrior"
+LAYERSERIES_COMPAT_freescale-layer = "warrior"
 
 # Add the Freescale-specific licenses into the metadata
 LICENSE_PATH += "${LAYERDIR}/custom-licenses"


### PR DESCRIPTION
If you want to use theses branches, use the respective platform.

Signed-off-by: Fabio Berton <fabio.berton@ossystems.com.br>