### PR TITLE
weston: Improve weston.ini selection logic

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -27,11 +27,17 @@ ${QORIQ_MIRROR} http://download.ossystems.com.br/bsp/freescale/source/ \n \
 "
 
 BBFILES_DYNAMIC += " \
+    aglprofilegraphical:${LAYERDIR}/dynamic-layers/aglprofilegraphical/*/*/*.bb \
+    aglprofilegraphical:${LAYERDIR}/dynamic-layers/aglprofilegraphical/*/*/*.bbappend \
+    \
     browser-layer:${LAYERDIR}/dynamic-layers/browser-layer/*/*/*.bb \
     browser-layer:${LAYERDIR}/dynamic-layers/browser-layer/*/*/*.bbappend \
     \
     filesystem-layer:${LAYERDIR}/dynamic-layers/filesystem-layer/*/*/*.bb \
     filesystem-layer:${LAYERDIR}/dynamic-layers/filesystem-layer/*/*/*.bbappend \
+    \
+    ivi:${LAYERDIR}/dynamic-layers/ivi/*/*/*.bb \
+    ivi:${LAYERDIR}/dynamic-layers/ivi/*/*/*.bbappend \
     \
     networking-layer:${LAYERDIR}/dynamic-layers/networking-layer/*/*/*.bb \
     networking-layer:${LAYERDIR}/dynamic-layers/networking-layer/*/*/*.bbappend \

--- a/dynamic-layers/aglprofilegraphical/recipes-graphics/wayland/weston_5.0.0.imx.bbappend
+++ b/dynamic-layers/aglprofilegraphical/recipes-graphics/wayland/weston_5.0.0.imx.bbappend
@@ -1,0 +1,2 @@
+# don't install default weston.ini
+WESTON_INI_INSTALL_FILE = ""

--- a/dynamic-layers/ivi/recipes-graphics/wayland/weston_5.0.0.imx.bbappend
+++ b/dynamic-layers/ivi/recipes-graphics/wayland/weston_5.0.0.imx.bbappend
@@ -1,0 +1,2 @@
+# install default weston.ini for IVI
+WESTON_INI_INSTALL_FILE = "${B}/ivi-shell/weston.ini"

--- a/recipes-graphics/wayland/weston_5.0.0.imx.bb
+++ b/recipes-graphics/wayland/weston_5.0.0.imx.bb
@@ -102,6 +102,9 @@ PACKAGECONFIG[imxg2d] = "--enable-imxg2d,--disable-imxg2d,virtual/libg2d"
 # Weston with OpenGL support
 PACKAGECONFIG[opengl] = "--enable-opengl,--disable-opengl"
 
+# Set to install a default weston.ini file
+WESTON_INI_INSTALL_FILE = "${B}/weston.ini"
+
 do_install_append() {
 	# Weston doesn't need the .la files to load modules, so wipe them
 	rm -f ${D}/${libdir}/libweston-${WESTON_MAJOR_VERSION}/*.la
@@ -120,13 +123,8 @@ do_install_append() {
 	fi
 
 	# install default weston.ini
-	if [ -n "${@bb.utils.filter('BBFILE_COLLECTIONS', 'aglprofilegraphical', d)}" ]; then
-		if [ "${@bb.utils.filter('BBFILE_COLLECTIONS', 'ivi', d)}" ]; then
-			WESTON_INI_SRCDIR=${B}/ivi-shell
-		else
-			WESTON_INI_SRCDIR=${B}
-		fi
-		install -D -m 0644 ${WESTON_INI_SRCDIR}/weston.ini ${D}${sysconfdir}/xdg/weston/weston.ini
+	if [ "${WESTON_INI_INSTALL_FILE}" != "" ]; then
+		install -D -m 0644 ${WESTON_INI_INSTALL_FILE} ${D}${sysconfdir}/xdg/weston/weston.ini
 	fi
 }
 


### PR DESCRIPTION
Add a variable WESTON_INI_INSTALL_FILE to make it easy to customize
the selection of the weston.ini file.

The main recipe now performs only a generic install of the selected file.

For AGL and IVI, we use the BBFILES_DYNAMIC mechanism to specify no
file and an IVI-specific file respectively.

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>