### PR TITLE
optee: add recipes for 3.7.0

### DIFF
--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -267,9 +267,9 @@ PREFERRED_VERSION_libdrm_mx7 ?= "2.4.91.imx"
 PREFERRED_VERSION_libdrm_mx8 ?= "2.4.91.imx"
 
 # Use i.MX optee Version
-PREFERRED_VERSION_optee-os_mx8     ?= "3.2.0.imx"
-PREFERRED_VERSION_optee-client_mx8 ?= "3.2.0.imx"
-PREFERRED_VERSION_optee-test_mx8   ?= "3.2.0.imx"
+PREFERRED_VERSION_optee-os     ?= "3.2.0.imx"
+PREFERRED_VERSION_optee-client ?= "3.2.0.imx"
+PREFERRED_VERSION_optee-test   ?= "3.2.0.imx"
 
 # Handle default kernel
 IMX_DEFAULT_KERNEL = "linux-imx"

--- a/recipes-security/optee-imx/optee-client_3.7.0.imx.bb
+++ b/recipes-security/optee-imx/optee-client_3.7.0.imx.bb
@@ -1,0 +1,53 @@
+# Copyright (C) 2019 NXP
+
+SUMMARY = "OPTEE Client libs"
+HOMEPAGE = "http://www.optee.org/"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=69663ab153298557a59c67a60a743e5b"
+
+inherit systemd
+
+SRCBRANCH = "master"
+OPTEE_CLIENT_SRC ?= "git://github.com/OP-TEE/optee_client.git;protocol=https"
+SRC_URI = "${OPTEE_CLIENT_SRC};branch=${SRCBRANCH}"
+SRCREV = "3.7.0"
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI_append = " file://tee-supplicant.service"
+
+S = "${WORKDIR}/git"
+SYSTEMD_SERVICE_${PN} = "tee-supplicant.service"
+
+do_compile () {
+    if [ ${TUNE_ARCH} = "aarch64" ]; then
+        oe_runmake -C ${S} ARCH=arm64 O=${B}
+    else
+        oe_runmake -C ${S} ARCH=arm O=${B}
+    fi
+}
+
+do_install () {
+	oe_runmake -C ${S} install
+
+	install -D -p -m0644 ${B}/export/usr/lib/libteec.so.1.0 ${D}${libdir}/libteec.so.1.0
+	ln -sf libteec.so.1.0 ${D}${libdir}/libteec.so
+	ln -sf libteec.so.1.0 ${D}${libdir}/libteec.so.1
+
+	install -D -p -m0755 ${B}/export/usr/sbin/tee-supplicant ${D}${bindir}/tee-supplicant
+
+	cp -a ${B}/export/usr/include ${D}/usr/
+
+	sed -i -e s:/etc:${sysconfdir}:g -e s:/usr/bin:${bindir}:g ${WORKDIR}/tee-supplicant.service
+	install -D -p -m0644 ${WORKDIR}/tee-supplicant.service ${D}${systemd_system_unitdir}/tee-supplicant.service
+}
+
+PACKAGES += "tee-supplicant"
+FILES_${PN} += "${libdir}/* ${includedir}/*"
+FILES_tee-supplicant += "${bindir}/tee-supplicant"
+
+INSANE_SKIP_${PN} = "ldflags dev-elf"
+INSANE_SKIP_${PN}-dev = "ldflags dev-elf"
+INSANE_SKIP_tee-supplicant = "ldflags"
+
+COMPATIBLE_MACHINE = "(imx)"

