### PR TITLE
[zeus] fsl-vivante-kernel-driver-handler: Fix kernel name in variable assign…

### DIFF
--- a/classes/fsl-vivante-kernel-driver-handler.bbclass
+++ b/classes/fsl-vivante-kernel-driver-handler.bbclass
@@ -41,9 +41,9 @@ python fsl_vivante_kernel_driver_handler () {
         return
 
     if use_vivante_kernel_driver_module != "1":
-        e.data.appendVar('RPROVIDES_kernel-base', ' kernel-module-imx-gpu-viv')
-        e.data.appendVar('RREPLACES_kernel-base', ' kernel-module-imx-gpu-viv')
-        e.data.appendVar('RCONFLICTS_kernel-base', ' kernel-module-imx-gpu-viv')
+        e.data.appendVar('RPROVIDES_${KERNEL_PACKAGE_NAME}-base', ' kernel-module-imx-gpu-viv')
+        e.data.appendVar('RREPLACES_${KERNEL_PACKAGE_NAME}-base', ' kernel-module-imx-gpu-viv')
+        e.data.appendVar('RCONFLICTS_${KERNEL_PACKAGE_NAME}-base', ' kernel-module-imx-gpu-viv')
 }
 
 addhandler fsl_vivante_kernel_driver_handler


### PR DESCRIPTION
…ment

If the graphics driver is built into the kernel, a warning is generated
for each i.MX kernel recipe, like this:

WARNING: /home/r60874/zeus/sources/meta-imx/meta-bsp/recipes-kernel/linux/linux-imx_5.4.bb: Variable key RPROVIDES_${KERNEL_PACKAGE_NAME}-base ( ${KERNEL_PACKAGE_NAME}-${KERNEL_VERSION}) replaces original key RPROVIDES_kernel-base ( kernel-module-imx-gpu-viv).

The problem is that the kernel name used in variables is no longer a
constant 'kernel', but is now parameterized:

https://github.com/openembedded/openembedded-core/commit/6c8c899849d101fd1b86aad0b8eed05c7c785924

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>