### PR TITLE
qemu-qoriq: enable aio/libusb PACKAGECONFIG

### DIFF
--- a/recipes-devtools/qemu/qemu-qoriq_4.1.0.bb
+++ b/recipes-devtools/qemu/qemu-qoriq_4.1.0.bb
@@ -41,7 +41,7 @@ do_install_append_class-nativesdk() {
 }
 
 PACKAGECONFIG ??= " \
-    fdt sdl kvm \
+    fdt sdl kvm aio libusb \
     ${@bb.utils.filter('DISTRO_FEATURES', 'alsa xen', d)} \
 "
 PACKAGECONFIG_class-nativesdk ??= "fdt sdl kvm"


### PR DESCRIPTION
aio is required for virtio-blk-dataplane and libusb for passthrough
of usb devices.

Signed-off-by: Ting Liu <ting.liu@nxp.com>