### PR TITLE
imx-boot: fix mkimage_uboot linking issue

### DIFF
--- a/recipes-bsp/imx-mkimage/imx-boot_0.2.bb
+++ b/recipes-bsp/imx-mkimage/imx-boot_0.2.bb
@@ -105,6 +105,8 @@ compile_mx8x() {
     cp ${DEPLOY_DIR_IMAGE}/${UBOOT_NAME}                     ${BOOT_STAGING}/u-boot.bin
 }
 do_compile() {
+    # mkimage_uboot requires libssl.so.1.1 from ${STAGING_LIBDIR_NATIVE}
+    export LD_LIBRARY_PATH=${STAGING_LIBDIR_NATIVE}:$LD_LIBRARY_PATH
     compile_${SOC_FAMILY}
     # mkimage for i.MX8
     if ${DEPLOY_OPTEE}; then


### PR DESCRIPTION
In imx-boot's Makefile, it downloads a native tool mkimage_uboot and
executes it, but this native tool requires libssl.so.1.1, which is in
${STAGING_LIBDIR_NATIVE}, we need set LD_LIBRARY_PATH to include it, or
it might run into following errors:
| ./mkimage_uboot -E -p 0x3000 -f u-boot.its u-boot.itb
| ./mkimage_uboot: error while loading shared libraries: libssl.so.1.1: cannot open shared object file: No such file or directory

Signed-off-by: Ming Liu <ming.liu@toradex.com>