### PR TITLE
u-boot-fslc-common: Bump revision to 015ff874b4

### DIFF
--- a/recipes-bsp/u-boot/u-boot-fslc-common_2019.04.inc
+++ b/recipes-bsp/u-boot/u-boot-fslc-common_2019.04.inc
@@ -10,7 +10,7 @@ DEPENDS += "bison-native"
 
 SRC_URI = "git://github.com/Freescale/u-boot-fslc.git;branch=${SRCBRANCH}"
 
-SRCREV = "d4eebd04278595fb7e1cc7c5725ec3a9e581be5e"
+SRCREV = "015ff874b446810481ce5f35ceb7674d1f3cf86c"
 SRCBRANCH = "2019.04+fslc"
 
 PV = "v2019.04+git${SRCPV}"

--- a/recipes-bsp/u-boot/u-boot-fslc_2019.04.bb
+++ b/recipes-bsp/u-boot/u-boot-fslc_2019.04.bb
@@ -6,7 +6,7 @@ order to provide support for some backported features and fixes, or because it \
 was submitted for revision and it takes some time to become part of a stable \
 version, or because it is not applicable for upstreaming."
 
-DEPENDS_append = " dtc-native"
+DEPENDS_append = " bc-native dtc-native"
 
 PROVIDES += "u-boot"
 


### PR DESCRIPTION
  - Add bc-native dependency
  - This commit merges remote-tracking branch 'imx/master' into 2019.04+fslc

Signed-off-by: Fabio Berton <fabio.berton@ossystems.com.br>