### PR TITLE
linux-imx: backport patch to fix perf build with latest binutils

### DIFF
--- a/recipes-kernel/linux/linux-imx-4.19.35/0001-perf-Make-perf-able-to-build-with-latest-libbfd.patch
+++ b/recipes-kernel/linux/linux-imx-4.19.35/0001-perf-Make-perf-able-to-build-with-latest-libbfd.patch
@@ -1,0 +1,61 @@
+From 0ada120c883d4f1f6aafd01cf0fbb10d8bbba015 Mon Sep 17 00:00:00 2001
+From: Changbin Du <changbin.du@gmail.com>
+Date: Tue, 28 Jan 2020 23:29:38 +0800
+Subject: [PATCH] perf: Make perf able to build with latest libbfd
+
+libbfd has changed the bfd_section_* macros to inline functions
+bfd_section_<field> since 2019-09-18. See below two commits:
+  o http://www.sourceware.org/ml/gdb-cvs/2019-09/msg00064.html
+  o https://www.sourceware.org/ml/gdb-cvs/2019-09/msg00072.html
+
+This fix make perf able to build with both old and new libbfd.
+
+Signed-off-by: Changbin Du <changbin.du@gmail.com>
+Acked-by: Jiri Olsa <jolsa@redhat.com>
+Cc: Peter Zijlstra <peterz@infradead.org>
+Link: http://lore.kernel.org/lkml/20200128152938.31413-1-changbin.du@gmail.com
+Signed-off-by: Arnaldo Carvalho de Melo <acme@redhat.com>
+Signed-off-by: Andrey Zhizhikin <andrey.zhizhikin@leica-geosystems.com>
+---
+ tools/perf/util/srcline.c | 16 +++++++++++++++-
+ 1 file changed, 15 insertions(+), 1 deletion(-)
+
+diff --git a/tools/perf/util/srcline.c b/tools/perf/util/srcline.c
+index 6ccf6f6d09df..5b7d6c16d33f 100644
+--- a/tools/perf/util/srcline.c
++++ b/tools/perf/util/srcline.c
+@@ -193,16 +193,30 @@ static void find_address_in_section(bfd *abfd, asection *section, void *data)
+ 	bfd_vma pc, vma;
+ 	bfd_size_type size;
+ 	struct a2l_data *a2l = data;
++	flagword flags;
+ 
+ 	if (a2l->found)
+ 		return;
+ 
+-	if ((bfd_get_section_flags(abfd, section) & SEC_ALLOC) == 0)
++#ifdef bfd_get_section_flags
++	flags = bfd_get_section_flags(abfd, section);
++#else
++	flags = bfd_section_flags(section);
++#endif
++	if ((flags & SEC_ALLOC) == 0)
+ 		return;
+ 
+ 	pc = a2l->addr;
++#ifdef bfd_get_section_vma
+ 	vma = bfd_get_section_vma(abfd, section);
++#else
++	vma = bfd_section_vma(section);
++#endif
++#ifdef bfd_get_section_size
+ 	size = bfd_get_section_size(section);
++#else
++	size = bfd_section_size(section);
++#endif
+ 
+ 	if (pc < vma || pc >= vma + size)
+ 		return;
+-- 
+2.17.1
+

--- a/recipes-kernel/linux/linux-imx_4.19.35.bb
+++ b/recipes-kernel/linux/linux-imx_4.19.35.bb
@@ -19,6 +19,7 @@ LOCALVERSION = "-1.1.0"
 SRCREV = "0f9917c56d5995e1dc3bde5658e2d7bc865464de"
 SRC_URI += "file://0001-Compiler-Attributes-add-support-for-__copy-gcc-9.patch \
             file://0002-include-linux-module.h-copy-__init-__exit-attrs-to-i.patch \
+            file://0001-perf-Make-perf-able-to-build-with-latest-libbfd.patch \
            "
 
 DEFAULT_PREFERENCE = "1"


### PR DESCRIPTION
Backport upstream patch, which solves the perf build issue when new
binutils are included.

Signed-off-by: Andrey Zhizhikin <andrey.zhizhikin@leica-geosystems.com>