### PR TITLE
imx-boot: Use imx-seco firmware

### DIFF
--- a/recipes-bsp/imx-mkimage/imx-boot_0.2.bb
+++ b/recipes-bsp/imx-mkimage/imx-boot_0.2.bb
@@ -1,4 +1,4 @@
-# Copyright 2017-2018 NXP
+# Copyright 2017-2019 NXP
 
 require imx-mkimage_git.inc
 
@@ -7,9 +7,9 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6"
 SECTION = "BSP"
 
-IMX_EXTRA_FIRMWARE      = "firmware-imx-8 imx-sc-firmware"
+IMX_EXTRA_FIRMWARE      = "firmware-imx-8 imx-sc-firmware imx-seco"
 IMX_EXTRA_FIRMWARE_mx8m = "firmware-imx-8m"
-IMX_EXTRA_FIRMWARE_mx8x = "firmware-imx-8x imx-sc-firmware"
+IMX_EXTRA_FIRMWARE_mx8x = "imx-sc-firmware imx-seco"
 DEPENDS += " \
     firmware-imx \
     ${IMX_EXTRA_FIRMWARE} \


### PR DESCRIPTION
Account for imx-seco split from firmware-imx.

Signed-off-by: Mihai Lindner <mihai.lindner@nxp.com>