### PR TITLE
dp-firmware-cadence: fix LICENSE

### DIFF
--- a/recipes-bsp/dp-firmware-cadence/dp-firmware-cadence_git.bb
+++ b/recipes-bsp/dp-firmware-cadence/dp-firmware-cadence_git.bb
@@ -1,5 +1,5 @@
 SUMMARY = "DP firmware"
-LICENSE = "NXP-Binary-EULA"
+LICENSE = "Proprietary"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6c12031a11b81db21cdfe0be88cac4b3"
 
 inherit deploy fsl-eula-unpack 


### PR DESCRIPTION
LICENSE should be "Proprieraty", not "NXP-Binary-EULA", otherwise fetch
with fsl-eula-unpack will fail.

Fixes #360

Signed-off-by: Matthias Schiffer <matthias.schiffer@tq-group.com>