### PR TITLE
linux-qoriq recipes: reorder merge_delta_config task

### DIFF
--- a/recipes-kernel/linux/linux-qoriq-rt_4.14.bb
+++ b/recipes-kernel/linux/linux-qoriq-rt_4.14.bb
@@ -37,7 +37,7 @@ do_merge_delta_config[dirs] = "${B}"
 do_merge_delta_config() {
     # create config with make config
     oe_runmake  -C ${S} O=${B} ${KERNEL_DEFCONFIG}
-    
+
     # check if bigendian is enabled
     if [ "${SITEINFO_ENDIANNESS}" = "be" ]; then
         echo "CONFIG_CPU_BIG_ENDIAN=y" >> .config
@@ -56,7 +56,7 @@ do_merge_delta_config() {
     done
     cp .config ${WORKDIR}/defconfig
 }
-addtask merge_delta_config before do_preconfigure after do_patch
+addtask merge_delta_config before do_configure after do_patch do_preconfigure
 
 # The link of dts folder is needed for 32b compile of aarch64 targets(e.g. ls1043ardb-32b)
 do_compile_prepend_fsl-lsch2-32b() {

--- a/recipes-kernel/linux/linux-qoriq_4.14.bb
+++ b/recipes-kernel/linux/linux-qoriq_4.14.bb
@@ -56,7 +56,7 @@ do_merge_delta_config() {
     done
     cp .config ${WORKDIR}/defconfig
 }
-addtask merge_delta_config before do_preconfigure after do_patch
+addtask merge_delta_config before do_configure after do_patch do_preconfigure
 
 # The link of dts folder is needed for 32b compile of aarch64 targets(e.g. ls1043ardb-32b)
 do_compile_prepend_fsl-lsch2-32b() {

--- a/recipes-kernel/linux/linux-qoriq_4.19.bb
+++ b/recipes-kernel/linux/linux-qoriq_4.19.bb
@@ -57,7 +57,7 @@ do_merge_delta_config() {
     done
     cp .config ${WORKDIR}/defconfig
 }
-addtask merge_delta_config before do_preconfigure after do_patch
+addtask merge_delta_config before do_configure after do_patch do_preconfigure
 
 # The link of dts folder is needed for 32b compile of aarch64 targets(e.g. ls1043ardb-32b)
 do_compile_prepend_fsl-lsch2-32b() {


### PR DESCRIPTION
I've tried build linux-variscite where the maintainers seem to have
copied the 'merge_delta_config' task from the linux-qoriq recipe from
meta-freescale.

When i tried to use that task to add some linux kernel config flags it
did not work. It seems like the 'do_preconfigure' task inherited by the
'fsl-kernel-localversion' class deletes all content of the '.config'
file AFTER it has been merged by the 'merge_delta_config' task.

I reordered the tasks so that merge_delta_config is run after
preconfigure:

addtask merge_delta_config before do_configure after do_patch
do_preconfigure

which solved the problem for me. The flags were then added and compiled
into the kernel.

Signed-off-by: Florian Voit <voit@zuhause-plattform.de>