### PR TITLE
mx8mm: use cortexa53-crypto tune for imx8m mini per default

### DIFF
--- a/conf/machine/imx8mmevk.conf
+++ b/conf/machine/imx8mmevk.conf
@@ -7,7 +7,7 @@
 MACHINEOVERRIDES =. "mx8:mx8m:mx8mm:"
 
 require conf/machine/include/imx-base.inc
-require conf/machine/include/arm/arch-arm64.inc
+require conf/machine/include/tune-cortexa53.inc
 
 MACHINE_FEATURES += " pci wifi bluetooth optee qca9377 qca6174"
 

--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -61,6 +61,7 @@ DEFAULTTUNE_mx6ul ?= "cortexa7thf-neon"
 DEFAULTTUNE_mx6ull ?= "cortexa7thf-neon"
 DEFAULTTUNE_mx7 ?= "cortexa7thf-neon"
 DEFAULTTUNE_vf ?= "cortexa5thf-neon"
+DEFAULTTUNE_mx8mm ?= "cortexa53-crypto"
 
 INHERIT += "machine-overrides-extender"
 


### PR DESCRIPTION
Current implementation of i.MX8M Mini is utilizing generic aarch64 tune
(arch-arm64) provided from OE meta layer.

According to IMX8MMRM [1] this CPU contains Cortex-A53 cores, so this commit
sets a default tune to cortexa53-crypto.

Note, that according to [1] ARM Crypto extensions are supported, therefore it
is beneficial to set the tune to -crypto, as this also enables NEON and VFP
support in GCC (via -march and -mcpu feature modifiers, see [2]).

[1]: https://www.nxp.com/webapp/Download?colCode=IMX8MMRM
[2]: https://gcc.gnu.org/onlinedocs/gcc/AArch64-Options.html#aarch64-feature-modifiers

Signed-off-by: Andrey Zhizhikin <andrey.z@gmail.com>