### PR TITLE
optee-os_3.2.0: change PLATFORM_FLAVOR for imx6ulz14x14evk [ZEUS]

### DIFF
--- a/recipes-security/optee-imx/optee-os_3.2.0.imx.bb
+++ b/recipes-security/optee-imx/optee-os_3.2.0.imx.bb
@@ -23,7 +23,7 @@ PLATFORM_FLAVOR_imx6qpdlsolox   = "mx6qsabresd"
 PLATFORM_FLAVOR_imx6ul7d        = "mx6ulevk"
 PLATFORM_FLAVOR_imx6ull14x14evk = "mx6ullevk"
 PLATFORM_FLAVOR_imx6ull9x9evk   = "mx6ullevk"
-PLATFORM_FLAVOR_imx6ulz14x14evk = "mx6ullevk"
+PLATFORM_FLAVOR_imx6ulz14x14evk = "mx6ulzevk"
 PLATFORM_FLAVOR_mx8mm   = "mx8mmevk"
 
 OPTEE_ARCH ?= "arm32"


### PR DESCRIPTION
The platform flavor 'mx6ulzevk' has been added to Optee-OS.

Signed-off-by: Clement Faure <clement.faure@nxp.com>
(cherry picked from commit 0812b771626eda0ac8854b0d2bfe7e92045ffe39)