### PR TITLE
optee imx8 support

### DIFF
--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -266,6 +266,11 @@ PREFERRED_VERSION_libdrm_mx6 ?= "2.4.91.imx"
 PREFERRED_VERSION_libdrm_mx7 ?= "2.4.91.imx"
 PREFERRED_VERSION_libdrm_mx8 ?= "2.4.91.imx"
 
+# Use i.MX optee Version
+PREFERRED_VERSION_optee-os_mx8     ?= "3.2.0.imx"
+PREFERRED_VERSION_optee-client_mx8 ?= "3.2.0.imx"
+PREFERRED_VERSION_optee-test_mx8   ?= "3.2.0.imx"
+
 # Handle default kernel
 IMX_DEFAULT_KERNEL = "linux-imx"
 IMX_DEFAULT_KERNEL_mxs = "linux-fslc"
@@ -287,19 +292,29 @@ SOC_DEFAULT_IMAGE_FSTYPES_mxs = "uboot-mxsboot-sdcard wic.gz"
 # Do not update fstab file when using wic images
 WIC_CREATE_EXTRA_ARGS ?= "--no-fstab-update"
 
+OPTEE_BOOT_IMAGE         = "uTee"
+OPTEE_BOOT_IMAGE_aarch64 = ""
+
+SDCARD_ROOTFS ?= "${IMGDEPLOYDIR}/${IMAGE_NAME}.rootfs.ext4"
+
 IMAGE_FSTYPES ?= "${SOC_DEFAULT_IMAGE_FSTYPES}"
 
 IMAGE_BOOT_FILES ?= " \
     ${KERNEL_IMAGETYPE} \
     ${@make_dtb_boot_files(d)} \
+    ${@bb.utils.contains('MACHINE_FEATURES', 'optee', '${OPTEE_BOOT_IMAGE}', '', d)} \
 "
 
 ### wic default support
+OPTEE_WKS_FILE_DEPENDS         = "optee-os"
+OPTEE_WKS_FILE_DEPENDS_aarch64 = ""
+
 WKS_FILE_DEPENDS ?= " \
     virtual/bootloader \
     \
     e2fsprogs-native \
     bmap-tools-native \
+    ${@bb.utils.contains('MACHINE_FEATURES', 'optee', '${OPTEE_WKS_FILE_DEPENDS}', '', d)} \
 "
 
 WKS_FILE_DEPENDS_mx8 += "imx-boot"

--- a/recipes-bsp/imx-atf/imx-atf_2.0.bb
+++ b/recipes-bsp/imx-atf/imx-atf_2.0.bb
@@ -30,16 +30,25 @@ EXTRA_OEMAKE += " \
     PLAT=${PLATFORM} \
 "
 
+BUILD_OPTEE = "${@bb.utils.contains('MACHINE_FEATURES', 'optee', 'true', 'false', d)}"
+
 do_compile() {
     # Clear LDFLAGS to avoid the option -Wl recognize issue
     unset LDFLAGS
     oe_runmake bl31
+    if ${BUILD_OPTEE}; then
+       oe_runmake clean BUILD_BASE=build-optee
+       oe_runmake BUILD_BASE=build-optee SPD=opteed bl31
+    fi
 }
 
 do_install[noexec] = "1"
 
 do_deploy() {
     install -Dm 0644 ${S}/build/${PLATFORM}/release/bl31.bin ${DEPLOYDIR}/${BOOT_TOOLS}/bl31-${PLATFORM}.bin
+    if ${BUILD_OPTEE}; then
+       install -m 0644 ${S}/build-optee/${PLATFORM}/release/bl31.bin ${DEPLOYDIR}/${BOOT_TOOLS}/bl31-${PLATFORM}.bin-optee
+    fi
 }
 addtask deploy after do_compile
 

