### PR TITLE
Create 5.4.y+fslc+qoriq

### DIFF
--- a/recipes-kernel/linux/linux-fslc-qoriq_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc-qoriq_5.4.bb
@@ -1,0 +1,17 @@
+# Released under the MIT license (see COPYING.MIT for the terms)
+
+SUMMARY = "Mainline/LTS rebased NXP/QorIQ patches + FSLC patches."
+DESCRIPTION = "Linux kernel based on LTS kernel used by FSL Community BSP in order to \
+provide support for some backported features and fixes, or because it was applied in linux-next \
+and takes some time to become part of a stable version, or because it is not applicable for \
+upstreaming."
+
+require recipes-kernel/linux/linux-qoriq.inc
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
+
+LINUX_VERSION = "5.4.41"
+
+SRCBRANCH = "5.4.y+qoriq+fslc"
+SRCREV = "e26bb86e9fc3d32725c4db1ff3b96fba69c77112"
+SRC_URI := "git://github.com/Freescale/linux-fslc.git;branch=${SRCBRANCH}"

--- a/recipes-kernel/linux/linux-qoriq.inc
+++ b/recipes-kernel/linux/linux-qoriq.inc
@@ -18,6 +18,9 @@ KERNEL_EXTRA_ARGS += "LOADADDR=${UBOOT_ENTRYPOINT}"
 ZIMAGE_BASE_NAME = "zImage-${PKGE}-${PKGV}-${PKGR}-${MACHINE}-${DATETIME}"
 ZIMAGE_BASE_NAME[vardepsexclude] = "DATETIME"
 
+# Set the PV to the correct kernel version to satisfy the kernel version sanity check
+PV = "${LINUX_VERSION}+git${SRCPV}"
+
 SCMVERSION ?= "y"
 LOCALVERSION = ""
 DELTA_KERNEL_DEFCONFIG ?= ""

--- a/recipes-kernel/linux/linux-qoriq_5.4.bb
+++ b/recipes-kernel/linux/linux-qoriq_5.4.bb
@@ -1,5 +1,7 @@
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
+LINUX_VERSION = "5.4.3"
+
 SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/linux;nobranch=1 \
     file://0001-Makfefile-linux-5.4-add-warning-cflags-on-LSDK-20.04.patch \
     file://0001-perf-Make-perf-able-to-build-with-latest-libbfd.patch \


### PR DESCRIPTION
Create a linux-fslc-qoriq kernel based on 5.4.41+QorIQ patches from NXP + some fixes and patches from fslc and l[sx]2xxx test builds.

@otavio: appropriate branches (at least [5.4.y+qoriq](https://github.com/rehsack/linux-fslc/tree/5.4.y+qoriq) and [5.4.y+qoriq+fslc](https://github.com/rehsack/linux-fslc/tree/5.4.y+qoriq+fslc) ) must be "merged" from [my linux-fslc fork](https://github.com/rehsack/linux-fslc/) first.