### PR TITLE
Revert "mx8qm: Use cortexa72-cortexa53 tune by default"

### DIFF
--- a/conf/machine/imx8qmmek.conf
+++ b/conf/machine/imx8qmmek.conf
@@ -6,7 +6,7 @@
 MACHINEOVERRIDES =. "mx8:mx8qm:"
 
 require conf/machine/include/imx-base.inc
-require conf/machine/include/tune-cortexa72-cortexa53.inc
+require conf/machine/include/arm/arch-arm64.inc
 
 MACHINE_FEATURES_append = " qca6174"
 

--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -68,7 +68,6 @@ DEFAULTTUNE_vf     ?= "cortexa5thf-neon"
 DEFAULTTUNE_mx8mm  ?= "cortexa53-crypto"
 DEFAULTTUNE_mx8mn  ?= "cortexa53-crypto"
 DEFAULTTUNE_mx8mq  ?= "cortexa53-crypto"
-DEFAULTTUNE_mx8qm  ?= "cortexa72-cortexa53-crypto"
 DEFAULTTUNE_mx8qxp ?= "cortexa35-crypto"
 
 INHERIT += "machine-overrides-extender"


### PR DESCRIPTION
Support for cortexa72-cortexa53 tuning is not available on zeus.

This reverts commit 9d6833f8a2e743c9907e20c8e0a0d46be9f65fd3.

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>