### PR TITLE
Fix for libximdmabuffer and update for gstreamer1.0-plugins-imx

### DIFF
--- a/recipes-bsp/libimxdmabuffer/files/run-ptest
+++ b/recipes-bsp/libimxdmabuffer/files/run-ptest
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+./test-alloc >/dev/null 2>&1
+
+if [ $? -eq 0 ]; then
+   echo "PASS: test-alloc"
+else
+   echo "FAIL: test-alloc"
+fi
+

--- a/recipes-bsp/libimxdmabuffer/libimxdmabuffer_1.0.1.bb
+++ b/recipes-bsp/libimxdmabuffer/libimxdmabuffer_1.0.1.bb
@@ -9,7 +9,10 @@ PV .= "+git${SRCPV}"
 
 SRCBRANCH ?= "master"
 SRCREV = "d2058aa404ee1e8e8abd552c6a637787bcdcf514"
-SRC_URI = "git://github.com/Freescale/libimxdmabuffer.git;branch=${SRCBRANCH}"
+SRC_URI = "git://github.com/Freescale/libimxdmabuffer.git;branch=${SRCBRANCH} \
+           file://run-ptest \
+          "
+
 
 S = "${WORKDIR}/git"
 
@@ -33,9 +36,11 @@ PACKAGECONFIG[ipu] = "--with-ipu-allocator=yes,               --with-ipu-allocat
 PACKAGECONFIG[g2d] = "--with-g2d-allocator=yes,               --with-g2d-allocator=no,virtual/libg2d"
 PACKAGECONFIG[pxp] = "--with-pxp-allocator=yes,               --with-pxp-allocator=no,"
 
-do_install_ptest () {
-    install -d ${D}${PTEST_PATH}/tests
-    install -m 0755 ${B}/test-alloc ${D}${PTEST_PATH}/tests
+# Using do_install_ptest_base instead of do_install_ptest, since
+# the default do_install_ptest_base is hardcoded to expect Makefiles.
+do_install_ptest_base() {
+    install -D ${WORKDIR}/run-ptest ${D}${PTEST_PATH}/run-ptest
+    install -m 0755 ${B}/test-alloc ${D}${PTEST_PATH}
 }
 
 COMPATIBLE_MACHINE = "(mx6|mx7|mx8)"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-imx_0.13.1.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-imx_0.13.1.bb
@@ -14,10 +14,10 @@ RDEPENDS_gstreamer1.0-plugins-imx = "gstreamer1.0-plugins-good"
 RDEPENDS_gstreamer1.0-plugins-imx-imxaudio = "gstreamer1.0-plugins-good-audioparsers"
 RDEPENDS_gstreamer1.0-plugins-imx-imxvpu = "gstreamer1.0-plugins-bad-videoparsersbad"
 
-PV = "0.13.0+git${SRCPV}"
+PV .= "+git${SRCPV}"
 
 SRCBRANCH ?= "master"
-SRCREV = "64485a1573f39a79f92688f9e32b2babab066b9d"
+SRCREV = "805987bff74af13fcb14ff111955206f1c92554d"
 SRC_URI = "git://github.com/Freescale/gstreamer-imx.git;branch=${SRCBRANCH}"
 
 S = "${WORKDIR}/git"
@@ -50,8 +50,8 @@ PACKAGECONFIG_append_imxipu   = " ipu"
 PACKAGECONFIG_append_imxvpu   = " vpu"
 PACKAGECONFIG_append_imxpxp   = " pxp"
 
-PACKAGECONFIG[g2d] = ",--disable-g2d,imx-gpu-viv"
-PACKAGECONFIG[g2dpango] = ",--disable-g2dpango,imx-gpu-viv pango"
+PACKAGECONFIG[g2d] = ",--disable-g2d,imx-gpu-g2d"
+PACKAGECONFIG[g2dpango] = ",--disable-g2dpango,imx-gpu-g2d pango"
 PACKAGECONFIG[pxp] = ",--disable-pxp,"
 PACKAGECONFIG[ipu] = ",--disable-ipu,"
 PACKAGECONFIG[vpu] = ",--disable-vpu,libimxvpuapi"


### PR DESCRIPTION
The libximdmabuffer fix corrects the way ptest is handled.
The gstreamer1.0-plugins-imx upgrade is mainly there to have the latest features and fixes of the 0.13.x series in a properly versioned release (instead of having to rely on some git revision). After this, development focus is on the 2.x series, which supports iMX6/7/8.