### PR TITLE
optee-imx: add (backported) patches for GCC 9 & musl

### DIFF
--- a/recipes-security/optee-imx/optee-test/0003-sock_server-fix-compilation-against-musl-sys-errno.h.patch
+++ b/recipes-security/optee-imx/optee-test/0003-sock_server-fix-compilation-against-musl-sys-errno.h.patch
@@ -1,0 +1,41 @@
+From dc8cd1c43edeedb9f7335020537c4ffdddd683f8 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Andr=C3=A9=20Draszik?= <andre.draszik@jci.com>
+Date: Thu, 7 Feb 2019 01:26:53 +0000
+Subject: [PATCH 1/3] sock_server: fix compilation against musl (sys/errno.h)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Compiling against musl-libc fails with the following error:
+
+| In file included from .../host/xtest/sock_server.c:24:
+| .../usr/include/sys/errno.h:1:2: error: #warning redirecting incorrect #include <sys/errno.h> to <errno.h> [-Werror=cpp]
+|  #warning redirecting incorrect #include <sys/errno.h> to <errno.h>
+|   ^~~~~~~
+
+Just remove the needless include.
+
+Signed-off-by: André Draszik <andre.draszik@jci.com>
+Acked-by: Jens Wiklander <jens.wiklander@linaro.org>
+Reviewed-by: Jerome Forissier <jerome.forissier@linaro.org>
+---
+Signed-off-by: André Draszik <andre.draszik@jci.com>
+Upstream-Status: Backport [3.5.0]
+ host/xtest/sock_server.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/host/xtest/sock_server.c b/host/xtest/sock_server.c
+index 0d2ff06..1ba73d6 100644
+--- a/host/xtest/sock_server.c
++++ b/host/xtest/sock_server.c
+@@ -21,7 +21,6 @@
+ #include <netdb.h>
+ #include <netinet/in.h>
+ #include <poll.h>
+-#include <sys/errno.h>
+ #include <sys/socket.h>
+ #include <unistd.h>
+ 
+-- 
+2.23.0.rc1
+

--- a/recipes-security/optee-imx/optee-test/0004-build-ignore-declaration-after-statement-warnings.patch
+++ b/recipes-security/optee-imx/optee-test/0004-build-ignore-declaration-after-statement-warnings.patch
@@ -1,0 +1,62 @@
+From 1401b89684ee81bf0b3d3dea06e2926b24ba3f97 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Andr=C3=A9=20Draszik?= <andre.draszik@jci.com>
+Date: Thu, 7 Feb 2019 01:29:08 +0000
+Subject: [PATCH 2/3] build: ignore declaration-after-statement warnings
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+| Makefile:37: recipe for target 'xtest' failed
+| make: *** [xtest] Error 2
+| make: *** Waiting for unfinished jobs....
+| arith_taf.c: In function 'get_handle':
+| arith_taf.c:56:2: warning: ISO C90 forbids mixed declarations and code [-Wdeclaration-after-statement]
+|   int h = handle_get(&hdb, ptr);
+|   ^~~
+| arith_taf.c: In function 'ta_entry_arith_new_var':
+| arith_taf.c:82:2: warning: ISO C90 forbids mixed declarations and code [-Wdeclaration-after-statement]
+|   size_t len = TEE_BigIntSizeInU32(params[0].value.a);
+|   ^~~~~~
+| arith_taf.c: In function 'ta_entry_arith_new_fmm_var':
+| arith_taf.c:129:2: warning: ISO C90 forbids mixed declarations and code [-Wdeclaration-after-statement]
+|   size_t len = TEE_BigIntFMMSizeInU32(params[0].value.a);
+|   ^~~~~~
+| arith_taf.c: In function 'ta_entry_arith_free_handle':
+| arith_taf.c:150:2: warning: ISO C90 forbids mixed declarations and code [-Wdeclaration-after-statement]
+|   void *ptr = put_handle(params[0].value.a & ~HT_MASK);
+|   ^~~~
+| arith_taf.c: In function 'ta_entry_arith_from_octet_string':
+| arith_taf.c:165:2: warning: ISO C90 forbids mixed declarations and code [-Wdeclaration-after-statement]
+|   TEE_BigInt *big_int = lookup_handle(HT_BIGINT, params[0].value.a);
+|   ^~~~~~~~~~
+| arith_taf.c: In function 'ta_entry_arith_from_s32':
+| arith_taf.c:181:2: warning: ISO C90 forbids mixed declarations and code [-Wdeclaration-after-statement]
+|   TEE_BigInt *big_int = lookup_handle(HT_BIGINT, params[0].value.a);
+|   ^~~~~~~~~~
+
+etc.
+
+Signed-off-by: André Draszik <andre.draszik@jci.com>
+Acked-by: Jens Wiklander <jens.wiklander@linaro.org>
+Reviewed-by: Jerome Forissier <jerome.forissier@linaro.org>
+---
+Signed-off-by: André Draszik <andre.draszik@jci.com>
+Upstream-Status: Backport [3.5.0]
+ host/xtest/Makefile | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/host/xtest/Makefile b/host/xtest/Makefile
+index f4291e0..e97e555 100644
+--- a/host/xtest/Makefile
++++ b/host/xtest/Makefile
+@@ -154,6 +154,7 @@ CFLAGS += -Wall -Wcast-align -Werror \
+ 	  -Wmissing-prototypes -Wnested-externs -Wpointer-arith \
+ 	  -Wshadow -Wstrict-prototypes -Wswitch-default \
+ 	  -Wwrite-strings \
++	  -Wno-declaration-after-statement \
+ 	  -Wno-missing-field-initializers -Wno-format-zero-length
+ endif
+ 
+-- 
+2.23.0.rc1
+

