### PR TITLE
linux-fslc: Bump revision to cd1d08333

### DIFF
--- a/recipes-kernel/linux/linux-fslc_5.1.bb
+++ b/recipes-kernel/linux/linux-fslc_5.1.bb
@@ -11,9 +11,9 @@ include linux-fslc.inc
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
-PV = "5.1.12+git${SRCPV}"
+PV = "5.1.15+git${SRCPV}"
 
 SRCBRANCH = "5.1.x+fslc"
-SRCREV = "111df67e3aa148d8b652ecf497ab1e54c8a13dfe"
+SRCREV = "cd1d083333e76e03d16f015c23f1f1b8c8637381"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"


### PR DESCRIPTION
This commit merge tag v5.1.15 into 5.1.x+fslc branch and apply
the following commits on top of it:

    - cd1d083333e7 ARM: imx_v6_v7_defconfig: Select the OV5645 camera driver
    - 4e89febe05f6 ARM: dts: imx6qdl-pico: Add OV5645 camera support
    - 2af073f8b465 ARM: dts: imx6qdl-pico: Add touchscreen support
    - ef23d262b6e2 drm/panel: simple: Pass flags/bus_format/bus_flags fields
    - 51226c7485b6 ARM: dts: imx6qdl-pico: Add parallel LCD support

Signed-off-by: Fabio Berton <fabio.berton@ossystems.com.br>