### PR TITLE
imx-usb-loader: Update to 29fa8ab revision

### DIFF
--- a/recipes-devtools/imx-usb-loader/imx-usb-loader_git.bb
+++ b/recipes-devtools/imx-usb-loader/imx-usb-loader_git.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
 DEPENDS = "libusb1"
 
-SRCREV = "e5394615dd413c3823d5bd1de340933e16a8c07c"
+SRCREV = "29fa8ab592924cf2294584b4a407f0a76858b60e"
 SRC_URI = "git://github.com/boundarydevices/imx_usb_loader.git;protocol=http"
 
 PV = "1.0+${SRCPV}"


### PR DESCRIPTION
Following changes are included:

29fa8ab imx_usb: use device found by find_imx_device
abe7f5d add support for relocatable installs
3d36c83 Fixed build for Visual Studio 2015 Express.
fe50624 imx_usb.config: add mx8mm_usb_sdp_spl.conf/mx8mm_usb_work.conf lines
f7752f4 mx8mq_usb_work.conf: use bl31-iMX8MQ-2g.bin to match branch boundary-imx_4.9.123_imx8mm_ga of imx-mkimage
8c9eee7 add mx8mm config files
4aa9809 imx_uart: fix type on help
95fe112 imx_usb: fix type on imx_usb help
eed0280 portable: use __builtin_bswap16 for BE16 if >= 4.8 GNUC
e99a093 portable: fix typo s/&&/&/ in BE16 fix
f000130 mx6ull_usb_work.conf: fix copy/paste error in comment
1041959 correct commit "portable.h: fix build with gcc older than 4.8"
bf25425 add mx6ull_usb_work.conf
9a88413 portable.h: fix build with gcc older than 4.8

Signed-off-by: Pierre-Jean Texier <pjtexier@koncepto.io>