### PR TITLE
atf: Fix the build on machines that don't support UEFI

### DIFF
--- a/recipes-bsp/atf/atf_git.bb
+++ b/recipes-bsp/atf/atf_git.bb
@@ -125,7 +125,7 @@ do_compile() {
                         cp -r ${S}/build/ls1012afrwy_512mb/release/fuse_fip.bin ${S}/fuse_fip_512mb.bin
                     fi
                 fi
-                if [ -n "${uefiboot}" ]; then
+                if [ -n "${uefiboot}" -a -f "${DEPLOY_DIR_IMAGE}/uefi/${PLATFORM}/${uefiboot}" ]; then
                     oe_runmake V=1 -C ${S} realclean
                     oe_runmake V=1 -C ${S} all fip pbl PLAT=${PLATFORM} BOOT_MODE=${d} RCW=${DEPLOY_DIR_IMAGE}/rcw/${PLATFORM}/${rcwimg} BL33=${DEPLOY_DIR_IMAGE}/uefi/${PLATFORM}/${uefiboot} ${bl32opt} ${spdopt} ${secureopt} ${fuseopt}
                     cp -r ${S}/build/${PLATFORM}/release/fip.bin ${S}/fip_uefi.bin


### PR DESCRIPTION
The uefi package silently build nothing on machines that are not
supported. On machines without UEFI support this lead to a build
failure in atf as it always try to build fip_uefi.bin. Fix the
compile step to only build fip_uefi.bin if there is an UEFI image.

Signed-off-by: Alban Bedel <alban.bedel@avionic-design.de>