### PR TITLE
machine: imx[6,7,8]: update dtb references for 5.4 kernel

### DIFF
--- a/conf/machine/imx6qdlsabresd.conf
+++ b/conf/machine/imx6qdlsabresd.conf
@@ -17,14 +17,23 @@ require conf/machine/include/imx-base.inc
 require conf/machine/include/tune-cortexa9.inc
 
 KERNEL_DEVICETREE = " \
-    imx6qp-sabresd.dtb imx6qp-sabresd-btwifi.dtb imx6qp-sabresd-hdcp.dtb \
-    imx6qp-sabresd-ldo.dtb imx6qp-sabresd-ldo-pcie-cert.dtb \
-    \
-    imx6q-sabresd.dtb imx6q-sabresd-ldo.dtb imx6q-sabresd-hdcp.dtb \
-    imx6q-sabresd-enetirq.dtb imx6q-sabresd-btwifi.dtb \
-    \
-    imx6dl-sabresd.dtb imx6dl-sabresd-ldo.dtb imx6dl-sabresd-hdcp.dtb \
-    imx6dl-sabresd-enetirq.dtb imx6dl-sabresd-btwifi.dtb \
+	imx6qp-sabresd-btwifi.dtb \
+	imx6qp-sabresd.dtb \
+	imx6qp-sabresd-hdcp.dtb \
+	imx6qp-sabresd-ldo.dtb \
+	\
+	imx6q-sabresd-btwifi.dtb \
+	imx6q-sabresd.dtb \
+	imx6q-sabresd-enetirq.dtb \
+	imx6q-sabresd-hdcp.dtb \
+	imx6q-sabresd-ldo.dtb \
+	imx6q-sabresd-uart.dtb \
+	\
+	imx6dl-sabresd-btwifi.dtb \
+	imx6dl-sabresd.dtb \
+	imx6dl-sabresd-enetirq.dtb \
+	imx6dl-sabresd-hdcp.dtb \
+	imx6dl-sabresd-ldo.dtb \
 "
 KERNEL_DEVICETREE_use-mainline-bsp = " \
     imx6qp-sabresd.dtb \

--- a/conf/machine/imx6sxsabreauto.conf
+++ b/conf/machine/imx6sxsabreauto.conf
@@ -9,7 +9,7 @@ MACHINEOVERRIDES =. "mx6:mx6sx:"
 require conf/machine/include/imx-base.inc
 require conf/machine/include/tune-cortexa9.inc
 
-KERNEL_DEVICETREE = "imx6sx-sabreauto.dtb imx6sx-sabreauto-m4.dtb"
+KERNEL_DEVICETREE = "imx6sx-sabreauto.dtb"
 KERNEL_DEVICETREE_use-mainline-bsp = "imx6sx-sabreauto.dtb"
 
 PREFERRED_PROVIDER_u-boot = "u-boot-imx"

--- a/conf/machine/imx6ulevk.conf
+++ b/conf/machine/imx6ulevk.conf
@@ -11,9 +11,16 @@ include conf/machine/include/tune-cortexa7.inc
 
 MACHINE_FEATURES += " pci wifi bluetooth"
 
-KERNEL_DEVICETREE = "imx6ul-14x14-evk.dtb imx6ul-14x14-evk-csi.dtb imx6ul-14x14-evk-btwifi.dtb \
-                     imx6ul-14x14-evk-gpmi-weim.dtb imx6ul-14x14-evk-usb-certi.dtb \
-                     imx6ul-14x14-evk-emmc.dtb "
+KERNEL_DEVICETREE = " \
+	imx6ul-14x14-evk-btwifi.dtb \
+	imx6ul-14x14-evk-btwifi-oob.dtb \
+	imx6ul-14x14-evk-csi.dtb \
+	imx6ul-14x14-evk.dtb \
+	imx6ul-14x14-evk-ecspi.dtb \
+	imx6ul-14x14-evk-ecspi-slave.dtb \
+	imx6ul-14x14-evk-emmc.dtb \
+	imx6ul-14x14-evk-gpmi-weim.dtb \
+"
 KERNEL_DEVICETREE_use-mainline-bsp = "imx6ul-14x14-evk.dtb"
 
 # Use fslc u-boot by default. See also imx-base.inc.

--- a/conf/machine/imx6ullevk.conf
+++ b/conf/machine/imx6ullevk.conf
@@ -9,9 +9,14 @@ MACHINEOVERRIDES =. "mx6:mx6ull:"
 include conf/machine/include/imx-base.inc
 include conf/machine/include/tune-cortexa7.inc
 
