### PR TITLE
optee-imx: Make it imx specific

### DIFF
--- a/recipes-security/optee-imx/optee-os_3.2.0.imx.bb
+++ b/recipes-security/optee-imx/optee-os_3.2.0.imx.bb
@@ -90,3 +90,4 @@ FILES_${PN}-staticdev = "/usr/include/optee/"
 RDEPENDS_${PN}-dev += "${PN}-staticdev"
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
+COMPATIBLE_MACHINE = "(imx)"


### PR DESCRIPTION
Fails to build on qemu
| core/arch/arm/plat-imx/conf.mk:112: *** Unsupported PLATFORM_FLAVOR "emuarm".  Stop.

Signed-off-by: Khem Raj <raj.khem@gmail.com>