### PR TITLE
u-boot-fslc-mxsboot-native: B!=S fix

### DIFF
--- a/recipes-bsp/u-boot/u-boot-fslc-mxsboot_2019.07.bb
+++ b/recipes-bsp/u-boot/u-boot-fslc-mxsboot_2019.07.bb
@@ -12,14 +12,14 @@ EXTRA_OEMAKE_class-native = 'CC="${BUILD_CC} ${BUILD_CFLAGS} ${BUILD_LDFLAGS}" H
 EXTRA_OEMAKE_class-nativesdk = 'CROSS_COMPILE="${HOST_PREFIX}" CC="${CC} ${CFLAGS} ${LDFLAGS}" HOSTCC="${BUILD_CC} ${BUILD_CFLAGS} ${BUILD_LDFLAGS}" STRIP=true V=1 CONFIG_MX28=y'
 
 do_compile () {
-    oe_runmake sandbox_defconfig
+    oe_runmake -C ${S} O=${B} sandbox_defconfig
 
     # Disable CONFIG_CMD_LICENSE, license.h is not used by tools and
     # generating it requires bin2header tool, which for target build
     # is built with target tools and thus cannot be executed on host.
     sed -i "s/CONFIG_CMD_LICENSE=.*/# CONFIG_CMD_LICENSE is not set/" .config
 
-    oe_runmake cross_tools NO_SDL=1
+    oe_runmake -C ${S} O=${B} cross_tools NO_SDL=1
 }
 
 do_install () {


### PR DESCRIPTION
MACHINEs such as the imx23evk and imx28evk (i.e. the mxs MACHINEs)
failed to build because the recipe for u-boot-fslc-mxsboot-native wasn't
instrumented to support ${B} != ${S}, which is used as a result of inheriting
u-boot-fslc-common. In other words, the inherit was setting up ${B} != ${S},
but then u-boot-fslc-mxsboot didn't know what to do in this scenario.

Signed-off-by: Trevor Woerner <twoerner@gmail.com>