### PR TITLE
qoriq-ppc: add fsl/ prefix in KERNEL_DEVICETREE

### DIFF
--- a/conf/machine/mpc8548cds.conf
+++ b/conf/machine/mpc8548cds.conf
@@ -8,7 +8,7 @@ require conf/machine/include/e500v2.inc
 UBOOT_CONFIG ??= "nor"
 UBOOT_CONFIG[nor] = "MPC8548CDS_defconfig,,u-boot-with-dtb.bin"
 
-KERNEL_DEVICETREE = "mpc8548cds_32b.dtb"
+KERNEL_DEVICETREE = "fsl/mpc8548cds_32b.dtb"
 KERNEL_DEFCONFIG = "mpc85xx_defconfig"
 
 USE_VT ?= "0"

--- a/conf/machine/p1020rdb.conf
+++ b/conf/machine/p1020rdb.conf
@@ -20,7 +20,7 @@ UBOOT_SOURCE_NAND = "u-boot-with-spl.bin"
 UBOOT_SOURCE_SPI = "u-boot-with-spl.bin"
 UBOOT_SOURCE_SD = "u-boot-with-spl.bin"
 
-KERNEL_DEVICETREE ?= "p1020rdb-pd.dtb"
+KERNEL_DEVICETREE ?= "fsl/p1020rdb-pd.dtb"
 KERNEL_DEFCONFIG ?= "mpc85xx_smp_defconfig"
 
 JFFS2_ERASEBLOCK = "0x20000"

--- a/conf/machine/p2020rdb.conf
+++ b/conf/machine/p2020rdb.conf
@@ -20,7 +20,7 @@ UBOOT_CONFIG[36bit-spi] = "P2020RDB-PC_36BIT_SPIFLASH_config,,u-boot-with-spl.bi
 UBOOT_CONFIG[36bit-nand] = "P2020RDB-PC_36BIT_NAND_config,,u-boot-with-spl.bin"
 UBOOT_CONFIG[36bit-sdcard] = "P2020RDB-PC_36BIT_SDCARD_config,,u-boot-with-spl.bin"
 
-KERNEL_DEVICETREE ?= "p2020rdb-pc_32b.dtb"
+KERNEL_DEVICETREE ?= "fsl/p2020rdb-pc_32b.dtb"
 KERNEL_DEFCONFIG ?= "mpc85xx_smp_defconfig"
 
 JFFS2_ERASEBLOCK = "0x20000"

--- a/conf/machine/p2041rdb.conf
+++ b/conf/machine/p2041rdb.conf
@@ -18,7 +18,7 @@ UBOOT_CONFIG[spi] = "P2041RDB_SPIFLASH_config,,u-boot.pbl"
 
 HV_CFG_M = "p2041rdb"
 
-KERNEL_DEVICETREE ?= "p2041rdb.dtb"
+KERNEL_DEVICETREE ?= "fsl/p2041rdb.dtb"
 KERNEL_DEFCONFIG ?= "corenet32_smp_defconfig"
 
 JFFS2_ERASEBLOCK = "0x10000"

--- a/conf/machine/p3041ds.conf
+++ b/conf/machine/p3041ds.conf
@@ -18,7 +18,7 @@ UBOOT_CONFIG[spi] = "P3041DS_SPIFLASH_config,,u-boot.pbl"
 
 HV_CFG_M = "p3041ds"
 
-KERNEL_DEVICETREE ?= "p3041ds.dtb"
+KERNEL_DEVICETREE ?= "fsl/p3041ds.dtb"
 KERNEL_DEFCONFIG ?= "corenet32_smp_defconfig"
 
 JFFS2_ERASEBLOCK = "0x10000"

--- a/conf/machine/p4080ds.conf
+++ b/conf/machine/p4080ds.conf
@@ -17,7 +17,7 @@ UBOOT_CONFIG[spi] = "P4080DS_SPIFLASH_config,,u-boot.pbl"
 
 HV_CFG_M = "p4080ds"
 
-KERNEL_DEVICETREE ?= "p4080ds.dtb"
+KERNEL_DEVICETREE ?= "fsl/p4080ds.dtb"
 KERNEL_DEFCONFIG ?= "corenet32_smp_defconfig"
 
 JFFS2_ERASEBLOCK = "0x10000"

--- a/conf/machine/p5040ds-64b.conf
+++ b/conf/machine/p5040ds-64b.conf
@@ -18,7 +18,7 @@ UBOOT_CONFIG[spi] = "P5040DS_SPIFLASH_config,,u-boot.pbl"
 
 HV_CFG_M = "p5040ds"
 
-KERNEL_DEVICETREE ?= "p5040ds.dtb"
+KERNEL_DEVICETREE ?= "fsl/p5040ds.dtb"
 KERNEL_DEFCONFIG ?= "corenet64_smp_defconfig"
 
 JFFS2_ERASEBLOCK = "0x10000"

--- a/conf/machine/p5040ds.conf
+++ b/conf/machine/p5040ds.conf
@@ -18,7 +18,7 @@ UBOOT_CONFIG[spi] = "P5040DS_SPIFLASH_config,,u-boot.pbl"
 
 HV_CFG_M = "p5040ds"
 
-KERNEL_DEVICETREE ?= "p5040ds.dtb"
+KERNEL_DEVICETREE ?= "fsl/p5040ds.dtb"
 KERNEL_DEFCONFIG ?= "corenet32_smp_defconfig"
 
 JFFS2_ERASEBLOCK = "0x10000"