-KERNEL_DEVICETREE = "imx6ull-14x14-evk.dtb imx6ull-14x14-evk-btwifi.dtb \
-                     imx6ull-14x14-evk-btwifi-oob.dtb imx6ull-14x14-evk-emmc.dtb \
-                     imx6ull-14x14-evk-gpmi-weim.dtb imx6ull-14x14-evk-usb-certi.dtb"
+KERNEL_DEVICETREE = " \
+	imx6ull-14x14-evk-btwifi.dtb \
+	imx6ull-14x14-evk-btwifi-oob.dtb \
+	imx6ull-14x14-evk.dtb \
+	imx6ull-14x14-evk-emmc.dtb \
+	imx6ull-14x14-evk-gpmi-weim.dtb \
+"
+
 UBOOT_CONFIG ??= "sd"
 UBOOT_CONFIG[sd] = "mx6ull_14x14_evk_config,sdcard"
 UBOOT_CONFIG[mfgtool] = "mx6ull_14x14_evk_config"

--- a/conf/machine/imx7dsabresd.conf
+++ b/conf/machine/imx7dsabresd.conf
@@ -11,11 +11,17 @@ require conf/machine/include/tune-cortexa7.inc
 
 MACHINE_FEATURES += " pci wifi bluetooth"
 
-KERNEL_DEVICETREE = "imx7d-sdb.dtb imx7d-sdb-epdc.dtb imx7d-sdb-gpmi-weim.dtb \
-                     imx7d-sdb-m4.dtb imx7d-sdb-mipi-dsi.dtb imx7d-sdb-qspi.dtb \
-                     imx7d-sdb-reva.dtb imx7d-sdb-reva-epdc.dtb imx7d-sdb-reva-gpmi-weim.dtb \
-                     imx7d-sdb-reva-hdmi-audio.dtb imx7d-sdb-reva-m4.dtb imx7d-sdb-reva-qspi.dtb \
-                     imx7d-sdb-reva-touch.dtb imx7d-sdb-reva-wm8960.dtb"
+KERNEL_DEVICETREE = " \
+	imx7d-sdb.dtb \
+	imx7d-sdb-epdc.dtb \
+	imx7d-sdb-gpmi-weim.dtb \
+	imx7d-sdb-m4.dtb \
+	imx7d-sdb-mipi-dsi.dtb \
+	imx7d-sdb-qspi.dtb \
+	imx7d-sdb-reva.dtb \
+	imx7d-sdb-sht11.dtb \
+"
+
 KERNEL_DEVICETREE_use-mainline-bsp = "imx7d-sdb.dtb"
 
 UBOOT_CONFIG ??= "sd"

--- a/conf/machine/imx7ulpevk.conf
+++ b/conf/machine/imx7ulpevk.conf
@@ -11,11 +11,20 @@ require conf/machine/include/tune-cortexa7.inc
 
 MACHINE_FEATURES += " pci wifi bluetooth qca9377"
 
-KERNEL_DEVICETREE = "imx7ulp-evk.dtb imx7ulp-evkb-emmc.dtb imx7ulp-evk-emmc-qspi.dtb imx7ulp-evk-ft5416.dtb imx7ulp-evk-mipi.dtb \
-                     imx7ulp-evkb-lpuart.dtb imx7ulp-evk-qspi.dtb imx7ulp-evkb-sd1.dtb imx7ulp-evkb-sensors-to-i2c5.dtb \
-                     imx7ulp-evkb-spi-slave.dtb imx7ulp-evk-wm8960.dtb \
-                     imx7ulp-evkb.dtb imx7ulp-evkb-mipi.dtb \
-                     imx7ulp-evkb-rm68200-wxga.dtb imx7ulp-evkb-rm68191-qhd.dtb"
+KERNEL_DEVICETREE = " \
+	imx7ulp-evkb.dtb \
+	imx7ulp-evkb-emmc.dtb \
+	imx7ulp-evkb-lpuart.dtb \
+	imx7ulp-evkb-mipi.dtb \
+	imx7ulp-evkb-rm68191-qhd.dtb \
+	imx7ulp-evkb-rm68200-wxga.dtb \
+	imx7ulp-evkb-sd1.dtb \
+	imx7ulp-evkb-sensors-to-i2c5.dtb \
+	imx7ulp-evkb-spi-slave.dtb \
+	imx7ulp-evk.dtb \
+	imx7ulp-evk-ft5416.dtb \
+	imx7ulp-evk-mipi.dtb \
+"
 
 UBOOT_CONFIG ??= "sd"
 UBOOT_CONFIG[sd] = "mx7ulp_evk_config,sdcard"

