### PR TITLE
qemu-qoriq: Mark is specific to imx/qoriq

### DIFF
--- a/recipes-devtools/qemu/qemu-qoriq_git.bb
+++ b/recipes-devtools/qemu/qemu-qoriq_git.bb
@@ -19,8 +19,7 @@ SRCREV = "79df0577f5467dfaf0b2469ce3973a342f0c9e90"
 
 S = "${WORKDIR}/git"
 
-COMPATIBLE_HOST_mipsarchn32 = "null"
-COMPATIBLE_HOST_mipsarchn64 = "null"
+COMPATIBLE_MACHINE = "(qoriq|imx)"
 
 PROVIDES = "qemu"
 


### PR DESCRIPTION
It has started to fail now that we have libssh dependency in 4.1 instead
of libssh2 in earlier versions, so this recipe needs to be upgraded to
use 4.1 release as well, but I dont have way to test it out.

Signed-off-by: Khem Raj <raj.khem@gmail.com>