### PR TITLE
imx6sllevk:imx7dsabresd:imx7ulpevk: Remove firmware-imx-brcm dependency

### DIFF
--- a/conf/machine/imx6sllevk.conf
+++ b/conf/machine/imx6sllevk.conf
@@ -9,7 +9,7 @@ MACHINEOVERRIDES =. "mx6:mx6sll:"
 include conf/machine/include/imx-base.inc
 include conf/machine/include/tune-cortexa9.inc
 
-MACHINE_FIRMWARE_append = " firmware-imx-epdc firmware-imx-brcm"
+MACHINE_FIRMWARE_append = " firmware-imx-epdc"
 
 KERNEL_DEVICETREE = "imx6sll-evk.dtb imx6sll-evk-btwifi.dtb imx6sll-evk-reva.dtb" 
 

--- a/conf/machine/imx7dsabresd.conf
+++ b/conf/machine/imx7dsabresd.conf
@@ -25,4 +25,3 @@ UBOOT_CONFIG[nand] = "mx7dsabresd_nand_config,ubifs"
 UBOOT_CONFIG[epdc] = "mx7dsabresd_epdc_config"
 UBOOT_CONFIG[mfgtool] = "mx7dsabresd_config"
 
-MACHINE_EXTRA_RRECOMMENDS += "firmware-imx-brcm"

--- a/conf/machine/imx7ulpevk.conf
+++ b/conf/machine/imx7ulpevk.conf
@@ -22,8 +22,5 @@ UBOOT_CONFIG[sd] = "mx7ulp_evk_config,sdcard"
 UBOOT_CONFIG[emmc] = "mx7ulp_evk_emmc_config,sdcard"
 UBOOT_CONFIG[mfgtool] = "mx7ulp_evk_config"
 
-# Install brcm firmware
-MACHINE_FIRMWARE_append = " firmware-imx-brcm"
-
 # Set Serial console
 SERIAL_CONSOLES = "115200;ttyLP0"


### PR DESCRIPTION
The Broadcom support was removed by
d94f748d14d89fd2c62f03ddf181706626b0de91 so we do not need to install it
on images any more.

Signed-off-by: Daiane Angolini <daiane.angolini@nxp.com>