--- a/conf/machine/imx8mqevk.conf
+++ b/conf/machine/imx8mqevk.conf
@@ -15,19 +15,22 @@ MACHINE_FEATURES += "pci wifi bluetooth optee qca6174"
 
 MACHINE_SOCARCH_FILTER_append_mx8mq = " virtual/libopenvg virtual/libgles1 virtual/libgles2 virtual/egl virtual/mesa virtual/libgl virtual/libg2d"
 
-KERNEL_DEVICETREE = "freescale/fsl-imx8mq-evk.dtb freescale/fsl-imx8mq-evk-ak4497.dtb \
-                     freescale/fsl-imx8mq-evk-audio-tdm.dtb freescale/fsl-imx8mq-evk-b3.dtb \
-                     freescale/fsl-imx8mq-evk-dcss-adv7535.dtb freescale/fsl-imx8mq-evk-dcss-rm67191.dtb \
-                     freescale/fsl-imx8mq-evk-dcss-adv7535-b3.dtb freescale/fsl-imx8mq-evk-dcss-rm67191-b3.dtb \
-                     freescale/fsl-imx8mq-evk-dual-display-b3.dtb \
-                     freescale/fsl-imx8mq-evk-dual-display.dtb freescale/fsl-imx8mq-evk-drm.dtb \
-                     freescale/fsl-imx8mq-evk-dp.dtb freescale/fsl-imx8mq-evk-edp.dtb \
-                     freescale/fsl-imx8mq-evk-inmate.dtb \
-                     freescale/fsl-imx8mq-evk-lcdif-adv7535.dtb \
-                     freescale/fsl-imx8mq-evk-lcdif-adv7535-b3.dtb \
-                     freescale/fsl-imx8mq-evk-m4.dtb freescale/fsl-imx8mq-evk-mipi-csi2.dtb \
-                     freescale/fsl-imx8mq-evk-pcie1-m2.dtb freescale/fsl-imx8mq-evk-pdm.dtb \
-                     freescale/fsl-imx8mq-evk-root.dtb"
+KERNEL_DEVICETREE = " \
+	freescale/imx8mq-evk-ak4497.dtb \
+	freescale/imx8mq-evk-audio-tdm.dtb \
+	freescale/imx8mq-evk-dcss-adv7535.dtb \
+	freescale/imx8mq-evk-dcss-rm67191.dtb \
+	freescale/imx8mq-evk-dp.dtb \
+	freescale/imx8mq-evk.dtb \
+	freescale/imx8mq-evk-dual-display.dtb \
+	freescale/imx8mq-evk-inmate.dtb \
+	freescale/imx8mq-evk-lcdif-adv7535.dtb \
+	freescale/imx8mq-evk-lcdif-rm67191.dtb \
+	freescale/imx8mq-evk-pcie1-m2.dtb \
+	freescale/imx8mq-evk-pdm.dtb \
+	freescale/imx8mq-evk-root.dtb \
+	freescale/imx8mq-evk-rpmsg.dtb \
+"
 
 UBOOT_CONFIG ??= "sd"
 UBOOT_CONFIG[sd] = "imx8mq_evk_config,sdcard"

--- a/conf/machine/imx8qmmek.conf
+++ b/conf/machine/imx8qmmek.conf
@@ -24,19 +24,22 @@ SERIAL_CONSOLES = "115200;ttyAMA0"
 # auto-serial-console there
 USE_VT = "0"
 
-KERNEL_DEVICETREE = "freescale/fsl-imx8qm-mek.dtb \
-                     freescale/fsl-imx8qm-mek_ca53.dtb freescale/fsl-imx8qm-mek_ca72.dtb \
-                     freescale/fsl-imx8qm-mek-dom0.dtb freescale/fsl-imx8qm-mek-dom0-dpu2.dtb \
-                     freescale/fsl-imx8qm-mek-domu-car.dtb \
-                     freescale/fsl-imx8qm-mek-domu-dpu1.dtb freescale/fsl-imx8qm-mek-domu-dpu1-hdmi.dtb \
-                     freescale/fsl-imx8qm-mek-domu.dtb \
-                     freescale/fsl-imx8qm-mek-dsi-rm67191.dtb freescale/fsl-imx8qm-mek-dsp.dtb \
-                     freescale/fsl-imx8qm-mek-enet2-tja1100.dtb \
-                     freescale/fsl-imx8qm-mek-hdmi.dtb freescale/fsl-imx8qm-mek-hdmi-in.dtb \
-                     freescale/fsl-imx8qm-mek-inmate.dtb freescale/fsl-imx8qm-mek-jdi-wuxga-lvds1-panel.dtb \
-                     freescale/fsl-imx8qm-mek-ov5640.dtb \
-                     freescale/fsl-imx8qm-mek-root.dtb \
-                     freescale/fsl-imx8qm-mek-rpmsg.dtb "
+KERNEL_DEVICETREE = " \
+	freescale/imx8qm-mek-ca53.dtb \
+	freescale/imx8qm-mek-ca72.dtb \
+	freescale/imx8qm-mek-dom0.dtb \
+	freescale/imx8qm-mek-domu.dtb \
+	freescale/imx8qm-mek-dsi-rm67191.dtb \
+	freescale/imx8qm-mek-dsp.dtb \
+	freescale/imx8qm-mek.dtb \
+	freescale/imx8qm-mek-enet2-tja1100.dtb \
+	freescale/imx8qm-mek-hdmi.dtb \
+	freescale/imx8qm-mek-inmate.dtb \
+	freescale/imx8qm-mek-jdi-wuxga-lvds1-panel.dtb \
+	freescale/imx8qm-mek-ov5640.dtb \
+	freescale/imx8qm-mek-root.dtb \
+	freescale/imx8qm-mek-rpmsg.dtb \
+"
 
 UBOOT_MAKE_TARGET = "u-boot.bin"
 UBOOT_SUFFIX = "bin"