--- a/conf/machine/t1024rdb-64b.conf
+++ b/conf/machine/t1024rdb-64b.conf
@@ -18,7 +18,7 @@ UBOOT_CONFIG[secure-boot] = "T1024RDB_SECURE_BOOT_config"
 
 HV_CFG_M = "t1024rdb"
 
-KERNEL_DEVICETREE ?= "t1024rdb.dtb"
+KERNEL_DEVICETREE ?= "fsl/t1024rdb.dtb"
 KERNEL_DEFCONFIG ?= "corenet64_smp_defconfig"
 
 JFFS2_ERASEBLOCK = "0x10000"

--- a/conf/machine/t1024rdb.conf
+++ b/conf/machine/t1024rdb.conf
@@ -18,7 +18,7 @@ UBOOT_CONFIG[secure-boot] = "T1024RDB_SECURE_BOOT_config"
 
 HV_CFG_M = "t1024rdb"
 
-KERNEL_DEVICETREE ?= "t1024rdb.dtb"
+KERNEL_DEVICETREE ?= "fsl/t1024rdb.dtb"
 KERNEL_DEFCONFIG ?= "corenet32_smp_defconfig"
 
 JFFS2_ERASEBLOCK = "0x10000"

--- a/conf/machine/t1042d4rdb-64b.conf
+++ b/conf/machine/t1042d4rdb-64b.conf
@@ -18,7 +18,7 @@ UBOOT_CONFIG[secure-boot] = "T1042D4RDB_SECURE_BOOT_config,,u-boot.bin"
 
 HV_CFG_M = "t1040rdb"
 
-KERNEL_DEVICETREE ?= "t1042d4rdb.dtb"
+KERNEL_DEVICETREE ?= "fsl/t1042d4rdb.dtb"
 KERNEL_DEFCONFIG ?= "corenet64_smp_defconfig"
 
 JFFS2_ERASEBLOCK = "0x10000"

--- a/conf/machine/t1042d4rdb.conf
+++ b/conf/machine/t1042d4rdb.conf
@@ -18,7 +18,7 @@ UBOOT_CONFIG[secure-boot] = "T1042D4RDB_SECURE_BOOT_config,,u-boot.bin"
 
 HV_CFG_M = "t1040rdb"
 
-KERNEL_DEVICETREE ?= "t1042d4rdb.dtb"
+KERNEL_DEVICETREE ?= "fsl/t1042d4rdb.dtb"
 KERNEL_DEFCONFIG ?= "corenet32_smp_defconfig"
 
 JFFS2_ERASEBLOCK = "0x10000"

--- a/conf/machine/t2080rdb-64b.conf
+++ b/conf/machine/t2080rdb-64b.conf
@@ -19,7 +19,7 @@ UBOOT_CONFIG[secure-boot] = "T2080RDB_SECURE_BOOT_config"
 
 HV_CFG_M = "t2080rdb"
 
-KERNEL_DEVICETREE ?= "t2080rdb.dtb"
+KERNEL_DEVICETREE ?= "fsl/t2080rdb.dtb"
 KERNEL_DEFCONFIG ?= "corenet64_smp_defconfig"
 
 JFFS2_ERASEBLOCK = "0x10000"

--- a/conf/machine/t2080rdb.conf
+++ b/conf/machine/t2080rdb.conf
@@ -19,7 +19,7 @@ UBOOT_CONFIG[secure-boot] = "T2080RDB_SECURE_BOOT_config"
 
 HV_CFG_M = "t2080rdb"
 
-KERNEL_DEVICETREE ?= "t2080rdb.dtb"
+KERNEL_DEVICETREE ?= "fsl/t2080rdb.dtb"
 KERNEL_DEFCONFIG ?= "corenet64_smp_defconfig"
 
 JFFS2_ERASEBLOCK = "0x10000"

--- a/conf/machine/t4240rdb-64b.conf
+++ b/conf/machine/t4240rdb-64b.conf
@@ -14,7 +14,7 @@ UBOOT_CONFIG[nor] = "T4240RDB_config,,u-boot-with-dtb.bin"
 
 HV_CFG_M = "t4240rdb"
 
-KERNEL_DEVICETREE ?= "t4240rdb.dtb"
+KERNEL_DEVICETREE ?= "fsl/t4240rdb.dtb"
 KERNEL_DEFCONFIG ?= "corenet64_smp_defconfig"
 
 JFFS2_ERASEBLOCK = "0x10000"

--- a/conf/machine/t4240rdb.conf
+++ b/conf/machine/t4240rdb.conf
@@ -14,7 +14,7 @@ UBOOT_CONFIG[nor] = "T4240RDB_config,,u-boot-with-dtb.bin"
 
 HV_CFG_M = "t4240rdb"
 
-KERNEL_DEVICETREE ?= "t4240rdb.dtb"
+KERNEL_DEVICETREE ?= "fsl/t4240rdb.dtb"
 KERNEL_DEFCONFIG ?= "corenet64_smp_defconfig"
 
 JFFS2_ERASEBLOCK = "0x10000"


### PR DESCRIPTION
Fix below issue when compiling linux-qoriq:
make[2]: *** No rule to make target 'arch/powerpc/boot/dts/p4080ds.dtb'.

Signed-off-by: Ting Liu <ting.liu@nxp.com>