### PR TITLE
atf: fix build failure due to optee binary not exist

### DIFF
--- a/recipes-bsp/atf/atf_git.bb
+++ b/recipes-bsp/atf/atf_git.bb
@@ -101,7 +101,7 @@ do_compile() {
     fi       
 
     if [ "${BUILD_OPTEE}" = "true" ]; then
-        bl32="${DEPLOY_DIR_IMAGE}/optee/tee_${MACHINE}.bin" 
+        bl32="${RECIPE_SYSROOT}${nonarch_base_libdir}/firmware/tee_${MACHINE}.bin" 
         bl32opt="BL32=${bl32}"
         spdopt="SPD=opteed" 
     fi


### PR DESCRIPTION
When optee enabled in DISTRO_FEATURES, optee-os-qoriq is added as
DEPENDS, and atf tries to find optee binary under ${DEPLOY_DIR_IMAGE}.
This has issue when do_deploy task of optee-os-qoriq does not run
before atf's do_compile.

Switch to find optee binary under ${RECIPE_SYSROOT} instead of
${DEPLOY_DIR_IMAGE}.

Steps to reproduce the issue:
$ echo 'DISTRO_FEATURES_append = " optee"' >>conf/local.conf
$ bitbake -c cleansstate atf optee-os-qoriq
$ bitbake -c install optee-os-qoriq
$ bitbake -c compile atf
| Building lx2160ardb
| Makefile:633: *** 'BL32=.../tmp/deploy/images/lx2160ardb/optee/tee_lx2160ardb.bin'
| was specified, but '.../tmp/deploy/images/lx2160ardb/optee/tee_lx2160ardb.bin'
| does not exist.  Stop.
| make: *** Waiting for unfinished jobs....

Signed-off-by: Ting Liu <ting.liu@nxp.com>