### PR TITLE
fix u-boot builds

### DIFF
--- a/recipes-bsp/u-boot/u-boot-fslc-common_2019.07.inc
+++ b/recipes-bsp/u-boot/u-boot-fslc-common_2019.07.inc
@@ -16,3 +16,4 @@ SRCBRANCH = "2019.07+fslc"
 PV = "v2019.07+git${SRCPV}"
 
 S = "${WORKDIR}/git"
+B = "${WORKDIR}/build"

--- a/recipes-bsp/u-boot/u-boot-qoriq-common_2019.09.inc
+++ b/recipes-bsp/u-boot/u-boot-qoriq-common_2019.09.inc
@@ -15,5 +15,6 @@ SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/u-boot;no
 SRCREV= "ebb420ac9d67ffeaf9df2d69a928fdb3df78394a"
 
 S = "${WORKDIR}/git"
+B = "${WORKDIR}/build"
 PV_append = "+fslgit"
 LOCALVERSION = "+fsl"


### PR DESCRIPTION
In upstream openembedded-core, the definition for the B variable moved from
u-boot.inc to u-boot-common.inc. None of the recipes in this layer use
upstream's u-boot-common.inc, so add the B to the *common* include files here
so u-boot continues to build. See:

	http://cgit.openembedded.org/openembedded-core/commit/meta/recipes-bsp/u-boot?h=master-next&id=26023b6b0f897842fd98b3e10a8acd5b3ad8f418

This was build-tested with all the imx and ls* lx* MACHINES:
	$ MACHINE=<machine> bitbake virtual/bootloader -c compile

Signed-off-by: Trevor Woerner <twoerner@gmail.com>