### PR TITLE
imx-base: make sure sha384sum is available for all i.MX 8 variants

### DIFF
--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -331,4 +331,4 @@ MACHINE_FEATURES = "usbgadget usbhost vfat alsa touchscreen"
 # Add the ability to specify _imx machines
 MACHINEOVERRIDES =. "imx:"
 
-HOSTTOOLS_NONFATAL_append_mx8x = " sha384sum"
+HOSTTOOLS_NONFATAL_append_mx8 = " sha384sum"


### PR DESCRIPTION
Image container generation of imx-boot requires sha384sum also
when building for i.MX 8 targets (e.g. i.MX 8QM). Make sure it
is available for all i.MX 8 families.

Signed-off-by: Stefan Agner <stefan.agner@toradex.com>