### PR TITLE
QorIQ: LSDK-20.04-update-290520

### DIFF
--- a/recipes-bsp/atf/atf-tools_git.bb
+++ b/recipes-bsp/atf/atf-tools_git.bb
@@ -3,7 +3,7 @@ LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://license.rst;md5=e927e02bca647e14efd87e9e914b2443"
 
 SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/atf;nobranch=1"
-SRCREV = "17f94e4315e81e3d1b22d863d9614d724e8273dc"
+SRCREV = "7d748e6f0ec652ba7c43733dc67a3d0b0217390a"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-bsp/atf/atf_git.bb
+++ b/recipes-bsp/atf/atf_git.bb
@@ -12,7 +12,7 @@ do_compile[depends] += "u-boot:do_deploy rcw:do_deploy uefi:do_deploy"
 S = "${WORKDIR}/git"
 
 SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/atf;nobranch=1"
-SRCREV = "4a82c939a0211196e2b80a495f966383803753bb"
+SRCREV = "7d748e6f0ec652ba7c43733dc67a3d0b0217390a"
 
 SRC_URI += "file://0001-fix-fiptool-build-error.patch \
     file://0001-Makefile-add-CC-gcc.patch \

--- a/recipes-bsp/ddr-phy/ddr-phy_git.bb
+++ b/recipes-bsp/ddr-phy/ddr-phy_git.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://NXP-Binary-EULA.txt;md5=89cc852481956e861228286ac7430
 inherit deploy
 
 SRC_URI = "git://github.com/nxp/ddr-phy-binary.git;nobranch=1"
-SRCREV = "14d03e6e748ed5ebb9440f264bb374f1280b061c"
+SRCREV = "fbc036b88acb6c06ffed02c898cbae9856ec75ba"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-bsp/rcw/rcw_git.bb
+++ b/recipes-bsp/rcw/rcw_git.bb
@@ -8,7 +8,7 @@ DEPENDS += "tcl-native"
 inherit deploy siteinfo
 
 SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/rcw;nobranch=1"
-SRCREV = "5689bf9c9f087f50aaa0d91b43d8a791fedbedd3"
+SRCREV = "e0fab6d9b61003caef577f7474c2fac61e6ba2ff"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-bsp/u-boot/u-boot-qoriq_2019.10.bb
+++ b/recipes-bsp/u-boot/u-boot-qoriq_2019.10.bb
@@ -23,7 +23,7 @@ SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/u-boot;no
     file://0001-binman-Move-to-use-Python-3.patch \
     file://0001-buildman-Convert-to-Python-3.patch \
 "
-SRCREV= "3cd9bc39934825200822855574fc91d8276e6584"
+SRCREV= "1e55b2f9e7f56b76569089b9e950f49c1579580e"
 
 S = "${WORKDIR}/git"
 B = "${WORKDIR}/build"

--- a/recipes-kernel/linux/linux-fslc-qoriq_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc-qoriq_5.4.bb
@@ -13,5 +13,5 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 LINUX_VERSION = "5.4.43"
 
 SRCBRANCH = "5.4.y+qoriq+fslc"
-SRCREV = "60cba81f6953d37ad438c8f30e4f175205bfa3d5"
+SRCREV = "e464752884a9a134daf72fe8babb2236df4fdcff"
 SRC_URI := "git://github.com/Freescale/linux-fslc.git;branch=${SRCBRANCH}"

--- a/recipes-kernel/linux/linux-qoriq_5.4.bb
+++ b/recipes-kernel/linux/linux-qoriq_5.4.bb
@@ -6,6 +6,6 @@ SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/linux;nob
     file://0001-Makfefile-linux-5.4-add-warning-cflags-on-LSDK-20.04.patch \
     file://0001-perf-Make-perf-able-to-build-with-latest-libbfd.patch \
 "
-SRCREV = "f8118585ee3c7025265b28985fdfe0af96a84466"
+SRCREV = "134788b16485dd9fa81988681d2365ee38633fa2"
 
 require recipes-kernel/linux/linux-qoriq.inc


### PR DESCRIPTION
Updating QorIQ BSP components to LSDK-20.04-update-290520.
Merging https://github.com/Freescale/meta-freescale/pull/417 first is recommended or superfluous :)
Merging https://github.com/Freescale/linux-fslc/pull/77 and https://github.com/Freescale/linux-fslc/pull/78 first is strongly encouraged