### PR TITLE
weston-init: Keep the logic to edit weston.ini to meta-freescale

### DIFF
--- a/recipes-graphics/wayland/weston-init.bbappend
+++ b/recipes-graphics/wayland/weston-init.bbappend
@@ -12,7 +12,7 @@ SRC_URI_append_mx6sl = "file://weston.config"
 # commented out. For example:
 #     #xwayland=true
 # Then add the assignment to INI_UNCOMMENT_ASSIGNMENTS.
-INI_UNCOMMENT_ASSIGNMENTS = " \
+INI_UNCOMMENT_ASSIGNMENTS_append_imx = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'x11 wayland', 'xwayland=true', '', d)} \
 "
 INI_UNCOMMENT_ASSIGNMENTS_append_mx7ulp = " \


### PR DESCRIPTION
This logic does not work across multiple layers even OE-Core machines
dont build with it. For now its best to keep this confined to
meta-freescale machines

Idea is good but it needs to align with OE-core's methods where
currently in OE-Core we expect machines to override weston.ini
completely per machine, this logic sort of goes against it. However it
has some goodness to it, eg. adding options based on DISTRO_FEATURES
which OE-Core could have too but maybe implemented differently.

Signed-off-by: Khem Raj <raj.khem@gmail.com>