### PR TITLE
optee-test_3.2.0.imx: add patch to use python3, backported from v3.8.0

### DIFF
--- a/recipes-security/optee-imx/optee-test/0001-use-python3-instead-of-python.patch
+++ b/recipes-security/optee-imx/optee-test/0001-use-python3-instead-of-python.patch
@@ -1,0 +1,48 @@
+From 6271160639002a2580d80b75b5397a96d56329f2 Mon Sep 17 00:00:00 2001
+From: Scott Branden <scott.branden@broadcom.com>
+Date: Fri, 27 Dec 2019 12:54:28 -0800
+Subject: [PATCH] use python3 instead of python
+
+use python3 instead of python as python2 is EOL January 2020.
+
+Signed-off-by: Scott Branden <scott.branden@broadcom.com>
+Reviewed-by: Jerome Forissier <jerome@forissier.org>
+Tested-by: Jerome Forissier <jerome@forissier.org> (QEMU, CFG_GCM_NIST_VECTORS=y)
+Upstream-Status: Backport from v3.8.0
+---
+ scripts/file_to_c.py       | 4 ++--
+ scripts/rsp_to_gcm_test.py | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/scripts/file_to_c.py b/scripts/file_to_c.py
+index ae16f52..b4ce2a2 100755
+--- a/scripts/file_to_c.py
++++ b/scripts/file_to_c.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python3
+ # SPDX-License-Identifier: BSD-2-Clause
+ #
+ # Copyright (c) 2018, Linaro Limited
+@@ -29,7 +29,7 @@ def main():
+ 
+     f.write("const uint8_t " + args.name + "[] = {\n")
+     i = 0
+-    for x in array.array("B", inf.read()):
++    for x in array.array("B", map(ord, (inf.read()))):
+         f.write("0x" + '{0:02x}'.format(x) + ",")
+         i = i + 1
+         if i % 8 == 0:
+diff --git a/scripts/rsp_to_gcm_test.py b/scripts/rsp_to_gcm_test.py
+index 0543541..e4418be 100755
+--- a/scripts/rsp_to_gcm_test.py
++++ b/scripts/rsp_to_gcm_test.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python3
+ 
+ modes = {'encrypt': 0, 'decrypt': 1}
+ 
+-- 
+2.7.4
+

--- a/recipes-security/optee-imx/optee-test_3.2.0.imx.bb
+++ b/recipes-security/optee-imx/optee-test_3.2.0.imx.bb
@@ -19,6 +19,7 @@ SRC_URI = "${OPTEE_TEST_SRC};branch=${SRCBRANCH} \
            file://0004-build-ignore-declaration-after-statement-warnings.patch \
            file://0005-benchmark_1000-fix-compilation-against-musl-uint.patch \
            file://0006-regression_8100-use-null-terminated-strings-with-fil.patch \
+           file://0001-use-python3-instead-of-python.patch \
 "
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
This avoids build errors such as
optee-test/3.2.0.imx-r0/git/out/ta/crypt//mid_crt.c] Error 127
| /usr/bin/env: ‘python’: No such file or directory

Signed-off-by: Peter Griffin <peter.griffin@linaro.org>