### PR TITLE
t2080: remove srio_pcie boot UBOOT_CONFIG

### DIFF
--- a/conf/machine/t2080rdb-64b.conf
+++ b/conf/machine/t2080rdb-64b.conf
@@ -9,12 +9,11 @@ require conf/machine/include/e6500-64b.inc
 
 MACHINEOVERRIDES =. "t2:t2080:"
 
-UBOOT_CONFIG ??= "sdcard spi nand srio-pcie-boot secure-boot nor"
+UBOOT_CONFIG ??= "sdcard spi nand secure-boot nor"
 UBOOT_CONFIG[nor] = "T2080RDB_config,,u-boot-with-dtb.bin"
 UBOOT_CONFIG[sdcard] = "T2080RDB_SDCARD_config,,u-boot-with-spl-pbl.bin"
 UBOOT_CONFIG[spi] = "T2080RDB_SPIFLASH_config,,u-boot-with-spl-pbl.bin"
 UBOOT_CONFIG[nand] = "T2080RDB_NAND_config,,u-boot-with-spl-pbl.bin"
-UBOOT_CONFIG[srio-pcie-boot] = "T2080RDB_SRIO_PCIE_BOOT_config"
 UBOOT_CONFIG[secure-boot] = "T2080RDB_SECURE_BOOT_config"
 
 HV_CFG_M = "t2080rdb"

--- a/conf/machine/t2080rdb.conf
+++ b/conf/machine/t2080rdb.conf
@@ -9,12 +9,11 @@ require conf/machine/include/e6500.inc
 
 MACHINEOVERRIDES =. "t2:t2080:"
 
-UBOOT_CONFIG ??= "sdcard spi nand srio-pcie-boot secure-boot nor"
+UBOOT_CONFIG ??= "sdcard spi nand secure-boot nor"
 UBOOT_CONFIG[nor] = "T2080RDB_config,,u-boot-with-dtb.bin"
 UBOOT_CONFIG[sdcard] = "T2080RDB_SDCARD_config,,u-boot-with-spl-pbl.bin"
 UBOOT_CONFIG[spi] = "T2080RDB_SPIFLASH_config,,u-boot-with-spl-pbl.bin"
 UBOOT_CONFIG[nand] = "T2080RDB_NAND_config,,u-boot-with-spl-pbl.bin"
-UBOOT_CONFIG[srio-pcie-boot] = "T2080RDB_SRIO_PCIE_BOOT_config"
 UBOOT_CONFIG[secure-boot] = "T2080RDB_SECURE_BOOT_config"
 
 HV_CFG_M = "t2080rdb"


### PR DESCRIPTION
For the srio_pcie boot, the DM pcie driver does not support
this feature. Remove it.

Signed-off-by: Ting Liu <ting.liu@nxp.com>