### PR TITLE
management-complex: avoid soft link loop in do_deploy

### DIFF
--- a/recipes-dpaa2/management-complex/management-complex_10.14.1.bb
+++ b/recipes-dpaa2/management-complex/management-complex_10.14.1.bb
@@ -25,7 +25,7 @@ do_deploy () {
     install -d ${DEPLOYDIR}/mc_app
     install -m 755 ${S}/${REGLEX}/*.itb ${DEPLOYDIR}/mc_app
     # make a symlink to the latest binary
-    for mc_binary in `ls ${DEPLOYDIR}/mc_app |sort`;do
+    for mc_binary in `find ${DEPLOYDIR}/mc_app -type f -printf "%f\n" |sort`;do
         ln -sfT ${mc_binary} ${DEPLOYDIR}/mc_app/mc.itb
     done
 }

--- a/recipes-dpaa2/management-complex/management-complex_10.20.4.bb
+++ b/recipes-dpaa2/management-complex/management-complex_10.20.4.bb
@@ -25,7 +25,7 @@ do_deploy () {
     install -d ${DEPLOYDIR}/mc_app
     install -m 755 ${S}/${REGLEX}/*.itb ${DEPLOYDIR}/mc_app
     # make a symlink to the latest binary
-    for mc_binary in `ls ${DEPLOYDIR}/mc_app |sort`;do
+    for mc_binary in `find ${DEPLOYDIR}/mc_app -type f -printf "%f\n" |sort`;do
         ln -sfT ${mc_binary} ${DEPLOYDIR}/mc_app/mc.itb
     done
 }


### PR DESCRIPTION
when the deploy mc_app directory is already populated, a soft link
loop from mc.itb to mc.itb will be created.

Steps to reproduce:
$ bitbake -c cleansstate management-complex
$ bitbake management-complex
$ bitbake -c deploy -f management-complex

Use 'find -type f' to exclude links.

Signed-off-by: Ting Liu <ting.liu@nxp.com>