### PR TITLE
mx8qxp: Use cortexa35-crypto tuning for i.MX 8 QXP default

### DIFF
--- a/conf/machine/imx8qxpmek.conf
+++ b/conf/machine/imx8qxpmek.conf
@@ -6,7 +6,7 @@
 MACHINEOVERRIDES =. "mx8:mx8x:mx8qxp:"
 
 require conf/machine/include/imx-base.inc
-require conf/machine/include/arm/arch-arm64.inc
+require conf/machine/include/tune-cortexa35.inc
 
 IMX_DEFAULT_BSP = "nxp"
 

--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -76,15 +76,17 @@ MACHINE_EXTRA_RRECOMMENDS = "kernel-modules"
 # handled by software
 # DEFAULTTUNE_mx6 ?= "cortexa9t-neon"
 # handled by hardware
-DEFAULTTUNE_mx6 ?= "cortexa9thf-neon"
-DEFAULTTUNE_mx6ul ?= "cortexa7thf-neon"
+DEFAULTTUNE_mx6    ?= "cortexa9thf-neon"
+DEFAULTTUNE_mx6ul  ?= "cortexa7thf-neon"
 DEFAULTTUNE_mx6ull ?= "cortexa7thf-neon"
-DEFAULTTUNE_mx7 ?= "cortexa7thf-neon"
-DEFAULTTUNE_vf ?= "cortexa5thf-neon"
-DEFAULTTUNE_mx8mm ?= "cortexa53-crypto"
-DEFAULTTUNE_mx8mn ?= "cortexa53-crypto"
-DEFAULTTUNE_mx8mq ?= "cortexa53-crypto"
-DEFAULTTUNE_mx8qm ?= "cortexa72-cortexa53-crypto"
+DEFAULTTUNE_mx7    ?= "cortexa7thf-neon"
+DEFAULTTUNE_vf     ?= "cortexa5thf-neon"
+
+DEFAULTTUNE_mx8mm  ?= "cortexa53-crypto"
+DEFAULTTUNE_mx8mn  ?= "cortexa53-crypto"
+DEFAULTTUNE_mx8mq  ?= "cortexa53-crypto"
+DEFAULTTUNE_mx8qm  ?= "cortexa72-cortexa53-crypto"
+DEFAULTTUNE_mx8qxp ?= "cortexa35-crypto"
 
 INHERIT += "machine-overrides-extender"
 


### PR DESCRIPTION
The i.MX 8QXP has Cortex-A35 cores plus Crypto
extensions, so enable them by default.

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>