### PR TITLE
firmware-imx: split sdma into their own packages

### DIFF
--- a/recipes-bsp/firmware-imx/firmware-imx_8.1.1.bb
+++ b/recipes-bsp/firmware-imx/firmware-imx_8.1.1.bb
@@ -60,6 +60,13 @@ python populate_packages_prepend() {
                       description='Freescale IMX Firmware %s',
                       extra_depends='',
                       prepend=True)
+
+    imxsdmadir = bb.data.expand('${base_libdir}/firmware/imx/sdma', d)
+    do_split_packages(d, imxsdmadir, '^sdma-([^-]*).*\.bin',
+                      output_pattern='firmware-imx-sdma-%s',
+                      description='Freescale IMX Firmware %s',
+                      extra_depends='',
+                      prepend=True)
 }
 
 ALLOW_EMPTY_${PN} = "1"


### PR DESCRIPTION
The sdma firmware of mx7d/mx6 are being installed to
${base_libdir}/firmware/imx/sdma, so they should be split into their
own packages by matching that directory.

Also change MACHINE_FIRMWARE to include these sdma firmware packages.

Signed-off-by: Ming Liu <liu.ming50@gmail.com>