### PR TITLE
u-boot-imx: Fix filename at install

### DIFF
--- a/recipes-bsp/u-boot/u-boot-imx_2017.03.bb
+++ b/recipes-bsp/u-boot/u-boot-imx_2017.03.bb
@@ -37,7 +37,7 @@ do_deploy_append_mx8m() {
                     install -d ${DEPLOYDIR}/${BOOT_TOOLS}
                     install -m 0777 ${B}/${config}/arch/arm/dts/${UBOOT_DTB_NAME}  ${DEPLOYDIR}/${BOOT_TOOLS}
                     install -m 0777 ${B}/${config}/tools/mkimage  ${DEPLOYDIR}/${BOOT_TOOLS}/mkimage_uboot
-                    install -m 0777 ${B}/${config}/u-boot-nodtb.bin  ${DEPLOYDIR}/${BOOT_TOOLS}/u-boot-nodtb.bin-${MACHINE}-${UBOOT_CONFIG}
+                    install -m 0777 ${B}/${config}/u-boot-nodtb.bin  ${DEPLOYDIR}/${BOOT_TOOLS}/u-boot-nodtb.bin
                 fi
             done
             unset  j


### PR DESCRIPTION
Cherry-pick u-boot filename deploy fix from warrior to thud