### PR TITLE
optee-test: update to python3-pycrypto-native dependency

### DIFF
--- a/recipes-security/optee-imx/optee-test_3.2.0.imx.bb
+++ b/recipes-security/optee-imx/optee-test_3.2.0.imx.bb
@@ -6,7 +6,7 @@ HOMEPAGE = "http://www.optee.org/"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://LICENSE.md;md5=daa2bcccc666345ab8940aab1315a4fa"
 
-DEPENDS = "optee-os optee-client python-pycrypto-native openssl"
+DEPENDS = "optee-os optee-client python3-pycrypto-native openssl"
 inherit python3native
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"


### PR DESCRIPTION
As python2 packages are now dropped in oe-core.

Signed-off-by: Peter Griffin <peter.griffin@linaro.org>