### PR TITLE
u-boot-fslc-common: Bump revision to ca0ab15271

### DIFF
--- a/recipes-bsp/u-boot/u-boot-fslc-common_2019.07.inc
+++ b/recipes-bsp/u-boot/u-boot-fslc-common_2019.07.inc
@@ -10,7 +10,7 @@ DEPENDS += "bison-native"
 
 SRC_URI = "git://github.com/Freescale/u-boot-fslc.git;branch=${SRCBRANCH}"
 
-SRCREV = "86ce1a1351b6349038709cdfd686aaf745124538"
+SRCREV = "ca0ab152714540f93bab9347ad5b706a0a54f037"
 SRCBRANCH = "2019.07+fslc"
 
 PV = "v2019.07+git${SRCPV}"


### PR DESCRIPTION
This commit includes the following change:

  ca0ab15271 pico-imx7d: Sync all defconfigs with pico-imx7d_defconfig

Signed-off-by: Fabio Berton <fabio.berton@ossystems.com.br>
(cherry picked from commit b097516ab4599164e4d0892e5ac058c2856db6c1)