### PR TITLE
cst: Fix build with gcc10

### DIFF
--- a/recipes-devtools/cst/cst/0001-tools-Mark-struct-input_field-file_field-extern.patch
+++ b/recipes-devtools/cst/cst/0001-tools-Mark-struct-input_field-file_field-extern.patch
@@ -1,0 +1,43 @@
+From 81ec65e72f357fb2c395e40c5195434bbaddf7f7 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sat, 16 May 2020 08:21:52 -0700
+Subject: [PATCH] tools: Mark struct input_field file_field extern
+
+This struct is already defined in common/parse_utils.c
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ tools/header_generation/create_hdr_common.c | 2 +-
+ tools/pbi_creation/create_pbi_common.c      | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/tools/header_generation/create_hdr_common.c b/tools/header_generation/create_hdr_common.c
+index bfa90a3..edf632c 100644
+--- a/tools/header_generation/create_hdr_common.c
++++ b/tools/header_generation/create_hdr_common.c
+@@ -39,7 +39,7 @@
+ #include <crypto_utils.h>
+ 
+ extern struct g_data_t gd;
+-struct input_field file_field;
++extern struct input_field file_field;
+ 
+ extern char line_data[];
+ static struct option long_options[] = {
+diff --git a/tools/pbi_creation/create_pbi_common.c b/tools/pbi_creation/create_pbi_common.c
+index ff2ed84..bd976da 100644
+--- a/tools/pbi_creation/create_pbi_common.c
++++ b/tools/pbi_creation/create_pbi_common.c
+@@ -57,7 +57,7 @@ static char *parse_list[] = {
+ 
+ extern struct g_data_t gd;
+ extern char line_data[];
+-struct input_field file_field;
++extern struct input_field file_field;
+ 
+ #define NUM_PARSE_LIST (sizeof(parse_list) / sizeof(char *))
+ 
+-- 
+2.26.2
+

--- a/recipes-devtools/cst/cst_git.bb
+++ b/recipes-devtools/cst/cst_git.bb
@@ -17,6 +17,7 @@ inherit kernel-arch
 #SECURE_PUB_KEY = "/path/srk.pub"
 
 SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/cst;nobranch=1 \
+           file://0001-tools-Mark-struct-input_field-file_field-extern.patch \
 "
 SRCREV = "9aafbdf2441858ceca2779279b6876c6bdc2d3ed"
 


### PR DESCRIPTION
Fixes
create_hdr_common.c:42: multiple definition of `file_field'; parse_utils.o:/mnt/b/yoe/master/build/tmp/work/x86_64-linux/cst-native/git-r0/git/common/parse_utils.c:29: first defined here
| collect2: error: ld returned 1 exit status
| make: *** [Makefile:131: create_hdr_isbc] Error 1

Signed-off-by: Khem Raj <raj.khem@gmail.com>