### PR TITLE
zeus: linux-fslc-lts-4.19: upgrade to 4.19.107

### DIFF
--- a/recipes-kernel/linux/linux-fslc-lts-4.19.bb
+++ b/recipes-kernel/linux/linux-fslc-lts-4.19.bb
@@ -11,9 +11,9 @@ include linux-fslc.inc
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
-PV = "4.19.78+git${SRCPV}"
+PV = "4.19.107+git${SRCPV}"
 
 SRCBRANCH = "4.19.x+fslc"
-SRCREV = "bc38ce926f0800f19b7523cdb88aea1944e46c51"
+SRCREV = "a764f56c765d081954d9d7c4c84a8c9be4c6d689"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"


### PR DESCRIPTION
This upgrade includes the merge of v4.19.107 tag and backport of
upstream patch [0ada120c883d4f1f6aafd01cf0fbb10d8bbba015], which
addresses the perf build issue when latest binutils are used.

Signed-off-by: Andrey Zhizhikin <andrey.zhizhikin@leica-geosystems.com>
(cherry picked from commit 61aeaa3da4251f62d4414217abb2126734c7066b)