### PR TITLE
wayland-protocols-imx: Upgrade to version 1.17

### DIFF
--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -254,9 +254,9 @@ PREFERRED_VERSION_weston_mx6 ?= "4.0.0.imx"
 PREFERRED_VERSION_weston_mx7 ?= "4.0.0.imx"
 PREFERRED_VERSION_weston_mx8 ?= "4.0.0.imx"
 
-PREFERRED_VERSION_wayland-protocols_mx6 ?= "1.13.imx"
-PREFERRED_VERSION_wayland-protocols_mx7 ?= "1.13.imx"
-PREFERRED_VERSION_wayland-protocols_mx8 ?= "1.13.imx"
+PREFERRED_VERSION_wayland-protocols_mx6 ?= "1.17.imx"
+PREFERRED_VERSION_wayland-protocols_mx7 ?= "1.17.imx"
+PREFERRED_VERSION_wayland-protocols_mx8 ?= "1.17.imx"
 
 # Use i.MX libdrm Version
 PREFERRED_VERSION_libdrm_mx6 ?= "2.4.91.imx"

--- a/recipes-graphics/wayland/wayland-protocols/0001-unstable-Add-alpha-compositing-protocol.patch
+++ b/recipes-graphics/wayland/wayland-protocols/0001-unstable-Add-alpha-compositing-protocol.patch
@@ -27,10 +27,10 @@ diff --git a/Makefile.am b/Makefile.am
 index 4b9a901..e6c44ec 100644
 --- a/Makefile.am
 +++ b/Makefile.am
-@@ -17,6 +17,7 @@ unstable_protocols =								\
- 	unstable/keyboard-shortcuts-inhibit/keyboard-shortcuts-inhibit-unstable-v1.xml \
- 	unstable/xdg-output/xdg-output-unstable-v1.xml				\
- 	unstable/input-timestamps/input-timestamps-unstable-v1.xml	\
+@@ -23,6 +23,7 @@ unstable_protocols =								\
+ 	unstable/xdg-decoration/xdg-decoration-unstable-v1.xml	\
+ 	unstable/linux-explicit-synchronization/linux-explicit-synchronization-unstable-v1.xml \
+ 	unstable/primary-selection/primary-selection-unstable-v1.xml		\
 +	unstable/alpha-compositing/alpha-compositing-unstable-v1.xml	\
  	$(NULL)
  

--- a/recipes-graphics/wayland/wayland-protocols/0002-unstable-Add-hdr10-metadata-protocol.patch
+++ b/recipes-graphics/wayland/wayland-protocols/0002-unstable-Add-hdr10-metadata-protocol.patch
@@ -21,9 +21,9 @@ diff --git a/Makefile.am b/Makefile.am
 index e6c44ec..b8206c7 100644
 --- a/Makefile.am
 +++ b/Makefile.am
-@@ -18,6 +18,7 @@ unstable_protocols =								\
- 	unstable/xdg-output/xdg-output-unstable-v1.xml				\
- 	unstable/input-timestamps/input-timestamps-unstable-v1.xml	\
+@@ -24,6 +24,7 @@ unstable_protocols =								\
+ 	unstable/linux-explicit-synchronization/linux-explicit-synchronization-unstable-v1.xml \
+ 	unstable/primary-selection/primary-selection-unstable-v1.xml		\
  	unstable/alpha-compositing/alpha-compositing-unstable-v1.xml	\
 +	unstable/hdr10-metadata/hdr10-metadata-unstable-v1.xml		\
  	$(NULL)

--- a/recipes-graphics/wayland/wayland-protocols_1.17.imx.bb
+++ b/recipes-graphics/wayland/wayland-protocols_1.17.imx.bb
@@ -9,13 +9,15 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://COPYING;md5=c7b12b6702da38ca028ace54aae3d484 \
                     file://stable/presentation-time/presentation-time.xml;endline=26;md5=4646cd7d9edc9fa55db941f2d3a7dc53"
 
-ARCHIVE_NAME = "${BPN}-1.13"
+ARCHIVE_NAME = "${BPN}-1.17"
 SRC_URI = "https://wayland.freedesktop.org/releases/${ARCHIVE_NAME}.tar.xz \
            file://0001-unstable-Add-alpha-compositing-protocol.patch \
            file://0002-unstable-Add-hdr10-metadata-protocol.patch"
-SRC_URI[md5sum] = "29312149dafcd4a0e739ba94995a574d"
-SRC_URI[sha256sum] = "0758bc8008d5332f431b2a84fea7de64d971ce270ed208206a098ff2ebc68f38"
+SRC_URI[md5sum] = "55ddd5fdb02b73b9de9559aaec267315"
+SRC_URI[sha256sum] = "df1319cf9705643aea9fd16f9056f4e5b2471bd10c0cc3713d4a4cdc23d6812f"
 S = "${WORKDIR}/${ARCHIVE_NAME}"
+
+UPSTREAM_CHECK_URI = "https://wayland.freedesktop.org/releases.html"
 
 inherit autotools pkgconfig
 


### PR DESCRIPTION
This is needed for GStreamer 1.16 Wayland support

Signed-off-by: Carlos Rafael Giani <crg7475@mailbox.org>