### PR TITLE
imx-alsa-plugins: update to commit cde60d6

### DIFF
--- a/recipes-multimedia/alsa/imx-alsa-plugins_1.0.26.bb
+++ b/recipes-multimedia/alsa/imx-alsa-plugins_1.0.26.bb
@@ -17,9 +17,9 @@ LIC_FILES_CHKSUM = "file://COPYING.GPL;md5=94d55d512a9ba36caa9b7df079bae19f"
 
 inherit autotools pkgconfig use-imx-headers
 
-SRCBRANCH = "nxp/master"
+SRCBRANCH = "MM_04.05.01_1909_L4.19.35"
 SRC_URI = "git://source.codeaurora.org/external/imx/imx-alsa-plugins.git;protocol=https;branch=${SRCBRANCH}"
-SRCREV = "9a63071e7734bd164017f3761b8d1944c017611f"
+SRCREV = "cde60d68ab2acee913dbfacb8aabb53d87dd3e38"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
With the change to linux-imx-headers 4.19.35 the build of imx-alsa-plugins
fails. Likely "linux/mxc_asrc.h" would require an include.
In the latest sources this is done in the source file which includes it.

| /workdir/oe/tmp/work/aarch64-mx8-tdx-linux/imx-alsa-plugins/1.0.26-r0/recipe-sysroot/usr/include/imx/linux/mxc_asrc.h:125:2: error: unknown type name 'snd_pcm_format_t'
|   125 |  snd_pcm_format_t input_format;
ff.

From the imx-alsa-plugins commit:
    Include latest asrc_pair change for k4.14 build [YOCIMX-3558]

    asrc_pair: update according to latest mxc_asrc.h

    The mxc_asrc.h is updated for supporting new module on 815.
    The main change is the xxx_word_width is replaced by xxx_format.

    As we've switched to use git fork build, change recipe PV to 'git'.
    Will upstream this recipe to community later.

    Signed-off-by: Yuqing Zhu <carol.zhu@nxp.com>

Signed-off-by: Max Krummenacher <max.krummenacher@toradex.com>