### PR TITLE
Allow to enable Etnaviv and Gallium for i.MX8

### DIFF
--- a/recipes-graphics/mesa/mesa_%.bbappend
+++ b/recipes-graphics/mesa/mesa_%.bbappend
@@ -16,8 +16,8 @@ python () {
 
 # Enable Etnaviv and Freedreno support
 PACKAGECONFIG_append_use-mainline-bsp = " gallium"
-GALLIUMDRIVERS_append_use-mainline-bsp_armv7a = ",etnaviv,freedreno,kmsro,vc4"
-GALLIUMDRIVERS_append_use-mainline-bsp_armv7ve = ",etnaviv,freedreno,kmsro,vc4"
+PACKAGECONFIG_append_use-mainline-bsp_armv7a = " etnaviv freedreno kmsro vc4"
+PACKAGECONFIG_append_use-mainline-bsp_armv7ve = " etnaviv freedreno kmsro vc4"
 
 # Define the osmesa block in PACKAGECONFIG for target, this block is
 # not defined in the master recipe, effectively causing the osmesa

--- a/recipes-graphics/mesa/mesa_%.bbappend
+++ b/recipes-graphics/mesa/mesa_%.bbappend
@@ -18,19 +18,19 @@ python () {
 PACKAGECONFIG_append_use-mainline-bsp = " gallium"
 PACKAGECONFIG_append_use-mainline-bsp_armv7a = " etnaviv freedreno kmsro vc4"
 PACKAGECONFIG_append_use-mainline-bsp_armv7ve = " etnaviv freedreno kmsro vc4"
+PACKAGECONFIG_append_use-mainline-bsp_mx8 = " etnaviv kmsro vc4"
 
-# Define the osmesa block in PACKAGECONFIG for target, this block is
-# not defined in the master recipe, effectively causing the osmesa
-# feature to be disabled and -Dosmesa=none set.
-PACKAGECONFIG_append_mx8 = " osmesa"
+USE_OSMESA_ONLY ?= "no"
 
-# Solve 'Problem encountered: OSMesa classic requires dri (classic) swrast.'
-# by defining the dri swrast for mx8mm machine
-DRIDRIVERS_append_mx8 = "swrast"
+# Etnaviv support state for i.MX8 is unknown, therefore only enable OSMesa and
+# disable Gallium for now. If you still want to enable Etnaviv, just set
+# USE_OSMESA_ONLY_mx8 = "no" in your bbappend.
+USE_OSMESA_ONLY_mx8 ?= "yes"
 
-# Solve 'ERROR: Problem encountered: Only one swrast provider can be built'
-# by excluding gallium support, dri is used together with 'classic' mesa backend.
-PACKAGECONFIG_remove_mx8 = "gallium"
+# Enable OSMesa which also requires dri (classic) swrast
+PACKAGECONFIG_append = " ${@oe.utils.conditional('USE_OSMESA_ONLY', 'yes', ' osmesa', '', d)}"
+PACKAGECONFIG_remove = " ${@oe.utils.conditional('USE_OSMESA_ONLY', 'yes', 'gallium', '', d)}"
+DRIDRIVERS_append = "${@oe.utils.conditional('USE_OSMESA_ONLY', 'yes', 'swrast', '', d)}"
 
 BACKEND = \
     "${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'wayland', \


### PR DESCRIPTION
**Change 1 (cosmetic):**
We don't need to manipulate the GALLIUMDRIVERS variable. Setting the
correct PACKAGECONFIG options is enough as the main recipe handles
the rest.

**Change 2 (support Etnaviv for i.MX8)**
Currently the settings for i.MX8 are fixed to only allow to use
OSMesa for offscreen rendering. Actually etnaviv is usable on
i.MX8MM an it should therefore be possible to let Gallium be
enabled instead of unconditionally disabling it.

Therefore we introduce the USE_OSMESA_ONLY variable, that can be
set to "no" for i.MX8 if etnaviv should be used just like for i.MX6.
