### PR TITLE
u-boot-imx: Fix x86_64-linux-gnu-gcc compilation error

### DIFF
--- a/recipes-bsp/u-boot/u-boot-imx/0001-tools-allow-to-override-python.patch
+++ b/recipes-bsp/u-boot/u-boot-imx/0001-tools-allow-to-override-python.patch
@@ -1,0 +1,46 @@
+From b48bfc74ee410b1e6681c620633ffef32aafaba0 Mon Sep 17 00:00:00 2001
+From: Stefano Babic <sbabic@denx.de>
+Date: Wed, 5 Apr 2017 17:46:41 +0200
+Subject: [PATCH] tools: allow to override python
+
+Not force to use python from PATH. Issue was noted when building with
+Yocto, because python from the distro is always taken instead of
+python-native built during Yocto process.
+
+Signed-off-by: Stefano Babic <sbabic@denx.de>
+CC: Simon Glass <sjg@chromium.org>
+Reviewed-by: Simon Glass <sjg@chromium.org>
+---
+ Makefile       | 2 +-
+ tools/Makefile | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 09b597d450..8d4e6050b3 100644
+--- a/Makefile
++++ b/Makefile
+@@ -348,7 +348,7 @@ OBJCOPY		= $(CROSS_COMPILE)objcopy
+ OBJDUMP		= $(CROSS_COMPILE)objdump
+ AWK		= awk
+ PERL		= perl
+-PYTHON		= python
++PYTHON		?= python
+ DTC		= dtc
+ CHECK		= sparse
+ 
+diff --git a/tools/Makefile b/tools/Makefile
+index fa1b85bdae..2fc4a583d4 100644
+--- a/tools/Makefile
++++ b/tools/Makefile
+@@ -120,7 +120,7 @@ _libfdt.so-sharedobjs += $(LIBFDT_OBJS)
+ libfdt:
+ 
+ tools/_libfdt.so: $(patsubst %.o,%.c,$(LIBFDT_OBJS)) tools/libfdt_wrap.c
+-	LDFLAGS="$(HOSTLDFLAGS)" python $(srctree)/lib/libfdt/setup.py \
++	LDFLAGS="$(HOSTLDFLAGS)" ${PYTHON} $(srctree)/lib/libfdt/setup.py \
+ 		"$(_hostc_flags)" $^
+ 	mv _libfdt.so $@
+ 
+-- 
+2.17.1
+

--- a/recipes-bsp/u-boot/u-boot-imx_2017.03.bb
+++ b/recipes-bsp/u-boot/u-boot-imx_2017.03.bb
@@ -11,7 +11,9 @@ LICENSE = "GPLv2+"
 LIC_FILES_CHKSUM = "file://Licenses/gpl-2.0.txt;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 SRCBRANCH = "imx_v2017.03_4.9.123_imx8mm_ga"
-SRC_URI = "git://source.codeaurora.org/external/imx/uboot-imx.git;protocol=https;branch=${SRCBRANCH}"
+SRC_URI = "git://source.codeaurora.org/external/imx/uboot-imx.git;protocol=https;branch=${SRCBRANCH} \
+           file://0001-tools-allow-to-override-python.patch \
+          "
 SRCREV = "8be98e9322040c655b9e5c9fb2c494e002e3fad9"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
This fixes the compiler error:

| unable to execute 'x86_64-linux-gnu-gcc': No such file or directory
| error: command 'x86_64-linux-gnu-gcc' failed with exit status 1

Signed-off-by: Carlos Rafael Giani <crg7475@mailbox.org>