### PR TITLE
wic: Fix image generation for i.MX with SPL and U-Boot

### DIFF
--- a/wic/imx-uboot-spl-bootpart.wks.in
+++ b/wic/imx-uboot-spl-bootpart.wks.in
@@ -13,7 +13,7 @@
 # 0 1kiB  69kiB   4MiB          16MiB + rootfs + IMAGE_EXTRA_SPACE (default 10MiB)
 #
 part SPL --source rawcopy --sourceparams="file=SPL" --ondisk mmcblk --no-table --align 1
-part u-boot --source rawcopy --sourceparams="file=u-boot.img" --ondisk mmcblk --no-table --align 69
+part u-boot --source rawcopy --sourceparams="file=${UBOOT_BINARY}" --ondisk mmcblk --no-table --align 69
 part /boot --source bootimg-partition --ondisk mmcblk --fstype=vfat --label boot --active --align 4096 --size 16
 part / --source rootfs --ondisk mmcblk --fstype=ext4 --label root --align 4096
 

--- a/wic/imx-uboot-spl.wks.in
+++ b/wic/imx-uboot-spl.wks.in
@@ -13,7 +13,7 @@
 # 0 1kiB  69kiB   4MiB + rootfs + IMAGE_EXTRA_SPACE (default 10MiB)
 #
 part SPL --source rawcopy --sourceparams="file=SPL" --ondisk mmcblk --no-table --align 1
-part u-boot --source rawcopy --sourceparams="file=u-boot.img" --ondisk mmcblk --no-table --align 69
+part u-boot --source rawcopy --sourceparams="file=${UBOOT_BINARY}" --ondisk mmcblk --no-table --align 69
 part / --source rootfs --ondisk mmcblk --fstype=ext4 --label root --align 4096
 
 bootloader --ptable msdos


### PR DESCRIPTION
Some boards expects a specific binary name.
Example : Pico i.MX7D required the u-boot-dtb.img file (instead of u-boot.img).

Signed-off-by: Joris Offouga <offougajoris@gmail.com>