### PR TITLE
qtbase: Set QT_QPA_PLATFORM for i.MX GPU

### DIFF
--- a/dynamic-layers/qt5-layer/recipes-qt/qt5/qtbase/qt5-fb.sh
+++ b/dynamic-layers/qt5-layer/recipes-qt/qt5/qtbase/qt5-fb.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+export QT_QPA_PLATFORM=eglfs

--- a/dynamic-layers/qt5-layer/recipes-qt/qt5/qtbase/qt5-wayland.sh
+++ b/dynamic-layers/qt5-layer/recipes-qt/qt5/qtbase/qt5-wayland.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+export QT_QPA_PLATFORM=wayland

--- a/dynamic-layers/qt5-layer/recipes-qt/qt5/qtbase/qt5-x11.sh
+++ b/dynamic-layers/qt5-layer/recipes-qt/qt5/qtbase/qt5-x11.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+export QT_QPA_PLATFORM=xcb

--- a/dynamic-layers/qt5-layer/recipes-qt/qt5/qtbase_%.bbappend
+++ b/dynamic-layers/qt5-layer/recipes-qt/qt5/qtbase_%.bbappend
@@ -5,6 +5,13 @@
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
+IMX_BACKEND = \
+    "${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'wayland',\
+        bb.utils.contains('DISTRO_FEATURES',     'x11',     'x11', \
+                                                             'fb', d), d)}"
+SRC_URI_append = " \
+    file://qt5-${IMX_BACKEND}.sh \
+"
 SRC_URI_append_imxgpu2d = " \
     file://0014-Add-IMX-GPU-support.patch \
     file://0001-egl.prf-Fix-build-error-when-egl-headers-need-platfo.patch \
@@ -29,3 +36,10 @@ PACKAGECONFIG_PLATFORM_imxgpu3d = " \
                                                        'eglfs', d), d)}"
 PACKAGECONFIG_PLATFORM_use-mainline-bsp = "${@bb.utils.contains('DISTRO_FEATURES', 'x11', '', 'eglfs', d)}"
 PACKAGECONFIG += "${PACKAGECONFIG_PLATFORM}"
+
+do_install_append_imxgpu () {
+    install -d ${D}${sysconfdir}/profile.d/
+    install -m 0755 ${WORKDIR}/qt5-${IMX_BACKEND}.sh ${D}${sysconfdir}/profile.d/qt5.sh
+}
+
+FILES_${PN}_append_imxgpu = " ${sysconfdir}/profile.d/qt5.sh"


### PR DESCRIPTION
Set QT_QPA_PLATFORM appropriately for i.MX GPU on the
configured graphics backend, wayland for wayland backend,
eglfs for framebuffer backend, and xcb for x11 backend.

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>