### PR TITLE
[zeus] imx8mq: Add tuning for cortexa53+crypto+crc

### DIFF
--- a/conf/machine/imx8mqevk.conf
+++ b/conf/machine/imx8mqevk.conf
@@ -7,7 +7,7 @@
 MACHINEOVERRIDES =. "mx8:mx8m:mx8mq:"
 
 require conf/machine/include/imx-base.inc
-require conf/machine/include/arm/arch-arm64.inc
+require conf/machine/include/tune-cortexa53.inc
 
 MACHINE_FEATURES += "pci wifi bluetooth optee qca6174"
 

--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -66,6 +66,7 @@ DEFAULTTUNE_mx7 ?= "cortexa7thf-neon"
 DEFAULTTUNE_vf ?= "cortexa5thf-neon"
 DEFAULTTUNE_mx8mm ?= "cortexa53-crypto"
 DEFAULTTUNE_mx8mn ?= "cortexa53-crypto"
+DEFAULTTUNE_mx8mq ?= "cortexa53-crypto"
 
 INHERIT += "machine-overrides-extender"
 


### PR DESCRIPTION
Like other i.MX 8M SOCs, the 8M Quad has Cortex-A53 cores
and supports ARM Crypto extensions. Enable them by default.

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>
(cherry picked from commit 5e62f2fb476405e77388da0f2963163173e0c090)