### PR TITLE
ls1043a/ls1046a/ls1028a: build dedicated dtb for dpdk

### DIFF
--- a/conf/machine/ls1028ardb.conf
+++ b/conf/machine/ls1028ardb.conf
@@ -22,6 +22,9 @@ UBOOT_CONFIG[tfa-secure-boot] = "ls1028ardb_tfa_SECURE_BOOT_defconfig,,u-boot-dt
 UBOOT_CONFIG[tfa] = "ls1028ardb_tfa_defconfig,,u-boot-dtb.bin"
 
 KERNEL_DEVICETREE ?= "freescale/fsl-ls1028a-rdb.dtb freescale/fsl-ls1028a-qds.dtb"
+KERNEL_DEVICETREE_append_use-nxp-bsp = "\
+    freescale/fsl-ls1028a-rdb-dpdk.dtb \
+"
 KERNEL_DEFCONFIG ?= "defconfig"
 
 SERIAL_CONSOLES ?= "115200;ttyS0 115200;ttyS1 115200;ttyAMA0"

--- a/conf/machine/ls1043ardb.conf
+++ b/conf/machine/ls1043ardb.conf
@@ -26,8 +26,10 @@ KERNEL_DEVICETREE ?= "\
     freescale/fsl-ls1043a-rdb.dtb \
     freescale/fsl-ls1043a-qds.dtb \
 "
+# usdpaa dtb is used for dpdk. TODO: rename in kernel
 KERNEL_DEVICETREE_append_use-nxp-bsp = "\
     freescale/fsl-ls1043a-rdb-sdk.dtb \
+    freescale/fsl-ls1043a-rdb-usdpaa.dtb \
     freescale/fsl-ls1043a-qds-sdk.dtb \
 "
 KERNEL_DEFCONFIG ?= "defconfig"

--- a/conf/machine/ls1046afrwy.conf
+++ b/conf/machine/ls1046afrwy.conf
@@ -24,8 +24,10 @@ UBOOT_CONFIG[tfa-secure-boot] = "ls1046afrwy_tfa_SECURE_BOOT_defconfig,,u-boot-d
 KERNEL_DEVICETREE ?= "\
     freescale/fsl-ls1046a-frwy.dtb \
 "
+# usdpaa dtb is used for dpdk. TODO: rename in kernel
 KERNEL_DEVICETREE_append_use-nxp-bsp = "\
     freescale/fsl-ls1046a-frwy-sdk.dtb \
+    freescale/fsl-ls1046a-frwy-usdpaa.dtb \
 "
 KERNEL_DEFCONFIG ?= "defconfig"
 

--- a/conf/machine/ls1046ardb.conf
+++ b/conf/machine/ls1046ardb.conf
@@ -25,8 +25,10 @@ KERNEL_DEVICETREE ?= "\
     freescale/fsl-ls1046a-rdb.dtb \
     freescale/fsl-ls1046a-qds.dtb \
 "
+# usdpaa dtb is used for dpdk. TODO: rename in kernel
 KERNEL_DEVICETREE_append_use-nxp-bsp = "\
     freescale/fsl-ls1046a-rdb-sdk.dtb \
+    freescale/fsl-ls1046a-rdb-usdpaa.dtb \
     freescale/fsl-ls1046a-qds-sdk.dtb \
 "
 KERNEL_DEFCONFIG ?= "defconfig"


### PR DESCRIPTION
to obtain best performance from DPDK software, dedicated dtb files are needed for ls1043a/ls1046a/ls1028a. Build them on NXP bsp only.