### PR TITLE
Fix WKS_FILE to use files with .in extension

### DIFF
--- a/conf/machine/imx6qdlsabreauto.conf
+++ b/conf/machine/imx6qdlsabreauto.conf
@@ -38,7 +38,7 @@ UBOOT_MACHINE ?= "mx6sabreauto_defconfig"
 UBOOT_MAKE_TARGET = "all"
 UBOOT_SUFFIX = "img"
 SPL_BINARY = "SPL"
-WKS_FILE = "imx-uboot-spl-bootpart.wks"
+WKS_FILE = "imx-uboot-spl-bootpart.wks.in"
 
 SERIAL_CONSOLES = "115200;ttymxc3"
 

--- a/conf/machine/imx6qdlsabresd.conf
+++ b/conf/machine/imx6qdlsabresd.conf
@@ -38,7 +38,7 @@ UBOOT_MACHINE ?= "mx6sabresd_defconfig"
 UBOOT_MAKE_TARGET = "all"
 UBOOT_SUFFIX = "img"
 SPL_BINARY = "SPL"
-WKS_FILE = "imx-uboot-spl-bootpart.wks"
+WKS_FILE = "imx-uboot-spl-bootpart.wks.in"
 
 SERIAL_CONSOLES = "115200;ttymxc0"
 

--- a/conf/machine/imx6ulevk.conf
+++ b/conf/machine/imx6ulevk.conf
@@ -20,7 +20,7 @@ KERNEL_DEVICETREE_use-mainline-bsp = "imx6ul-14x14-evk.dtb"
 UBOOT_MAKE_TARGET = ""
 UBOOT_SUFFIX = "img"
 SPL_BINARY = "SPL"
-WKS_FILE = "imx-uboot-spl-bootpart.wks"
+WKS_FILE = "imx-uboot-spl-bootpart.wks.in"
 
 UBOOT_CONFIG ??= "sd"
 UBOOT_CONFIG[sd] = "mx6ul_14x14_evk_config,sdcard"


### PR DESCRIPTION
meta-freescale commit 6be9d197386b5c3bd72023981df805d42f87684c
renamed imx-uboot-spl-bootpart.wks to imx-uboot-spl-bootpart.wks.in
The .in extension in wks files allows bitbake variables to be used in
kickstarter files. Set WKS_FILES for all machines to match this new
filename.

Signed-off-by: Fabio Berton <fabio.berton@ossystems.com.br>
(cherry picked from commit da4d8a203c173f8719229df5cb525b6ed644a7c6)