### PR TITLE
kernel-module-qcacld-lea: Mark imx soc specific

### DIFF
--- a/recipes-extended/dpdk/dpdk.inc
+++ b/recipes-extended/dpdk/dpdk.inc
@@ -17,7 +17,14 @@ do_configure[depends] += "virtual/kernel:do_shared_workdir"
 
 inherit module
 
-export RTE_TARGET = "${ARCH}-dpaa-linuxapp-gcc"
+COMPATIBLE_HOST = '(aarch64|arm|i.86|x86_64).*-linux'
+COMPATIBLE_HOST_libc-musl = 'null'
+
+DPDK_RTE_TARGET_x86-64 = "x86_64-native-linuxapp-gcc"
+DPDK_RTE_TARGET_x86 = "i686-native-linuxapp-gcc"
+DPDK_RTE_TARGET ?= "${ARCH}-dpaa-linuxapp-gcc"
+
+export RTE_TARGET = "${DPDK_RTE_TARGET}"
 export RTE_OUTPUT = "${S}/${RTE_TARGET}"
 export  MODULE_DIR = "/lib/modules/${KERNEL_VERSION}/kernel/drivers/net"
 

--- a/recipes-extended/vpp-core/dpdkvpp.bb
+++ b/recipes-extended/vpp-core/dpdkvpp.bb
@@ -17,7 +17,14 @@ do_configure[depends] += "virtual/kernel:do_shared_workdir"
 
 inherit module
 
-export RTE_TARGET = "${ARCH}-dpaa-linuxapp-gcc"
+COMPATIBLE_HOST = '(aarch64|arm|i.86|x86_64).*-linux'
+COMPATIBLE_HOST_libc-musl = 'null'
+
+DPDK_RTE_TARGET_x86-64 = "x86_64-native-linuxapp-gcc"
+DPDK_RTE_TARGET_x86 = "i686-native-linuxapp-gcc"
+DPDK_RTE_TARGET ?= "${ARCH}-dpaa-linuxapp-gcc"
+
+export RTE_TARGET = "${DPDK_RTE_TARGET}"
 export RTE_OUTPUT = "${S}/${RTE_TARGET}"
 
 S = "${WORKDIR}/git"

--- a/recipes-kernel/kernel-modules/kernel-module-qcacld-lea.inc
+++ b/recipes-kernel/kernel-modules/kernel-module-qcacld-lea.inc
@@ -19,5 +19,5 @@ EXTRA_OEMAKE += " \
     TARGET_BUILD_VARIANT=user \
 "
 
-COMPATIBLE_HOST = '(aarch64|arm).*-linux'
+COMPATIBLE_MACHINE = "(imx)"
 COMPATIBLE_HOST_libc-musl = 'null'


### PR DESCRIPTION
It tries to build for qemuarm and qemuarm64 as well and
fails to build e.g.

https://errors.yoctoproject.org/Errors/Details/251571/

Signed-off-by: Khem Raj <raj.khem@gmail.com>