### PR TITLE
u-boot-imx-mfgtool: Add u-boot-imx to search path

### DIFF
--- a/recipes-bsp/u-boot/u-boot-imx-mfgtool_2017.03.bb
+++ b/recipes-bsp/u-boot/u-boot-imx-mfgtool_2017.03.bb
@@ -2,5 +2,7 @@
 # Copyright (C) 2014-2016 Freescale Semiconductor
 # Copyright 2017 NXP
 
+FILESEXTRAPATHS_prepend := "${THISDIR}/u-boot-imx:"
+
 require u-boot-imx_${PV}.bb
 require u-boot-mfgtool.inc


### PR DESCRIPTION
u-boot-imx_2017.03.bb SRC_URI entry 0001-tools-allow-to-override-python.patch
cannot be found by u-boot-imx-mfgtool_2017.03.bb, which requires the first
recipe.

Add 'u-boot-imx' folder to the recipe search path so it is also able to find
the file under that folder.

Signed-off-by: Gonzalo Ruiz <Gonzalo.Ruiz@digi.com>