--- a/recipes-security/optee-imx/optee-client/0001-libteec-refactor-_dprintf.patch
+++ b/recipes-security/optee-imx/optee-client/0001-libteec-refactor-_dprintf.patch
@@ -1,0 +1,171 @@
+Upstream-Status: Backport 3.3.0
+
+Signed-off-by: Peter Griffin <peter.griffin@linaro.org>
+---
+From 0361f9b21bb1acfaf23323a121f542fe03dcd2c8 Mon Sep 17 00:00:00 2001
+From: Jerome Forissier <jerome.forissier@linaro.org>
+Date: Thu, 5 Jul 2018 15:15:31 +0200
+Subject: [PATCH] libteec: refactor _dprintf()
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+GCC8.1 gives an error when compiling _dprintf():
+
+src/teec_trace.c: In function ‘_dprintf’:
+src/teec_trace.c:110:5: error: ‘%s’ directive output may be truncated writing up to 255 bytes into a region of size 246 [-Werror=format-truncation=]
+     "%s [%d] %s:%s:%d: %s",
+     ^~~~~~~~~~~~~~~~~~~~~~
+src/teec_trace.c:112:11:
+     line, raw);
+           ~~~
+src/teec_trace.c:109:3: note: ‘snprintf’ output 11 or more bytes (assuming 266) into a destination of size 256
+   snprintf(prefixed, MAX_PRINT_SIZE,
+   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     "%s [%d] %s:%s:%d: %s",
+     ~~~~~~~~~~~~~~~~~~~~~~~
+     trace_level_strings[level], thread_id, prefix, func,
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     line, raw);
+     ~~~~~~~~~~
+
+Fix this error by using a single output buffer, printing the prefix first
+then the other arguments with the supplied format.
+
+In addition, further simplify the function by getting rid of things that
+do not make much sense:
+- Remove the 'flen' parameter, which is only ever set to zero or
+  strlen(__func__).
+- Remove the TRACE_FUNC_LENGTH_CST macro which is not set by default and
+  does not seem very useful.
+- Change the return type to void because callers do not care about success
+  or failure.
+
+Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>
+Reviewed-by: Joakim Bech <joakim.bech@linaro.org>
+---
+ libteec/src/teec_trace.c | 63 +++++++++++++++---------------------------------
+ public/teec_trace.h      |  8 +++---
+ 2 files changed, 23 insertions(+), 48 deletions(-)
+
+diff --git a/libteec/src/teec_trace.c b/libteec/src/teec_trace.c
+index 78b79d6..3a2a0da 100644
+--- a/libteec/src/teec_trace.c
++++ b/libteec/src/teec_trace.c
+@@ -47,7 +47,6 @@
+  * PPPP: MMMMM [FFFFFFFFFFFFFFF : LLLLL]
+  */
+ #define MAX_PRINT_SIZE 256
+-#define MAX_FUNC_PRINT_SIZE 32
+ 
+ #ifdef TEEC_LOG_FILE
+ static void log_to_file(const char *buffer)
+@@ -69,57 +68,33 @@ static const char * const trace_level_strings[] = {
+ 	"", "ERR", "INF", "DBG", "FLW"
+ };
+ 
+-int _dprintf(const char *function, int flen, int line, int level,
+-	     const char *prefix, const char *fmt, ...)
++void _dprintf(const char *function, int line, int level, const char *prefix,
++	      const char *fmt, ...)
+ {
+-	char raw[MAX_PRINT_SIZE];
+-	char prefixed[MAX_PRINT_SIZE];
+-	char *to_print = NULL;
+-	const char *func;
+-	int err;
++	char msg[MAX_PRINT_SIZE];
++	int n = 0;
+ 	va_list ap;
+ 
+-	va_start(ap, fmt);
+-	err = vsnprintf(raw, sizeof(raw), fmt, ap);
+-	va_end(ap);
+-
+ 	if (function) {
+-#ifdef TRACE_FUNC_LENGTH_CST
+-		char func_buf[MAX_FUNC_PRINT_SIZE];
+-		/* Limit the function name to MAX_FUNC_PRINT_SIZE characters. */
+-		strncpy(func_buf, function, flen > MAX_FUNC_PRINT_SIZE ?
+-			(MAX_FUNC_PRINT_SIZE - 1) : flen);
+-		if (flen < (MAX_FUNC_PRINT_SIZE - 1)) {
+-			memset(func_buf + flen, 0x20,
+-			       (MAX_FUNC_PRINT_SIZE - flen));
+-		}
+-		func_buf[MAX_FUNC_PRINT_SIZE - 1] = '\0';
+-		func = func_buf;
+-#else
+-		(void)flen;
+-		func = function;
+-#endif
++		int thread_id = syscall(SYS_gettid);
+ 
+-		/*
+-		 * pthread_self returns the POSIX tid which is different from
+-		 * the kernel id
+-		 */
+-		int thread_id = syscall(SYS_gettid);	/* perf issue ? */
+-
+-		snprintf(prefixed, MAX_PRINT_SIZE,
+-			 "%s [%d] %s:%s:%d: %s",
+-			 trace_level_strings[level], thread_id, prefix, func,
+-			 line, raw);
+-		to_print = prefixed;
+-	} else {
+-		to_print = raw;
++		n = snprintf(msg, sizeof(msg), "%s [%d] %s:%s:%d: ",
++			trace_level_strings[level], thread_id, prefix,
++			function, line);
++		if (n < 0)
++			return;
+ 	}
+ 
+-	fprintf(stdout, "%s", to_print);
+-
+-	log_to_file(to_print);
++	if ((size_t)n < sizeof(msg)) {
++		va_start(ap, fmt);
++		n = vsnprintf(msg + n, sizeof(msg) - n, fmt, ap);
++		va_end(ap);
++		if (n < 0)
++			return;
++	}
+ 
+-	return err;
++	fprintf(stdout, "%s", msg);
++	log_to_file(msg);
+ }
+ 
+ #if (defined(DEBUGLEVEL_3) || defined(DEBUGLEVEL_true) || defined(DEBUGLEVEL_4))
+diff --git a/public/teec_trace.h b/public/teec_trace.h
+index 28e290c..f75358f 100644
+--- a/public/teec_trace.h
++++ b/public/teec_trace.h
+@@ -91,12 +91,12 @@ extern "C" {
+ #define __PRINTFLIKE(__fmt, __varargs) __attribute__\
+ 	((__format__(__printf__, __fmt, __varargs)))
+ 
+-int _dprintf(const char *function, int flen, int line, int level,
+-	     const char *prefix, const char *fmt, ...) __PRINTFLIKE(6, 7);
++void _dprintf(const char *function, int line, int level, const char *prefix,
++	      const char *fmt, ...) __PRINTFLIKE(5, 6);
+ 
+ #define dprintf(level, x...) do { \
+ 		if ((level) <= DEBUGLEVEL) { \
+-			_dprintf(__func__, strlen(__func__), __LINE__, level, \
++			_dprintf(__func__, __LINE__, level, \
+ 				 BINARY_PREFIX, x); \
+ 		} \
+ 	} while (0)
+@@ -118,7 +118,7 @@ int _dprintf(const char *function, int flen, int line, int level,
+ 
+ #define dprintf_raw(level, x...) do { \
+ 		if ((level) <= DEBUGLEVEL) \
+-			_dprintf(0, 0, 0, (level), BINARY_PREFIX, x); \
++			_dprintf(0, 0, (level), BINARY_PREFIX, x); \
+ 	} while (0)
+ 
+ #define EMSG_RAW(fmt, ...)   dprintf_raw(TRACE_ERROR, fmt, ##__VA_ARGS__)
+-- 
+2.7.4
+

--- a/recipes-security/optee-imx/optee-client/tee-supplicant.service
+++ b/recipes-security/optee-imx/optee-client/tee-supplicant.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=TEE Supplicant
+
+[Service]
+User=root
+EnvironmentFile=-/etc/default/tee-supplicant
+ExecStart=/usr/bin/tee-supplicant $OPTARGS
+
+[Install]
+WantedBy=basic.target
+

--- a/recipes-security/optee-imx/optee-client_3.2.0.imx.bb
+++ b/recipes-security/optee-imx/optee-client_3.2.0.imx.bb
@@ -1,0 +1,57 @@
+# Copyright (C) 2017-2018 NXP
+
+SUMMARY = "OPTEE Client libs"
+HOMEPAGE = "http://www.optee.org/"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=69663ab153298557a59c67a60a743e5b"
+
+inherit pythonnative systemd
+
+SRCBRANCH = "imx_4.14.78_1.0.0_ga"
+OPTEE_CLIENT_SRC ?= "git://source.codeaurora.org/external/imx/imx-optee-client.git;protocol=https"
+SRC_URI = "${OPTEE_CLIENT_SRC};branch=${SRCBRANCH}"
+
+SRCREV = "d06647d201520ac57f1331e97db6138d63bc2666" 
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI_append = " file://0001-libteec-refactor-_dprintf.patch \
+                   file://tee-supplicant.service"
+
+S = "${WORKDIR}/git"
+SYSTEMD_SERVICE_${PN} = "tee-supplicant.service"
+
+EXTRA_OEMAKE = "CFG_SECURE_DATA_PATH=y"
+
+do_compile () {
+    if [ ${DEFAULTTUNE} = "aarch64" ]; then
+        oe_runmake -C ${S} ARCH=arm64
+    else
+        oe_runmake -C ${S} ARCH=arm
+    fi
+}
+
+do_install () {
+	oe_runmake install
+
+	install -D -p -m0644 ${S}/out/export/lib/libteec.so.1.0 ${D}${libdir}/libteec.so.1.0
+	ln -sf libteec.so.1.0 ${D}${libdir}/libteec.so
+	ln -sf libteec.so.1.0 ${D}${libdir}/libteec.so.1
+
+	install -D -p -m0755 ${S}/out/export/bin/tee-supplicant ${D}${bindir}/tee-supplicant
+
+	cp -a ${S}/out/export/include ${D}/usr/
+
+	sed -i -e s:/etc:${sysconfdir}:g -e s:/usr/bin:${bindir}:g ${WORKDIR}/tee-supplicant.service
+	install -D -p -m0644 ${WORKDIR}/tee-supplicant.service ${D}${systemd_system_unitdir}/tee-supplicant.service
+}
+
+PACKAGES += "tee-supplicant"
+FILES_${PN} += "${libdir}/* ${includedir}/*"
+FILES_tee-supplicant += "${bindir}/tee-supplicant"
+
+INSANE_SKIP_${PN} = "ldflags dev-elf"
+INSANE_SKIP_${PN}-dev = "ldflags dev-elf"
+INSANE_SKIP_tee-supplicant = "ldflags"
+
+COMPATIBLE_MACHINE = "(mx6|mx7|mx8)"

--- a/recipes-security/optee-imx/optee-os_3.2.0.imx.bb
+++ b/recipes-security/optee-imx/optee-os_3.2.0.imx.bb
@@ -1,0 +1,92 @@
+# Copyright (C) 2017-2018 NXP
+
+SUMMARY = "OPTEE OS"
+DESCRIPTION = "OPTEE OS"
+HOMEPAGE = "http://www.optee.org/"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=69663ab153298557a59c67a60a743e5b"
+
+inherit deploy pythonnative autotools
+DEPENDS = "python-pycrypto-native u-boot-mkimage-native"
+
+SRCBRANCH = "imx_4.14.78_1.0.0_ga"
+OPTEE_OS_SRC ?= "git://source.codeaurora.org/external/imx/imx-optee-os.git;protocol=https"
+SRC_URI = "${OPTEE_OS_SRC};branch=${SRCBRANCH}"
+SRCREV = "6a52487eb0ff664e4ebbd48497f0d3322844d51d"
+
+S = "${WORKDIR}/git"
+B = "${WORKDIR}/build.${PLATFORM_FLAVOR}"
+
+# The platform flavor corresponds to the Yocto machine without the leading 'i'.
+PLATFORM_FLAVOR                 = "${@d.getVar('MACHINE')[1:]}"
+PLATFORM_FLAVOR_imx6qpdlsolox   = "mx6qsabresd"
+PLATFORM_FLAVOR_imx6ul7d        = "mx6ulevk"
+PLATFORM_FLAVOR_imx6ull14x14evk = "mx6ullevk"
+PLATFORM_FLAVOR_imx6ull9x9evk   = "mx6ullevk"
+PLATFORM_FLAVOR_imx6ulz14x14evk = "mx6ullevk"
+PLATFORM_FLAVOR_mx8mm   = "mx8mmevk"
+
+OPTEE_ARCH ?= "arm32"
+OPTEE_ARCH_armv7a = "arm32"
+OPTEE_ARCH_aarch64 = "arm64"
+
+# Optee-os can be built for 32 bits and 64 bits at the same time
+# as long as the compilers are correctly defined.
+# For 64bits, CROSS_COMPILE64 must be set
+# When defining CROSS_COMPILE and CROSS_COMPILE64, we assure that
+# any 32 or 64 bits builds will pass
+EXTRA_OEMAKE = "PLATFORM=imx PLATFORM_FLAVOR=${PLATFORM_FLAVOR} \
+                CROSS_COMPILE=${HOST_PREFIX} \
+                CROSS_COMPILE64=${HOST_PREFIX} \
+                NOWERROR=1 \
+                LDFLAGS= \
+                O=${B} \
+                CFG_SECURE_DATA_PATH=y \
+                CFG_TEE_SDP_MEM_BASE=0xCC000000 \
+                CFG_TEE_SDP_MEM_SIZE=0x02000000 \
+                CFG_TEE_SDP_NONCACHE=y \
+                "
+
+
+do_compile () {
+    unset LDFLAGS
+    export CFLAGS="${CFLAGS} --sysroot=${STAGING_DIR_HOST}"
+    oe_runmake -C ${S} all CFG_TEE_TA_LOG_LEVEL=0
+}
+
+
+do_deploy () {
+    install -d ${DEPLOYDIR}
+    ${TARGET_PREFIX}objcopy -O binary ${B}/core/tee.elf ${DEPLOYDIR}/tee.${PLATFORM_FLAVOR}.bin
+
+    if [ "${OPTEE_ARCH}" != "arm64" ]; then
+        IMX_LOAD_ADDR=`cat ${B}/core/tee-init_load_addr.txt` && \
+        uboot-mkimage -A arm -O linux -C none -a ${IMX_LOAD_ADDR} -e ${IMX_LOAD_ADDR} \
+            -d ${DEPLOYDIR}/tee.${PLATFORM_FLAVOR}.bin ${DEPLOYDIR}/uTee-${OPTEE_BIN_EXT}
+    fi
+
+    cd ${DEPLOYDIR}
+    ln -sf tee.${PLATFORM_FLAVOR}.bin tee.bin
+    cd -
+}
+
+do_install () {
+    install -d ${D}/lib/firmware/
+    install -m 644 ${B}/core/*.bin ${D}/lib/firmware/
+
+    # Install the TA devkit
+    install -d ${D}/usr/include/optee/export-user_ta_${OPTEE_ARCH}/
+
+    for f in ${B}/export-ta_${OPTEE_ARCH}/*; do
+        cp -aR $f ${D}/usr/include/optee/export-user_ta_${OPTEE_ARCH}/
+    done
+}
+
+addtask deploy after do_compile before do_install
+
+
+FILES_${PN} = "${nonarch_base_libdir}/firmware/"
+FILES_${PN}-staticdev = "/usr/include/optee/"
+RDEPENDS_${PN}-dev += "${PN}-staticdev"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"

--- a/recipes-security/optee-imx/optee-test/0001-regression-4011-correct-potential-overflow.patch
+++ b/recipes-security/optee-imx/optee-test/0001-regression-4011-correct-potential-overflow.patch
@@ -1,0 +1,72 @@
+Upstream-Status: Backport 3.4.0
+
+Signed-off-by: Peter Griffin <peter.griffin@linaro.org>
+---
+From 0953bf0abb08fb98d24b7966001171a707fbb9b9 Mon Sep 17 00:00:00 2001
+From: Etienne Carriere <etienne.carriere@linaro.org>
+Date: Fri, 21 Dec 2018 15:36:25 +0100
+Subject: [PATCH] regression 4011: correct potential overflow
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Fix issues reported by GCC 8.2.0.
+
+build/optee_test/host/xtest/regression_4000.c: In function ‘xtest_tee_test_4011’:
+build/optee_test/host/xtest/regression_4000.c:5029:3: error: ‘memmove’ pointer overflow between offset [0, 8] and size [4294967295, 2147483647] accessing array ‘tmp’ with type ‘uint8_t[1024]’ {aka ‘unsigned char[1024]’} [-Werror=array-bounds]
+   memmove(tmp + n + i, tmp + m, tmp_size - m);
+   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+build/optee_test/host/xtest/regression_4000.c:4927:10: note: array ‘tmp’ declared here
+  uint8_t tmp[1024];
+          ^~~
+build/optee_test/host/xtest/regression_4000.c:5029:3: error: ‘memmove’ specified size 4294967295 exceeds maximum object size 2147483647 [-Werror=stringop-overflow=]
+   memmove(tmp + n + i, tmp + m, tmp_size - m);
+   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+cc1: all warnings being treated as errors
+
+Reported-by: Simon Hughes <simon.hughes@arm.com>
+Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>
+Reviewed-by: Jens Wiklander <jens.wiklander@linaro.org>
+---
+ host/xtest/regression_4000.c | 16 +++++++++++++---
+ 1 file changed, 13 insertions(+), 3 deletions(-)
+
+diff --git a/host/xtest/regression_4000.c b/host/xtest/regression_4000.c
+index 766aad2..205a226 100644
+--- a/host/xtest/regression_4000.c
++++ b/host/xtest/regression_4000.c
+@@ -5018,18 +5018,28 @@ static void xtest_tee_test_4011(ADBG_Case_t *c)
+ 				out, out_size, tmp, &tmp_size)))
+ 			goto out;
+ 
++		if (!ADBG_EXPECT_COMPARE_UNSIGNED(c, tmp_size, <=, sizeof(tmp)))
++			goto out;
++
+ 		/* 4.1 */
+-		for (n = 0; n < tmp_size; n++)
++		for (n = 0; n < tmp_size - i; n++)
+ 			if (tmp[n] == 0xff)
+ 				break;
++
++		/* Shall find at least a padding start before buffer end */
++	        if (!ADBG_EXPECT_COMPARE_UNSIGNED(c, n, <, tmp_size - i - 1))
++			goto out;
++
+ 		for (m = n + 1; m < tmp_size; m++)
+ 			if (tmp[m] != 0xff)
+ 				break;
++
+ 		/* 4.2 */
+ 		memmove(tmp + n + i, tmp + m, tmp_size - m);
++
+ 		/* 4.3 */
+-		for (n = n + tmp_size - m + i; n < tmp_size; n++)
+-			tmp[n] = 0;
++		n = n + i + tmp_size - m;
++		memset(tmp + n, 0, tmp_size - n);
+ 
+ 		/* 5 */
+ 		out_size = sizeof(out);
+-- 
+2.7.4
+

--- a/recipes-security/optee-imx/optee-test/0001-xtest-prevent-unexpected-build-warning-with-strncpy.patch
+++ b/recipes-security/optee-imx/optee-test/0001-xtest-prevent-unexpected-build-warning-with-strncpy.patch
@@ -1,0 +1,66 @@
+Upstream-Status: Backport 3.4.0
+
+Signed-off-by: Peter Griffin <peter.griffin@linaro.org>
+---
+From 493574ad1f4f56dd63097a652b87c25c507ce99c Mon Sep 17 00:00:00 2001
+From: Etienne Carriere <etienne.carriere@linaro.org>
+Date: Fri, 21 Dec 2018 15:36:00 +0100
+Subject: [PATCH] xtest: prevent unexpected build warning with strncpy
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This change modifies adbg_run.c to prevent a false positive
+warning reported by GCC 8.2 on usage of strncpy():
+
+    build/optee_test/host/xtest/adbg/src/adbg_run.c: In function ‘Do_ADBG_AppendToSuite’:
+    build/optee_test/host/xtest/adbg/src/adbg_run.c:103:3: error: ‘strncpy’ specified bound depends on the length of the source argument [-Werror=stringop-overflow=]
+       strncpy(p, Source_p->SuiteID_p, size);
+       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    build/optee_test/host/xtest/adbg/src/adbg_run.c:88:9: note: length computed here
+      size = strlen(Source_p->SuiteID_p);
+             ^~~~~~~~~~~~~~~~~~~~~~~~~~~
+    cc1: all warnings being treated as errors
+
+From [1]:
+  Using strncpy Safely
+  In general, it is not possible to avoid string truncation by strncpy
+  except by sizing the destination to be at least a byte larger than
+  the length of the source string. With that approach, however, using
+  strncpy becomes unnecessary and the function can be avoided in favor
+  of other APIs such as strcpy or (less preferably) memcpy. Much has
+  been written about the problems with strncpy and we recommend to
+  avoid it whenever possible. It is, however, worth keeping in mind
+  that unlike other standard string-handling functions, strncpy always
+  writes exactly as many characters as specified by the third argument;
+  if the source string is shorter, the function fills the remaining
+  bytes with NULs.
+
+This change prefers using a snprintf() as used in the alternate
+instruction block of the strncpy() call.
+
+[1] https://developers.redhat.com/blog/2018/05/24/detecting-string-truncation-with-gcc-8/
+
+Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>
+Signed-off-by: Simon Hughes <simon.hughes@arm.com>
+Reviewed-by: Jens Wiklander <jens.wiklander@linaro.org>
+---
+ host/xtest/adbg/src/adbg_run.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/host/xtest/adbg/src/adbg_run.c b/host/xtest/adbg/src/adbg_run.c
+index 406e429..2739db5 100644
+--- a/host/xtest/adbg/src/adbg_run.c
++++ b/host/xtest/adbg/src/adbg_run.c
+@@ -100,7 +100,7 @@ int Do_ADBG_AppendToSuite(
+ 		snprintf(p, size, "%s+%s", Dest_p->SuiteID_p,
+ 			 Source_p->SuiteID_p);
+ 	else
+-		strncpy(p, Source_p->SuiteID_p, size);
++		snprintf(p, size, "%s", Source_p->SuiteID_p);
+ 	free((void *)Dest_p->SuiteID_p);
+ 	Dest_p->SuiteID_p = p;
+ 
+-- 
+2.7.4
+

--- a/recipes-security/optee-imx/optee-test_3.2.0.imx.bb
+++ b/recipes-security/optee-imx/optee-test_3.2.0.imx.bb
@@ -1,0 +1,57 @@
+# Copyright (C) 2017-2018 NXP
+
+SUMMARY = "OPTEE test"
+HOMEPAGE = "http://www.optee.org/"
+
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://LICENSE.md;md5=daa2bcccc666345ab8940aab1315a4fa"
+
+DEPENDS = "optee-os optee-client python-pycrypto-native openssl"
+inherit pythonnative
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRCBRANCH = "imx_4.14.78_1.0.0_ga"
+OPTEE_TEST_SRC ?= "git://source.codeaurora.org/external/imx/imx-optee-test.git;protocol=https"
+
+SRC_URI = "${OPTEE_TEST_SRC};branch=${SRCBRANCH} \
+           file://0001-regression-4011-correct-potential-overflow.patch \
+           file://0001-xtest-prevent-unexpected-build-warning-with-strncpy.patch \
+"
+
+S = "${WORKDIR}/git"
+
+SRCREV = "eb7f698da9a7fa1587f96aa92ad8668abb0f0f48" 
+
+
+
+do_compile () {
+    if [ ${DEFAULTTUNE} = "aarch64" ];then
+        export TA_DEV_KIT_DIR=${STAGING_INCDIR}/optee/export-user_ta_arm64/
+        export ARCH=arm64
+    else
+        export TA_DEV_KIT_DIR=${STAGING_INCDIR}/optee/export-user_ta_arm32/
+        export ARCH=arm
+    fi
+    export OPTEE_CLIENT_EXPORT=${STAGING_DIR_HOST}/usr
+    export CROSS_COMPILE_HOST=${HOST_PREFIX}
+    export CROSS_COMPILE_TA=${HOST_PREFIX}
+    export CROSS_COMPILE=${HOST_PREFIX}
+    export OPTEE_OPENSSL_EXPORT=${STAGING_INCDIR}/
+    oe_runmake V=1
+}
+
+do_install () {
+    install -d ${D}/usr/bin
+    install ${S}/out/xtest/xtest ${D}/usr/bin/
+
+    install -d ${D}/lib/optee_armtz
+    find ${S}/out/ta -name '*.ta' | while read name; do
+    install -m 444 $name ${D}/lib/optee_armtz/
+    done
+
+}
+
+FILES_${PN} = "/usr/bin/ /lib*/optee_armtz/"
+
+COMPATIBLE_MACHINE = "(mx6|mx7|mx8)"


### PR DESCRIPTION
This pull request adds the optee iMX forks. This has been done using the PREFERRED_VERSION method for enabling the fork, similar to what is done already for Weston and Wayland imx forks. This means it can co-exist nicely in builds that include multiple bsp layers that also have optee rather than having a different package name.

Tested on iMX8M-evk board. op-tee Xtest test suite reports

+-----------------------------------------------------
16103 subtests of which 3 failed
75 test cases of which 1 failed
0 test case was skipped
TEE test application done!
