### PR TITLE
qoriq-ppc: not build secure-boot u-boot configs

### DIFF
--- a/conf/machine/p2041rdb.conf
+++ b/conf/machine/p2041rdb.conf
@@ -9,10 +9,9 @@ require conf/machine/include/e500mc.inc
 
 MACHINEOVERRIDES =. "p2041:"
 
-UBOOT_CONFIG ??= "nand secure-boot sdcard spi nor"
+UBOOT_CONFIG ??= "nand sdcard spi nor"
 UBOOT_CONFIG[nor] = "P2041RDB_config,,u-boot-with-dtb.bin"
 UBOOT_CONFIG[nand] = "P2041RDB_NAND_config,,u-boot.pbl"
-UBOOT_CONFIG[secure-boot] = "P2041RDB_SECURE_BOOT_config"
 UBOOT_CONFIG[sdcard] = "P2041RDB_SDCARD_config,,u-boot.pbl"
 UBOOT_CONFIG[spi] = "P2041RDB_SPIFLASH_config,,u-boot.pbl"
 

--- a/conf/machine/p3041ds.conf
+++ b/conf/machine/p3041ds.conf
@@ -9,10 +9,9 @@ require conf/machine/include/e500mc.inc
 
 MACHINEOVERRIDES =. "p3041:"
 
-UBOOT_CONFIG ??= "nand secure-boot sdcard spi nor"
+UBOOT_CONFIG ??= "nand sdcard spi nor"
 UBOOT_CONFIG[nor] = "P3041DS_config,,u-boot-with-dtb.bin"
 UBOOT_CONFIG[nand] = "P3041DS_NAND_config,,u-boot.pbl"
-UBOOT_CONFIG[secure-boot] = "P3041DS_SECURE_BOOT_config"
 UBOOT_CONFIG[sdcard] = "P3041DS_SDCARD_config,,u-boot.pbl"
 UBOOT_CONFIG[spi] = "P3041DS_SPIFLASH_config,,u-boot.pbl"
 

--- a/conf/machine/p4080ds.conf
+++ b/conf/machine/p4080ds.conf
@@ -9,9 +9,8 @@ require conf/machine/include/e500mc.inc
 
 MACHINEOVERRIDES =. "p4080:"
 
-UBOOT_CONFIG ??= "secure-boot sdcard spi nor"
+UBOOT_CONFIG ??= "sdcard spi nor"
 UBOOT_CONFIG[nor] = "P4080DS_config,,u-boot-with-dtb.bin"
-UBOOT_CONFIG[secure-boot] = "P4080DS_SECURE_BOOT_config"
 UBOOT_CONFIG[sdcard] = "P4080DS_SDCARD_config,,u-boot.pbl"
 UBOOT_CONFIG[spi] = "P4080DS_SPIFLASH_config,,u-boot.pbl"
 

--- a/conf/machine/p5040ds-64b.conf
+++ b/conf/machine/p5040ds-64b.conf
@@ -9,10 +9,9 @@ require conf/machine/include/e5500-64b.inc
 
 MACHINEOVERRIDES =. "p5040:"
 
-UBOOT_CONFIG ??= "nand secure-boot sdcard spi nor"
+UBOOT_CONFIG ??= "nand sdcard spi nor"
 UBOOT_CONFIG[nor] = "P5040DS_config,,u-boot-with-dtb.bin"
 UBOOT_CONFIG[nand] = "P5040DS_NAND_config,,u-boot.pbl"
-UBOOT_CONFIG[secure-boot] = "P5040DS_SECURE_BOOT_config"
 UBOOT_CONFIG[sdcard] = "P5040DS_SDCARD_config,,u-boot.pbl"
 UBOOT_CONFIG[spi] = "P5040DS_SPIFLASH_config,,u-boot.pbl"
 

