### PR TITLE
imx-imx-boot-bootpart.wks.in: increase boot partition to 64m

### DIFF
--- a/wic/imx-imx-boot-bootpart.wks.in
+++ b/wic/imx-imx-boot-bootpart.wks.in
@@ -14,7 +14,7 @@
 #   ${IMX_BOOT_SEEK} 32 or 33kiB, see reference manual
 #
 part u-boot --source rawcopy --sourceparams="file=imx-boot" --ondisk mmcblk --no-table --align ${IMX_BOOT_SEEK}
-part /boot --source bootimg-partition --ondisk mmcblk --fstype=vfat --label boot --active --align 4096 --size 16
+part /boot --source bootimg-partition --ondisk mmcblk --fstype=vfat --label boot --active --align 4096 --size 64
 part / --source rootfs --ondisk mmcblk --fstype=ext4 --label root --align 4096
 
 bootloader --ptable msdos


### PR DESCRIPTION
The i.MX8 / i.MX8X kernel's size is about 22MB.
Increase the boot partitions minimum size to have space for two kernel
images and have a constant partition size.

Signed-off-by: Max Krummenacher <max.krummenacher@toradex.com>