### PR TITLE
python: add python-pyelftools

### DIFF
--- a/recipes-devtools/python/python-pyelftools.inc
+++ b/recipes-devtools/python/python-pyelftools.inc
@@ -1,0 +1,12 @@
+SUMMARY = "Python library and tools for doing stuff with EFL files."
+DESCRIPTION = "Minimal but very flexible implementation of the expect pattern"
+SECTION = "devel/python"
+HOMEPAGE = " git://github.com/eliben/pyelftools"
+LICENSE = "PD"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=5ce2a2b07fca326bc7c146d10105ccfc"
+
+inherit pypi python3native
+
+SRC_URI[sha256sum] = "89c6da6f56280c37a5ff33468591ba9a124e17d71fe42de971818cbff46c1b24"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/python/python3-pyelftools_0.25.bb
+++ b/recipes-devtools/python/python3-pyelftools_0.25.bb
@@ -1,0 +1,2 @@
+inherit setuptools3
+require python-pyelftools.inc


### PR DESCRIPTION
```pyelftools``` is a pure-Python library for parsing and analyzing ELF files and DWARF debugging information. See the User's guide for more details.

Pyelftool has been added to OE core in ```master``` branch:
https://github.com/openembedded/meta-openembedded/commit/799925fd48cf0156caa85ef3b7f38da792fb5337

It won't be backport to OE zeus branch unfortunately.

This recipe is required by Optee 3.7.0