### PR TITLE
fix: handle if KERNEL_DEVICETREE isn't defined

### DIFF
--- a/conf/machine/include/utilities.inc
+++ b/conf/machine/include/utilities.inc
@@ -6,6 +6,11 @@ def make_dtb_boot_files(d):
     # Use only the basename for dtb files:
     alldtbs = d.getVar('KERNEL_DEVICETREE')
 
+
+    # DTBs may be built out of kernel with devicetree.bbclass
+    if not alldtbs:
+        return ''
+
     def transform(dtb):
         if not (dtb.endswith('dtb') or dtb.endswith('dtbo')):
             # eg: whatever/bcm2708-rpi-b.dtb has:


### PR DESCRIPTION
Currently, if KERNEL_DEVICETREE isn't defined `make_dtb_boot_files` function will throw an error since the parameter is a `NoneType`.

DTB files can be added outside of the kernel build with devicetree.bbclass, like this:
https://github.com/Xilinx/meta-xilinx/blob/master/meta-xilinx-bsp/recipes-bsp/device-tree/device-tree.bb