### PR TITLE
imx6ullevk: Stop forcing the U-Boot and Linux kernel to imx flavour

### DIFF
--- a/conf/machine/imx6ullevk.conf
+++ b/conf/machine/imx6ullevk.conf
@@ -10,9 +10,12 @@ include conf/machine/include/imx-base.inc
 include conf/machine/include/tune-cortexa7.inc
 
 KERNEL_DEVICETREE = " \
+	imx6ull-14x14-evk.dtb \
+"
+
+KERNEL_DEVICETREE_append_use-nxp-bsp = " \
 	imx6ull-14x14-evk-btwifi.dtb \
 	imx6ull-14x14-evk-btwifi-oob.dtb \
-	imx6ull-14x14-evk.dtb \
 	imx6ull-14x14-evk-emmc.dtb \
 	imx6ull-14x14-evk-gpmi-weim.dtb \
 "

--- a/conf/machine/imx6ullevk.conf
+++ b/conf/machine/imx6ullevk.conf
@@ -21,10 +21,6 @@ UBOOT_CONFIG ??= "sd"
 UBOOT_CONFIG[sd] = "mx6ull_14x14_evk_config,sdcard"
 UBOOT_CONFIG[mfgtool] = "mx6ull_14x14_evk_config"
 
-PREFERRED_PROVIDER_u-boot = "u-boot-imx"
-PREFERRED_PROVIDER_virtual/bootloader = "u-boot-imx"
-PREFERRED_PROVIDER_virtual/kernel = "linux-imx"
-
 SERIAL_CONSOLES = "115200;ttymxc0"
 
 MACHINE_FEATURES += "wifi bluetooth"


### PR DESCRIPTION
We should avoid overriding the U-Boot and Linux kernel to imx flavour as
we might use mainline or their forks; this fixes build errors when using
fslc distros as:

,----[ Build error ]
| ERROR: Nothing PROVIDES 'virtual/kernel'
| linux-fslc-lts-4.19 PROVIDES virtual/kernel but was skipped: PREFERRED_PROVIDER_virtual/kernel set to linux-imx, not linux-fslc-lts-4.19
| linux-fslc-imx PROVIDES virtual/kernel but was skipped: incompatible with machine imx6ullevk (not in COMPATIBLE_MACHINE)
| linux-qoriq PROVIDES virtual/kernel but was skipped: incompatible with machine imx6ullevk (not in COMPATIBLE_MACHINE)
| linux-fslc PROVIDES virtual/kernel but was skipped: PREFERRED_PROVIDER_virtual/kernel set to linux-imx, not linux-fslc
| linux-imx PROVIDES virtual/kernel but was skipped: incompatible with machine imx6ullevk (not in COMPATIBLE_MACHINE)
| linux-fslc-qoriq PROVIDES virtual/kernel but was skipped: incompatible with machine imx6ullevk (not in COMPATIBLE_MACHINE)
| linux-yocto-rt PROVIDES virtual/kernel but was skipped: incompatible with machine imx6ullevk (not in COMPATIBLE_MACHINE)
| linux-yocto-tiny PROVIDES virtual/kernel but was skipped: incompatible with machine imx6ullevk (not in COMPATIBLE_MACHINE)
| linux-yocto-dev PROVIDES virtual/kernel but was skipped: incompatible with machine imx6ullevk (not in COMPATIBLE_MACHINE)
| linux-yocto PROVIDES virtual/kernel but was skipped: incompatible with machine imx6ullevk (not in COMPATIBLE_MACHINE)
| linux-dummy PROVIDES virtual/kernel but was skipped: PREFERRED_PROVIDER_virtual/kernel set to linux-imx, not linux-dummy
| ERROR: Required build target 'core-image-minimal' has no buildable providers.
| Missing or unbuildable dependency chain was: ['core-image-minimal', 'virtual/kernel']
`----

Fixes: #432
Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>