### PR TITLE
Finalize linux kernel update, resolve outstanding build errors

### DIFF
--- a/recipes-kernel/kernel-modules/kernel-module-imx-gpu-viv_6.4.0.p1.0.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-imx-gpu-viv_6.4.0.p1.0.bb
@@ -7,14 +7,14 @@ allowing flexibility to use a newer graphics release with an older kernel."
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6"
 
-SRCBRANCH = "imx_4.14.98_2.0.0_ga"
+SRCBRANCH = "imx_4.19.35_1.1.0"
 LOCALVERSION = "-${SRCBRANCH}"
 KERNEL_SRC ?= "git://source.codeaurora.org/external/imx/linux-imx.git;protocol=https"
 SRC_URI = " \
     ${KERNEL_SRC};branch=${SRCBRANCH};subpath=drivers/mxc/gpu-viv;destsuffix=git/src \
     file://Add-makefile.patch \
 "
-SRCREV = "f54dc1486d13d44766cdb6551d094313f077b535"
+SRCREV = "0f9917c56d5995e1dc3bde5658e2d7bc865464de"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-kernel/linux/linux-imx-headers_4.19.35.bb
+++ b/recipes-kernel/linux/linux-imx-headers_4.19.35.bb
@@ -5,7 +5,7 @@ SUMMARY = "Installs i.MX-specific kernel headers"
 DESCRIPTION = "Installs i.MX-specific kernel headers to userspace. \            
 New headers are installed in ${includedir}/imx."                                
 LICENSE = "GPLv2"                                                               
-LIC_FILES_CHKSUM = "file://COPYING;md5=d7810fab7487fb0aad327b76f1be7cd7"        
+LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
                                                                                 
 SRCBRANCH = "imx_4.19.35_1.1.0"                                              
 LOCALVERSION = "-1.1.0"                                                           


### PR DESCRIPTION
Since the kernel update, there has been few build errors that this PR is addressing:
- Vivante Kernel module was left from kernel version 4.14.y which caused compilation error, this is solved by updating to the version available in 4.19.y kernel source tree from NXP;
- Linux header recipe had an old MD5 checksum of License file, this has been updated to match the License available in 4.19.y tree.

-- andrey