--- a/conf/machine/imx8qxpmek.conf
+++ b/conf/machine/imx8qxpmek.conf
@@ -24,15 +24,25 @@ SERIAL_CONSOLES = "115200;ttyAMA0"
 # auto-serial-console there
 USE_VT = "0"
 
-KERNEL_DEVICETREE = "freescale/fsl-imx8qxp-mek.dtb freescale/fsl-imx8qxp-mek-dom0.dtb \
-                     freescale/fsl-imx8qxp-mek-dsi-rm67191.dtb freescale/fsl-imx8qxp-mek-dsp.dtb \
-                     freescale/fsl-imx8qxp-mek-enet2.dtb freescale/fsl-imx8qxp-mek-enet2-tja1100.dtb \
-                     freescale/fsl-imx8qxp-mek-it6263-lvds0-dual-channel.dtb freescale/fsl-imx8qxp-mek-it6263-lvds1-dual-channel.dtb \
-                     freescale/fsl-imx8qxp-mek-inmate.dtb \
-                     freescale/fsl-imx8qxp-mek-lcdif.dtb \
-                     freescale/fsl-imx8qxp-mek-jdi-wuxga-lvds1-panel.dtb freescale/fsl-imx8qxp-mek-jdi-wuxga-lvds0-panel.dtb \
-                     freescale/fsl-imx8qxp-mek-ov5640.dtb \
-                     freescale/fsl-imx8qxp-mek-rpmsg.dtb freescale/fsl-imx8qxp-mek-root.dtb"
+KERNEL_DEVICETREE = " \
+	freescale/imx8qxp-mek-a0.dtb \
+	freescale/imx8qxp-mek-dom0.dtb \
+	freescale/imx8qxp-mek-dsi-rm67191.dtb \
+	freescale/imx8qxp-mek-dsp.dtb \
+	freescale/imx8qxp-mek.dtb \
+	freescale/imx8qxp-mek-enet2.dtb \
+	freescale/imx8qxp-mek-enet2-tja1100.dtb \
+	freescale/imx8qxp-mek-inmate.dtb \
+	freescale/imx8qxp-mek-it6263-lvds0-dual-channel.dtb \
+	freescale/imx8qxp-mek-it6263-lvds1-dual-channel.dtb \
+	freescale/imx8qxp-mek-jdi-wuxga-lvds0-panel.dtb \
+	freescale/imx8qxp-mek-jdi-wuxga-lvds1-panel.dtb \
+	freescale/imx8qxp-mek-ov5640.dtb \
+	freescale/imx8qxp-mek-root.dtb \
+	freescale/imx8qxp-mek-rpmsg.dtb \
+	freescale/imx8qxp-mek-sof-cs42888.dtb \
+	freescale/imx8qxp-mek-sof-wm8960.dtb \
+"
 
 UBOOT_MAKE_TARGET = "u-boot.bin"
 UBOOT_SUFFIX = "bin"


### PR DESCRIPTION
Updated kernel has some DTS files added and some dropped for various
i.MX derivatives. Those should be aligned with respective machines in
order to deliver proper DTB files, and do not fail the build for those
are missing.

Device tree files listed in respective machines are those only present
in updated 5.4 kernel release from NXP. Derivatives, which relied on
those device trees that are discarded from the new kernel release should
backport their respective files onto that update.

In other words: if after this update the DTS file used for the HW happens
to be missing - it should be manually added for that HW, since the default
version is no longer provided by NXP in their updated kernel tree.

Signed-off-by: Andrey Zhizhikin <andrey.zhizhikin@leica-geosystems.com>