### PR TITLE
qca-tools: Limit to arm/arm64 hosts alone

### DIFF
--- a/recipes-bsp/firmware-qca/qca-tools_2.0.1.bb
+++ b/recipes-bsp/firmware-qca/qca-tools_2.0.1.bb
@@ -15,3 +15,5 @@ do_install() {
     install -d ${D}${sbindir}/fcc_tools
     cp -r ${S}/fcc_tools/${FCC_TOOLS_FOLDER} ${D}${sbindir}/fcc_tools
 }
+
+COMPATIBLE_HOST = '(aarch64|arm).*-linux'


### PR DESCRIPTION
The firmware ends up in stripping errors on non-arm arches
rightly so since the binaries are arm arch specific.

Signed-off-by: Khem Raj <raj.khem@gmail.com>