### PR TITLE
weston: Restore partial clients for i.MX 6 and 7

### DIFF
--- a/recipes-graphics/wayland/weston_8.0.0.imx.bb
+++ b/recipes-graphics/wayland/weston_8.0.0.imx.bb
@@ -146,11 +146,15 @@ PACKAGECONFIG_OPENGL_imxgpu3d     = "opengl"
 
 PACKAGECONFIG_append = " ${@bb.utils.filter('DISTRO_FEATURES', '${PACKAGECONFIG_OPENGL}', d)}"
 
-PACKAGECONFIG_remove_imxfbdev = "kms clients"
-PACKAGECONFIG_append_imxfbdev = " fbdev"
+PACKAGECONFIG_remove_imxfbdev = "kms"
+PACKAGECONFIG_append_imxfbdev = " fbdev clients"
 PACKAGECONFIG_append_imxgpu   = " imxgpu"
 PACKAGECONFIG_append_imxgpu2d = " imxg2d"
 
+# Clients support
+SIMPLE_CLIENTS = "all"
+SIMPLE_CLIENTS_imxfbdev = "damage,im,egl,shm,touch,dmabuf-v4l"
+PACKAGECONFIG[clients] = "-Dsimple-clients=${SIMPLE_CLIENTS} -Ddemo-clients=true,-Dsimple-clients= -Ddemo-clients=false"
 # Weston with i.MX GPU support
 PACKAGECONFIG[imxgpu] = "-Dimxgpu=true,-Dimxgpu=false,virtual/egl"
 # Weston with i.MX G2D renderer


### PR DESCRIPTION
The clients configuration for fbdev was recently removed from
meta-freescale [1] because of the following error:

```
| Run-time dependency gbm found: NO (tried pkgconfig and cmake)
|
| clients/meson.build:134:4: ERROR: Problem encountered: weston-simple-dmabuf-egl requires gbm which was not found. If you rather not build this, drop "dmabuf-egl" from simple-clients option.
```

[1] eda44e49618610c13ebe4c026cd4981b404a1543

It was also removed for non-Wayland from OE-core [2] because of the
following error in the same client dmabuf-egl:

```
clients/meson.build:141:4: ERROR: Problem encountered: weston-simple-dmabuf-egl
requires option renderer-gl which is not enabled. If you rather not build this,
drop "dmabuf-egl" from simple-clients option.
```

[2] 9b1d30810eeecb46b977c8eed68be69aef891312

Restore the working subset of clients.

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>