### PR TITLE
glmark2: Remove imxgpu3d PACKAGECONFIG override

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-benchmark/glmark2/glmark2_%.bbappend
+++ b/dynamic-layers/openembedded-layer/recipes-benchmark/glmark2/glmark2_%.bbappend
@@ -1,4 +1,0 @@
-PACKAGECONFIG_imxgpu3d = "${@bb.utils.contains('DISTRO_FEATURES', 'wayland opengl', 'wayland-gles2', \
-                                bb.utils.contains('DISTRO_FEATURES', 'x11 opengl',     'x11-gl x11-gles2', '', d), d)}"
-PACKAGECONFIG_imxgpu2d = "${@bb.utils.contains('DISTRO_FEATURES', 'wayland opengl', '', \
-                                bb.utils.contains('DISTRO_FEATURES', 'x11 opengl',     'x11-gl', '', d), d)}"


### PR DESCRIPTION
The default PACKAGECONFIG for glmark2 builds just fine on imxgpu3d
platforms, and doing so enables support for the drm based tests.

Signed-off-by: Joshua Watt <Joshua.Watt@garmin.com>