### PR TITLE
qca-tools: Disable for musl hosts

### DIFF
--- a/recipes-bsp/firmware-qca/qca-tools_2.0.1.bb
+++ b/recipes-bsp/firmware-qca/qca-tools_2.0.1.bb
@@ -17,3 +17,4 @@ do_install() {
 }
 
 COMPATIBLE_HOST = '(aarch64|arm).*-linux'
+COMPATIBLE_HOST_libc-musl = 'null'

--- a/recipes-fsl/packagegroups/packagegroup-fsl-qca6174.bb
+++ b/recipes-fsl/packagegroups/packagegroup-fsl-qca6174.bb
@@ -7,5 +7,5 @@ inherit packagegroup
 RDEPENDS_${PN} = " \
     kernel-module-qca6174 \
     firmware-qca6174 \
-    qca-tools \
 "
+RDEPENDS_${PN}_append_libc-glibc = " qca-tools"

--- a/recipes-fsl/packagegroups/packagegroup-fsl-qca9377.bb
+++ b/recipes-fsl/packagegroups/packagegroup-fsl-qca9377.bb
@@ -7,5 +7,6 @@ inherit packagegroup
 RDEPENDS_${PN} = " \
     kernel-module-qca9377 \
     firmware-qca9377 \
-    qca-tools \
 "
+
+RDEPENDS_${PN}_append_libc-glibc = " qca-tools"


### PR DESCRIPTION
The prebuilt tools are for glibc based targets
no point in building for musl

Signed-off-by: Khem Raj <raj.khem@gmail.com>