### PR TITLE
gstreamer: add inc files back

### DIFF
--- a/recipes-multimedia/gstreamer/gst-plugins-package.inc
+++ b/recipes-multimedia/gstreamer/gst-plugins-package.inc
@@ -1,0 +1,56 @@
+PACKAGESPLITFUNCS_prepend = " split_gstreamer10_packages "
+PACKAGESPLITFUNCS_append = " set_metapkg_rdepends "
+
+python split_gstreamer10_packages () {
+    gst_libdir = d.expand('${libdir}/gstreamer-${LIBV}')
+    postinst = d.getVar('plugin_postinst')
+    glibdir = d.getVar('libdir')
+
+    do_split_packages(d, glibdir, r'^lib(.*)\.so\.*', 'lib%s', 'gstreamer %s library', extra_depends='', allow_links=True)
+    do_split_packages(d, gst_libdir, r'libgst(.*)\.so$', d.expand('${PN}-%s'), 'GStreamer plugin for %s', postinst=postinst, extra_depends='')
+    do_split_packages(d, glibdir+'/girepository-1.0', r'Gst(.*)-1.0\.typelib$', d.expand('${PN}-%s-typelib'), 'GStreamer typelib file for %s', postinst=postinst, extra_depends='')
+    do_split_packages(d, gst_libdir, r'libgst(.*)\.la$', d.expand('${PN}-%s-dev'), 'GStreamer plugin for %s (development files)', extra_depends='${PN}-dev')
+    do_split_packages(d, gst_libdir, r'libgst(.*)\.a$', d.expand('${PN}-%s-staticdev'), 'GStreamer plugin for %s (static development files)', extra_depends='${PN}-staticdev')
+}
+
+python set_metapkg_rdepends () {
+    import os
+    import oe.utils
+
+    pn = d.getVar('PN')
+    metapkg =  pn + '-meta'
+    d.setVar('ALLOW_EMPTY_' + metapkg, "1")
+    d.setVar('FILES_' + metapkg, "")
+    blacklist = [ pn, pn + '-meta' ]
+    metapkg_rdepends = []
+    pkgdest = d.getVar('PKGDEST')
+    for pkg in oe.utils.packages_filter_out_system(d):
+        if pkg not in blacklist and pkg not in metapkg_rdepends:
+            # See if the package is empty by looking at the contents of its PKGDEST subdirectory. 
+            # If this subdirectory is empty, then the package is.
+            # Empty packages do not get added to the meta package's RDEPENDS
+            pkgdir = os.path.join(pkgdest, pkg)
+            if os.path.exists(pkgdir):
+                dir_contents = os.listdir(pkgdir) or []
+            else:
+                dir_contents = []
+            is_empty = len(dir_contents) == 0
+            if not is_empty:
+                metapkg_rdepends.append(pkg)
+    d.setVar('RDEPENDS_' + metapkg, ' '.join(metapkg_rdepends))
+    d.setVar('DESCRIPTION_' + metapkg, pn + ' meta package')
+}
+
+# each plugin-dev depends on PN-dev, plugin-staticdev on PN-staticdev
+# so we need them even when empty (like in gst-plugins-good case)
+ALLOW_EMPTY_${PN} = "1"
+ALLOW_EMPTY_${PN}-dev = "1"
+ALLOW_EMPTY_${PN}-staticdev = "1"
+
+PACKAGES += "${PN}-apps ${PN}-meta ${PN}-glib"
+
+FILES_${PN} = ""
+FILES_${PN}-apps = "${bindir}"
+FILES_${PN}-glib = "${datadir}/glib-2.0"
+
+RRECOMMENDS_${PN} += "${PN}-meta"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins.inc
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins.inc
@@ -1,0 +1,41 @@
+SUMMARY = "Plugins for the GStreamer multimedia framework 1.x"
+HOMEPAGE = "http://gstreamer.freedesktop.org/"
+BUGTRACKER = "https://bugzilla.gnome.org/enter_bug.cgi?product=Gstreamer"
+SECTION = "multimedia"
+
+DEPENDS = "gstreamer1.0 glib-2.0-native"
+
+SRC_URI_append = " file://gtk-doc-tweaks.patch"
+
+inherit autotools pkgconfig upstream-version-is-even gtk-doc
+
+acpaths = "-I ${S}/common/m4 -I ${S}/m4"
+
+LIBV = "1.0"
+require gst-plugins-package.inc
+
+# Orc enables runtime JIT compilation of data processing routines from Orc
+# bytecode to SIMD instructions for various architectures (currently SSE, MMX,
+# MIPS, Altivec and NEON are supported).
+
+GSTREAMER_ORC ?= "orc"
+
+PACKAGECONFIG[debug] = "--enable-debug,--disable-debug"
+PACKAGECONFIG[orc] = "--enable-orc,--disable-orc,orc orc-native"
+PACKAGECONFIG[valgrind] = "--enable-valgrind,--disable-valgrind,valgrind"
+
+export ORCC = "${STAGING_DIR_NATIVE}${bindir}/orcc"
+
+EXTRA_OECONF = " \
+    --disable-examples \
+"
+
+delete_pkg_m4_file() {
+	# This m4 file is out of date and is missing PKG_CONFIG_SYSROOT_PATH tweaks which we need for introspection
+	rm "${S}/common/m4/pkg.m4" || true
+	rm -f "${S}/common/m4/gtk-doc.m4"
+}
+
+do_configure[prefuncs] += " delete_pkg_m4_file"
+
+PACKAGES_DYNAMIC = "^${PN}-.*"


### PR DESCRIPTION
The gst-plugins-package.inc and gstreamer1.0-plugins.inc have been
dropped in OE after commit 238080ed:
[ gstreamer: Remove unused common files and patches ]

add them here, this fixes the following errors:
| ERROR: ParseError at meta-freescale/recipes-multimedia/gstreamer/gstreamer1.0-rtsp-server_1.16.0.bb:27:
| Could not include required file recipes-multimedia/gstreamer/gst-plugins-package.inc
| ERROR: ParseError at meta-freescale/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly_1.16.0.bb:1:
| Could not include required file recipes-multimedia/gstreamer/gstreamer1.0-plugins.inc

Signed-off-by: Ming Liu <liu.ming50@gmail.com>