### PR TITLE
mx8qm: Use cortexa72-cortexa53 tune by default

### DIFF
--- a/conf/machine/imx8qmmek.conf
+++ b/conf/machine/imx8qmmek.conf
@@ -6,7 +6,7 @@
 MACHINEOVERRIDES =. "mx8:mx8qm:"
 
 require conf/machine/include/imx-base.inc
-require conf/machine/include/arm/arch-arm64.inc
+require conf/machine/include/tune-cortexa72-cortexa53.inc
 
 MACHINE_FEATURES_append = " qca6174"
 

--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -66,6 +66,7 @@ DEFAULTTUNE_mx7 ?= "cortexa7thf-neon"
 DEFAULTTUNE_vf ?= "cortexa5thf-neon"
 DEFAULTTUNE_mx8mm ?= "cortexa53-crypto"
 DEFAULTTUNE_mx8mn ?= "cortexa53-crypto"
+DEFAULTTUNE_mx8qm ?= "cortexa72-cortexa53-crypto"
 
 INHERIT += "machine-overrides-extender"
 


### PR DESCRIPTION
Use the cortexa72-cortexa53-crypto tune for IMX.8 QuadMax devices
instead of the more generic aarch64. Update the QuadMax MEK machine to
require the file that provides this tune.

Signed-off-by: Joshua Watt <Joshua.Watt@garmin.com>