### PR TITLE
imx-base.inc: Use UBOOT_SUFFIX in UBOOT_BINARY variable

### DIFF
--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -14,8 +14,8 @@ PREFERRED_PROVIDER_virtual/bootloader ??= "${IMX_DEFAULT_BOOTLOADER}"
 
 PREFERRED_PROVIDER_u-boot-mxsboot-native ??= "u-boot-fslc-mxsboot-native"
 
-UBOOT_BINARY ?= "u-boot.imx"
-UBOOT_MAKE_TARGET ?= "u-boot.imx"
+UBOOT_BINARY ?= "u-boot.${UBOOT_SUFFIX}"
+UBOOT_MAKE_TARGET ?= "u-boot.${UBOOT_SUFFIX}"
 UBOOT_MAKE_TARGET_mxs ?= "u-boot.sb"
 UBOOT_MAKE_TARGET_mx8 ?= ""
 


### PR DESCRIPTION
UBOOT_SUFFIX is already set in machine configuration files and
we can use this variable to set u-boot suffix for UBOOT_BINARY.

(cherry picked from commit 739cab987341d48e3654374ea4bbda77c72bfbe9)
Signed-off-by: Joris Offouga <offougajoris@gmail.com>