### PR TITLE
kernel-itbimage.bbclass: Align the usage to spaces for indentation, as spaces raise the warning

### DIFF
--- a/classes/kernel-itbimage.bbclass
+++ b/classes/kernel-itbimage.bbclass
@@ -12,9 +12,9 @@ python __anonymous () {
         else:
             replacementtype = "vmlinux"
 
-	# Override KERNEL_IMAGETYPE_FOR_MAKE variable, which is internal
-	# to kernel.bbclass . We have to override it, since we pack zImage
-	# (at least for now) into the fitImage .
+        # Override KERNEL_IMAGETYPE_FOR_MAKE variable, which is internal
+        # to kernel.bbclass . We have to override it, since we pack zImage
+        # (at least for now) into the fitImage .
         typeformake = d.getVar("KERNEL_IMAGETYPE_FOR_MAKE") or ""
         if 'itbImage' in typeformake.split():
             d.setVar('KERNEL_IMAGETYPE_FOR_MAKE', typeformake.replace('itbImage', replacementtype))


### PR DESCRIPTION

Signed-off-by: Darko Komljenovic <dkomljenovic@zoho.com>