### PR TITLE
u-boot-fslc-fw-utils: set correctly make source build dir

### DIFF
--- a/recipes-bsp/u-boot/u-boot-fslc-common_2020.01.inc
+++ b/recipes-bsp/u-boot/u-boot-fslc-common_2020.01.inc
@@ -16,3 +16,4 @@ SRCBRANCH = "2020.01+fslc"
 PV = "v2020.01+git${SRCPV}"
 
 S = "${WORKDIR}/git"
+B = "${WORKDIR}/build"

--- a/recipes-bsp/u-boot/u-boot-fslc-fw-utils_2020.01.bb
+++ b/recipes-bsp/u-boot/u-boot-fslc-fw-utils_2020.01.bb
@@ -10,8 +10,8 @@ EXTRA_OEMAKE_class-cross = 'ARCH=${TARGET_ARCH} CC="${CC} ${CFLAGS} ${LDFLAGS}" 
 inherit uboot-config
 
 do_compile () {
-    oe_runmake ${UBOOT_MACHINE}
-    oe_runmake envtools
+    oe_runmake -C ${S} O=${B} ${UBOOT_MACHINE}
+    oe_runmake -C ${S} O=${B} envtools
 }
 
 do_install () {


### PR DESCRIPTION
This partially revert commit 4e5c7e0d4959b027698e15565df7d3286e6860fa:
   u-boot-fslc: Set build dir only for u-boot recipe

Not setting the build dir in u-boot-fslc-common is breaking the build of
u-boot-fslc-mxsboot.

Instead of unsetting ${B}, set correctly the output and source dir in make

Signed-off-by: Nicola Lunghi <nick83ola@gmail.com>