### PR TITLE
cst: Fix build for target recipe and limit dpdk to imx alone

### DIFF
--- a/recipes-devtools/cst/cst_git.bb
+++ b/recipes-devtools/cst/cst_git.bb
@@ -4,8 +4,11 @@ LICENSE = "BSD"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=e959d5d617e33779d0e90ce1d9043eff"
 
-DEPENDS += "openssl"
+DEPENDS += "openssl cst-native"
 RDEPENDS_${PN} = "bash"
+
+GENKEYS ?= "${STAGING_BINDIR_NATIVE}/cst/gen_keys"
+GENKEYS_class-native = "./gen_keys"
 
 inherit kernel-arch
 
@@ -25,13 +28,13 @@ PARALLEL_MAKE = ""
 
 do_install () {
     oe_runmake install DESTDIR=${D} BIN_DEST_DIR=${bindir}
+
     if [ -n "${SECURE_PRI_KEY}" ]; then
        cp -f ${SECURE_PRI_KEY} ${D}/${bindir}/cst/srk.pri
        cp -f ${SECURE_PUB_KEY} ${D}/${bindir}/cst/srk.pub
     elif [ ! -f ${D}/${bindir}/cst/srk.pri -o ! ${D}/${bindir}/cst/srk.pub ]; then
-       cd ${D}/${bindir}/cst  && ./gen_keys 1024
+       cd ${D}/${bindir}/cst  && ${GENKEYS} 1024
     fi
-    
 }
 
 FILES_${PN}-dbg += "${bindir}/cst/.debug"

--- a/recipes-extended/dpdk/dpdk.inc
+++ b/recipes-extended/dpdk/dpdk.inc
@@ -24,6 +24,8 @@ COMPATIBLE_HOST_armv4 = 'null'
 COMPATIBLE_HOST_armv5 = 'null'
 COMPATIBLE_HOST_armv6 = 'null'
 
+COMPATIBLE_MACHINE = "(imx)"
+
 DPDK_RTE_TARGET_x86-64 = "x86_64-native-linuxapp-gcc"
 DPDK_RTE_TARGET_x86 = "i686-native-linuxapp-gcc"
 DPDK_RTE_TARGET_armv7a = "${ARCH}-armv7a-linuxapp-gcc"

--- a/recipes-extended/vpp-core/dpdkvpp.bb
+++ b/recipes-extended/vpp-core/dpdkvpp.bb
@@ -24,6 +24,8 @@ COMPATIBLE_HOST_armv4 = 'null'
 COMPATIBLE_HOST_armv5 = 'null'
 COMPATIBLE_HOST_armv6 = 'null'
 
+COMPATIBLE_MACHINE = "(imx)"
+
 DPDK_RTE_TARGET_x86-64 = "x86_64-native-linuxapp-gcc"
 DPDK_RTE_TARGET_x86 = "i686-native-linuxapp-gcc"
 DPDK_RTE_TARGET_armv7a = "${ARCH}-armv7a-linuxapp-gcc"


### PR DESCRIPTION
gen_keys when cross-built can not execute on build host
so better to depend on native version and call out native gen_keys
binary

Fixes
TOPDIR/build/tmp/work/mips32r2-yoe-linux/cst/git-r0/temp/run.do_install.29171: line 111: ./gen_keys: cannot execute binary file: Exec format error
WARNING: TOPDIR/build/tmp/work/mips32r2-yoe-linux/cst/git-r0/temp/run.do_install.29171:1 exit 126 from './gen_keys 1024'

Signed-off-by: Khem Raj <raj.khem@gmail.com>