### PR TITLE
gstreamer1.0-*: change to new gstreamer1.0 plugin includes

### DIFF
--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.16.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.16.imx.bb
@@ -1,4 +1,4 @@
-require recipes-multimedia/gstreamer/gstreamer1.0-plugins.inc
+require recipes-multimedia/gstreamer/gstreamer1.0-plugins-common.inc
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=73a5855a8119deb017f5f13cf327095d \
                     file://COPYING.LIB;md5=21682e4e8fea52413fd26c60acb907e5 "

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.16.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.16.imx.bb
@@ -1,4 +1,4 @@
-require recipes-multimedia/gstreamer/gstreamer1.0-plugins.inc
+require recipes-multimedia/gstreamer/gstreamer1.0-plugins-common.inc
 
 LICENSE = "GPLv2+ & LGPLv2+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6762ed442b3822387a51c92d928ead0d \

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.16.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.16.imx.bb
@@ -1,4 +1,4 @@
-require recipes-multimedia/gstreamer/gstreamer1.0-plugins.inc
+require recipes-multimedia/gstreamer/gstreamer1.0-plugins-common.inc
 
 LICENSE = "GPLv2+ & LGPLv2.1+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=a6f89e2100d9b6cdffcea4f398e37343 \

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-imx_git.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-imx_git.bb
@@ -61,9 +61,7 @@ PACKAGECONFIG[v4l2sink] = ",--disable-imxv4l2videosink,"
 PACKAGECONFIG[uniaudiodec] = ",--disable-uniaudiodec,imx-codec"
 PACKAGECONFIG[mp3encoder] = ",--disable-mp3encoder,imx-codec"
 
-# LIBV is used by gst-plugins-package.inc to specify the GStreamer version (0.10 vs 1.0)
-LIBV = "1.0"
-require recipes-multimedia/gstreamer/gst-plugins-package.inc
+require recipes-multimedia/gstreamer/gstreamer1.0-plugins-packaging.inc
 
 # the following line is required to produce one package for each plugin
 PACKAGES_DYNAMIC = "^${PN}-.*"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly_1.16.0.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly_1.16.0.bb
@@ -1,4 +1,4 @@
-require recipes-multimedia/gstreamer/gstreamer1.0-plugins.inc
+require recipes-multimedia/gstreamer/gstreamer1.0-plugins-common.inc
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=a6f89e2100d9b6cdffcea4f398e37343 \
                     file://tests/check/elements/xingmux.c;beginline=1;endline=21;md5=4c771b8af188724855cb99cadd390068"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-rtsp-server_1.16.0.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-rtsp-server_1.16.0.bb
@@ -23,8 +23,7 @@ inherit autotools pkgconfig upstream-version-is-even gobject-introspection gtk-d
 EXTRA_OECONF = "--disable-examples --disable-tests --disable-introspection "
 
 # Starting with 1.8.0 gst-rtsp-server includes dependency-less plugins as well
-LIBV = "1.0"
-require recipes-multimedia/gstreamer/gst-plugins-package.inc
+require recipes-multimedia/gstreamer/gstreamer1.0-plugins-packaging.inc
 
 delete_pkg_m4_file() {
         # This m4 file is out of date and is missing PKG_CONFIG_SYSROOT_PATH tweaks which we need for introspection


### PR DESCRIPTION
gst-plugins-package.inc and gstreamer1.0-plugins.inc got replaced by
gstreamer1.0-plugins-packaging.inc and gstreamer1.0-plugins-common.inc,
respectively in OE-core rev 238080ed896ea817a23aab2f25c246832ab9c7b3.

Therefore apply this change for meta-freescale too.

Signed-off-by: Richard Leitner <richard.leitner@skidata.com>