### PR TITLE
linux-fslc-imx_4.9-1.0.x: Backport patches to fix building with gcc 9

### DIFF
--- a/recipes-kernel/linux/linux-fslc-imx/0001-compiler-attributes-add-support-for-copy-gcc-9.patch
+++ b/recipes-kernel/linux/linux-fslc-imx/0001-compiler-attributes-add-support-for-copy-gcc-9.patch
@@ -1,0 +1,132 @@
+From mboxrd@z Thu Jan  1 00:00:00 1970
+Return-Path: <SRS0=AQQw=UD=vger.kernel.org=stable-owner@kernel.org>
+X-Spam-Checker-Version: SpamAssassin 3.4.0 (2014-02-07) on
+	aws-us-west-2-korg-lkml-1.web.codeaurora.org
+X-Spam-Level: 
+X-Spam-Status: No, score=-9.1 required=3.0 tests=DKIM_SIGNED,DKIM_VALID,
+	DKIM_VALID_AU,HEADER_FROM_DIFFERENT_DOMAINS,INCLUDES_PATCH,MAILING_LIST_MULTI,
+	SIGNED_OFF_BY,SPF_HELO_NONE,SPF_PASS,URIBL_BLOCKED,USER_AGENT_GIT
+	autolearn=ham autolearn_force=no version=3.4.0
+Received: from mail.kernel.org (mail.kernel.org [198.145.29.99])
+	by smtp.lore.kernel.org (Postfix) with ESMTP id 354C8C282CE
+	for <stable@archiver.kernel.org>; Tue,  4 Jun 2019 13:25:01 +0000 (UTC)
+Received: from vger.kernel.org (vger.kernel.org [209.132.180.67])
+	by mail.kernel.org (Postfix) with ESMTP id 0D01C24291
+	for <stable@archiver.kernel.org>; Tue,  4 Jun 2019 13:25:01 +0000 (UTC)
+Authentication-Results: mail.kernel.org;
+	dkim=pass (1024-bit key) header.d=agner.ch header.i=@agner.ch header.b="HG5nfXC5"
+Received: (majordomo@vger.kernel.org) by vger.kernel.org via listexpand
+        id S1727392AbfFDNZA (ORCPT <rfc822;stable@archiver.kernel.org>);
+        Tue, 4 Jun 2019 09:25:00 -0400
+Received: from mail.kmu-office.ch ([178.209.48.109]:48336 "EHLO
+        mail.kmu-office.ch" rhost-flags-OK-OK-OK-OK) by vger.kernel.org
+        with ESMTP id S1727340AbfFDNZA (ORCPT
+        <rfc822;stable@vger.kernel.org>); Tue, 4 Jun 2019 09:25:00 -0400
+Received: from trochilidae.toradex.int (unknown [46.140.72.82])
+        by mail.kmu-office.ch (Postfix) with ESMTPSA id 8BE845C2138;
+        Tue,  4 Jun 2019 15:24:55 +0200 (CEST)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; d=agner.ch; s=dkim;
+        t=1559654695;
+        h=from:from:reply-to:subject:subject:date:date:message-id:message-id:
+         to:to:cc:cc:mime-version:mime-version:content-type:content-type:
+         content-transfer-encoding:content-transfer-encoding:in-reply-to:
+         references; bh=2lQNwDLO9/HfsHTvSmLn5csGG1S09yt0LuSYqXeE0y0=;
+        b=HG5nfXC5qPZvu4E7tM2iveXY8wtjralMObB8KMvD1S6NWkkOwkeLjXonm495Hz+G+geOig
+        NlbMrAg5b6wYCzvMgqUeSBmGkYCjB/7IFlotEiTcUNmOCorD2pTasqUOcpObuc6WqBkEjM
+        3seyrLJVs51y9A3weXf9CMO3OMOXwRA=
+From:   Stefan Agner <stefan@agner.ch>
+To:     gregkh@linuxfoundation.org
+Cc:     stable@vger.kernel.org,
+        Miguel Ojeda <miguel.ojeda.sandonis@gmail.com>,
+        Martin Sebor <msebor@gcc.gnu.org>,
+        Nick Desaulniers <ndesaulniers@google.com>,
+        Stefan Agner <stefan@agner.ch>
+Subject: [PATCH BACKPORT 4.19 1/2] Compiler Attributes: add support for __copy (gcc >= 9)
+Date:   Tue,  4 Jun 2019 15:24:40 +0200
+Message-Id: <20190604132441.15383-1-stefan@agner.ch>
+X-Mailer: git-send-email 2.21.0
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Sender: stable-owner@vger.kernel.org
+Precedence: bulk
+List-ID: <stable.vger.kernel.org>
+X-Mailing-List: stable@vger.kernel.org
+Archived-At: <https://lore.kernel.org/stable/20190604132441.15383-1-stefan@agner.ch/>
+List-Archive: <https://lore.kernel.org/stable/>
+List-Post: <mailto:stable@vger.kernel.org>
+
+From: Miguel Ojeda <miguel.ojeda.sandonis@gmail.com>
+
+[ Upstream commit c0d9782f5b6d7157635ae2fd782a4b27d55a6013 ]
+
+>From the GCC manual:
+
+  copy
+  copy(function)
+
+    The copy attribute applies the set of attributes with which function
+    has been declared to the declaration of the function to which
+    the attribute is applied. The attribute is designed for libraries
+    that define aliases or function resolvers that are expected
+    to specify the same set of attributes as their targets. The copy
+    attribute can be used with functions, variables, or types. However,
+    the kind of symbol to which the attribute is applied (either
+    function or variable) must match the kind of symbol to which
+    the argument refers. The copy attribute copies only syntactic and
+    semantic attributes but not attributes that affect a symbol’s
+    linkage or visibility such as alias, visibility, or weak.
+    The deprecated attribute is also not copied.
+
+  https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html
+
+The upcoming GCC 9 release extends the -Wmissing-attributes warnings
+(enabled by -Wall) to C and aliases: it warns when particular function
+attributes are missing in the aliases but not in their target, e.g.:
+
+    void __cold f(void) {}
+    void __alias("f") g(void);
+
+diagnoses:
+
+    warning: 'g' specifies less restrictive attribute than
+    its target 'f': 'cold' [-Wmissing-attributes]
+
+Using __copy(f) we can copy the __cold attribute from f to g:
+
+    void __cold f(void) {}
+    void __copy(f) __alias("f") g(void);
+
+This attribute is most useful to deal with situations where an alias
+is declared but we don't know the exact attributes the target has.
+
+For instance, in the kernel, the widely used module_init/exit macros
+define the init/cleanup_module aliases, but those cannot be marked
+always as __init/__exit since some modules do not have their
+functions marked as such.
+
+Cc: <stable@vger.kernel.org> # 4.14+
+Suggested-by: Martin Sebor <msebor@gcc.gnu.org>
+Reviewed-by: Nick Desaulniers <ndesaulniers@google.com>
+Signed-off-by: Miguel Ojeda <miguel.ojeda.sandonis@gmail.com>
+Signed-off-by: Stefan Agner <stefan@agner.ch>
+---
+ include/linux/compiler-gcc.h   | 4 ++++
+ include/linux/compiler_types.h | 4 ++++
+ 2 files changed, 8 insertions(+)
+
+Index: git/include/linux/compiler-gcc.h
+===================================================================
+--- git.orig/include/linux/compiler-gcc.h
++++ git/include/linux/compiler-gcc.h
+@@ -282,6 +282,10 @@
+ 
+ #endif	/* gcc version >= 40000 specific checks */
+ 
++#if GCC_VERSION >= 90100
++#define __copy(symbol)                 __attribute__((__copy__(symbol)))
++#endif
++
+ #if !defined(__noclone)
+ #define __noclone	/* not needed */
+ #endif

--- a/recipes-kernel/linux/linux-fslc-imx/0002-include-linux-module.h-copy-init-exit-attrs-to-.patch
+++ b/recipes-kernel/linux/linux-fslc-imx/0002-include-linux-module.h-copy-init-exit-attrs-to-.patch
@@ -1,0 +1,135 @@
+From mboxrd@z Thu Jan  1 00:00:00 1970
+Return-Path: <SRS0=AQQw=UD=vger.kernel.org=stable-owner@kernel.org>
+X-Spam-Checker-Version: SpamAssassin 3.4.0 (2014-02-07) on
+	aws-us-west-2-korg-lkml-1.web.codeaurora.org
+X-Spam-Level: 
+X-Spam-Status: No, score=-9.1 required=3.0 tests=DKIM_SIGNED,DKIM_VALID,
+	DKIM_VALID_AU,HEADER_FROM_DIFFERENT_DOMAINS,INCLUDES_PATCH,MAILING_LIST_MULTI,
+	SIGNED_OFF_BY,SPF_HELO_NONE,SPF_PASS,URIBL_BLOCKED,USER_AGENT_GIT
+	autolearn=ham autolearn_force=no version=3.4.0
+Received: from mail.kernel.org (mail.kernel.org [198.145.29.99])
+	by smtp.lore.kernel.org (Postfix) with ESMTP id 63BF0C46470
+	for <stable@archiver.kernel.org>; Tue,  4 Jun 2019 13:25:01 +0000 (UTC)
+Received: from vger.kernel.org (vger.kernel.org [209.132.180.67])
+	by mail.kernel.org (Postfix) with ESMTP id 3D9B223D29
+	for <stable@archiver.kernel.org>; Tue,  4 Jun 2019 13:25:01 +0000 (UTC)
+Authentication-Results: mail.kernel.org;
+	dkim=pass (1024-bit key) header.d=agner.ch header.i=@agner.ch header.b="QWkQ/3jN"
+Received: (majordomo@vger.kernel.org) by vger.kernel.org via listexpand
+        id S1727340AbfFDNZA (ORCPT <rfc822;stable@archiver.kernel.org>);
+        Tue, 4 Jun 2019 09:25:00 -0400
+Received: from mail.kmu-office.ch ([178.209.48.109]:48348 "EHLO
+        mail.kmu-office.ch" rhost-flags-OK-OK-OK-OK) by vger.kernel.org
+        with ESMTP id S1727343AbfFDNZA (ORCPT
+        <rfc822;stable@vger.kernel.org>); Tue, 4 Jun 2019 09:25:00 -0400
+Received: from trochilidae.toradex.int (unknown [46.140.72.82])
+        by mail.kmu-office.ch (Postfix) with ESMTPSA id A3CC45C1F29;
+        Tue,  4 Jun 2019 15:24:57 +0200 (CEST)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; d=agner.ch; s=dkim;
+        t=1559654697;
+        h=from:from:reply-to:subject:subject:date:date:message-id:message-id:
+         to:to:cc:cc:mime-version:mime-version:content-type:
+         content-transfer-encoding:content-transfer-encoding:
+         in-reply-to:in-reply-to:references:references;
+        bh=tc6JvYRo2QJoJQVnFd/oGDG0/z6TF30OxAP+nBfruDc=;
+        b=QWkQ/3jNBkysiiD5SMb2UF+0YtSMCbOyP2/dUXeDQChYIal8jUex+QvYHjBh6l4Gff6WwG
+        3Zd44X6jE/KqxygBkoglOSb/dHwZ5AS8B8vpUM8vh2CzhrW4fD9eguoEIImOJJZ9RHgx0b
+        Gwno+ZPPhuPOcFbSrBwNsKK6mZLGttY=
+From:   Stefan Agner <stefan@agner.ch>
+To:     gregkh@linuxfoundation.org
+Cc:     stable@vger.kernel.org,
+        Miguel Ojeda <miguel.ojeda.sandonis@gmail.com>,
+        Martin Sebor <msebor@gcc.gnu.org>,
+        Jessica Yu <jeyu@kernel.org>, Stefan Agner <stefan@agner.ch>
+Subject: [PATCH BACKPORT 4.19 2/2] include/linux/module.h: copy __init/__exit attrs to init/cleanup_module
+Date:   Tue,  4 Jun 2019 15:24:41 +0200
+Message-Id: <20190604132441.15383-2-stefan@agner.ch>
+X-Mailer: git-send-email 2.21.0
+In-Reply-To: <20190604132441.15383-1-stefan@agner.ch>
+References: <20190604132441.15383-1-stefan@agner.ch>
+MIME-Version: 1.0
+Content-Transfer-Encoding: 8bit
+Sender: stable-owner@vger.kernel.org
+Precedence: bulk
+List-ID: <stable.vger.kernel.org>
+X-Mailing-List: stable@vger.kernel.org
+Archived-At: <https://lore.kernel.org/stable/20190604132441.15383-2-stefan@agner.ch/>
+List-Archive: <https://lore.kernel.org/stable/>
+List-Post: <mailto:stable@vger.kernel.org>
+
+From: Miguel Ojeda <miguel.ojeda.sandonis@gmail.com>
+
+[ Upstream commit a6e60d84989fa0e91db7f236eda40453b0e44afa ]
+
+The upcoming GCC 9 release extends the -Wmissing-attributes warnings
+(enabled by -Wall) to C and aliases: it warns when particular function
+attributes are missing in the aliases but not in their target.
+
+In particular, it triggers for all the init/cleanup_module
+aliases in the kernel (defined by the module_init/exit macros),
+ending up being very noisy.
+
+These aliases point to the __init/__exit functions of a module,
+which are defined as __cold (among other attributes). However,
+the aliases themselves do not have the __cold attribute.
+
+Since the compiler behaves differently when compiling a __cold
+function as well as when compiling paths leading to calls
+to __cold functions, the warning is trying to point out
+the possibly-forgotten attribute in the alias.
+
+In order to keep the warning enabled, we decided to silence
+this case. Ideally, we would mark the aliases directly
+as __init/__exit. However, there are currently around 132 modules
+in the kernel which are missing __init/__exit in their init/cleanup
+functions (either because they are missing, or for other reasons,
+e.g. the functions being called from somewhere else); and
+a section mismatch is a hard error.
+
+A conservative alternative was to mark the aliases as __cold only.
+However, since we would like to eventually enforce __init/__exit
+to be always marked,  we chose to use the new __copy function
+attribute (introduced by GCC 9 as well to deal with this).
+With it, we copy the attributes used by the target functions
+into the aliases. This way, functions that were not marked
+as __init/__exit won't have their aliases marked either,
+and therefore there won't be a section mismatch.
+
+Note that the warning would go away marking either the extern
+declaration, the definition, or both. However, we only mark
+the definition of the alias, since we do not want callers
+(which only see the declaration) to be compiled as if the function
+was __cold (and therefore the paths leading to those calls
+would be assumed to be unlikely).
+
+Cc: <stable@vger.kernel.org> # 4.14+
+Link: https://lore.kernel.org/lkml/20190123173707.GA16603@gmail.com/
+Link: https://lore.kernel.org/lkml/20190206175627.GA20399@gmail.com/
+Suggested-by: Martin Sebor <msebor@gcc.gnu.org>
+Acked-by: Jessica Yu <jeyu@kernel.org>
+Signed-off-by: Miguel Ojeda <miguel.ojeda.sandonis@gmail.com>
+Signed-off-by: Stefan Agner <stefan@agner.ch>
+---
+ include/linux/module.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+Index: git/include/linux/module.h
+===================================================================
+--- git.orig/include/linux/module.h
++++ git/include/linux/module.h
+@@ -129,13 +129,13 @@ extern void cleanup_module(void);
+ #define module_init(initfn)					\
+ 	static inline initcall_t __inittest(void)		\
+ 	{ return initfn; }					\
+-	int init_module(void) __attribute__((alias(#initfn)));
++	int init_module(void) __copy(initfn) __attribute__((alias(#initfn)));
+ 
+ /* This is only required if you want to be unloadable. */
+ #define module_exit(exitfn)					\
+ 	static inline exitcall_t __exittest(void)		\
+ 	{ return exitfn; }					\
+-	void cleanup_module(void) __attribute__((alias(#exitfn)));
++	void cleanup_module(void) __copy(exitfn) __attribute__((alias(#exitfn)));
+ 
+ #endif
+ 

--- a/recipes-kernel/linux/linux-fslc-imx_4.9-1.0.x.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_4.9-1.0.x.bb
@@ -12,5 +12,8 @@ PV .= "+git${SRCPV}"
 
 SRCBRANCH = "4.9-1.0.x-imx"
 SRCREV = "953c6e30c9701fda69ef08e2476c541dc4fb1453"
+SRC_URI += "file://0001-compiler-attributes-add-support-for-copy-gcc-9.patch \
+            file://0002-include-linux-module.h-copy-init-exit-attrs-to-.patch \
+           "
 
 COMPATIBLE_MACHINE = "(mx6|mx7)"


### PR DESCRIPTION
Closes #192.

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>