### PR TITLE
weston: fix a patch fuzz issue

### DIFF
--- a/recipes-graphics/wayland/weston/0003-weston-touch-calibrator-Advertise-the-touchscreen-ca.patch
+++ b/recipes-graphics/wayland/weston/0003-weston-touch-calibrator-Advertise-the-touchscreen-ca.patch
@@ -15,12 +15,12 @@ Signed-off-by: Jun Zhu <junzhu@nxp.com>
  1 file changed, 3 insertions(+)
 
 diff --git a/weston.ini.in b/weston.ini.in
-index 83dd56e..6e20e11 100644
+index d9094b1f..8adcc646 100644
 --- a/weston.ini.in
 +++ b/weston.ini.in
-@@ -3,6 +3,9 @@
- idle-time=0
- #use-g2d=1
+@@ -7,6 +7,9 @@ idle-time=0
+ #[shell]
+ #size=1920x1080
  
 +[libinput]
 +touchscreen_calibrator=true


### PR DESCRIPTION
Fix a following QA warning:
| WARNING: weston-5.0.0.imx-r0 do_patch: Fuzz detected:
|
| Applying patch 0003-weston-touch-calibrator-Advertise-the-touchscreen-ca.patch
| patching file weston.ini.in
| Hunk #1 succeeded at 7 with fuzz 2 (offset 4 lines).
|
| The context lines in the patches can be updated with devtool:
|
|    devtool modify weston
|    devtool finish --force-patch-refresh weston <layer_path>
|
| Don't forget to review changes done by devtool!

Signed-off-by: Ming Liu <ming.liu@toradex.com>