### PR TITLE
u-boot-qoriq-fw-utils: Avoid stripping debug symbols

### DIFF
--- a/recipes-bsp/u-boot/u-boot-qoriq-fw-utils_2019.04.bb
+++ b/recipes-bsp/u-boot/u-boot-qoriq-fw-utils_2019.04.bb
@@ -3,9 +3,8 @@ require u-boot-qoriq-common_${PV}.inc
 SUMMARY = "U-Boot bootloader fw_printenv/setenv utilities"
 DEPENDS = "mtd-utils bison-native"
 
-INSANE_SKIP_${PN} = "already-stripped"
-EXTRA_OEMAKE_class-target = 'CROSS_COMPILE=${TARGET_PREFIX} CC="${CC} ${CFLAGS} ${LDFLAGS}" HOSTCC="${BUILD_CC} ${BUILD_CFLAGS} ${BUILD_LDFLAGS}" V=1'
-EXTRA_OEMAKE_class-cross = 'ARCH=${TARGET_ARCH} CC="${CC} ${CFLAGS} ${LDFLAGS}" V=1'
+EXTRA_OEMAKE_class-target = 'CROSS_COMPILE=${TARGET_PREFIX} CC="${CC} ${CFLAGS} ${LDFLAGS}" HOSTCC="${BUILD_CC} ${BUILD_CFLAGS} ${BUILD_LDFLAGS}" STRIP=true V=1'
+EXTRA_OEMAKE_class-cross = 'ARCH=${TARGET_ARCH} CC="${CC} ${CFLAGS} ${LDFLAGS}" STRIP=true V=1'
 
 inherit uboot-config
 


### PR DESCRIPTION
This gets rid of the INSANE_SKIP and allows debug symbols in these binaries.