### PR TITLE
weston: fix the test condition for agl builds

### DIFF
--- a/recipes-graphics/wayland/weston_5.0.0.imx.bb
+++ b/recipes-graphics/wayland/weston_5.0.0.imx.bb
@@ -120,7 +120,7 @@ do_install_append() {
 	fi
 
 	# install default weston.ini
-	if [ -z "${@bb.utils.filter('BBFILE_COLLECTIONS', 'aglprofilegraphical', d)}" ]; then
+	if [ -n "${@bb.utils.filter('BBFILE_COLLECTIONS', 'aglprofilegraphical', d)}" ]; then
 		if [ "${@bb.utils.filter('BBFILE_COLLECTIONS', 'ivi', d)}" ]; then
 			WESTON_INI_SRCDIR=${B}/ivi-shell
 		else


### PR DESCRIPTION
Fix the variable test condition, wich is used during inclusion of
weston.ini file in the agl and non-agl builds.

Since for non-agl build there is no algprofilegraphics in the
collection, variable expands to an empty string and test condition
evaluates to true for both agl and non-agl builds.
This causes the weston.ini file to be installed regardless of whether
the agl is found or not.

Usage of a different condition check (lenght instead of empty) eliminates
this issue.

Signed-off-by: Andrey Zhizhikin <andrey.zhizhikin@leica-geosystems.com>