--- a/recipes-security/optee-imx/optee-os/0001-imx-change-imx8-prefixe-to-mx8.patch
+++ b/recipes-security/optee-imx/optee-os/0001-imx-change-imx8-prefixe-to-mx8.patch
@@ -1,0 +1,219 @@
+From 80753240b46aa50154363a040512242c28c377cf Mon Sep 17 00:00:00 2001
+From: Clement Faure <clement.faure@nxp.com>
+Date: Thu, 14 Nov 2019 13:59:19 +0100
+Subject: [PATCH] imx: change imx8 prefixe to mx8
+
+For consistency, change all imx8 prefixe to mx8.
+This change affects:
+ * CFG_IMX8*
+ * platform flavors
+
+Signed-off-by: Clement Faure <clement.faure@nxp.com>
+Acked-by: Jens Wiklander <jens.wiklander@linaro.org>
+Acked-by: Jerome Forissier <jerome@forissier.org>
+---
+ .shippable.yml                           | 10 ++---
+ core/arch/arm/plat-imx/conf.mk           | 48 ++++++++++++------------
+ core/arch/arm/plat-imx/imx-common.c      |  4 +-
+ core/arch/arm/plat-imx/imx-regs.h        |  6 +--
+ core/arch/arm/plat-imx/registers/imx8m.h |  4 +-
+ core/drivers/crypto/caam/hal/sub.mk      |  2 +-
+ 6 files changed, 37 insertions(+), 37 deletions(-)
+
+diff --git a/.shippable.yml b/.shippable.yml
+index cd471f86f..712a4ce52 100644
+--- a/.shippable.yml
++++ b/.shippable.yml
+@@ -85,11 +85,11 @@ build:
+     - _make PLATFORM=imx-mx6qapalis
+     - _make PLATFORM=imx-mx7dsabresd
+     - _make PLATFORM=imx-mx7ulpevk
+-    - _make PLATFORM=imx-imx8mmevk
+-    - _make PLATFORM=imx-imx8mnevk
+-    - _make PLATFORM=imx-imx8mqevk
+-    - _make PLATFORM=imx-imx8qxpmek
+-    - _make PLATFORM=imx-imx8qmmek
++    - _make PLATFORM=imx-mx8mmevk
++    - _make PLATFORM=imx-mx8mnevk
++    - _make PLATFORM=imx-mx8mqevk
++    - _make PLATFORM=imx-mx8qxpmek
++    - _make PLATFORM=imx-mx8qmmek
+     - _make PLATFORM=k3-j721e
+     - _make PLATFORM=k3-j721e CFG_ARM64_core=y
+     - _make PLATFORM=k3-am65x
+diff --git a/core/arch/arm/plat-imx/conf.mk b/core/arch/arm/plat-imx/conf.mk
+index 032dd3151..cf4dcd826 100644
+--- a/core/arch/arm/plat-imx/conf.mk
++++ b/core/arch/arm/plat-imx/conf.mk
+@@ -57,20 +57,20 @@ mx7s-flavorlist = \
+ mx7ulp-flavorlist = \
+ 	mx7ulpevk
+ 
+-imx8mq-flavorlist = \
+-	imx8mqevk
++mx8mq-flavorlist = \
++	mx8mqevk
+ 
+-imx8mm-flavorlist = \
+-	imx8mmevk
++mx8mm-flavorlist = \
++	mx8mmevk
+ 
+-imx8mn-flavorlist = \
+-	imx8mnevk
++mx8mn-flavorlist = \
++	mx8mnevk
+ 
+-imx8qm-flavorlist = \
+-	imx8qmmek \
++mx8qm-flavorlist = \
++	mx8qmmek \
+ 
+-imx8qx-flavorlist = \
+-	imx8qxpmek \
++mx8qx-flavorlist = \
++	mx8qxpmek \
+ 
+ ifneq (,$(filter $(PLATFORM_FLAVOR),$(mx6ul-flavorlist)))
+ $(call force,CFG_MX6,y)
+@@ -134,34 +134,34 @@ $(call force,CFG_TZC380,n)
+ $(call force,CFG_CSU,n)
+ $(call force,CFG_NXP_CAAM,n)
+ include core/arch/arm/cpu/cortex-a7.mk
+-else ifneq (,$(filter $(PLATFORM_FLAVOR),$(imx8mq-flavorlist)))
+-$(call force,CFG_IMX8MQ,y)
++else ifneq (,$(filter $(PLATFORM_FLAVOR),$(mx8mq-flavorlist)))
++$(call force,CFG_MX8MQ,y)
+ $(call force,CFG_ARM64_core,y)
+ CFG_IMX_UART ?= y
+ CFG_DRAM_BASE ?= 0x40000000
+ CFG_TEE_CORE_NB_CORE ?= 4
+-else ifneq (,$(filter $(PLATFORM_FLAVOR),$(imx8mm-flavorlist)))
+-$(call force,CFG_IMX8MM,y)
++else ifneq (,$(filter $(PLATFORM_FLAVOR),$(mx8mm-flavorlist)))
++$(call force,CFG_MX8MM,y)
+ $(call force,CFG_ARM64_core,y)
+ CFG_IMX_UART ?= y
+ CFG_DRAM_BASE ?= 0x40000000
+ CFG_TEE_CORE_NB_CORE ?= 4
+-else ifneq (,$(filter $(PLATFORM_FLAVOR),$(imx8mn-flavorlist)))
+-$(call force,CFG_IMX8MN,y)
++else ifneq (,$(filter $(PLATFORM_FLAVOR),$(mx8mn-flavorlist)))
++$(call force,CFG_MX8MN,y)
+ $(call force,CFG_ARM64_core,y)
+ CFG_IMX_UART ?= y
+ CFG_DRAM_BASE ?= 0x40000000
+ CFG_TEE_CORE_NB_CORE ?= 4
+-else ifneq (,$(filter $(PLATFORM_FLAVOR),$(imx8qm-flavorlist)))
+-$(call force,CFG_IMX8QM,y)
++else ifneq (,$(filter $(PLATFORM_FLAVOR),$(mx8qm-flavorlist)))
++$(call force,CFG_MX8QM,y)
+ $(call force,CFG_ARM64_core,y)
+ $(call force,CFG_IMX_SNVS,n)
+ CFG_IMX_LPUART ?= y
+ CFG_DRAM_BASE ?= 0x40000000
+ CFG_TEE_CORE_NB_CORE ?= 6
+ $(call force,CFG_NXP_CAAM,n)
+-else ifneq (,$(filter $(PLATFORM_FLAVOR),$(imx8qx-flavorlist)))
+-$(call force,CFG_IMX8QX,y)
++else ifneq (,$(filter $(PLATFORM_FLAVOR),$(mx8qx-flavorlist)))
++$(call force,CFG_MX8QX,y)
+ $(call force,CFG_ARM64_core,y)
+ CFG_IMX_LPUART ?= y
+ CFG_DRAM_BASE ?= 0x40000000
+@@ -282,22 +282,22 @@ CFG_DDR_SIZE ?= 0x10000000
+ CFG_NS_ENTRY_ADDR ?= 0x80800000
+ endif
+ 
+-ifneq (,$(filter $(PLATFORM_FLAVOR),imx8mqevk))
++ifneq (,$(filter $(PLATFORM_FLAVOR),mx8mqevk))
+ CFG_DDR_SIZE ?= 0xc0000000
+ CFG_UART_BASE ?= UART1_BASE
+ endif
+ 
+-ifneq (,$(filter $(PLATFORM_FLAVOR),imx8mmevk))
++ifneq (,$(filter $(PLATFORM_FLAVOR),mx8mmevk))
+ CFG_DDR_SIZE ?= 0x80000000
+ CFG_UART_BASE ?= UART2_BASE
+ endif
+ 
+-ifneq (,$(filter $(PLATFORM_FLAVOR),imx8mnevk))
++ifneq (,$(filter $(PLATFORM_FLAVOR),mx8mnevk))
+ CFG_DDR_SIZE ?= 0x80000000
+ CFG_UART_BASE ?= UART2_BASE
+ endif
+ 
+-ifneq (,$(filter $(PLATFORM_FLAVOR),imx8qxpmek imx8qmmek))
++ifneq (,$(filter $(PLATFORM_FLAVOR),mx8qxpmek mx8qmmek))
+ CFG_DDR_SIZE ?= 0x80000000
+ CFG_UART_BASE ?= UART0_BASE
+ endif
+diff --git a/core/arch/arm/plat-imx/imx-common.c b/core/arch/arm/plat-imx/imx-common.c
+index e355c4199..106e2fb04 100644
+--- a/core/arch/arm/plat-imx/imx-common.c
++++ b/core/arch/arm/plat-imx/imx-common.c
+@@ -27,9 +27,9 @@ static void imx_digproc(void)
+ 
+ #if defined(CFG_MX7ULP)
+ 	digprog = SOC_MX7ULP << 16;
+-#elif defined(CFG_IMX8QX)
++#elif defined(CFG_MX8QX)
+ 	digprog = SOC_MX8QX << 16;
+-#elif defined(CFG_IMX8QM)
++#elif defined(CFG_MX8QM)
+ 	digprog = SOC_MX8QM << 16;
+ #else
+ 	anatop_addr = core_mmu_get_va(ANATOP_BASE, MEM_AREA_IO_SEC);
+diff --git a/core/arch/arm/plat-imx/imx-regs.h b/core/arch/arm/plat-imx/imx-regs.h
+index 22c536c14..4cbe96b2e 100644
+--- a/core/arch/arm/plat-imx/imx-regs.h
++++ b/core/arch/arm/plat-imx/imx-regs.h
+@@ -36,12 +36,12 @@
+ #include <registers/imx7.h>
+ #elif defined(CFG_MX7ULP)
+ #include <registers/imx7ulp.h>
+-#elif defined(CFG_IMX8MQ) || defined(CFG_IMX8MM) || defined(CFG_IMX8MN)
++#elif defined(CFG_MX8MQ) || defined(CFG_MX8MM) || defined(CFG_MX8MN)
+ #include <registers/imx8m.h>
+-#elif defined(CFG_IMX8QX) || defined(CFG_IMX8QM)
++#elif defined(CFG_MX8QX) || defined(CFG_MX8QM)
+ #include <registers/imx8q.h>
+ #else
+-#error "CFG_MX6/7/7ULP or CFG_IMX8MQ/8MM/8QX/8QM is not defined"
++#error "CFG_MX6/7/7ULP or CFG_MX8MQ/8MM/8QX/8QM is not defined"
+ #endif
+ 
+ #define IOMUXC_GPR4_OFFSET	0x10
+diff --git a/core/arch/arm/plat-imx/registers/imx8m.h b/core/arch/arm/plat-imx/registers/imx8m.h
+index 73e2936a1..6870812e5 100644
+--- a/core/arch/arm/plat-imx/registers/imx8m.h
++++ b/core/arch/arm/plat-imx/registers/imx8m.h
+@@ -16,10 +16,10 @@
+ #define CAAM_BASE	0x30900000
+ #define ANATOP_BASE	0x30360000
+ 
+-#ifdef CFG_IMX8MQ
++#ifdef CFG_MX8MQ
+ #define DIGPROG_OFFSET	0x06c
+ #endif
+-#if defined(CFG_IMX8MM) || defined(CFG_IMX8MN)
++#if defined(CFG_MX8MM) || defined(CFG_MX8MN)
+ #define DIGPROG_OFFSET	0x800
+ #endif
+ 
+diff --git a/core/drivers/crypto/caam/hal/sub.mk b/core/drivers/crypto/caam/hal/sub.mk
+index e26ada50d..46f84c27f 100644
+--- a/core/drivers/crypto/caam/hal/sub.mk
++++ b/core/drivers/crypto/caam/hal/sub.mk
+@@ -4,7 +4,7 @@ endif
+ ifeq ($(filter y, $(CFG_MX6) $(CFG_MX7) $(CFG_MX7ULP)),y)
+ CAAM_HAL_DIR = imx_6_7
+ endif
+-ifeq ($(filter y, $(CFG_IMX8MQ) $(CFG_IMX8MM) $(CFG_IMX8MN)),y)
++ifeq ($(filter y, $(CFG_MX8MQ) $(CFG_MX8MM) $(CFG_MX8MN)),y)
+ CAAM_HAL_DIR = imx_8m
+ endif
+ 
+-- 
+2.17.1
+

