### PR TITLE
imx-base: non-overriding append for WKS_FILE_DEPENDS

### DIFF
--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -325,7 +325,7 @@ WKS_FILE_DEPENDS ?= " \
     ${@bb.utils.contains('MACHINE_FEATURES', 'optee', '${OPTEE_WKS_FILE_DEPENDS}', '', d)} \
 "
 
-WKS_FILE_DEPENDS_mx8 += "imx-boot"
+WKS_FILE_DEPENDS_append_mx8 = " imx-boot "
 
 SOC_DEFAULT_WKS_FILE ?= "imx-uboot-bootpart.wks.in"
 SOC_DEFAULT_WKS_FILE_mx8 ?= "imx-imx-boot-bootpart.wks.in"


### PR DESCRIPTION
On mx8,
  `WKS_FILE_DEPENDS_mx8 += "imx-boot"`
overrides the content of `WKS_FILE_DEPENDS` instead
of appending, causing `do_image_wic` to complain about
missing dependencies for `wic-tools`.