### PR TITLE
linux-fslc: bump to Linux version 5.4.30

### DIFF
--- a/recipes-kernel/linux/linux-fslc_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc_5.4.bb
@@ -11,9 +11,9 @@ include linux-fslc.inc
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
-PV = "5.4.28+git${SRCPV}"
+PV = "5.4.30+git${SRCPV}"
 
 SRCBRANCH = "5.4.x+fslc"
-SRCREV = "81c8c8b757d9b014f5179fdf088f1831ead5d99d"
+SRCREV = "49dbf49dd37d27b4db2d3b3084c4c26ec676e836"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"


### PR DESCRIPTION
tested on`warp7`:

```
root@imx7s-warp:~# uname -a
Linux imx7s-warp 5.4.30-fslc+g49dbf49dd37d #1 SMP Fri Apr 3 16:46:40 UTC 2020 armv7l GNU/Linux
```

Signed-off-by: Pierre-Jean Texier <pjtexier@koncepto.io>