### PR TITLE
readme: update mailing list url

### DIFF
--- a/README
+++ b/README
@@ -27,7 +27,7 @@ follow-up discussions please use the GitHub's notification system.
 
 Mailing list:
 
-    https://lists.yoctoproject.org/listinfo/meta-freescale
+    https://lists.yoctoproject.org/g/meta-freescale
 
 Source code:
 


### PR DESCRIPTION
The current link returns a 404 error.

Update the mailing list link to:
    https://lists.yoctoproject.org/g/meta-freescale

Signed-off-by: Mattijs Korpershoek <mattijs.korpershoek@gmail.com>