### PR TITLE
Revert "qtbase: Do not pin gles2 when using open source graphic stack"

### DIFF
--- a/dynamic-layers/qt5-layer/recipes-qt/qt5/qtbase_%.bbappend
+++ b/dynamic-layers/qt5-layer/recipes-qt/qt5/qtbase_%.bbappend
@@ -19,7 +19,7 @@ SRC_URI_append_imxgpu3d = " \
 PACKAGECONFIG_GL_imxpxp   = "gles2"
 PACKAGECONFIG_GL_imxgpu2d = "${@bb.utils.contains('DISTRO_FEATURES', 'x11', ' gl', '', d)}"
 PACKAGECONFIG_GL_imxgpu3d = "gles2"
-PACKAGECONFIG_GL_use-mainline-bsp = "gles2 gbm kms"
+PACKAGECONFIG_GL_use-mainline-bsp ?= "gles2 gbm kms"
 
 PACKAGECONFIG_PLATFORM          = ""
 PACKAGECONFIG_PLATFORM_imxgpu2d = "no-opengl linuxfb"

--- a/dynamic-layers/qt5-layer/recipes-qt/qt5/qtbase_%.bbappend
+++ b/dynamic-layers/qt5-layer/recipes-qt/qt5/qtbase_%.bbappend
@@ -19,7 +19,7 @@ SRC_URI_append_imxgpu3d = " \
 PACKAGECONFIG_GL_imxpxp   = "gles2"
 PACKAGECONFIG_GL_imxgpu2d = "${@bb.utils.contains('DISTRO_FEATURES', 'x11', ' gl', '', d)}"
 PACKAGECONFIG_GL_imxgpu3d = "gles2"
-PACKAGECONFIG_GL_append_use-mainline-bsp = " gbm kms"
+PACKAGECONFIG_GL_use-mainline-bsp = "gles2 gbm kms"
 
 PACKAGECONFIG_PLATFORM          = ""
 PACKAGECONFIG_PLATFORM_imxgpu2d = "no-opengl linuxfb"


### PR DESCRIPTION
This reverts commit 1cf9efd20fd94afdd2f7484b0570c570a21b8b65.

The qtbase configure fail to find any suitable GL library, so it fails
with:

,----
| WARNING: No QPA platform plugin enabled! This will produce a Qt that
| cannot run GUI applications.  See "Platform backends" in the output of
| --help.
|
| ERROR: Feature 'opengl-desktop' was enabled, but the pre-condition
| '(config.win32 && !config.winrt && !features.opengles2
|     && (config.msvc || libs.opengl))
|  || (!config.watchos && !config.win32 && !config.wasm && libs.opengl)' failed.
|
| ERROR: Feature 'eglfs' was enabled, but the pre-condition
|   '!config.android && !config.darwin && !config.win32 && !config.wasm
|   && features.egl' failed.
`----

Fixed: #378

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>