### PR TITLE
u-boot: Split out u-boot tools

### DIFF
--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -10,6 +10,10 @@ IMX_DEFAULT_BOOTLOADER = "u-boot-fslc"
 IMX_DEFAULT_BOOTLOADER_mx8 = "u-boot-imx"
 
 PREFERRED_PROVIDER_u-boot ??= "${IMX_DEFAULT_BOOTLOADER}"
+PREFERRED_PROVIDER_u-boot-tools-native ??= "${IMX_DEFAULT_BOOTLOADER}-tools-native"
+PREDERRED_PROVIDED_nativesdk-u-boot-tools ??= "${IMX_DEFAULT_BOOTLOADER}-tools-native"
+PREFERRED_PROVIDER_u-boot-mkimage-native ??= "${IMX_DEFAULT_BOOTLOADER}-tools-native"
+PREFERRED_PROVIDER_nativesdk-u-boot-mkimage ??= "${IMX_DEFAULT_BOOTLOADER}-tools-native"
 PREFERRED_PROVIDER_virtual/bootloader ??= "${IMX_DEFAULT_BOOTLOADER}"
 
 PREFERRED_PROVIDER_u-boot-mxsboot-native ??= "u-boot-fslc-mxsboot-native"

--- a/recipes-bsp/imx-mkimage/imx-boot_0.2.bb
+++ b/recipes-bsp/imx-mkimage/imx-boot_0.2.bb
@@ -15,6 +15,7 @@ DEPENDS += " \
     ${IMX_EXTRA_FIRMWARE} \
     imx-atf \
     ${@bb.utils.contains('MACHINE_FEATURES', 'optee', 'optee-os', '', d)} \
+    u-boot-mkimage-native \
 "
 DEPENDS_append_mx8m = " dtc-native"
 BOOT_NAME = "imx-boot"
@@ -85,7 +86,7 @@ compile_mx8m() {
     cp ${DEPLOY_DIR_IMAGE}/${BOOT_TOOLS}/${UBOOT_DTB_NAME}   ${BOOT_STAGING}
     cp ${DEPLOY_DIR_IMAGE}/${BOOT_TOOLS}/u-boot-nodtb.bin-${MACHINE}-${UBOOT_CONFIG} \
                                                              ${BOOT_STAGING}/u-boot-nodtb.bin
-    cp ${DEPLOY_DIR_IMAGE}/${BOOT_TOOLS}/mkimage_uboot       ${BOOT_STAGING}
+    cp ${STAGING_DIR_NATIVE}/${bindir}/mkimage               ${BOOT_STAGING}/mkimage_uboot
     cp ${DEPLOY_DIR_IMAGE}/${BOOT_TOOLS}/${ATF_MACHINE_NAME} ${BOOT_STAGING}/bl31.bin
     cp ${DEPLOY_DIR_IMAGE}/${UBOOT_NAME}                     ${BOOT_STAGING}/u-boot.bin
 }

--- a/recipes-bsp/u-boot/u-boot-imx-common.inc
+++ b/recipes-bsp/u-boot/u-boot-imx-common.inc
@@ -1,0 +1,20 @@
+DESCRIPTION = "i.MX U-Boot suppporting i.MX reference boards."
+
+LICENSE = "GPLv2+"
+LIC_FILES_CHKSUM = "file://Licenses/gpl-2.0.txt;md5=b234ee4d69f5fce4486a80fdaf4a4263"
+
+SRCBRANCH = "imx_v2019.04_4.19.35_1.1.0"
+SRC_URI = "git://source.codeaurora.org/external/imx/uboot-imx.git;protocol=https;branch=${SRCBRANCH}"
+SRCREV = "4d377539a1190e838eae5d8b8a794dde0696d572"
+
+DEPENDS += "flex-native bison-native bc-native dtc-native"
+
+S = "${WORKDIR}/git"
+B = "${WORKDIR}/build"
+
+inherit fsl-u-boot-localversion
+
+LOCALVERSION ?= "-${SRCBRANCH}"
+
+BOOT_TOOLS = "imx-boot-tools"
+

--- a/recipes-bsp/u-boot/u-boot-imx-tools_2019.04.bb
+++ b/recipes-bsp/u-boot/u-boot-imx-tools_2019.04.bb
@@ -1,0 +1,9 @@
+require recipes-bsp/u-boot/u-boot-tools.inc
+require u-boot-imx-common.inc
+
+PROVIDES_append_class-target = " ${MLPREFIX}u-boot-tools"
+PROVIDES_append_class-native = " u-boot-tools-native"
+PROVIDES_append_class-nativesdk = " nativesdk-u-boot-tools"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+COMPATIBLE_MACHINE_class-target = "(mx6|mx7|mx8)"

--- a/recipes-bsp/u-boot/u-boot-imx_2019.04.bb
+++ b/recipes-bsp/u-boot/u-boot-imx_2019.04.bb
@@ -2,27 +2,10 @@
 # Copyright 2018 (C) O.S. Systems Software LTDA.
 # Copyright 2017-2019 NXP
 
-DESCRIPTION = "i.MX U-Boot suppporting i.MX reference boards."
 require recipes-bsp/u-boot/u-boot.inc
+require u-boot-imx-common.inc
 
 PROVIDES += "u-boot"
-
-LICENSE = "GPLv2+"
-LIC_FILES_CHKSUM = "file://Licenses/gpl-2.0.txt;md5=b234ee4d69f5fce4486a80fdaf4a4263"
-
-SRCBRANCH = "imx_v2019.04_4.19.35_1.1.0"
-SRC_URI = "git://source.codeaurora.org/external/imx/uboot-imx.git;protocol=https;branch=${SRCBRANCH}"
-SRCREV = "4d377539a1190e838eae5d8b8a794dde0696d572"
-
-DEPENDS += "flex-native bison-native bc-native dtc-native"
-
-S = "${WORKDIR}/git"
-
-inherit fsl-u-boot-localversion
-
-LOCALVERSION ?= "-${SRCBRANCH}"
-
-BOOT_TOOLS = "imx-boot-tools"
 
 do_deploy_append_mx8m() {
     # Deploy the mkimage, u-boot-nodtb.bin and fsl-imx8m*-XX.dtb for mkimage to generate boot binary


### PR DESCRIPTION
Splits out the IMX u-boot tools build to it's own recipe. This is
required because these are native tools and thus need to be in a -native
recipe to be properly relocated (instead of being built as part of the
target u-boot-imx recipe). If the tools aren't built in a -native
recipe, then the mkimage tool will contain a hard coded path to the
uninative program loader from the sandbox where it was first built and
this will not get corrected when restored from sstate. The result is
that the mkimage_uboot executable can't run because it's looking for a
hard coded program loader that does not exist, resulting in strange
build errors like:

 ./mkimage_uboot: Command not found

even though the executable is obviously in the correct location.

Signed-off-by: Joshua Watt <Joshua.Watt@garmin.com>