### PR TITLE
xf86-video-imx-vivante: fix compile by updating to 6.4.0

### DIFF
--- a/recipes-graphics/xorg-driver/xf86-video-imx-vivante_6.4.0.p0.0.bb
+++ b/recipes-graphics/xorg-driver/xf86-video-imx-vivante_6.4.0.p0.0.bb
@@ -13,7 +13,7 @@ DEPENDS += "virtual/xserver virtual/libx11 libgal-imx imx-gpu-viv virtual/libg2d
 
 LIC_FILES_CHKSUM = "file://COPYING-MIT;md5=b5e9d9f5c02ea831ab3ecf802bb7c4f3"
 
-SRCREV = "b765c3ffc0dcc4246afa659aa0d59f78a6736b08"
+SRCREV = "c828e8a7c38743e960967e7bb78c134cec31c102"
 SRCBRANCH = "imx_exa_viv6_g2d"
 SRC_URI = "git://source.codeaurora.org/external/imx/xf86-video-imx-vivante.git;protocol=https;branch=${SRCBRANCH} \
            file://rc.autohdmi"


### PR DESCRIPTION
Using the current HEAD fixes the following compile error:

| vivante_gal/vivante_gal_surface.c:493:38: error: 'gcvPOOL_CONTIGUOUS' undeclared (first use in this function); did you mean 'gcvSURF_CONTIGUOUS'?
|   493 |             surf->mVideoNode.mPool = gcvPOOL_CONTIGUOUS;
|       |                                      ^~~~~~~~~~~~~~~~~~

meta-fsl-bsp-release sets version to 6.4.0.p0.0 for this git hash,
follow that here.

Changelog:
MGS-4783 [#ccc] Integrate EXA patches for 6.4.0 beta

Signed-off-by: Max Krummenacher <max.krummenacher@toradex.com>