### PR TITLE
imx-base: Enable wic.bmap image generation for mxs

### DIFF
--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -298,7 +298,7 @@ IMX_DEFAULT_KERNEL_use-mainline-bsp = "linux-fslc"
 PREFERRED_PROVIDER_virtual/kernel ??= "${IMX_DEFAULT_KERNEL}"
 
 SOC_DEFAULT_IMAGE_FSTYPES = "wic.bmap wic.gz"
-SOC_DEFAULT_IMAGE_FSTYPES_mxs = "uboot-mxsboot-sdcard wic.gz"
+SOC_DEFAULT_IMAGE_FSTYPES_mxs = "uboot-mxsboot-sdcard wic.bmap wic.gz"
 
 # Do not update fstab file when using wic images
 WIC_CREATE_EXTRA_ARGS ?= "--no-fstab-update"


### PR DESCRIPTION
See similar commit fb753d427add595d9c425fab9d4720a041db1b6d:
  imx-base: Enable wic.bmap image generation as default

  Bmaptool is a generic tool for creating the block map (bmap) for a
  file and copying files using the block map. Is faster than use dd
  to flash images to SD Cards. More info about bmap here [1].

Signed-off-by: Nicola Lunghi <nick83ola@gmail.com>