### PR TITLE
glmark2: don't build drm flavours for machines not supporting it

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-benchmark/glmark2/glmark2_%.bbappend
+++ b/dynamic-layers/openembedded-layer/recipes-benchmark/glmark2/glmark2_%.bbappend
@@ -1,0 +1,4 @@
+# Only _mx8 machine do provide virtual/libgbm required for any drm* flavour
+DRM-REMOVE_imxgpu = "drm-gl drm-gles2"
+DRM-REMOVE_imxgpu_mx8 = ""
+PACKAGECONFIG_remove = "${DRM-REMOVE}"


### PR DESCRIPTION
Note that commit 7801868f is already slated for a backport to zeus #301. Thus this fix will also need to be cherry-picked into zeus.

imx-gpu-viv_6.4.0.p1.0-aarch32 does not provide virtual/libgbm and thus
a build with drm* in PACKAGECONFIG does fail.
Thus remove drm* from PACKAGECONFIG for those machines.

| ERROR: Nothing PROVIDES 'virtual/libgbm' (but .../glmark2_git.bb DEPENDS on or otherwise requires it)
| gpulib PROVIDES virtual/libgbm but was skipped: incompatible with machine

fixes: 7801868f glmark2: Remove bbappend

Signed-off-by: Max Krummenacher <max.krummenacher@toradex.com>