### PR TITLE
u-boot-fslc: add lzop-native dependency for imx6qdlsabreauto

### DIFF
--- a/recipes-bsp/u-boot/u-boot-fslc_2019.07.bb
+++ b/recipes-bsp/u-boot/u-boot-fslc_2019.07.bb
@@ -7,6 +7,7 @@ was submitted for revision and it takes some time to become part of a stable \
 version, or because it is not applicable for upstreaming."
 
 DEPENDS_append = " bc-native dtc-native"
+DEPENDS_append_imx6qdlsabreauto = " lzop-native"
 
 PROVIDES += "u-boot"
 


### PR DESCRIPTION
The imx6qdlsabreauto MACHINE needs lzop-native for its u-boot to build.

Signed-off-by: Trevor Woerner <twoerner@gmail.com>