### PR TITLE
glmark2: Remove bbappend

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-benchmark/glmark2/glmark2_%.bbappend
+++ b/dynamic-layers/openembedded-layer/recipes-benchmark/glmark2/glmark2_%.bbappend
@@ -1,4 +1,0 @@
-PACKAGECONFIG_imxgpu3d = "${@bb.utils.contains('DISTRO_FEATURES', 'wayland opengl', 'wayland-gles2', \
-                                bb.utils.contains('DISTRO_FEATURES', 'x11 opengl',     'x11-gl x11-gles2', '', d), d)}"
-PACKAGECONFIG_imxgpu2d = "${@bb.utils.contains('DISTRO_FEATURES', 'wayland opengl', '', \
-                                bb.utils.contains('DISTRO_FEATURES', 'x11 opengl',     'x11-gl', '', d), d)}"


### PR DESCRIPTION
The default PACKAGECONFIG for glmark2 builds just fine on imxgpu3d and
imxgpu2d platforms, and doing so enables support for the drm based
tests.

Tested on imx8mq and imx8qm

Backport to zeus

Signed-off-by: Joshua Watt <Joshua.Watt@garmin.com>
(cherry picked from commit 7801868f4969bc3f93f9d419e7852206e45fad53)