### PR TITLE
Fix atf build on board not supported by optee-os (backport to warrior)

### DIFF
--- a/conf/machine/ls1012afrwy.conf
+++ b/conf/machine/ls1012afrwy.conf
@@ -10,6 +10,8 @@ MACHINEOVERRIDES =. "fsl-lsch2:ls1012a:"
 require conf/machine/include/qoriq-arm64.inc
 require conf/machine/include/arm/arch-arm64.inc
 
+MACHINE_FEATURES += "optee"
+
 KERNEL_CLASSES  = " kernel-fitimage "
 KERNEL_IMAGETYPES = "fitImage"
 

--- a/conf/machine/ls1012ardb.conf
+++ b/conf/machine/ls1012ardb.conf
@@ -10,6 +10,8 @@ MACHINEOVERRIDES =. "fsl-lsch2:ls1012a:"
 require conf/machine/include/qoriq-arm64.inc
 require conf/machine/include/arm/arch-arm64.inc
 
+MACHINE_FEATURES += "optee"
+
 KERNEL_CLASSES  = " kernel-fitimage "
 KERNEL_IMAGETYPES = "fitImage"
 

--- a/conf/machine/ls1021atwr.conf
+++ b/conf/machine/ls1021atwr.conf
@@ -10,6 +10,8 @@ MACHINEOVERRIDES =. "ls102xa:"
 require conf/machine/include/qoriq-arm.inc
 require conf/machine/include/tune-cortexa7.inc
 
+MACHINE_FEATURES += "optee"
+
 DEFAULTTUNE = "cortexa7hf-neon"
 
 UBOOT_CONFIG ??= "sdcard-ifc-secure-boot sdcard-ifc sdcard-qspi lpuart qspi secure-boot nor"

--- a/conf/machine/ls1043ardb.conf
+++ b/conf/machine/ls1043ardb.conf
@@ -10,6 +10,8 @@ MACHINEOVERRIDES =. "fsl-lsch2:ls1043a:"
 require conf/machine/include/qoriq-arm64.inc
 require conf/machine/include/arm/arch-arm64.inc
 
+MACHINE_FEATURES += "optee"
+
 KERNEL_CLASSES  = " kernel-fitimage "
 KERNEL_IMAGETYPES = "fitImage"
 

--- a/conf/machine/ls1046ardb.conf
+++ b/conf/machine/ls1046ardb.conf
@@ -9,6 +9,8 @@ MACHINEOVERRIDES =. "fsl-lsch2:ls1046a:"
 require conf/machine/include/qoriq-arm64.inc
 require conf/machine/include/arm/arch-arm64.inc
 
+MACHINE_FEATURES += "optee"
+
 KERNEL_CLASSES  = " kernel-fitimage "
 KERNEL_IMAGETYPES = "fitImage"
 

--- a/conf/machine/ls1088ardb-pb.conf
+++ b/conf/machine/ls1088ardb-pb.conf
@@ -9,6 +9,8 @@ require conf/machine/include/arm/arch-arm64.inc
 
 MACHINEOVERRIDES =. "fsl-lsch3:ls1088a:"
 
+MACHINE_FEATURES += "optee"
+
 KERNEL_CLASSES  = " kernel-fitimage "
 KERNEL_IMAGETYPES = "fitImage"
 

--- a/conf/machine/ls1088ardb.conf
+++ b/conf/machine/ls1088ardb.conf
@@ -9,6 +9,8 @@ require conf/machine/include/arm/arch-arm64.inc
 
 MACHINEOVERRIDES =. "fsl-lsch3:ls1088a:"
 
+MACHINE_FEATURES += "optee"
+
 KERNEL_CLASSES  = " kernel-fitimage "
 KERNEL_IMAGETYPES = "fitImage"
 

--- a/conf/machine/ls2088ardb.conf
+++ b/conf/machine/ls2088ardb.conf
@@ -9,6 +9,8 @@ require conf/machine/include/arm/arch-arm64.inc
 
 MACHINEOVERRIDES =. "fsl-lsch3:ls2088a:"
 
+MACHINE_FEATURES += "optee"
+
 KERNEL_CLASSES  = " kernel-fitimage "
 KERNEL_IMAGETYPES = "fitImage"
 

--- a/conf/machine/lx2160ardb.conf
+++ b/conf/machine/lx2160ardb.conf
@@ -9,6 +9,8 @@ require conf/machine/include/arm/arch-arm64.inc
 
 MACHINEOVERRIDES =. "fsl-lsch3:lx2160a:"
 
+MACHINE_FEATURES += "optee"
+
 KERNEL_CLASSES  = " kernel-fitimage "
 KERNEL_IMAGETYPES = "fitImage"
 

--- a/recipes-bsp/atf/atf_git.bb
+++ b/recipes-bsp/atf/atf_git.bb
@@ -7,7 +7,6 @@ inherit deploy
 
 DEPENDS += "u-boot-mkimage-native u-boot openssl openssl-native mbedtls rcw cst-native"
 DEPENDS_append_lx2160a += "ddr-phy"
-DEPENDS_append_qoriq-arm64 += "optee-os-qoriq"
 do_compile[depends] += "u-boot:do_deploy rcw:do_deploy uefi:do_deploy"
 
 S = "${WORKDIR}/git"
@@ -32,8 +31,13 @@ LD[unexport] = "1"
 
 BOOTTYPE ?= "nor nand qspi flexspi_nor sd emmc"
 BUILD_SECURE = "${@bb.utils.contains('DISTRO_FEATURES', 'secure', 'true', 'false', d)}"
-BUILD_OPTEE = "${@bb.utils.contains('DISTRO_FEATURES', 'optee', 'true', 'false', d)}"
+BUILD_OPTEE = "${@bb.utils.contains('COMBINED_FEATURES', 'optee', 'true', 'false', d)}"
 BUILD_FUSE = "${@bb.utils.contains('DISTRO_FEATURES', 'fuse', 'true', 'false', d)}"
+
+PACKAGECONFIG ??= " \
+    ${@bb.utils.filter('COMBINED_FEATURES', 'optee', d)} \
+"
+PACKAGECONFIG[optee] = ",,optee-os-qoriq"
 
 uboot_boot_sec ?= "${DEPLOY_DIR_IMAGE}/u-boot.bin-tfa-secure-boot"
 uboot_boot ?= "${DEPLOY_DIR_IMAGE}/u-boot.bin-tfa"


### PR DESCRIPTION
This a backport of PR #149 to warrior, for reference:

Currently optee-os is always added as a dependency of atf on qoriq-arm64, even if atf is built without optee support. This make the build of atf impossible on board that are not supported by optee-os.

This series add the optee machine feature and then use it in the atf recipe to only depend on optee-os when the distro and machines support it.