### PR TITLE
u-boot-qoriq: fix bug with gcc10

### DIFF
--- a/recipes-bsp/u-boot/u-boot-qoriq/0001-Remove-redundant-YYLOC-global-declaration.patch
+++ b/recipes-bsp/u-boot/u-boot-qoriq/0001-Remove-redundant-YYLOC-global-declaration.patch
@@ -1,0 +1,29 @@
+From 018921ee79d3f30893614b3b2b63b588d8544f73 Mon Sep 17 00:00:00 2001
+From: Peter Robinson <pbrobinson@gmail.com>
+Date: Thu, 30 Jan 2020 09:37:15 +0000
+Subject: [PATCH] Remove redundant YYLOC global declaration
+
+Same as the upstream fix for building dtc with gcc 10.
+
+Upstream-Status: Backport
+
+Signed-off-by: Peter Robinson <pbrobinson@gmail.com>
+---
+ scripts/dtc/dtc-lexer.l | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/scripts/dtc/dtc-lexer.l b/scripts/dtc/dtc-lexer.l
+index fd825ebba69c..24af54997758 100644
+--- a/scripts/dtc/dtc-lexer.l
++++ b/scripts/dtc/dtc-lexer.l
+@@ -38,7 +38,6 @@ LINECOMMENT	"//".*\n
+ #include "srcpos.h"
+ #include "dtc-parser.tab.h"
+ 
+-YYLTYPE yylloc;
+ extern bool treesource_error;
+ 
+ /* CAUTION: this will stop working if we ever use yyless() or yyunput() */
+-- 
+2.26.2
+

--- a/recipes-bsp/u-boot/u-boot-qoriq_2019.10.bb
+++ b/recipes-bsp/u-boot/u-boot-qoriq_2019.10.bb
@@ -22,6 +22,7 @@ SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/u-boot;no
     file://0001-binman-Convert-a-few-tests-to-Python-3.patch \
     file://0001-binman-Move-to-use-Python-3.patch \
     file://0001-buildman-Convert-to-Python-3.patch \
+    file://0001-Remove-redundant-YYLOC-global-declaration.patch \
 "
 SRCREV= "1e55b2f9e7f56b76569089b9e950f49c1579580e"
 


### PR DESCRIPTION
Newer buildhost distributions as Fedora 32 come with GCC10+, which causes:
	gcc  -isystemtmp/work/lx2160acex7-poky-linux/u-boot-qoriq/2019.10+fslgit-r0/recipe-sysroot-native/usr/include -O2 -pipe -Ltmp/work/lx2160acex7-poky-linux/u-boot-qoriq/2019.10+fslgit-r0/recipe-sysroot-native/usr/lib                         -Ltmp/work/lx2160acex7-poky-linux/u-boot-qoriq/2019.10+fslgit-r0/recipe-sysroot-native/lib                         -Wl,--enable-new-dtags                         -Wl,-rpath-link,tmp/work/lx2160acex7-poky-linux/u-boot-qoriq/2019.10+fslgit-r0/recipe-sysroot-native/usr/lib                         -Wl,-rpath-link,tmp/work/lx2160acex7-poky-linux/u-boot-qoriq/2019.10+fslgit-r0/recipe-sysroot-native/lib                         -Wl,-rpath,tmp/work/lx2160acex7-poky-linux/u-boot-qoriq/2019.10+fslgit-r0/recipe-sysroot-native/usr/lib                         -Wl,-rpath,tmp/work/lx2160acex7-poky-linux/u-boot-qoriq/2019.10+fslgit-r0/recipe-sysroot-native/lib                         -Wl,-O1 -Wl,--allow-shlib-undefined -Wl,--dynamic-linker=tmp/sysroots-uninative/x86_64-linux/lib/ld-linux-x86-64.so.2  -o scripts/dtc/dtc scripts/dtc/dtc.o scripts/dtc/flattree.o scripts/dtc/fstree.o scripts/dtc/data.o scripts/dtc/livetree.o scripts/dtc/treesource.o scripts/dtc/srcpos.o scripts/dtc/checks.o scripts/dtc/util.o scripts/dtc/dtc-lexer.lex.o scripts/dtc/dtc-parser.tab.o
	tmp/hosttools/ld: scripts/dtc/dtc-parser.tab.o:(.bss+0x10): multiple definition of `yylloc'; scripts/dtc/dtc-lexer.lex.o:(.bss+0x0): first defined here
	collect2: error: ld returned 1 exit status
	make[3]: *** [scripts/Makefile.host:106: scripts/dtc/dtc] Error 1
	make[2]: *** [tmp/work/lx2160acex7-poky-linux/u-boot-qoriq/2019.10+fslgit-r0/git/scripts/Makefile.build:432: scripts/dtc] Error 2
	make[1]: *** [tmp/work/lx2160acex7-poky-linux/u-boot-qoriq/2019.10+fslgit-r0/git/Makefile:528: scripts] Error 2
	make[1]: Leaving directory 'tmp/work/lx2160acex7-poky-linux/u-boot-qoriq/2019.10+fslgit-r0/build/mdr_gt_tfa_defconfig

'Backporting' fix from mainline to this failure.

Signed-off-by: Jens Rehsack <sno@netbsd.org>