### PR TITLE
imx7ulpevk.conf: Fix MACHINEOVERRIDES order

### DIFF
--- a/conf/machine/imx7ulpevk.conf
+++ b/conf/machine/imx7ulpevk.conf
@@ -4,12 +4,12 @@
 #@DESCRIPTION: Machine configuration for NXP i.MX7ULP EVK
 #@MAINTAINER: Alexandru Palalau <ioan-alexandru.palalau@nxp.com>
 
+MACHINEOVERRIDES =. "mx7:mx7ulp:"
+
 require conf/machine/include/imx-base.inc
 require conf/machine/include/tune-cortexa7.inc
 
 MACHINE_FEATURES += " pci wifi bluetooth qca9377"
-
-MACHINEOVERRIDES =. "mx7:mx7ulp:"
 
 KERNEL_DEVICETREE = "imx7ulp-evk.dtb imx7ulp-evkb-emmc.dtb imx7ulp-evk-emmc-qspi.dtb imx7ulp-evk-ft5416.dtb imx7ulp-evk-mipi.dtb \
                      imx7ulp-evkb-lpuart.dtb imx7ulp-evk-qspi.dtb imx7ulp-evkb-sd1.dtb imx7ulp-evkb-sensors-to-i2c5.dtb \


### PR DESCRIPTION
Setting the SOC family and the SOC in MACHINEOVERRIDES after
tune-cortexa7.inc has updated MACHINEOVERRIDES causes the tuning
overrides to have higher priority than the SOC overrides, which
is wrong.

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>