### PR TITLE
qca-modules: Mark arm/aarch64 specific

### DIFF
--- a/recipes-fsl/packagegroups/packagegroup-fsl-qca6174.bb
+++ b/recipes-fsl/packagegroups/packagegroup-fsl-qca6174.bb
@@ -8,4 +8,6 @@ RDEPENDS_${PN} = " \
     kernel-module-qca6174 \
     firmware-qca6174 \
 "
-RDEPENDS_${PN}_append_libc-glibc = " qca-tools"
+
+COMPATIBLE_HOST = '(aarch64|arm).*-linux'
+COMPATIBLE_HOST_libc-musl = 'null'

--- a/recipes-fsl/packagegroups/packagegroup-fsl-qca9377.bb
+++ b/recipes-fsl/packagegroups/packagegroup-fsl-qca9377.bb
@@ -8,5 +8,5 @@ RDEPENDS_${PN} = " \
     kernel-module-qca9377 \
     firmware-qca9377 \
 "
-
-RDEPENDS_${PN}_append_libc-glibc = " qca-tools"
+COMPATIBLE_HOST = '(aarch64|arm).*-linux'
+COMPATIBLE_HOST_libc-musl = 'null'

--- a/recipes-kernel/kernel-modules/kernel-module-qcacld-lea.inc
+++ b/recipes-kernel/kernel-modules/kernel-module-qcacld-lea.inc
@@ -19,4 +19,5 @@ EXTRA_OEMAKE += " \
     TARGET_BUILD_VARIANT=user \
 "
 
-RDEPENDS_${PN} = "qca-tools"
+COMPATIBLE_HOST = '(aarch64|arm).*-linux'
+COMPATIBLE_HOST_libc-musl = 'null'


### PR DESCRIPTION
These modules rdepends on qca-tools which is currently arm/aarch64 and
glibc specific, therefore mark the recipes depending on qca-tools so as
well.

Signed-off-by: Khem Raj <raj.khem@gmail.com>