### PR TITLE
u-boot-imx-tools: Make recipe visible only for mx6, mx7 and mx8 machines

### DIFF
--- a/recipes-bsp/u-boot/u-boot-imx-tools_2019.04.bb
+++ b/recipes-bsp/u-boot/u-boot-imx-tools_2019.04.bb
@@ -6,4 +6,5 @@ PROVIDES_append_class-native = " u-boot-tools-native"
 PROVIDES_append_class-nativesdk = " nativesdk-u-boot-tools"
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
+COMPATIBLE_MACHINE = "(mx6|mx7|mx8)"
 COMPATIBLE_MACHINE_class-target = "(mx6|mx7|mx8)"


### PR DESCRIPTION
When building an image for a external meta-freescale machine,
e.g. raspberrypi3, and with meta-freescale in bblayer.conf we get:

NOTE: Multiple providers are available for u-boot-mkimage-native
(u-boot-imx-tools-native, u-boot-tools-native) Consider defining
a PREFERRED_PROVIDER entry to match u-boot-mkimage-native

Set COMPATIBLE_MACHINE to reduce visibility only for mx6, mx7 and
mx8 machines.

Signed-off-by: Fabio Berton <fabio.berton@ossystems.com.br>