### PR TITLE
u-boot-fslc: add lzop-native dependency

### DIFF
--- a/recipes-bsp/u-boot/u-boot-fslc_2019.07.bb
+++ b/recipes-bsp/u-boot/u-boot-fslc_2019.07.bb
@@ -6,7 +6,7 @@ order to provide support for some backported features and fixes, or because it \
 was submitted for revision and it takes some time to become part of a stable \
 version, or because it is not applicable for upstreaming."
 
-DEPENDS_append = " bc-native dtc-native"
+DEPENDS_append = " bc-native dtc-native lzop-native"
 
 PROVIDES += "u-boot"
 


### PR DESCRIPTION
Currently imx6qdlsabreauto is configured to generate an lzop-compressed u-boot
fit image, therefore a lzop-native is required on the host. Add this
dependency generically since more MACHINEs might switch over in time.

Signed-off-by: Trevor Woerner <twoerner@gmail.com>