--- a/recipes-security/optee-imx/optee-test/0005-benchmark_1000-fix-compilation-against-musl-uint.patch
+++ b/recipes-security/optee-imx/optee-test/0005-benchmark_1000-fix-compilation-against-musl-uint.patch
@@ -1,0 +1,57 @@
+From f74e9f339a8e8cb97fc8ea03bef51d7e3862a60a Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Andr=C3=A9=20Draszik?= <andre.draszik@jci.com>
+Date: Thu, 7 Feb 2019 01:31:27 +0000
+Subject: [PATCH 3/3] benchmark_1000: fix compilation against musl (uint)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Compiling against musl-libc fails with the following error:
+
+| .../host/xtest/benchmark_1000.c: In function 'show_test_result':
+| .../host/xtest/benchmark_1000.c:102:2: error: unknown type name 'uint'; did you mean 'int'?
+|   uint i;
+|   ^~~~
+|   int
+| ...host/xtest/benchmark_1000.c:108:16: error: comparison of integer expressions of different signedness: 'int' and 'size_t' {aka 'unsigned int'} [-Werror=sign-compare]
+|   for (i = 0; i < size; i++) {
+|                 ^
+
+etc.
+
+Convert to using more standard size_t
+
+Signed-off-by: André Draszik <andre.draszik@jci.com>
+Acked-by: Jens Wiklander <jens.wiklander@linaro.org>
+Reviewed-by: Jerome Forissier <jerome.forissier@linaro.org>
+---
+Signed-off-by: André Draszik <andre.draszik@jci.com>
+Upstream-Status: Backport [3.5.0]
+ host/xtest/benchmark_1000.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/host/xtest/benchmark_1000.c b/host/xtest/benchmark_1000.c
+index bf92fa0..1caf420 100644
+--- a/host/xtest/benchmark_1000.c
++++ b/host/xtest/benchmark_1000.c
+@@ -99,7 +99,7 @@ static TEEC_Result run_chunk_access_test(enum storage_benchmark_cmd cmd,
+ 
+ static void show_test_result(struct test_record records[], size_t size)
+ {
+-	uint i;
++	size_t i;
+ 
+ 	printf("-----------------+---------------+----------------\n");
+ 	printf(" Data Size (B) \t | Time (s)\t | Speed (kB/s)\t \n");
+@@ -119,7 +119,7 @@ static void chunk_test(ADBG_Case_t *c, enum storage_benchmark_cmd cmd)
+ {
+ 	uint32_t chunk_size = DEFAULT_CHUNK_SIZE;
+ 	struct test_record records[ARRAY_SIZE(data_size_table) - 1];
+-	uint i;
++	size_t i;
+ 
+ 	for (i = 0; data_size_table[i]; i++) {
+ 		ADBG_EXPECT_TEEC_SUCCESS(c,
+-- 
+2.23.0.rc1
+

--- a/recipes-security/optee-imx/optee-test/0006-regression_8100-use-null-terminated-strings-with-fil.patch
+++ b/recipes-security/optee-imx/optee-test/0006-regression_8100-use-null-terminated-strings-with-fil.patch
@@ -1,0 +1,88 @@
+From 7d566ed585d1e13f444d48fde5705b5be54de4af Mon Sep 17 00:00:00 2001
+From: Ricardo Salveti <ricardo@foundries.io>
+Date: Wed, 26 Jun 2019 17:32:11 -0300
+Subject: [PATCH] regression_8100: use null terminated strings with file_to_c
+
+GCC 9 is more strict with string manipulation, causing the build to
+fail as the string data converted via file_to_c is not null terminated,
+as described by the following build error:
+
+regression_8100.c:100:29: error: '%*s' directive argument is not a
+nul-terminated string [-Werror=format-overflow=]
+tlen = myasprintf(&trust, "%*s", (int)sizeof(regression_8100_ca_crt),
+                           ^~~
+      regression_8100_ca_crt);
+      ~~~~~~~~~~~~~~~~~~~~~~
+
+Change file_to_c to terminate the string after conversion and update the
+string size to remove the null terminated byte. Also update
+regression_8100 to use the size variable defined via file_to_c instead
+of manually calling sizeof.
+
+Signed-off-by: Ricardo Salveti <ricardo@foundries.io>
+Acked-by: Jens Wiklander <jens.wiklander@linaro.org>
+---
+Signed-off-by: André Draszik <andre.draszik@jci.com>
+Upstream-Status: Backport [3.6.0]
+ host/xtest/regression_8100.c | 10 +++++-----
+ scripts/file_to_c.py         |  4 ++--
+ 2 files changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/host/xtest/regression_8100.c b/host/xtest/regression_8100.c
+index 04d62d9..13780e1 100644
+--- a/host/xtest/regression_8100.c
++++ b/host/xtest/regression_8100.c
+@@ -91,13 +91,13 @@ static void test_8102(ADBG_Case_t *c)
+ 		return;
+ 
+ 	clen = myasprintf(&chain, "%*s\n%*s",
+-			  (int)sizeof(regression_8100_my_crt),
++			  (int)regression_8100_my_crt_size,
+ 			  regression_8100_my_crt,
+-			  (int)sizeof(regression_8100_mid_crt),
++			  (int)regression_8100_mid_crt_size,
+ 			   regression_8100_mid_crt);
+ 	if (!ADBG_EXPECT_COMPARE_SIGNED(c, clen, !=, -1))
+ 		goto out;
+-	tlen = myasprintf(&trust, "%*s", (int)sizeof(regression_8100_ca_crt),
++	tlen = myasprintf(&trust, "%*s", (int)regression_8100_ca_crt_size,
+ 			  regression_8100_ca_crt);
+ 	if (!ADBG_EXPECT_COMPARE_SIGNED(c, tlen, !=, -1))
+ 		goto out;
+@@ -282,7 +282,7 @@ static void test_8103(ADBG_Case_t *c)
+ 					      NULL, &ret_orig)))
+ 		return;
+ 
+-	clen = myasprintf(&csr, "%*s", (int)sizeof(regression_8100_my_csr),
++	clen = myasprintf(&csr, "%*s", (int)regression_8100_my_csr_size,
+ 			  regression_8100_my_csr);
+ 	if (!ADBG_EXPECT_COMPARE_SIGNED(c, clen, >=, 0))
+ 		goto out;
+@@ -300,7 +300,7 @@ static void test_8103(ADBG_Case_t *c)
+ 	if (!ADBG_EXPECT_TEEC_SUCCESS(c, res))
+ 		goto out;
+ 
+-	myasprintf(&ca, "%*s", (int)sizeof(regression_8100_ca_crt),
++	myasprintf(&ca, "%*s", (int)regression_8100_ca_crt_size,
+ 		   regression_8100_ca_crt);
+ 	if (!ADBG_EXPECT_NOT_NULL(c, ca))
+ 		goto out;
+diff --git a/scripts/file_to_c.py b/scripts/file_to_c.py
+index 83a9832..ae16f52 100755
+--- a/scripts/file_to_c.py
++++ b/scripts/file_to_c.py
+@@ -37,9 +37,9 @@ def main():
+         else:
+             f.write(" ")
+ 
+-    f.write("};\n")
++    f.write("'\\0'};\n")
+     f.write("const size_t " + args.name + "_size = sizeof(" + 
+-            args.name + ");\n")
++            args.name + ") - 1;\n")
+ 
+     f.close()
+     inf.close()
+-- 
+2.23.0.rc1
+

--- a/recipes-security/optee-imx/optee-test_3.2.0.imx.bb
+++ b/recipes-security/optee-imx/optee-test_3.2.0.imx.bb
@@ -17,6 +17,10 @@ OPTEE_TEST_SRC ?= "git://source.codeaurora.org/external/imx/imx-optee-test.git;p
 SRC_URI = "${OPTEE_TEST_SRC};branch=${SRCBRANCH} \
            file://0001-regression-4011-correct-potential-overflow.patch \
            file://0001-xtest-prevent-unexpected-build-warning-with-strncpy.patch \
+           file://0003-sock_server-fix-compilation-against-musl-sys-errno.h.patch \
+           file://0004-build-ignore-declaration-after-statement-warnings.patch \
+           file://0005-benchmark_1000-fix-compilation-against-musl-uint.patch \
+           file://0006-regression_8100-use-null-terminated-strings-with-fil.patch \
 "
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
This is cherry-picked from master. Also required on Zeus
to get a working build.

See the individual patches - all patches are simply
backports from optee upstream releases.

Signed-off-by: André Draszik <andre.draszik@jci.com>