### PR TITLE
ls1046ardb: fix duplicate dtb issue

### DIFF
--- a/conf/machine/ls1046ardb.conf
+++ b/conf/machine/ls1046ardb.conf
@@ -27,7 +27,7 @@ KERNEL_DEVICETREE ?= "\
 "
 KERNEL_DEVICETREE_append_use-nxp-bsp = "\
     freescale/fsl-ls1046a-rdb-sdk.dtb \
-    freescale/fsl-ls1046a-rdb-sdk.dtb \
+    freescale/fsl-ls1046a-qds-sdk.dtb \
 "
 KERNEL_DEFCONFIG ?= "defconfig"
 


### PR DESCRIPTION
fsl-ls1046a-rdb-sdk.dtb is listed twice and one is supposed to be
fsl-ls1046a-qds-sdk.dtb. This is due to a typo in previous commit:

41c93da5a ls1043a/ls1046a: append non-upstream dtb on NXP bsp only

Fix it with fsl-ls1046a-qds-sdk.dtb.

Signed-off-by: Ting Liu <ting.liu@nxp.com>