--- a/conf/machine/p5040ds.conf
+++ b/conf/machine/p5040ds.conf
@@ -9,10 +9,9 @@ require conf/machine/include/e5500.inc
 
 MACHINEOVERRIDES =. "p5040:"
 
-UBOOT_CONFIG ??= "nand secure-boot sdcard spi nor"
+UBOOT_CONFIG ??= "nand sdcard spi nor"
 UBOOT_CONFIG[nor] = "P5040DS_config,,u-boot-with-dtb.bin"
 UBOOT_CONFIG[nand] = "P5040DS_NAND_config,,u-boot.pbl"
-UBOOT_CONFIG[secure-boot] = "P5040DS_SECURE_BOOT_config"
 UBOOT_CONFIG[sdcard] = "P5040DS_SDCARD_config,,u-boot.pbl"
 UBOOT_CONFIG[spi] = "P5040DS_SPIFLASH_config,,u-boot.pbl"
 

--- a/conf/machine/t1024rdb-64b.conf
+++ b/conf/machine/t1024rdb-64b.conf
@@ -9,12 +9,11 @@ require conf/machine/include/e5500-64b.inc
 
 MACHINEOVERRIDES =. "t1:t1024:"
 
-UBOOT_CONFIG ??= "nand sdcard spi secure-boot nor"
+UBOOT_CONFIG ??= "nand sdcard spi nor"
 UBOOT_CONFIG[nor] = "T1024RDB_config,,u-boot-with-dtb.bin"
 UBOOT_CONFIG[nand] = "T1024RDB_NAND_config,,u-boot-with-spl-pbl.bin"
 UBOOT_CONFIG[sdcard] = "T1024RDB_SDCARD_config,,u-boot-with-spl-pbl.bin"
 UBOOT_CONFIG[spi] = "T1024RDB_SPIFLASH_config,,u-boot-with-spl-pbl.bin"
-UBOOT_CONFIG[secure-boot] = "T1024RDB_SECURE_BOOT_config"
 
 HV_CFG_M = "t1024rdb"
 

--- a/conf/machine/t1024rdb.conf
+++ b/conf/machine/t1024rdb.conf
@@ -9,12 +9,11 @@ require conf/machine/include/e5500.inc
 
 MACHINEOVERRIDES =. "t1:t1024:"
 
-UBOOT_CONFIG ??= "nand sdcard spi secure-boot nor"
+UBOOT_CONFIG ??= "nand sdcard spi nor"
 UBOOT_CONFIG[nor] = "T1024RDB_config,,u-boot-with-dtb.bin"
 UBOOT_CONFIG[nand] = "T1024RDB_NAND_config,,u-boot-with-spl-pbl.bin"
 UBOOT_CONFIG[sdcard] = "T1024RDB_SDCARD_config,,u-boot-with-spl-pbl.bin"
 UBOOT_CONFIG[spi] = "T1024RDB_SPIFLASH_config,,u-boot-with-spl-pbl.bin"
-UBOOT_CONFIG[secure-boot] = "T1024RDB_SECURE_BOOT_config"
 
 HV_CFG_M = "t1024rdb"
 

--- a/conf/machine/t1042d4rdb-64b.conf
+++ b/conf/machine/t1042d4rdb-64b.conf
@@ -9,12 +9,11 @@ require conf/machine/include/e5500-64b.inc
 
 MACHINEOVERRIDES =. "t1:t1042:"
 
-UBOOT_CONFIG ??= "nand sdcard spi secure-boot nor"
+UBOOT_CONFIG ??= "nand sdcard spi nor"
 UBOOT_CONFIG[nor] = "T1042D4RDB_config,,u-boot-with-dtb.bin"
 UBOOT_CONFIG[nand] = "T1042D4RDB_NAND_config,,u-boot-with-spl-pbl.bin"
 UBOOT_CONFIG[sdcard] = "T1042D4RDB_SDCARD_config,,u-boot-with-spl-pbl.bin"
 UBOOT_CONFIG[spi] = "T1042D4RDB_SPIFLASH_config,,u-boot-with-spl-pbl.bin"
