### PR TITLE
imx-dpu-g2d: Upgrade to 1.8.3

### DIFF
--- a/recipes-graphics/imx-dpu-g2d/imx-dpu-g2d_1.8.3.bb
+++ b/recipes-graphics/imx-dpu-g2d/imx-dpu-g2d_1.8.3.bb
@@ -4,12 +4,12 @@
 
 DESCRIPTION = "GPU G2D library and apps for i.MX with 2D GPU and DPU"
 LICENSE = "Proprietary"
-LIC_FILES_CHKSUM = "file://COPYING;md5=6c12031a11b81db21cdfe0be88cac4b3"
+LIC_FILES_CHKSUM = "file://COPYING;md5=fd4b227530cd88a82af6a5982cfb724d"
 PROVIDES += "virtual/libg2d"
 
 SRC_URI = "${FSL_MIRROR}/${BPN}-${PV}.bin;fsl-eula=true"
-SRC_URI[md5sum] = "b34737fe41688672e1d9522e931509f4"
-SRC_URI[sha256sum] = "46c72ce9b98b7116e9f7f53a66aadc8fb66910473477c6553db77ed71e54d7ea"
+SRC_URI[md5sum] = "57a0a0a7d20e4ea1a0d2dcd162abfa79"
+SRC_URI[sha256sum] = "f8bc83e23263e179bd66492dafaeb104a3967337d76325d0ec97993ae846fb13"
 
 inherit fsl-eula-unpack
 


### PR DESCRIPTION
c27d26b MGS-5479 remove g2d_multiblit_test
9730281 MGS-5435 [QNX] G2D - child and parent window can not rotate correctly
73354dc MGS-5103 add YUV mode for BT.601 and BT.709
43ff464 MA-16215 Avoid change input parameter value in g2d_blitEx
807cf04 MGS-5403 enable G2D tile-status feature

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>