### PR TITLE
imx-boot: drop dependency to u-boot

### DIFF
--- a/recipes-bsp/imx-mkimage/imx-boot_0.2.bb
+++ b/recipes-bsp/imx-mkimage/imx-boot_0.2.bb
@@ -11,7 +11,6 @@ IMX_EXTRA_FIRMWARE      = "firmware-imx-8 imx-sc-firmware"
 IMX_EXTRA_FIRMWARE_mx8m = "firmware-imx-8m"
 IMX_EXTRA_FIRMWARE_mx8x = "firmware-imx-8x imx-sc-firmware"
 DEPENDS += " \
-    u-boot \
     firmware-imx \
     ${IMX_EXTRA_FIRMWARE} \
     imx-atf \


### PR DESCRIPTION
The recipe do_compile task depends on virtual/bootloader which makes
sure the necessary dependencies are available once imx-boot do_compile
is executed.

Signed-off-by: Stefan Agner <stefan.agner@toradex.com>