-UBOOT_CONFIG[secure-boot] = "T1042D4RDB_SECURE_BOOT_config,,u-boot.bin"
 
 HV_CFG_M = "t1040rdb"
 

--- a/conf/machine/t1042d4rdb.conf
+++ b/conf/machine/t1042d4rdb.conf
@@ -9,12 +9,11 @@ require conf/machine/include/e5500.inc
 
 MACHINEOVERRIDES =. "t1:t1042:"
 
-UBOOT_CONFIG ??= "nand sdcard spi secure-boot nor"
+UBOOT_CONFIG ??= "nand sdcard spi nor"
 UBOOT_CONFIG[nor] = "T1042D4RDB_config,,u-boot-with-dtb.bin"
 UBOOT_CONFIG[nand] = "T1042D4RDB_NAND_config,,u-boot-with-spl-pbl.bin"
 UBOOT_CONFIG[sdcard] = "T1042D4RDB_SDCARD_config,,u-boot-with-spl-pbl.bin"
 UBOOT_CONFIG[spi] = "T1042D4RDB_SPIFLASH_config,,u-boot-with-spl-pbl.bin"
-UBOOT_CONFIG[secure-boot] = "T1042D4RDB_SECURE_BOOT_config,,u-boot.bin"
 
 HV_CFG_M = "t1040rdb"
 

--- a/conf/machine/t2080rdb-64b.conf
+++ b/conf/machine/t2080rdb-64b.conf
@@ -9,12 +9,11 @@ require conf/machine/include/e6500-64b.inc
 
 MACHINEOVERRIDES =. "t2:t2080:"
 
-UBOOT_CONFIG ??= "sdcard spi nand secure-boot nor"
+UBOOT_CONFIG ??= "sdcard spi nand nor"
 UBOOT_CONFIG[nor] = "T2080RDB_config,,u-boot-with-dtb.bin"
 UBOOT_CONFIG[sdcard] = "T2080RDB_SDCARD_config,,u-boot-with-spl-pbl.bin"
 UBOOT_CONFIG[spi] = "T2080RDB_SPIFLASH_config,,u-boot-with-spl-pbl.bin"
 UBOOT_CONFIG[nand] = "T2080RDB_NAND_config,,u-boot-with-spl-pbl.bin"
-UBOOT_CONFIG[secure-boot] = "T2080RDB_SECURE_BOOT_config"
 
 HV_CFG_M = "t2080rdb"
 

--- a/conf/machine/t2080rdb.conf
+++ b/conf/machine/t2080rdb.conf
@@ -9,12 +9,11 @@ require conf/machine/include/e6500.inc
 
 MACHINEOVERRIDES =. "t2:t2080:"
 
-UBOOT_CONFIG ??= "sdcard spi nand secure-boot nor"
+UBOOT_CONFIG ??= "sdcard spi nand nor"
 UBOOT_CONFIG[nor] = "T2080RDB_config,,u-boot-with-dtb.bin"
 UBOOT_CONFIG[sdcard] = "T2080RDB_SDCARD_config,,u-boot-with-spl-pbl.bin"
 UBOOT_CONFIG[spi] = "T2080RDB_SPIFLASH_config,,u-boot-with-spl-pbl.bin"
 UBOOT_CONFIG[nand] = "T2080RDB_NAND_config,,u-boot-with-spl-pbl.bin"
-UBOOT_CONFIG[secure-boot] = "T2080RDB_SECURE_BOOT_config"
 
 HV_CFG_M = "t2080rdb"
 


### PR DESCRIPTION
Secure boot does not have DM mode support for PPC, and driver
related changes are not tested due to bandwidth limitation.

Remove secure-boot u-boot configs from the build list.

Signed-off-by: Ting Liu <ting.liu@nxp.com>