### PR TITLE
imx8*.conf: remove fsl- from UBOOT_DTB_NAME

### DIFF
--- a/conf/machine/imx8mmevk.conf
+++ b/conf/machine/imx8mmevk.conf
@@ -39,7 +39,7 @@ SPL_BINARY = "spl/u-boot-spl.bin"
 DDR_FIRMWARE_NAME = "lpddr4_pmu_train_1d_imem.bin lpddr4_pmu_train_1d_dmem.bin lpddr4_pmu_train_2d_imem.bin lpddr4_pmu_train_2d_dmem.bin"
 
 # Set u-boot DTB
-UBOOT_DTB_NAME = "fsl-imx8mm-evk.dtb"
+UBOOT_DTB_NAME = "imx8mm-evk.dtb"
 
 # Set imx-mkimage boot target
 IMXBOOT_TARGETS = "${@bb.utils.contains('UBOOT_CONFIG', 'fspi', 'flash_evk_flexspi', 'flash_evk', d)}"

--- a/conf/machine/imx8mnevk.conf
+++ b/conf/machine/imx8mnevk.conf
@@ -36,7 +36,7 @@ DDR_FIRMWARE_NAME = "ddr4_imem_1d_201810.bin \
                      ddr4_dmem_2d_201810.bin"
 
 # Set u-boot DTB
-UBOOT_DTB_NAME = "fsl-imx8mn-ddr4-evk.dtb"
+UBOOT_DTB_NAME = "imx8mn-ddr4-evk.dtb"
 
 # Set imx-mkimage boot target
 IMXBOOT_TARGETS = "${@bb.utils.contains('UBOOT_CONFIG', 'fspi', 'flash_ddr4_evk_flexspi', 'flash_ddr4_evk', d)}"

--- a/conf/machine/imx8mqevk.conf
+++ b/conf/machine/imx8mqevk.conf
@@ -41,7 +41,7 @@ SPL_BINARY = "spl/u-boot-spl.bin"
 DDR_FIRMWARE_NAME = "lpddr4_pmu_train_1d_imem.bin lpddr4_pmu_train_1d_dmem.bin lpddr4_pmu_train_2d_imem.bin lpddr4_pmu_train_2d_dmem.bin"
 
 # Set u-boot DTB
-UBOOT_DTB_NAME = "fsl-imx8mq-evk.dtb"
+UBOOT_DTB_NAME = "imx8mq-evk.dtb"
 
 # Set imx-mkimage boot target
 IMXBOOT_TARGETS = "flash_evk flash_evk_no_hdmi flash_dp_evk"


### PR DESCRIPTION
Minor fix for UBOOT_DTB_NAME, which were not renamed along with the device trees.

Signed-off-by: Antonin Godard <agodard@witekio.com>