### PR TITLE
linux-imx-headers: fix imx headers missing in sdk

### DIFF
--- a/classes/use-imx-headers.bbclass
+++ b/classes/use-imx-headers.bbclass
@@ -14,6 +14,12 @@
 # Copyright 2018 (C) O.S. Systems Software LTDA.
 
 DEPENDS_append_imx = " linux-imx-headers"
+
+# Set runtime dependency of -dev for package inheriting this class to
+# linux-imx-headers-dev package. This is required in order to propagate
+# headers into the SDK
+RDEPENDS_${PN}-dev += "linux-imx-headers-dev"
+
 PACKAGE_ARCH_imx ?= "${MACHINE_SOCARCH}"
 
 STAGING_INCDIR_IMX = "${STAGING_INCDIR}/imx"

--- a/recipes-kernel/linux/linux-imx-headers_5.4.3.bb
+++ b/recipes-kernel/linux/linux-imx-headers_5.4.3.bb
@@ -59,6 +59,14 @@ do_install() {
     done
 }
 
+# Allow to build empty main package, this is required in order for -dev package
+# to be propagated into the SDK
+#
+# Without this setting the RDEPENDS in other recipes fails to find this
+# package, therefore causing the -dev package also to be skipped effectively not
+# populating it into SDK
+ALLOW_EMPTY_${PN} = "1"
+
 INHIBIT_DEFAULT_DEPS = "1"
 DEPENDS += "unifdef-native bison-native rsync-native"
 


### PR DESCRIPTION
i.MX-specific headers are missing in SDK once generated via:
`bitbake <image recipe> -c populate_sdk`

This was caused by dropped `ALLOW_EMPTY` package-controlling variable which is required for this recipe in order to indicate that package can have `RDEPENDS`.

Additional `RDEPENDS` are also required by packages using new mechanisms to include `linux-imx-headers`, this allows headers to be propagated to the SDK when dependent package is included.

Introduce `ALLOW_EMPTY` in recipe and `RDEPENDS` in `use-imx-headers.bbclass` to have imx headers to be populated in the SDK.

This solves the #405