### PR TITLE
qoriq: remove usdpaa dtb and relocate sdk dtb

### DIFF
--- a/conf/machine/include/qoriq-base.inc
+++ b/conf/machine/include/qoriq-base.inc
@@ -20,6 +20,15 @@ EXTRA_IMAGEDEPENDS += "u-boot cst-native"
 
 MACHINEOVERRIDES =. "qoriq:"
 
+# Machines or distros can define which BSP it should use by default. We are
+# intending to default for nxp BSP by default and specific machines or
+# DISTROs might change it if need.
+#
+# Two values are considered valid: mainline, nxp
+QORIQ_DEFAULT_BSP ?= "nxp"
+
+MACHINEOVERRIDES =. "use-${QORIQ_DEFAULT_BSP}-bsp:"
+
 # Sub-architecture support
 MACHINE_SOCARCH_SUFFIX ?= ""
 MACHINE_SOCARCH_SUFFIX_qoriq = "-qoriq"

--- a/conf/machine/ls1043ardb.conf
+++ b/conf/machine/ls1043ardb.conf
@@ -22,7 +22,7 @@ UBOOT_CONFIG ??= "tfa-secure-boot tfa"
 UBOOT_CONFIG[tfa] = "ls1043ardb_tfa_defconfig,,u-boot-dtb.bin"
 UBOOT_CONFIG[tfa-secure-boot] = "ls1043ardb_tfa_SECURE_BOOT_defconfig,,u-boot-dtb.bin"
 
-KERNEL_DEVICETREE ?= "freescale/fsl-ls1043a-rdb-sdk.dtb freescale/fsl-ls1043a-rdb-usdpaa.dtb freescale/fsl-ls1043a-qds.dtb freescale/fsl-ls1043a-qds-sdk.dtb"
+KERNEL_DEVICETREE ?= "freescale/fsl-ls1043a-rdb-sdk.dtb freescale/fsl-ls1043a-qds.dtb freescale/fsl-ls1043a-qds-sdk.dtb"
 KERNEL_DEFCONFIG ?= "defconfig"
 
 UEFI_NORBOOT ?= "LS1043ARDB_EFI_NORBOOT.fd"

--- a/conf/machine/ls1043ardb.conf
+++ b/conf/machine/ls1043ardb.conf
@@ -22,7 +22,14 @@ UBOOT_CONFIG ??= "tfa-secure-boot tfa"
 UBOOT_CONFIG[tfa] = "ls1043ardb_tfa_defconfig,,u-boot-dtb.bin"
 UBOOT_CONFIG[tfa-secure-boot] = "ls1043ardb_tfa_SECURE_BOOT_defconfig,,u-boot-dtb.bin"
 
-KERNEL_DEVICETREE ?= "freescale/fsl-ls1043a-rdb-sdk.dtb freescale/fsl-ls1043a-qds.dtb freescale/fsl-ls1043a-qds-sdk.dtb"
+KERNEL_DEVICETREE ?= "\
+    freescale/fsl-ls1043a-rdb.dtb \
+    freescale/fsl-ls1043a-qds.dtb \
+"
+KERNEL_DEVICETREE_append_use-nxp-bsp = "\
+    freescale/fsl-ls1043a-rdb-sdk.dtb \
+    freescale/fsl-ls1043a-qds-sdk.dtb \
+"
 KERNEL_DEFCONFIG ?= "defconfig"
 
 UEFI_NORBOOT ?= "LS1043ARDB_EFI_NORBOOT.fd"

--- a/conf/machine/ls1046afrwy.conf
+++ b/conf/machine/ls1046afrwy.conf
@@ -22,6 +22,9 @@ UBOOT_CONFIG[tfa] = "ls1046afrwy_tfa_defconfig,,u-boot-dtb.bin"
 UBOOT_CONFIG[tfa-secure-boot] = "ls1046afrwy_tfa_SECURE_BOOT_defconfig,,u-boot-dtb.bin"
 
 KERNEL_DEVICETREE ?= "\
+    freescale/fsl-ls1046a-frwy.dtb \
+"
+KERNEL_DEVICETREE_append_use-nxp-bsp = "\
     freescale/fsl-ls1046a-frwy-sdk.dtb \
 "
 KERNEL_DEFCONFIG ?= "defconfig"

--- a/conf/machine/ls1046afrwy.conf
+++ b/conf/machine/ls1046afrwy.conf
@@ -23,7 +23,6 @@ UBOOT_CONFIG[tfa-secure-boot] = "ls1046afrwy_tfa_SECURE_BOOT_defconfig,,u-boot-d
 
 KERNEL_DEVICETREE ?= "\
     freescale/fsl-ls1046a-frwy-sdk.dtb \
-    freescale/fsl-ls1046a-frwy-usdpaa.dtb \
 "
 KERNEL_DEFCONFIG ?= "defconfig"
 

--- a/conf/machine/ls1046ardb.conf
+++ b/conf/machine/ls1046ardb.conf
@@ -23,7 +23,6 @@ UBOOT_CONFIG[tfa-secure-boot] = "ls1046ardb_tfa_SECURE_BOOT_defconfig,,u-boot-dt
 
 KERNEL_DEVICETREE ?= "\
     freescale/fsl-ls1046a-rdb-sdk.dtb \
-    freescale/fsl-ls1046a-rdb-usdpaa.dtb \
     freescale/fsl-ls1046a-qds.dtb \
     freescale/fsl-ls1046a-qds-sdk.dtb \
 "

--- a/conf/machine/ls1046ardb.conf
+++ b/conf/machine/ls1046ardb.conf
@@ -22,9 +22,12 @@ UBOOT_CONFIG[tfa] = "ls1046ardb_tfa_defconfig,,u-boot-dtb.bin"
 UBOOT_CONFIG[tfa-secure-boot] = "ls1046ardb_tfa_SECURE_BOOT_defconfig,,u-boot-dtb.bin"
 
 KERNEL_DEVICETREE ?= "\
-    freescale/fsl-ls1046a-rdb-sdk.dtb \
+    freescale/fsl-ls1046a-rdb.dtb \
     freescale/fsl-ls1046a-qds.dtb \
-    freescale/fsl-ls1046a-qds-sdk.dtb \
+"
+KERNEL_DEVICETREE_append_use-nxp-bsp = "\
+    freescale/fsl-ls1046a-rdb-sdk.dtb \
+    freescale/fsl-ls1046a-rdb-sdk.dtb \
 "
 KERNEL_DEFCONFIG ?= "defconfig"
 


### PR DESCRIPTION
To build with pure mainline kernel, update dtb in KERNEL_DEVICETREE
* usdpaa is an unsupported feature now, remove dtb for it.
* add QORIQ_DEFAULT_BSP definition to easily choose which BSP to use
* dtb with -sdk suffix only exist in kernel from NXP bsp, append them on NXP bsp only.