### PR TITLE
u-boot-fslc: Set build dir only for u-boot recipe

### DIFF
--- a/recipes-bsp/u-boot/u-boot-fslc-common_2020.01.inc
+++ b/recipes-bsp/u-boot/u-boot-fslc-common_2020.01.inc
@@ -16,4 +16,3 @@ SRCBRANCH = "2020.01+fslc"
 PV = "v2020.01+git${SRCPV}"
 
 S = "${WORKDIR}/git"
-B = "${WORKDIR}/build"

--- a/recipes-bsp/u-boot/u-boot-fslc_2020.01.bb
+++ b/recipes-bsp/u-boot/u-boot-fslc_2020.01.bb
@@ -10,6 +10,8 @@ DEPENDS_append = " bc-native dtc-native lzop-native"
 
 PROVIDES += "u-boot"
 
+B = "${WORKDIR}/build"
+
 # FIXME: Allow linking of 'tools' binaries with native libraries
 #        used for generating the boot logo and other tools used
 #        during the build process.


### PR DESCRIPTION
If build dir is set in u-boot-fslc-common_2020.01.inc file,
u-boot-fslc-fw-utils can't find defconfig files.

Signed-off-by: Fabio Berton <fabio.berton@ossystems.com.br>