### PR TITLE
recipes-*: refine restrictions for NXP BSP

### DIFF
--- a/classes/use-imx-headers.bbclass
+++ b/classes/use-imx-headers.bbclass
@@ -17,3 +17,15 @@ DEPENDS_append_imx = " linux-imx-headers"
 PACKAGE_ARCH_imx ?= "${MACHINE_SOCARCH}"
 
 STAGING_INCDIR_IMX = "${STAGING_INCDIR}/imx"
+
+# Recipes that inherit this class are contracted to use NXP BSP only.
+# This is done by overriding the COMPATIBLE_HOST, as this would effectively
+# cause recipes to be skipped in case if 'use-nxp-bsp' override is not
+# defined for them. This effectively marks recipes that should only be
+# built using NXP BSP, and gives an indication to mainline BSP creators
+# that recipe is not compatible with mainline.
+#
+# Typical example here would be imx-vpu-hantro recipe, which requires NXP
+# BSP and is not compatible with mainline.
+COMPATIBLE_HOST = '(null)'
+COMPATIBLE_HOST_use-nxp-bsp = '.*'

--- a/recipes-bsp/imx-test/imx-test_git.bb
+++ b/recipes-bsp/imx-test/imx-test_git.bb
@@ -79,7 +79,3 @@ FILES_${PN} += "/unit_tests /home/root/.profile"
 RDEPENDS_${PN} = "bash"
 
 FILES_${PN}-dbg += "/unit_tests/.debug"
-
-COMPATIBLE_MACHINE = "(mx6|mx7|mx8)"
-COMPATIBLE_HOST ?= "(none)"
-COMPATIBLE_HOST_use-nxp-bsp = "(.*)"

--- a/recipes-kernel/linux/linux-imx-headers_5.4.3.bb
+++ b/recipes-kernel/linux/linux-imx-headers_5.4.3.bb
@@ -63,5 +63,8 @@ INHIBIT_DEFAULT_DEPS = "1"
 DEPENDS += "unifdef-native bison-native rsync-native"
 
 PACKAGE_ARCH = "${MACHINE_SOCARCH}"
-COMPATIBLE_HOST_imx = "(use-nxp-bsp)"
-COMPATIBLE_HOST ?= "(none)"
+
+# Restrict this recipe to NXP BSP only, this recipe is not compatible
+# with mainline BSP
+COMPATIBLE_HOST = '(null)'
+COMPATIBLE_HOST_use-nxp-bsp = '.*'


### PR DESCRIPTION
Certain packages are using linux-imx-headers, which enforces them to use
NXP BSP since headers are provided from the NXP kernel tree.

Those recipes, which requires NXP kernel headers, are now including the
use-imx-headers class to make sure the correct headers package is used.

Since the introduction of separation between NXP and Mainline BSP for
certain machines, recipes which are NXP-dependent are getting their
COMPATIBLE_HOST to be marked as (null) effectively making them
incompatible with mainline BSP which is expected behavior.

By extending this restriction into the use-imx-headers class, all
recipes which inherits is (because it is required) are getting
automatically restricted to NXP BSP, hence making package NXP-dependent
much easier.

linux-imx-headers is marked as "NXP-only" but it is done explicitly
inside the recipe in order to avoid confusion of inheriting the class.

Signed-off-by: Andrey Zhizhikin <andrey.zhizhikin@leica-geosystems.com>