### PR TITLE
imx-base.inc: Do not pin weston's version when using mainline-bsp

### DIFF
--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -255,6 +255,7 @@ PREFERRED_PROVIDER_virtual/libg2d            ?= "imx-gpu-g2d"
 PREFERRED_PROVIDER_virtual/libg2d_imxdpu     ?= "imx-dpu-g2d"
 
 PREFERRED_VERSION_weston_imx ?= "6.0.1.imx"
+PREFERRED_VERSION_weston_use-mainline-bsp = ""
 
 PREFERRED_VERSION_wayland-protocols_mx6 ?= "1.17.imx"
 PREFERRED_VERSION_wayland-protocols_mx7 ?= "1.17.imx"


### PR DESCRIPTION
Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>