### PR TITLE
imx7ulpevk.conf: Fix MACHINEOVERRIDES order

### DIFF
--- a/conf/machine/imx7ulpevk.conf
+++ b/conf/machine/imx7ulpevk.conf
@@ -4,12 +4,12 @@
 #@DESCRIPTION: Machine configuration for NXP i.MX7ULP EVK
 #@MAINTAINER: Lauren Post <Lauren.Post@nxp.com>
 
+MACHINEOVERRIDES =. "mx7:mx7ulp:"
+
 require conf/machine/include/imx-base.inc
 require conf/machine/include/tune-cortexa7.inc
 
 MACHINE_FEATURES += " pci wifi bluetooth qca9377"
-
-MACHINEOVERRIDES =. "mx7:mx7ulp:"
 
 KERNEL_DEVICETREE = "imx7ulp-evk.dtb imx7ulp-evk-emmc.dtb imx7ulp-evk-emmc-qspi.dtb imx7ulp-evk-ft5416.dtb imx7ulp-evk-mipi.dtb"
 KERNEL_DEVICETREE += "imx7ulp-evk-lpuart.dtb imx7ulp-evk-qspi.dtb imx7ulp-evk-sd1.dtb imx7ulp-evk-sensors-to-i2c5.dtb"


### PR DESCRIPTION
The exact manifestation that uncovered this problem was not recorded.
Generally speaking, a recipe misconfiguration was occurring due to an
incorrect variable value, caused by incorrectly choosing the _imx
override of the variable instead of the SOC override.

This is fixed by setting the SOC family and the SOC in MACHINEOVERRIDES
before including tune-cortexa7.inc.

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>