### PR TITLE
libdrm imx: fix building libdrm-vivante

### DIFF
--- a/recipes-graphics/drm/libdrm/0001-meson-add-libdrm-vivante-to-the-meson-meta-data.patch
+++ b/recipes-graphics/drm/libdrm/0001-meson-add-libdrm-vivante-to-the-meson-meta-data.patch
@@ -1,0 +1,140 @@
+From 45f48f8a5de59c04b0510c23853772bc970f411e Mon Sep 17 00:00:00 2001
+From: Max Krummenacher <max.krummenacher@toradex.com>
+Date: Thu, 9 Jan 2020 01:01:35 +0000
+Subject: [PATCH] meson: add libdrm-vivante to the meson meta data
+
+Upstream libdrm added the option to use meason as the buildsystem.
+Integrate Vivante into the relevant meson build information.
+
+Upstream-Status: Pending
+
+Signed-off-by: Max Krummenacher <max.krummenacher@toradex.com>
+---
+ meson.build         | 14 +++++++++++++
+ meson_options.txt   |  7 +++++++
+ vivante/meson.build | 50 +++++++++++++++++++++++++++++++++++++++++++++
+ 3 files changed, 71 insertions(+)
+ create mode 100644 vivante/meson.build
+
+diff --git a/meson.build b/meson.build
+index e292554a..f4740634 100644
+--- a/meson.build
++++ b/meson.build
+@@ -157,6 +157,15 @@ if _vc4 != 'false'
+   with_vc4 = _vc4 == 'true' or ['arm', 'aarch64'].contains(host_machine.cpu_family())
+ endif
+ 
++with_vivante = false
++_vivante = get_option('vivante')
++if _vivante == 'true'
++  if not with_atomics
++    error('libdrm_vivante requires atomics.')
++  endif
++  with_vivante = true
++endif
++
+ # XXX: Apparently only freebsd and dragonfly bsd actually need this (and
+ # gnu/kfreebsd), not openbsd and netbsd
+ with_libkms = false
+@@ -312,6 +321,7 @@ install_headers(
+   'include/drm/savage_drm.h', 'include/drm/sis_drm.h',
+   'include/drm/tegra_drm.h', 'include/drm/vc4_drm.h',
+   'include/drm/via_drm.h', 'include/drm/virtgpu_drm.h',
++  'include/drm/vivante_drm.h',
+   subdir : 'libdrm',
+ )
+ if with_vmwgfx
+@@ -362,6 +372,9 @@ endif
+ if with_etnaviv
+   subdir('etnaviv')
+ endif
++if with_vivante
++  subdir('vivante')
++endif
+ if with_man_pages
+   subdir('man')
+ endif
+@@ -382,5 +395,6 @@ message('  EXYNOS API     @0@'.format(with_exynos))
+ message('  Freedreno API  @0@ (kgsl: @1@)'.format(with_freedreno, with_freedreno_kgsl))
+ message('  Tegra API      @0@'.format(with_tegra))
+ message('  VC4 API        @0@'.format(with_vc4))
++message('  Vivante API    @0@'.format(with_etnaviv))
+ message('  Etnaviv API    @0@'.format(with_etnaviv))
+ message('')
+diff --git a/meson_options.txt b/meson_options.txt
+index 8af33f1c..dc69563d 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -95,6 +95,13 @@ option(
+   choices : ['true', 'false', 'auto'],
+   description : '''Enable support for vc4's KMS API.''',
+ )
++option(
++  'vivante',
++  type : 'combo',
++  value : 'false',
++  choices : ['true', 'false', 'auto'],
++  description : '''Enable support for vivante's propriatary experimental KMS API.''',
++)
+ option(
+   'etnaviv',
+   type : 'combo',
+diff --git a/vivante/meson.build b/vivante/meson.build
+new file mode 100644
+index 00000000..f6adb598
+--- /dev/null
++++ b/vivante/meson.build
+@@ -0,0 +1,50 @@
++# Copyright © 2017-2018 Intel Corporation
++
++# Permission is hereby granted, free of charge, to any person obtaining a copy
++# of this software and associated documentation files (the "Software"), to deal
++# in the Software without restriction, including without limitation the rights
++# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
++# copies of the Software, and to permit persons to whom the Software is
++# furnished to do so, subject to the following conditions:
++
++# The above copyright notice and this permission notice shall be included in
++# all copies or substantial portions of the Software.
++
++# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
++# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
++# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
++# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
++# SOFTWARE.
++
++
++libdrm_vivante = shared_library(
++  'drm_vivante',
++  [
++    files(
++      'vivante_bo.c',
++    ),
++    config_file
++  ],
++  include_directories : [inc_root, inc_drm],
++  link_with : libdrm,
++  c_args : libdrm_c_args,
++  dependencies : [dep_pthread_stubs, dep_rt, dep_atomic_ops],
++  version : '1.0.0',
++  install : true,
++)
++
++pkg.generate(
++  name : 'libdrm_vivante',
++  libraries : libdrm_vivante,
++  subdirs : ['.', 'libdrm'],
++  version : meson.project_version(),
++  requires_private : 'libdrm',
++  description : 'Userspace interface to Vivante kernel DRM services',
++)
++
++ext_libdrm_vivante = declare_dependency(
++  link_with : [libdrm, libdrm_vivante],
++  include_directories : [inc_drm, include_directories('.')],
++)
+-- 
+2.20.1
+

--- a/recipes-graphics/drm/libdrm_2.4.99.imx.bb
+++ b/recipes-graphics/drm/libdrm_2.4.99.imx.bb
@@ -13,7 +13,8 @@ DEPENDS = "libpthread-stubs"
 IMX_LIBDRM_SRC ?= "git://source.codeaurora.org/external/imx/libdrm-imx.git;protocol=https;nobranch=1"
 IMX_LIBDRM_BRANCH ?= "libdrm-imx-2.4.99"
 SRC_URI = "${IMX_LIBDRM_SRC};branch=${IMX_LIBDRM_BRANCH} \
-           file://musl-ioctl.patch"
+           file://musl-ioctl.patch \
+           file://0001-meson-add-libdrm-vivante-to-the-meson-meta-data.patch "
 SRCREV = "5748c8ff40f1ae87487c01e580f145a43542cbda"
 S = "${WORKDIR}/git"
 
@@ -63,8 +64,10 @@ FILES_${PN}-etnaviv = "${libdir}/libdrm_etnaviv.so.*"
 
 BBCLASSEXTEND = "native nativesdk"
 
-PACKAGES_append_imxgpu = " ${PN}-vivante"
+PACKAGES_prepend_imxgpu = "${PN}-vivante "
 RRECOMMENDS_${PN}-drivers_append_imxgpu = " ${PN}-vivante"
 FILES_${PN}-vivante = "${libdir}/libdrm_vivante.so.*"
+PACKAGECONFIG_append_imxgpu = " vivante"
+PACKAGECONFIG[vivante] = "-Dvivante=true,-Dvivante=false"
 
 PACKAGE_ARCH = "${MACHINE_SOCARCH}"


### PR DESCRIPTION
The recipe updates pulled in from  upstream now builds with meson but
the libdrm imx fork does not provide meson build information. Patch the
imx fork to get the ability to build with meson.

Change the recipe to actually configure libdrm-vivante and to deploy
it into its own package.

Signed-off-by: Max Krummenacher <max.krummenacher@toradex.com>