### PR TITLE
Revert "linux-qoriq recipes: reorder merge_delta_config task"

### DIFF
--- a/recipes-kernel/linux/linux-qoriq-rt_4.14.bb
+++ b/recipes-kernel/linux/linux-qoriq-rt_4.14.bb
@@ -37,7 +37,7 @@ do_merge_delta_config[dirs] = "${B}"
 do_merge_delta_config() {
     # create config with make config
     oe_runmake  -C ${S} O=${B} ${KERNEL_DEFCONFIG}
-
+    
     # check if bigendian is enabled
     if [ "${SITEINFO_ENDIANNESS}" = "be" ]; then
         echo "CONFIG_CPU_BIG_ENDIAN=y" >> .config
@@ -56,7 +56,7 @@ do_merge_delta_config() {
     done
     cp .config ${WORKDIR}/defconfig
 }
-addtask merge_delta_config before do_configure after do_patch do_preconfigure
+addtask merge_delta_config before do_preconfigure after do_patch
 
 # The link of dts folder is needed for 32b compile of aarch64 targets(e.g. ls1043ardb-32b)
 do_compile_prepend_fsl-lsch2-32b() {

--- a/recipes-kernel/linux/linux-qoriq_4.14.bb
+++ b/recipes-kernel/linux/linux-qoriq_4.14.bb
@@ -56,7 +56,7 @@ do_merge_delta_config() {
     done
     cp .config ${WORKDIR}/defconfig
 }
-addtask merge_delta_config before do_configure after do_patch do_preconfigure
+addtask merge_delta_config before do_preconfigure after do_patch
 
 # The link of dts folder is needed for 32b compile of aarch64 targets(e.g. ls1043ardb-32b)
 do_compile_prepend_fsl-lsch2-32b() {

--- a/recipes-kernel/linux/linux-qoriq_4.19.bb
+++ b/recipes-kernel/linux/linux-qoriq_4.19.bb
@@ -57,7 +57,7 @@ do_merge_delta_config() {
     done
     cp .config ${WORKDIR}/defconfig
 }
-addtask merge_delta_config before do_configure after do_patch do_preconfigure
+addtask merge_delta_config before do_preconfigure after do_patch
 
 # The link of dts folder is needed for 32b compile of aarch64 targets(e.g. ls1043ardb-32b)
 do_compile_prepend_fsl-lsch2-32b() {


### PR DESCRIPTION
This reverts commit 6e0b6f295fa7f62484b7a448fb729fbd32191a6b,
which unfortunately causes a blank build for e.g. ls2088ardb fail as that

This closes https://github.com/Freescale/meta-freescale/issues/229