### PR TITLE
xserver-xf86-config: Fix xorg.conf for 6ULL

### DIFF
--- a/recipes-graphics/xorg-xserver/xserver-xf86-config/mx6ull/xorg.conf
+++ b/recipes-graphics/xorg-xserver/xserver-xf86-config/mx6ull/xorg.conf
@@ -1,0 +1,12 @@
+Section "Device"
+    Identifier  "Kernel Framebuffer Device"
+    Driver      "fbdev"
+    Option      "fbdev" "/dev/fb0"
+EndSection
+
+Section "ServerFlags"
+    Option "BlankTime"  "0"
+    Option "StandbyTime"  "0"
+    Option "SuspendTime"  "0"
+    Option "OffTime"  "0"
+EndSection


### PR DESCRIPTION
The 6ULL does not have a hardware-accelerated framebuffer
device, so switch to the kernel framebuffer device.

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>