### PR TITLE
ovs-dpdk: add configurable buffer parameter via env

### DIFF
--- a/recipes-extended/ovs-dpdk/files/0001-netdev-dpdk-have-env-based-configurable-number-of-pa.patch
+++ b/recipes-extended/ovs-dpdk/files/0001-netdev-dpdk-have-env-based-configurable-number-of-pa.patch
@@ -1,0 +1,34 @@
+From 95c5c42b9581f595881df11ca8393dc6925f7d7d Mon Sep 17 00:00:00 2001
+From: Nipun Gupta <nipun.gupta@nxp.com>
+Date: Thu, 14 Feb 2019 17:57:14 +0530
+Subject: [PATCH] netdev-dpdk: have env based configurable number of packet
+ buffers
+
+use $export DPDK_NUM_MBUF=number
+
+Upstream-Status: Pending
+
+Signed-off-by: Nipun Gupta <nipun.gupta@nxp.com>
+---
+ lib/netdev-dpdk.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/lib/netdev-dpdk.c b/lib/netdev-dpdk.c
+index 6187129c0..1f456a63f 100644
+--- a/lib/netdev-dpdk.c
++++ b/lib/netdev-dpdk.c
+@@ -656,6 +656,11 @@ dpdk_calculate_mbufs(struct netdev_dpdk *dev, int mtu, bool per_port_mp)
+ {
+     uint32_t n_mbufs;
+ 
++    if (getenv("DPDK_NUM_MBUF")) {
++        n_mbufs = atoi(getenv("DPDK_NUM_MBUF"));
++        return n_mbufs;
++    }
++
+     if (!per_port_mp) {
+         /* Shared memory are being used.
+          * XXX: this is a really rough method of provisioning memory.
+-- 
+2.17.1
+

--- a/recipes-extended/ovs-dpdk/ovs-dpdk_2.13.0.bb
+++ b/recipes-extended/ovs-dpdk/ovs-dpdk_2.13.0.bb
@@ -8,6 +8,7 @@ RDEPENDS_${PN} = "bash libcrypto libssl python3"
 inherit python3native
 
 SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/ovs-dpdk;nobranch=1 \
+    file://0001-netdev-dpdk-have-env-based-configurable-number-of-pa.patch \
 "
 SRCREV = "71d553b995d0bd527d3ab1e9fbaf5a2ae34de2f3"
 


### PR DESCRIPTION
Provide an alternative way to set packet buffer via env variable
DPDK_NUM_MBUF, besides automatic calculation.

Signed-off-by: Ting Liu <ting.liu@nxp.com>