### PR TITLE
utilities.inc: split by any number of whitespaces

### DIFF
--- a/conf/machine/include/utilities.inc
+++ b/conf/machine/include/utilities.inc
@@ -13,4 +13,4 @@ def make_dtb_boot_files(d):
             #     destination: bcm2708-rpi-b.dtb
             return os.path.basename(dtb)
 
-    return ' '.join([transform(dtb) for dtb in alldtbs.split(' ') if dtb])
+    return ' '.join([transform(dtb) for dtb in alldtbs.split() if dtb])


### PR DESCRIPTION
Split alldtbs by any number of whitespace instead of just one to fix machines
with dtbs listed on multiple lines of KERNEL_DEVICETREE variable.

Signed-off-by: Diego Rondini <diego.rondini@kynetics.com>