### PR TITLE
libimxvpuapi2: Update to version 2.0.1

### DIFF
--- a/recipes-multimedia/libimxvpuapi/libimxvpuapi2_2.0.1.bb
+++ b/recipes-multimedia/libimxvpuapi/libimxvpuapi2_2.0.1.bb
@@ -5,10 +5,10 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=38fa42a5a6425b26d2919b17b1527324"
 SECTION = "multimedia"
 DEPENDS = "virtual/imxvpu libimxdmabuffer"
 
-PV = "2.0.0+${SRCPV}"
+PV .= "+git${SRCPV}"
 
 SRCBRANCH ?= "master"
-SRCREV = "86028967644d2da8e99d4e206ca1d71ff4bcb7f7"
+SRCREV = "9a5e84af53e6765c4f0ea299df264a4e32a13ea7"
 SRC_URI = "git://github.com/Freescale/libimxvpuapi.git;branch=${SRCBRANCH}"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
* imx6: replace mxcfb.h check with i.MX6 specific imx header check
  the mcxfb.h check only makes sense with i.MX6 devices, so requiring
  those for others like i.MX8 led to build errors
* update waf to 2.0.12 and switch wscript to use Python 3
* imx6: fix encoder pointer usage in vpu_EncGiveCommand() call

Signed-off-by: Carlos Rafael Giani <crg7475@mailbox.org>