### PR TITLE
Fix atf package architecture

### DIFF
--- a/recipes-bsp/atf/atf_git.bb
+++ b/recipes-bsp/atf/atf_git.bb
@@ -18,6 +18,7 @@ SRC_URI += "file://0001-fix-fiptool-build-error.patch \
     file://0001-Makefile-add-CC-gcc.patch \
 "
 COMPATIBLE_MACHINE = "(qoriq)"
+PACKAGE_ARCH = "${MACHINE_ARCH}"
 PLATFORM = "${MACHINE}"
 PLATFORM_ls1088ardb-pb = "ls1088ardb"
 # requires CROSS_COMPILE set by hand as there is no configure script

--- a/recipes-bsp/atf/atf_git.bb
+++ b/recipes-bsp/atf/atf_git.bb
@@ -217,4 +217,3 @@ do_deploy() {
 addtask deploy after do_install
 FILES_${PN} += "/boot"
 BBCLASSEXTEND = "native nativesdk"
-COMPATIBLE_MACHINE = "(qoriq)"


### PR DESCRIPTION
The atf package has the wrong architecture and a redundant definition of COMPATIBLE_MACHINE.
This series fix both problems.