### PR TITLE
qtbase: Fix patch fuzz for mkspecs/linux-oe-g++/qmake.conf

### DIFF
--- a/dynamic-layers/qt5-layer/recipes-qt/qt5/qtbase/0015-Add-eglfs-to-IMX-GPU.patch
+++ b/dynamic-layers/qt5-layer/recipes-qt/qt5/qtbase/0015-Add-eglfs-to-IMX-GPU.patch
@@ -1,8 +1,8 @@
-Index: git/mkspecs/linux-oe-g++/qmake.conf
-===================================================================
---- git.orig/mkspecs/linux-oe-g++/qmake.conf	2016-12-14 17:03:17.000000000 -0600
-+++ git/mkspecs/linux-oe-g++/qmake.conf	2016-12-14 17:06:23.000000000 -0600
-@@ -37,6 +37,8 @@ QMAKE_LINK_C_SHLIB = $$(OE_QMAKE_LINK)
+diff --git a/mkspecs/linux-oe-g++/qmake.conf b/mkspecs/linux-oe-g++/qmake.conf
+index c202c47fa1..2bfb96f4ec 100644
+--- a/mkspecs/linux-oe-g++/qmake.conf
++++ b/mkspecs/linux-oe-g++/qmake.conf
+@@ -33,6 +33,8 @@ QMAKE_CFLAGS_ISYSTEM =
  # for the SDK
  isEmpty(QMAKE_QT_CONFIG):QMAKE_QT_CONFIG = $$(OE_QMAKE_QT_CONFIG)
  
@@ -10,4 +10,7 @@ Index: git/mkspecs/linux-oe-g++/qmake.conf
 +
  include(../oe-device-extra.pri)
  
- QMAKE_LIBS_EGL        += -lEGL
+ load(device_config)
+-- 
+2.17.1
+


### PR DESCRIPTION
The current version of the patch causes a fuzz because of a context
change. This happens when not using x11, which is coherent with https://github.com/Freescale/meta-freescale/blob/a44d0e61e09ecefeee56403236e81a2f2eb0ab1d/dynamic-layers/qt5-layer/recipes-qt/qt5/qtbase_%25.bbappend#L12

```
WARNING: qtbase-5.14.99+5.15-beta4+gitAUTOINC+806bc5fc05-r0 do_patch: Fuzz detected:

Applying patch 0015-Add-eglfs-to-IMX-GPU.patch
patching file mkspecs/linux-oe-g++/qmake.conf
Hunk #1 succeeded at 33 with fuzz 1 (offset -4 lines).

The context lines in the patches can be updated with devtool:

    devtool modify qtbase
    devtool finish --force-patch-refresh qtbase <layer_path>

Don't forget to review changes done by devtool!
```

This happens on master as well.