### PR TITLE
gstreamer1.0_1.14.imx: Add backported patches for GST_PROTECTION_UNSP…

### DIFF
--- a/recipes-multimedia/gstreamer/files/0001-protection-Add-a-new-definition-for-unspecified-syst.patch
+++ b/recipes-multimedia/gstreamer/files/0001-protection-Add-a-new-definition-for-unspecified-syst.patch
@@ -1,0 +1,68 @@
+From 05a3da347b3b8dbaf470793dc3f9ebb23e6fc67f Mon Sep 17 00:00:00 2001
+From: Yacine Bandou <yacine.bandou@softathome.com>
+Date: Mon, 1 Oct 2018 12:11:47 +0200
+Subject: [PATCH] protection: Add a new definition for unspecified system
+ protection
+
+In some cases the system protection ID is not present in the contents
+or in their metadata.
+This define is used to set the value of the "system_id" field in GstProtectionEvent,
+with this value, the application will use an external information to choose which
+protection system to use.
+
+Example: The matroskademux uses this value in the case of encrypted WebM,
+the application will choose the appropriate protection system based on the information
+received through EME API.
+
+https://bugzilla.gnome.org/show_bug.cgi?id=797231
+Upstream-Status: Backport [1.15.1]
+
+---
+ docs/gst/gstreamer-sections.txt |  1 +
+ gst/gstprotection.h             | 18 ++++++++++++++++++
+ 2 files changed, 19 insertions(+)
+
+diff --git a/docs/gst/gstreamer-sections.txt b/docs/gst/gstreamer-sections.txt
+index 492c4d5..ecc6b04 100644
+--- a/docs/gst/gstreamer-sections.txt
++++ b/docs/gst/gstreamer-sections.txt
+@@ -2506,6 +2506,7 @@ gst_buffer_get_protection_meta
+ gst_protection_select_system
+ gst_protection_filter_systems_by_available_decryptors
+ GST_PROTECTION_SYSTEM_ID_CAPS_FIELD
++GST_PROTECTION_UNSPECIFIED_SYSTEM_ID
+ <SUBSECTION Standard>
+ GST_PROTECTION_META_API_TYPE
+ GST_PROTECTION_META_INFO
+diff --git a/gst/gstprotection.h b/gst/gstprotection.h
+index a7669ea..0ed87e4 100644
+--- a/gst/gstprotection.h
++++ b/gst/gstprotection.h
+@@ -34,6 +34,24 @@ G_BEGIN_DECLS
+  */
+ #define GST_PROTECTION_SYSTEM_ID_CAPS_FIELD "protection-system"
+ 
++/**
++ * GST_PROTECTION_UNSPECIFIED_SYSTEM_ID:
++ *
++ * The protection system value of the unspecified UUID.
++ * In some cases the system protection ID is not present in the contents or in their
++ * metadata, as encrypted WebM.
++ * This define is used to set the value of the "system_id" field in GstProtectionEvent,
++ * with this value, the application will use an external information to choose which
++ * protection system to use.
++ *
++ * Example: The matroskademux uses this value in the case of encrypted WebM,
++ * the application will choose the appropriate protection system based on the information
++ * received through EME API.
++ *
++ * Since: 1.16
++ */
++#define GST_PROTECTION_UNSPECIFIED_SYSTEM_ID "unspecified.gstreamer.org"
++
+ typedef struct _GstProtectionMeta GstProtectionMeta;
+ /**
+  * GstProtectionMeta:
+-- 
+2.7.4
+

--- a/recipes-multimedia/gstreamer/files/0001-protection-Fix-the-string-to-define-unspecified-syst.patch
+++ b/recipes-multimedia/gstreamer/files/0001-protection-Fix-the-string-to-define-unspecified-syst.patch
@@ -1,0 +1,28 @@
+From b89b1802df44829a0c034db5807bc893ad3c7774 Mon Sep 17 00:00:00 2001
+From: Thibault Saunier <tsaunier@igalia.com>
+Date: Wed, 3 Oct 2018 18:23:01 +0200
+Subject: [PATCH] protection: Fix the string to define unspecified system id
+
+Setting it to "unspecified-system-id".
+
+Upstream-Status: Backport [1.15.1]
+---
+ gst/gstprotection.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gst/gstprotection.h b/gst/gstprotection.h
+index 0ed87e4..f77a7bf 100644
+--- a/gst/gstprotection.h
++++ b/gst/gstprotection.h
+@@ -50,7 +50,7 @@ G_BEGIN_DECLS
+  *
+  * Since: 1.16
+  */
+-#define GST_PROTECTION_UNSPECIFIED_SYSTEM_ID "unspecified.gstreamer.org"
++#define GST_PROTECTION_UNSPECIFIED_SYSTEM_ID "unspecified-system-id"
+ 
+ typedef struct _GstProtectionMeta GstProtectionMeta;
+ /**
+-- 
+2.7.4
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0_1.14.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0_1.14.imx.bb
@@ -26,6 +26,8 @@ SRC_URI = " \
     file://0001-introspection.m4-prefix-pkgconfig-paths-with-PKG_CON.patch \
     file://gtk-doc-tweaks.patch \
     file://0001-gst-gstpluginloader.c-when-env-var-is-set-do-not-fal.patch \
+    file://0001-protection-Add-a-new-definition-for-unspecified-syst.patch \
+    file://0001-protection-Fix-the-string-to-define-unspecified-syst.patch \
 "
 SRCREV = "d42548da09724ad8cc1aa4f1944607920be2f4c0"
 


### PR DESCRIPTION
…ECIFIED_SYSTEM_ID

latest wpewebkit uses GST_PROTECTION_UNSPECIFIED_SYSTEM_ID definition
in its EME implementation.

Signed-off-by: Peter Griffin <peter.griffin@linaro.org>