--- a/recipes-security/optee-imx/optee-os_3.7.0.imx.bb
+++ b/recipes-security/optee-imx/optee-os_3.7.0.imx.bb
@@ -1,0 +1,86 @@
+# Copyright (C) 2019 NXP
+
+SUMMARY = "OPTEE OS"
+DESCRIPTION = "OPTEE OS"
+HOMEPAGE = "http://www.optee.org/"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=c1f21c4f72f372ef38a5a4aee55ec173"
+
+inherit deploy python3native autotools
+DEPENDS = "python3-pycrypto-native u-boot-mkimage-native python3-pyelftools-native"
+
+SRCBRANCH = "master"
+OPTEE_OS_SRC ?= "git://github.com/OP-TEE/optee_os.git;protocol=https"
+SRC_URI = "${OPTEE_OS_SRC};branch=${SRCBRANCH}"
+SRCREV = "3.7.0"
+
+SRC_URI_append = " file://0001-imx-change-imx8-prefixe-to-mx8.patch"
+
+S = "${WORKDIR}/git"
+B = "${WORKDIR}/build.${PLATFORM_FLAVOR}"
+
+# The platform flavor corresponds to the Yocto machine without the leading 'i'.
+PLATFORM_FLAVOR                 = "${@d.getVar('MACHINE')[1:]}"
+PLATFORM_FLAVOR_imx6qpdlsolox   = "mx6qsabresd"
+PLATFORM_FLAVOR_imx6ul7d        = "mx6ulevk"
+PLATFORM_FLAVOR_imx6ull14x14evk = "mx6ullevk"
+PLATFORM_FLAVOR_imx6ull9x9evk   = "mx6ullevk"
+PLATFORM_FLAVOR_imx6ulz14x14evk = "mx6ullevk"
+
+OPTEE_ARCH ?= "arm32"
+OPTEE_ARCH_armv7a = "arm32"
+OPTEE_ARCH_aarch64 = "arm64"
+
+# Optee-os can be built for 32 bits and 64 bits at the same time
+# as long as the compilers are correctly defined.
+# For 64bits, CROSS_COMPILE64 must be set
+# When defining CROSS_COMPILE and CROSS_COMPILE64, we assure that
+# any 32 or 64 bits builds will pass
+EXTRA_OEMAKE = "PLATFORM=imx PLATFORM_FLAVOR=${PLATFORM_FLAVOR} \
+                CROSS_COMPILE=${HOST_PREFIX} \
+                CROSS_COMPILE64=${HOST_PREFIX} \
+                NOWERROR=1 \
+                O=${B} \
+                "
+
+do_compile () {
+    unset LDFLAGS
+    export CFLAGS="${CFLAGS} --sysroot=${STAGING_DIR_HOST}"
+    oe_runmake -C ${S} all
+}
+
+do_deploy () {
+    install -d ${DEPLOYDIR}
+    ${TARGET_PREFIX}objcopy -O binary ${B}/core/tee.elf ${DEPLOYDIR}/tee.${PLATFORM_FLAVOR}.bin
+
+    if [ "${OPTEE_ARCH}" != "arm64" ]; then
+        IMX_LOAD_ADDR=`cat ${B}/core/tee-init_load_addr.txt` && \
+        uboot-mkimage -A arm -O linux -C none -a ${IMX_LOAD_ADDR} -e ${IMX_LOAD_ADDR} \
+            -d ${DEPLOYDIR}/tee.${PLATFORM_FLAVOR}.bin ${DEPLOYDIR}/uTee-${OPTEE_BIN_EXT}
+    fi
+
+    cd ${DEPLOYDIR}
+    ln -sf tee.${PLATFORM_FLAVOR}.bin tee.bin
+    cd -
+}
+
+do_install () {
+    install -d ${D}/lib/firmware/
+    install -m 644 ${B}/core/*.bin ${D}/lib/firmware/
+
+    # Install the TA devkit
+    install -d ${D}/usr/include/optee/export-user_ta_${OPTEE_ARCH}/
+
+    for f in ${B}/export-ta_${OPTEE_ARCH}/*; do
+        cp -aR $f ${D}/usr/include/optee/export-user_ta_${OPTEE_ARCH}/
+    done
+}
+
+addtask deploy after do_compile before do_install
+
+FILES_${PN} = "${nonarch_base_libdir}/firmware/"
+FILES_${PN}-staticdev = "/usr/include/optee/"
+RDEPENDS_${PN}-dev += "${PN}-staticdev"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+COMPATIBLE_MACHINE = "(imx)"

--- a/recipes-security/optee-imx/optee-test/0001-fix-build-failure-with-GCC-9-v2.patch
+++ b/recipes-security/optee-imx/optee-test/0001-fix-build-failure-with-GCC-9-v2.patch
@@ -1,0 +1,27 @@
+From 825c59ba5ac7bb1e63d58b80c7d41d9ad22e89bd Mon Sep 17 00:00:00 2001
+From: Clement Faure <clement.faure@nxp.com>
+Date: Wed, 27 Nov 2019 18:18:48 +0100
+Subject: [PATCH] fix build failure with GCC 9 v2
+
+Signed-off-by: Clement Faure <clement.faure@nxp.com>
+---
+ host/xtest/Makefile | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/host/xtest/Makefile b/host/xtest/Makefile
+index 7b3de36..0c95e95 100644
+--- a/host/xtest/Makefile
++++ b/host/xtest/Makefile
+@@ -160,7 +160,8 @@ CFLAGS += -Wall -Wcast-align -Werror \
+ 	  -Wwrite-strings \
+ 	  -Wno-declaration-after-statement \
+ 	  -Wno-unsafe-loop-optimizations \
+-	  -Wno-missing-field-initializers -Wno-format-zero-length
++	  -Wno-missing-field-initializers -Wno-format-zero-length \
++	  -Wno-format-overflow
+ endif
+ 
+ CFLAGS += -g3
+-- 
+2.17.1
+

--- a/recipes-security/optee-imx/optee-test_3.7.0.imx.bb
+++ b/recipes-security/optee-imx/optee-test_3.7.0.imx.bb
@@ -1,0 +1,49 @@
+# Copyright (C) 2019 NXP
+
+SUMMARY = "OPTEE test"
+HOMEPAGE = "http://www.optee.org/"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://LICENSE.md;md5=daa2bcccc666345ab8940aab1315a4fa"
+
+DEPENDS = "optee-os optee-client python3-pycrypto-native openssl"
+inherit pythonnative
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRCBRANCH = "master"
+OPTEE_TEST_SRC ?= "git://github.com/OP-TEE/optee_test.git;protocol=https"
+SRCREV = "3.7.0"
+SRC_URI = "${OPTEE_TEST_SRC};branch=${SRCBRANCH}"
+SRC_URI_append = " file://0001-fix-build-failure-with-GCC-9-v2.patch"
+
+S = "${WORKDIR}/git"
+
+do_compile () {
+    if [ ${TUNE_ARCH} = "aarch64" ];then
+        export TA_DEV_KIT_DIR=${STAGING_INCDIR}/optee/export-user_ta_arm64/
+        export ARCH=arm64
+    else
+        export TA_DEV_KIT_DIR=${STAGING_INCDIR}/optee/export-user_ta_arm32/
+        export ARCH=arm
+    fi
+    export OPTEE_CLIENT_EXPORT=${STAGING_DIR_HOST}/usr
+    export CROSS_COMPILE_HOST=${HOST_PREFIX}
+    export CROSS_COMPILE_TA=${HOST_PREFIX}
+    export CROSS_COMPILE=${HOST_PREFIX}
+    export OPTEE_OPENSSL_EXPORT=${STAGING_INCDIR}/
+    oe_runmake -C ${S} O=${B}
+}
+
+do_install () {
+    install -d ${D}/usr/bin
+    install ${B}/xtest/xtest ${D}/usr/bin/
+
+    install -d ${D}/lib/optee_armtz
+    find ${B}/ta -name '*.ta' | while read name; do
+    install -m 444 $name ${D}/lib/optee_armtz/
+    done
+}
+
+FILES_${PN} = "/usr/bin/ /lib*/optee_armtz/"
+
+COMPATIBLE_MACHINE = "(imx)"


### PR DESCRIPTION
Add 3.7.0 recipes for the following packages:
	* optee-os
	* optee-test
	* optee-client

Signed-off-by: Clement Faure <clement.faure@nxp.com>