### PR TITLE
xserver-xorg: Fix X server 1.20.1 crash [YOCIMX-3280]

### DIFF
--- a/recipes-graphics/xorg-xserver/xserver-xorg/0003-Remove-check-for-useSIGIO-option.patch
+++ b/recipes-graphics/xorg-xserver/xserver-xorg/0003-Remove-check-for-useSIGIO-option.patch
@@ -1,0 +1,47 @@
+From cf407b16cd65ad6e26a9c8e5984e163409a5c0f7 Mon Sep 17 00:00:00 2001
+From: Prabhu Sundararaj <prabhu.sundararaj@nxp.com>
+Date: Mon, 30 Jan 2017 16:32:06 -0600
+Subject: [PATCH] Remove check for useSIGIO option
+
+Commit 6a5a4e60373c1386b311b2a8bb666c32d68a9d99 removes the configure of useSIGIO
+option.
+
+As the xfree86 SIGIO support is reworked to use internal versions of OsBlockSIGIO
+and OsReleaseSIGIO.
+
+No longer the check for useSIGIO is needed
+
+Upstream-Status: Pending
+
+Signed-off-by: Prabhu Sundararaj <prabhu.sundararaj@nxp.com>
+---
+ hw/xfree86/os-support/shared/sigio.c | 6 ------
+ 1 file changed, 6 deletions(-)
+
+diff --git a/hw/xfree86/os-support/shared/sigio.c b/hw/xfree86/os-support/shared/sigio.c
+index 884a71c..be76498 100644
+--- a/hw/xfree86/os-support/shared/sigio.c
++++ b/hw/xfree86/os-support/shared/sigio.c
+@@ -185,9 +185,6 @@ xf86InstallSIGIOHandler(int fd, void (*f) (int, void *), void *closure)
+     int i;
+     int installed = FALSE;
+ 
+-    if (!xf86Info.useSIGIO)
+-        return 0;
+-
+     for (i = 0; i < MAX_FUNCS; i++) {
+         if (!xf86SigIOFuncs[i].f) {
+             if (xf86IsPipe(fd))
+@@ -256,9 +253,6 @@ xf86RemoveSIGIOHandler(int fd)
+     int max;
+     int ret;
+ 
+-    if (!xf86Info.useSIGIO)
+-        return 0;
+-
+     max = 0;
+     ret = 0;
+     for (i = 0; i < MAX_FUNCS; i++) {
+-- 
+2.7.4
+

--- a/recipes-graphics/xorg-xserver/xserver-xorg_%.bbappend
+++ b/recipes-graphics/xorg-xserver/xserver-xorg_%.bbappend
@@ -3,3 +3,6 @@ IMX_OPENGL_PKGCONFIGS_REMOVE_imxgpu = "glamor"
 OPENGL_PKGCONFIGS_remove_mx6        = "${IMX_OPENGL_PKGCONFIGS_REMOVE}"
 OPENGL_PKGCONFIGS_remove_mx7        = "${IMX_OPENGL_PKGCONFIGS_REMOVE}"
 OPENGL_PKGCONFIGS_remove_mx8        = "${IMX_OPENGL_PKGCONFIGS_REMOVE}"
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
+SRC_URI_append_imxgpu2d = "file://0003-Remove-check-for-useSIGIO-option.patch"


### PR DESCRIPTION
Addresses issue #93.

I've seen the issue with master and thud, I expect warrior to be also affected.