### PR TITLE
Fix unexpected host dependencies of native tools during atf/ddr-phy builds

### DIFF
--- a/recipes-bsp/atf/atf-tools_git.bb
+++ b/recipes-bsp/atf/atf-tools_git.bb
@@ -1,0 +1,19 @@
+SUMMARY = "Tools for ARM Trusted Firmware, e.g. FIP image creation tool"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://license.rst;md5=e927e02bca647e14efd87e9e914b2443"
+
+SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/atf;nobranch=1"
+SRCREV = "17f94e4315e81e3d1b22d863d9614d724e8273dc"
+
+S = "${WORKDIR}/git"
+
+DEPENDS += "openssl"
+
+EXTRA_OEMAKE = "fiptool V=1 HOSTCC='${CC} ${CPPFLAGS} ${CFLAGS} ${LDFLAGS}'"
+
+do_install () {
+    install -m 0755 -d ${D}/${bindir}
+    install -m 0755 ${S}/tools/fiptool/fiptool ${D}/${bindir}/
+}
+
+BBCLASSEXTEND = "native"

--- a/recipes-bsp/atf/atf_git.bb
+++ b/recipes-bsp/atf/atf_git.bb
@@ -30,6 +30,8 @@ LDFLAGS[unexport] = "1"
 AS[unexport] = "1"
 LD[unexport] = "1"
 
+EXTRA_OEMAKE += "HOSTCC='${BUILD_CC} ${BUILD_CPPFLAGS} ${BUILD_CFLAGS} ${BUILD_LDFLAGS}'"
+
 BOOTTYPE ?= "nor nand qspi flexspi_nor sd emmc"
 BUILD_SECURE = "${@bb.utils.contains('DISTRO_FEATURES', 'secure', 'true', 'false', d)}"
 BUILD_OPTEE = "${@bb.utils.contains('DISTRO_FEATURES', 'optee', 'true', 'false', d)}"

--- a/recipes-bsp/ddr-phy/ddr-phy_git.bb
+++ b/recipes-bsp/ddr-phy/ddr-phy_git.bb
@@ -4,19 +4,18 @@ LIC_FILES_CHKSUM = "file://NXP-Binary-EULA.txt;md5=89cc852481956e861228286ac7430
 
 inherit deploy fsl-eula-unpack
 
-SRC_URI = "git://github.com/nxp/ddr-phy-binary.git;fsl-eula=true;nobranch=1 \
-    git://source.codeaurora.org/external/qoriq/qoriq-components/atf;nobranch=1;destsuffix=git/atf;name=atf"
+SRC_URI = "git://github.com/nxp/ddr-phy-binary.git;fsl-eula=true;nobranch=1"
 SRCREV = "14d03e6e748ed5ebb9440f264bb374f1280b061c"
-SRCREV_atf = "17f94e4315e81e3d1b22d863d9614d724e8273dc"
 
 S = "${WORKDIR}/git"
 
 REGLEX_lx2160a = "lx2160a"
 
-do_install () {
-    oe_runmake -C ${S}/atf fiptool
+DEPENDS += "atf-tools-native"
+
+do_compile() {
     cd ${S}/${REGLEX}
-    ${S}/atf/tools/fiptool/fiptool create --ddr-immem-udimm-1d ddr4_pmu_train_imem.bin \
+    fiptool create --ddr-immem-udimm-1d ddr4_pmu_train_imem.bin \
     --ddr-immem-udimm-2d ddr4_2d_pmu_train_imem.bin \
     --ddr-dmmem-udimm-1d ddr4_pmu_train_dmem.bin \
     --ddr-dmmem-udimm-2d ddr4_2d_pmu_train_dmem.bin \
@@ -25,6 +24,9 @@ do_install () {
     --ddr-dmmem-rdimm-1d ddr4_rdimm_pmu_train_dmem.bin \
     --ddr-dmmem-rdimm-2d ddr4_rdimm2d_pmu_train_dmem.bin \
     fip_ddr_all.bin
+}
+
+do_install () {
     install -d ${D}/boot
     install -m 755 ${S}/${REGLEX}/*.bin ${D}/boot
 }


### PR DESCRIPTION
atf and ddr-phy recipes compile native tools from atf repository to use them during their own build process. These native builds should use Yocto's native toolchain settings. This allows `DEPENDS = "openssl-native"` to work, instead of silently using the host's openssl (which may not even be available).

For ddr-phy, it seemed most useful to split the fiptool build into a new, separate recipe: atf-tools-native.

For atf, I'm less sure whether that's possible or even useful, so for now I've just overridden HOSTCC there.

This fixes #141