### PR TITLE
Fix problems with dirty DEPLOYDIR during do_deploy

### DIFF
--- a/recipes-bsp/atf/atf_git.bb
+++ b/recipes-bsp/atf/atf_git.bb
@@ -207,6 +207,7 @@ do_deploy() {
         cp -r ${D}/boot/atf/fip_ddr_sec.bin ${DEPLOYDIR}/atf/fip_ddr_sec.bin
     fi
 }
+do_deploy[cleandirs] = "${DEPLOYDIR}"
 addtask deploy after do_install
 FILES_${PN} += "/boot"
 BBCLASSEXTEND = "native nativesdk"

--- a/recipes-bsp/ddr-phy/ddr-phy_git.bb
+++ b/recipes-bsp/ddr-phy/ddr-phy_git.bb
@@ -33,6 +33,7 @@ do_deploy () {
     install -d ${DEPLOYDIR}/ddr-phy
     install -m 755 ${S}/${REGLEX}/*.bin ${DEPLOYDIR}/ddr-phy
 }
+do_deploy[cleandirs] = "${DEPLOYDIR}"
 addtask deploy before do_populate_sysroot after do_install
 
 PACKAGES += "${PN}-image"

--- a/recipes-bsp/firmware-imx/firmware-imx-8_8.1.1.bb
+++ b/recipes-bsp/firmware-imx/firmware-imx-8_8.1.1.bb
@@ -16,6 +16,7 @@ do_deploy() {
     # SECO
     install -m 0644 ${S}/firmware/seco/mx8qm-ahab-container.img ${DEPLOYDIR}
 }
+do_deploy[cleandirs] = "${DEPLOYDIR}"
 addtask deploy after do_install before do_build
 
 PACKAGE_ARCH = "${MACHINE_SOCARCH}"

--- a/recipes-bsp/firmware-imx/firmware-imx-8m_8.1.1.bb
+++ b/recipes-bsp/firmware-imx/firmware-imx-8m_8.1.1.bb
@@ -17,6 +17,7 @@ do_deploy() {
     install -m 0644 ${S}/firmware/hdmi/cadence/signed_dp_imx8m.bin ${DEPLOYDIR}
     install -m 0644 ${S}/firmware/hdmi/cadence/signed_hdmi_imx8m.bin ${DEPLOYDIR}
 }
+do_deploy[cleandirs] = "${DEPLOYDIR}"
 addtask deploy after do_install before do_build
 
 PACKAGE_ARCH = "${MACHINE_SOCARCH}"

--- a/recipes-bsp/firmware-imx/firmware-imx-8x_8.1.1.bb
+++ b/recipes-bsp/firmware-imx/firmware-imx-8x_8.1.1.bb
@@ -13,6 +13,7 @@ do_deploy() {
     install -m 0644 ${S}/firmware/seco/mx8qx-ahab-container.img ${DEPLOYDIR}
 }
 
+do_deploy[cleandirs] = "${DEPLOYDIR}"
 addtask deploy after do_install before do_build
 
 PACKAGE_ARCH = "${MACHINE_SOCARCH}"

--- a/recipes-bsp/imx-atf/imx-atf_2.0.bb
+++ b/recipes-bsp/imx-atf/imx-atf_2.0.bb
@@ -41,6 +41,7 @@ do_install[noexec] = "1"
 do_deploy() {
     install -Dm 0644 ${S}/build/${PLATFORM}/release/bl31.bin ${DEPLOYDIR}/${BOOT_TOOLS}/bl31-${PLATFORM}.bin
 }
+do_deploy[cleandirs] = "${DEPLOYDIR}"
 addtask deploy after do_compile
 
 PACKAGE_ARCH = "${MACHINE_SOCARCH}"

--- a/recipes-bsp/imx-mkimage/imx-boot_0.2.bb
+++ b/recipes-bsp/imx-mkimage/imx-boot_0.2.bb
@@ -156,6 +156,7 @@ do_deploy() {
     ln -sf ${BOOT_CONFIG_MACHINE}-${IMAGE_IMXBOOT_TARGET} ${BOOT_NAME}
     cd -
 }
+do_deploy[cleandirs] = "${DEPLOYDIR}"
 addtask deploy before do_build after do_compile
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"

--- a/recipes-bsp/imx-mkimage/imx-mkimage_git.bb
+++ b/recipes-bsp/imx-mkimage/imx-mkimage_git.bb
@@ -32,4 +32,5 @@ do_deploy () {
     install -m 0644 ${S}/iMX8QM/imx8qm_dcd.cfg.tmp ${DEPLOYDIR}
     install -m 0644 ${S}/iMX8QX/imx8qx_dcd.cfg.tmp ${DEPLOYDIR}
 }
+do_deploy[cleandirs] = "${DEPLOYDIR}"
 addtask deploy before do_build after do_install

--- a/recipes-bsp/imx-sc-firmware/imx-sc-firmware_1.2.bb
+++ b/recipes-bsp/imx-sc-firmware/imx-sc-firmware_1.2.bb
@@ -29,6 +29,7 @@ do_deploy() {
     install -Dm 0644 ${S}/${SC_FIRMWARE_NAME} ${DEPLOYDIR}/${BOOT_TOOLS}/${SC_FIRMWARE_NAME}
     ln -sf ${SC_FIRMWARE_NAME} ${DEPLOYDIR}/${BOOT_TOOLS}/${symlink_name}
 }
+do_deploy[cleandirs] = "${DEPLOYDIR}"
 addtask deploy after do_install
 
 INHIBIT_PACKAGE_STRIP = "1"

--- a/recipes-bsp/inphi/inphi_git.bb
+++ b/recipes-bsp/inphi/inphi_git.bb
@@ -18,6 +18,7 @@ do_deploy () {
     install -d ${DEPLOYDIR}/inphi
     cp -fr ${S}/in112525-phy-ucode.txt ${DEPLOYDIR}/inphi
 }
+do_deploy[cleandirs] = "${DEPLOYDIR}"
 addtask deploy before do_build after do_install
 
 PACKAGES += "${PN}-image"

--- a/recipes-bsp/ls2-phy/ls2-phy_git.bb
+++ b/recipes-bsp/ls2-phy/ls2-phy_git.bb
@@ -18,6 +18,7 @@ do_deploy () {
     install -d ${DEPLOYDIR}/ls2-phy
     cp -fr ${S}/* ${DEPLOYDIR}/ls2-phy
 }
+do_deploy[cleandirs] = "${DEPLOYDIR}"
 addtask deploy before do_build after do_install
 
 PACKAGES += "${PN}-image"

--- a/recipes-bsp/mc-utils/mc-utils_git.bb
+++ b/recipes-bsp/mc-utils/mc-utils_git.bb
@@ -38,6 +38,7 @@ do_deploy () {
             cp -r ${S}/config/${MC_CFG}/RDB/custom/*.dtb ${DEPLOYDIR}/mc-utils/custom
         fi
 }
+do_deploy[cleandirs] = "${DEPLOYDIR}"
 addtask deploy after do_install
 
 PACKAGES += "${PN}-image"

--- a/recipes-bsp/ppfe-firmware/ppfe-firmware_git.bb
+++ b/recipes-bsp/ppfe-firmware/ppfe-firmware_git.bb
@@ -24,7 +24,7 @@ do_deploy () {
     install -d ${DEPLOYDIR}/engine-pfe-bin
     cp -r ${D}/boot/engine-pfe-bin/* ${DEPLOYDIR}/engine-pfe-bin
 }
-
+do_deploy[cleandirs] = "${DEPLOYDIR}"
 addtask deploy after do_install
 
 FILES_${PN} += "/lib/firmware /boot/"

--- a/recipes-bsp/qe-ucode/qe-ucode_git.bb
+++ b/recipes-bsp/qe-ucode/qe-ucode_git.bb
@@ -19,6 +19,7 @@ do_deploy () {
        install -d ${DEPLOYDIR}/boot
        install -m 644 ${B}/*.bin ${DEPLOYDIR}/boot
 }
+do_deploy[cleandirs] = "${DEPLOYDIR}"
 addtask deploy before do_build after do_install
 
 PACKAGES += "${PN}-image"

--- a/recipes-bsp/rcw/rcw_git.bb
+++ b/recipes-bsp/rcw/rcw_git.bb
@@ -31,6 +31,7 @@ do_deploy () {
     install -d ${DEPLOYDIR}/rcw
     cp -r ${D}/boot/rcw/* ${DEPLOYDIR}/rcw/
 }
+do_deploy[cleandirs] = "${DEPLOYDIR}"
 addtask deploy after do_install
 
 PACKAGES += "${PN}-image"

--- a/recipes-bsp/uefi/uefi_git.bb
+++ b/recipes-bsp/uefi/uefi_git.bb
@@ -25,6 +25,7 @@ do_deploy () {
            cp -r  ${B}/${MACHINE} ${DEPLOYDIR}/uefi
        fi
 }
+do_deploy[cleandirs] = "${DEPLOYDIR}"
 addtask deploy before do_build after do_install
 
 PACKAGES += "${PN}-image"

--- a/recipes-dpaa/fm-ucode/fm-ucode_git.bb
+++ b/recipes-dpaa/fm-ucode/fm-ucode_git.bb
@@ -32,6 +32,7 @@ do_deploy () {
     install -d ${DEPLOYDIR}/
     install -m 644 ${B}/fsl_fman_ucode_${UCODE}*.bin ${DEPLOYDIR}
 }
+do_deploy[cleandirs] = "${DEPLOYDIR}"
 addtask deploy before do_build after do_install
 
 PACKAGES += "${PN}-image"

--- a/recipes-dpaa2/dpl-examples/dpl-examples_git.bb
+++ b/recipes-dpaa2/dpl-examples/dpl-examples_git.bb
@@ -25,6 +25,7 @@ do_deploy () {
     install -m 644 ${S}/${REGLEX}/RDB/*.dtb ${DEPLOYDIR}/dpl-examples
     install -m 644 ${S}/${REGLEX}/RDB/custom/*.dtb ${DEPLOYDIR}/dpl-examples
 }
+do_deploy[cleandirs] = "${DEPLOYDIR}"
 addtask deploy before do_build after do_install
 
 PACKAGES += "${PN}-image"

--- a/recipes-dpaa2/management-complex/management-complex_10.16.2.bb
+++ b/recipes-dpaa2/management-complex/management-complex_10.16.2.bb
@@ -27,6 +27,7 @@ do_deploy () {
     mc_binary="$(ls ${DEPLOYDIR}/mc_app | grep -v ^mc.itb$ | sort | tail -1)"
     ln -sfT "$mc_binary" ${DEPLOYDIR}/mc_app/mc.itb
 }
+do_deploy[cleandirs] = "${DEPLOYDIR}"
 addtask deploy before do_build after do_install
 
 PACKAGES += "${PN}-image"

--- a/recipes-dpaa2/management-complex/management-complex_10.16.2.bb
+++ b/recipes-dpaa2/management-complex/management-complex_10.16.2.bb
@@ -24,9 +24,8 @@ do_deploy () {
     install -d ${DEPLOYDIR}/mc_app
     install -m 755 ${S}/${REGLEX}/*.itb ${DEPLOYDIR}/mc_app
     # make a symlink to the latest binary
-    for mc_binary in `ls ${DEPLOYDIR}/mc_app |sort`;do
-        ln -sfT ${mc_binary} ${DEPLOYDIR}/mc_app/mc.itb
-    done
+    mc_binary="$(ls ${DEPLOYDIR}/mc_app | grep -v ^mc.itb$ | sort | tail -1)"
+    ln -sfT "$mc_binary" ${DEPLOYDIR}/mc_app/mc.itb
 }
 addtask deploy before do_build after do_install
 

--- a/recipes-security/optee/optee-os-qoriq_git.bb
+++ b/recipes-security/optee/optee-os-qoriq_git.bb
@@ -65,7 +65,7 @@ do_deploy() {
             cp $f ${DEPLOYDIR}/optee/
         done
 }
-
+do_deploy[cleandirs] = "${DEPLOYDIR}"
 addtask deploy before do_build after do_install
 
 FILES_${PN} = "/lib/firmware/"


### PR DESCRIPTION
The management-complex recipe (and possibly others) assumed that DEPLOYDIR was empty before do_deploy. But this is not always true - with incremental builds, DEPLOYDIR can contain files from previous builds (possibly with different configuration even).

Here I saw the problem specifically with management-complex.bb, which created a recursive mc.itb symlink, because do_deploy didn't handle the case when mc.itb already exists. This can be fixed by writing do_deploy such that it can handle existing files (which I tried to do for management-complex). But the more generic approach seems to be doing `do_deploy[cleandirs] = "${DEPLOYDIR}"`, telling bitbake to empty the directory every time.

Both fixes are included in this pull request, to fix the specific issue with management-complex but also to prevent similar issues that may be possible now or in the future for the other recipes using do_deploy.