### PR TITLE
utilities.inc: handle illicit KERNEL_DEVICETREE entries

### DIFF
--- a/conf/machine/include/utilities.inc
+++ b/conf/machine/include/utilities.inc
@@ -13,4 +13,4 @@ def make_dtb_boot_files(d):
             #     destination: bcm2708-rpi-b.dtb
             return os.path.basename(dtb)
 
-    return ' '.join([transform(dtb) for dtb in alldtbs.split(' ') if dtb])
+    return ' '.join([transform(dtb) for dtb in alldtbs.split() if dtb])

--- a/conf/machine/include/utilities.inc
+++ b/conf/machine/include/utilities.inc
@@ -4,13 +4,18 @@ def make_dtb_boot_files(d):
     # Generate IMAGE_BOOT_FILES entries for device tree files listed in
     # KERNEL_DEVICETREE.
     # Use only the basename for dtb files:
-    alldtbs = d.getVar('KERNEL_DEVICETREE')
+    alldtbs = d.getVar('KERNEL_DEVICETREE', True)
 
-    def transform(dtb):
+    def transform(dtb, alldtbs):
         if dtb.endswith('dtb') or dtb.endswith('dtbo'):
             # eg: whatever/bcm2708-rpi-b.dtb has:
             #     DEPLOYDIR file: bcm2708-rpi-b.dtb
             #     destination: bcm2708-rpi-b.dtb
             return os.path.basename(dtb)
+        else:
+            alldtbs = alldtbs.replace(dtb, '')
+            d.setVar('KERNEL_DEVICETREE', alldtbs)
+            bb.warn("Ignoring KERNEL_DEVICETREE entry %s because it is not a .dtb or .dtbo file." % (dtb) )
+            return ""
 
-    return ' '.join([transform(dtb) for dtb in alldtbs.split() if dtb])
+    return ' '.join([transform(dtb, alldtbs) for dtb in alldtbs.split() if dtb])


### PR DESCRIPTION
Function `make_dtb_boot_files` didn't return if KERNEL_DEVICETREE contained illicit non .dtb or .dtbo files, resulting in Python `str` method `join` trying to concatenate `None` and string objects.
Instead we now raise a warning, remove the illicit device tree entries and return an empty string.