### PR TITLE
imx-usb-loader: bump to revision f009770

### DIFF
--- a/recipes-devtools/imx-usb-loader/imx-usb-loader_git.bb
+++ b/recipes-devtools/imx-usb-loader/imx-usb-loader_git.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
 DEPENDS = "libusb1"
 
-SRCREV = "29fa8ab592924cf2294584b4a407f0a76858b60e"
+SRCREV = "f009770d841468204ab104bf7d3b0c5bc8425dbb"
 SRC_URI = "git://github.com/boundarydevices/imx_usb_loader.git;protocol=http"
 
 PV = "1.0+${SRCPV}"


### PR DESCRIPTION
Following changes are included:

f009770 imx_sdp: don't try to load hdmi firmware
c5c4d28 add SPDS protocol support, imx8mn(nano)
15dbbd7 tests: add pid 0x1001
353791c tests: add pids 0x0134/0x1000
06fb581 tests: pid=0x0080 is for mx6ull
6b07a0a mx8mm_usb_sdp_spl.conf/ mx8mm_usb_work.conf: s/imx-mkimage/u-boot-imx6/
b00b0e2 mx8mq_usb_work.conf: load flash.bin from u-boot-imx6 directory
bda7ab6 add mx8mq_usb_sdp_spl.conf
7984efc Moving libusb_free_device_list to get imx_usb to work on Windows.

Signed-off-by: Pierre-Jean Texier <pjtexier@koncepto.io>