### PR TITLE
optee-test_3.2.0.imx: fix TA_DEV_KIT_DIR is not correctly defined error

### DIFF
--- a/recipes-security/optee-imx/optee-test_3.2.0.imx.bb
+++ b/recipes-security/optee-imx/optee-test_3.2.0.imx.bb
@@ -26,14 +26,14 @@ S = "${WORKDIR}/git"
 
 SRCREV = "b7114b828b82f2c0eec124ed424eff1230cc5319"
 
+OPTEE_ARCH ?= "arm32"
+OPTEE_ARCH_armv7a = "arm32"
+OPTEE_ARCH_aarch64 = "arm64"
+
 do_compile () {
-    if [ ${DEFAULTTUNE} = "aarch64" ];then
-        export TA_DEV_KIT_DIR=${STAGING_INCDIR}/optee/export-user_ta_arm64/
-        export ARCH=arm64
-    else
-        export TA_DEV_KIT_DIR=${STAGING_INCDIR}/optee/export-user_ta_arm32/
-        export ARCH=arm
-    fi
+    export TA_DEV_KIT_DIR=${STAGING_INCDIR}/optee/export-user_ta_${OPTEE_ARCH}/
+    export ARCH=${OPTEE_ARCH}
+
     export OPTEE_CLIENT_EXPORT=${STAGING_DIR_HOST}/usr
     export CROSS_COMPILE_HOST=${HOST_PREFIX}
     export CROSS_COMPILE_TA=${HOST_PREFIX}


### PR DESCRIPTION
DEFAULTTUNE is no longer aarch64 which means optee-test
build fails. Update to use the same mechanism as optee-os
recipe for setting arch.

Build now passes on imx8mq-evk and optee xtest suite
passes

+-----------------------------------------------------
16078 subtests of which 3 failed
74 test cases of which 3 failed
0 test case was skipped
TEE test application done!

Signed-off-by: Peter Griffin <peter.griffin@linaro.org>