### PR TITLE
u-boot-imx: resolve build issue with missing target

### DIFF
--- a/recipes-bsp/u-boot/u-boot-imx-mfgtool_2019.04.bb
+++ b/recipes-bsp/u-boot/u-boot-imx-mfgtool_2019.04.bb
@@ -2,5 +2,7 @@
 # Copyright (C) 2014-2016 Freescale Semiconductor
 # Copyright 2017-2019 NXP
 
+FILESEXTRAPATHS_prepend := "${THISDIR}/u-boot-imx:"
+
 require u-boot-imx_${PV}.bb
 require u-boot-mfgtool.inc

--- a/recipes-bsp/u-boot/u-boot-imx/0001-Add-target-to-generate-initial-environment.patch
+++ b/recipes-bsp/u-boot/u-boot-imx/0001-Add-target-to-generate-initial-environment.patch
@@ -1,0 +1,49 @@
+From bdaa73a5b3923257add182b4ab8058dbfa33421b Mon Sep 17 00:00:00 2001
+From: Stefano Babic <sbabic@denx.de>
+Date: Wed, 13 Mar 2019 09:46:45 +0100
+Subject: [PATCH] Add target to generate initial environment
+
+The initial environment is linked to the u-boot binary. Modifying the
+environment from User Space with the env tools requires that the tools
+are always built together with the bootloader to be sure that they
+contain the initial environment in case no environment is stored into
+persistent storage or when a board boots with just the default
+environment. This makes difficult for distros to provide a general
+package to access the environment. A simpler way is if the tools are
+generic for all boards and a configuration file is given to provide the
+initial environment.
+
+The patch just generates the initial environment by extracting it from
+the compiled object. This file can then be used for tools in user space
+to initialize the environment.
+
+Signed-off-by: Stefano Babic <sbabic@denx.de>
+
+Upstream-Status: Backport [https://github.com/u-boot/u-boot/commit/bdaa73a5b3923257add182b4ab8058dbfa33421b]
+
+Signed-off-by: Andrey Zhizhikin <andrey.zhizhikin@leica-geosystems.com>
+---
+ Makefile | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/Makefile b/Makefile
+index 66a09ac900..f2c7bb6041 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1977,6 +1977,13 @@ endif
+ 	$(build)=$(build-dir) $(@:.ko=.o)
+ 	$(Q)$(MAKE) -f $(srctree)/scripts/Makefile.modpost
+ 
++quiet_cmd_genenv = GENENV $@
++cmd_genenv = $(OBJCOPY) --dump-section .rodata.default_environment=$@ env/common.o; \
++	sed --in-place -e 's/\x00/\x0A/g' $@
++
++u-boot-initial-env: u-boot.bin
++	$(call if_changed,genenv)
++
+ # Consistency checks
+ # ---------------------------------------------------------------------------
+ 
+-- 
+2.17.1
+

--- a/recipes-bsp/u-boot/u-boot-imx_2019.04.bb
+++ b/recipes-bsp/u-boot/u-boot-imx_2019.04.bb
@@ -5,6 +5,8 @@
 require recipes-bsp/u-boot/u-boot.inc
 require u-boot-imx-common.inc
 
+SRC_URI += "file://0001-Add-target-to-generate-initial-environment.patch"
+
 PROVIDES += "u-boot"
 
 do_deploy_append_mx8m() {


### PR DESCRIPTION
Since the replacement of u-boot-fw-utils with libubootenv in OE-Core,
U-Boot recipe requires an additional target to be built, which contains
the default environment.

This target has been introduced in U-Boot with version 2019.07 and is
missing in NXP fork of U-Boot source tree, therefore one patch from the
U-Boot source tree is backported in order to introduce a missing build
target.

Signed-off-by: Andrey Zhizhikin <andrey.zhizhikin@leica-geosystems.com>