### PR TITLE
linux-fslc-qoriq: update to 5.4.51

### DIFF
--- a/recipes-kernel/linux/linux-fslc-qoriq_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc-qoriq_5.4.bb
@@ -10,8 +10,8 @@ require recipes-kernel/linux/linux-qoriq.inc
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
-LINUX_VERSION = "5.4.43"
+LINUX_VERSION = "5.4.51"
 
 SRCBRANCH = "5.4.y+qoriq+fslc"
-SRCREV = "e464752884a9a134daf72fe8babb2236df4fdcff"
+SRCREV = "8221fcf6c01e7ed451510e2792c9f45422a4ca8c"
 SRC_URI := "git://github.com/Freescale/linux-fslc.git;branch=${SRCBRANCH}"


### PR DESCRIPTION
Update fslc maintained branch for QorIQ platforms to recent stable LTS
v5.4.51, which contains since v5.4.43:
    1c54d3c15afa (tag: v5.4.51, stable/linux-5.4.y) Linux 5.4.51
    8ba1913cd6ba efi: Make it possible to disable efivar_ssdt entirely
    43986c32ee00 dm zoned: assign max_io_len correctly
    215e562251bb x86/resctrl: Fix memory bandwidth counter width for AMD
    d827fe702e07 mm, compaction: make capture control handling safe wrt interrupts
    64a94c550c44 mm, compaction: fully assume capture is not NULL in compact_zone_order()
    2a9278ac9c55 irqchip/gic: Atomically update affinity
    7ba23593cbc5 dma-buf: Move dma_buf_release() from fops to dentry_ops
    4ae695a05516 drm/amdgpu/atomfirmware: fix vram_info fetching for renoir
    2b8c0876bf71 drm/amdgpu: use %u rather than %d for sclk/mclk
    94de85d16b0c drm/amd/display: Only revalidate bandwidth on medium and fast updates
    032343ed6927 MIPS: Add missing EHB in mtc0 -> mfc0 sequence for DSPen
    2e859b14da39 MIPS: lantiq: xway: sysctrl: fix the GPHY clock alias names
    71a20b798da3 cifs: Fix the target file was deleted when rename failed.
    49dae9bed7dd SMB3: Honor 'handletimeout' flag for multiuser mounts
    7ab27439fec7 SMB3: Honor lease disabling for multiuser mounts
    0d5824aea7a0 SMB3: Honor persistent/resilient handle flags for multiuser mounts
    d56787683c61 SMB3: Honor 'seal' flag for multiuser mounts
    e0ed5a36fb3a Revert "ALSA: usb-audio: Improve frames size computation"
    fe05e114d0fd nfsd: apply umask on fs without ACL support
    4ee7f1d2f1c9 spi: spi-fsl-dspi: Fix external abort on interrupt in resume or exit paths
    9d60af5c3bb3 i2c: mlxcpld: check correct size of maximum RECV_LEN packet
    b460fc9d0525 i2c: algo-pca: Add 0x78 as SCL stuck low status for PCA9665
    a632f91f7a9c samples/vfs: avoid warning in statx override
    cd62eeb31512 nvme: fix a crash in nvme_mpath_add_disk
    c64141c68f72 nvme: fix identify error status silent ignore
    7d3f489e61b6 SMB3: Honor 'posix' flag for multiuser mounts
    8964c93436ad virtio-blk: free vblk-vqs in error path of virtblk_probe()
    f795a88eade5 drm: sun4i: hdmi: Remove extra HPD polling
    c84138b3c162 nfsd: fix nfsdfs inode reference count leak
    2571e1735602 nfsd4: fix nfsdfs reference count loop
    31ec38ec9cd5 thermal/drivers/rcar_gen3: Fix undefined temperature if negative
    a65bde001008 thermal/drivers/mediatek: Fix bank number settings on mt8183
    c9426817eac7 hwmon: (acpi_power_meter) Fix potential memory leak in acpi_power_meter_add()
    3e7bd7e10639 hwmon: (max6697) Make sure the OVERT mask is set correctly
    0465f54c5cc4 cxgb4: fix SGE queue dump destination buffer context
    6bcb00d08361 cxgb4: use correct type for all-mask IP address comparison
    f68bda772639 cxgb4: fix endian conversions for L4 ports in filters
    180fbf10a26d cxgb4: parse TC-U32 key values and masks natively
    0dc4dd433b94 cxgb4: use unaligned conversion for fetching timestamp
    8a1b8e64204e RDMA/counter: Query a counter before release
    53e9b62672f7 rxrpc: Fix afs large storage transmission performance drop
    60d7de28e0ca drm/msm/dpu: fix error return code in dpu_encoder_init
    cc0f67835302 crypto: af_alg - fix use-after-free in af_alg_accept() due to bh_lock_sock()
    5d6b46a94dbb tpm: Fix TIS locality timeout problems
    563e9491f0a3 selftests: tpm: Use /bin/sh instead of /bin/bash
    1f98a9ed5799 kgdb: Avoid suspicious RCU usage warning
    e6b2e3b5e16e nvme-multipath: fix bogus request queue reference put
    5e9523d7e8cd nvme-multipath: fix deadlock due to head->lock
    ad69fbe1d262 nvme-multipath: fix deadlock between ana_work and scan_work
    c4f007d3dbdd nvme-multipath: set bdi capabilities once
    8f4aa3a6de24 s390/debug: avoid kernel warning on too large number of pages
    517326aaf41e tools lib traceevent: Handle __attribute__((user)) in field names
    6f3b8c269d88 tools lib traceevent: Add append() function helper for appending strings
    3dca0a299ff4 usb: usbtest: fix missing kfree(dev->buf) in usbtest_disconnect
    0ff5b1b50d5c rxrpc: Fix race between incoming ACK parser and retransmitter
    fe688b144c14 mm/slub: fix stack overruns with SLUB_STATS
    f459e8fc7c69 mm/slub.c: fix corrupted freechain in deactivate_slab()
    542d541c1edd sched/debug: Make sd->flags sysctl read-only
    ab9ee18f4646 usbnet: smsc95xx: Fix use-after-free after removal
    58ab86e58b55 EDAC/amd64: Read back the scrub rate PCI register on F15h
    d0e533584a05 mm: fix swap cache node allocation mask
    1c4404efcf2c io_uring: make sure async workqueue is canceled on exit
    e75220890bf6 (tag: v5.4.50, qoriq/git.kernel.org/linux-stable/linux-5.4.y) Linux 5.4.50
    a160afebd779 Revert "tty: hvc: Fix data abort due to race in hvc_open"
    ffd40b7962d4 xfs: add agf freeblocks verify in xfs_agf_verify
    cc66553004f4 dm writecache: add cond_resched to loop in persistent_memory_claim()
    a51e71cbf6e6 dm writecache: correct uncommitted_block when discarding uncommitted entry
    de1d70dad6f2 xprtrdma: Fix handling of RDMA_ERROR replies
    4d35ca872ac3 NFSv4 fix CLOSE not waiting for direct IO compeletion
    02917bef8f1b pNFS/flexfiles: Fix list corruption if the mirror count changes
    7b99577ff376 SUNRPC: Properly set the @subbuf parameter of xdr_buf_subsegment()
    c27d205baa82 sunrpc: fixed rollback in rpc_gssd_dummy_populate()
    60bdb51d44fa Staging: rtl8723bs: prevent buffer overflow in update_sta_support_rate()
    c6f88afa6ae1 drm/amdgpu: add fw release for sdma v5_0
    05124abe1fb0 drm/radeon: fix fb_div check in ni_init_smc_spll_table()
    834a3aa2ceb4 drm: rcar-du: Fix build error
    176a3c488476 drm/amd: fix potential memleak in err branch
    0b3cc973f16f ring-buffer: Zero out time extend if it is nested and not absolute
    9a59a88b3d31 tracing: Fix event trigger to accept redundant spaces
    c036eb65fdfc arm64: dts: imx8mn-ddr4-evk: correct ldo1/ldo2 voltage range
    90bd9c611f21 arm64: dts: imx8mm-evk: correct ldo1/ldo2 voltage range
    73f79b420bd0 arm64: perf: Report the PC value in REGS_ABI_32 mode
    7a9e3e25a9d2 mm/memcontrol.c: add missed css_put()
    ff6aff13a8cf ocfs2: fix panic on nfs server over ocfs2
    a8d82ebaee97 ocfs2: fix value of OCFS2_INVALID_SLOT
    4685df862c8b ocfs2: load global_inode_alloc
    7fa716a594a6 ocfs2: avoid inode removal while nfsd is accessing it
    fbca1aee1397 mm/slab: use memzero_explicit() in kzfree()
    a79c3a99ac81 btrfs: fix failure of RWF_NOWAIT write into prealloc extent beyond eof
    863a197f7f10 btrfs: check if a log root exists before locking the log_mutex on unlink
    53a081661047 btrfs: fix data block group relocation failure due to concurrent scrub
    0a4dfc69ea7e btrfs: fix bytes_may_use underflow when running balance and scrub in parallel
    df13086490db x86/asm/64: Align start of __clear_user() loop to 16-bytes
    3ceaf206b706 x86/cpu: Use pinning mask for CR4 bits needing to be 0
    96a80133559f KVM: VMX: Stop context switching MSR_IA32_UMWAIT_CONTROL
    8ccc6ac51eac KVM: nVMX: Plumb L2 GPA through to PML emulation
    5774f9fa563b KVM: X86: Fix MSR range of APIC registers in X2APIC mode
    0236040fcf97 erofs: fix partially uninitialized misuse in z_erofs_onlinepage_fixup
    824d0b6225f3 ACPI: configfs: Disallow loading ACPI tables when locked down
    3c4f9a5541bb ACPI: sysfs: Fix pm_profile_attr type
    6ee4d61403d2 ALSA: hda/realtek: Add mute LED and micmute LED support for HP systems
    1a1bc3ae6935 ALSA: hda/realtek - Add quirk for MSI GE63 laptop
    0211e0d7f185 ALSA: hda: Add NVIDIA codec IDs 9a & 9d through a0 to patch table
    f06a6294e113 RISC-V: Don't allow write+exec only page mapping request in mmap
    26b0956cb374 block: update hctx map when use multiple maps
    72647ea37700 blktrace: break out of blktrace setup on concurrent calls
    d14eb5d8f0f4 kprobes: Suppress the suspicious RCU warning on kprobes
    8ed391a3dbc4 recordmcount: support >64k sections
    803d114e8f19 kbuild: improve cc-option to clean up all temporary files
    cbed4eb0a92f arm64: sve: Fix build failure when ARM64_SVE=y and SYSCTL=n
    a9a3b33b20aa s390/vdso: fix vDSO clock_getres()
    68a3cbc44660 s390/vdso: Use $(LD) instead of $(CC) to link vDSO
    7c17909a889d s390/ptrace: fix setting syscall number
    64f7b10a91a4 s390/ptrace: pass invalid syscall numbers to tracing
    453cfe187723 pinctrl: tegra: Use noirq suspend/resume callbacks
    7851257375ae pinctrl: qcom: spmi-gpio: fix warning about irq chip reusage
    8dba9173a37a test_objagg: Fix potential memory leak in error handling
    6fd916e24935 net: alx: fix race condition in alx_remove
    855dbf10c9a7 ibmvnic: Harden device login requests
    07b8b2d46371 hwrng: ks-sa - Fix runtime PM imbalance on error
    b8403f7e45e5 riscv/atomic: Fix sign extension for RV64I
    81616542adcc drm/amd/display: Use kfree() to free rgb_user in calculate_user_regamma_ramp()
    f7f181582f1b ata/libata: Fix usage of page address by page_address in ata_scsi_mode_select_xlat function
    4dfc238a2441 sata_rcar: handle pm_runtime_get_sync failure cases
    83bdf7f8b712 sched/core: Fix PI boosting between RT and DEADLINE tasks
    3dc7138943b1 sched/deadline: Initialize ->dl_boosted
    bfd4981fe3d6 afs: Fix storage of cell names
    5cee9e67596f i2c: core: check returned size of emulated smbus block read
    4a6e6413059e i2c: fsi: Fix the port number field in status register
    0935afc39797 clk: sifive: allocate sufficient memory for struct __prci_data
    b78bae5ab399 net: bcmgenet: use hardware padding of runt frames
    ae6d80f62c73 netfilter: ipset: fix unaligned atomic access
    8d93603bf60c nvme: don't protect ns mutation with ns->head->lock
    f9dc5e708ab8 usb: renesas_usbhs: getting residue from callback_result
    56ee0ed97df5 usb: gadget: udc: Potential Oops in error handling code
    a3a86515d017 scsi: lpfc: Avoid another null dereference in lpfc_sli4_hba_unset()
    1e812023f478 ARM: imx5: add missing put_device() call in imx_suspend_alloc_ocram()
    61f488765dff cxgb4: move handling L2T ARP failures to caller
    065f225ef975 net: qede: fix use-after-free on recovery and AER handling
    f490e70fa7eb net: qede: fix PTP initialization on recovery
    7180c8fc4a03 net: qed: fix excessive QM ILT lines consumption
    32cf4ff4ec52 net: qed: fix NVMe login fails over VFs
    d0717a95a06b net: qede: stop adding events on an already destroyed workqueue
    164d9a15652f net: qed: fix async event callbacks unregistering
    5cf7f0c68405 net: qed: fix left elements count calculation
    33104571648b iommu/vt-d: Update scalable mode paging structure coherency
    ede796e5ac87 iommu/vt-d: Enable PCI ACS for platform opt in hint
    67db9e032b6e selftests/net: report etf errors correctly
    34f45567462d RDMA/mad: Fix possible memory leak in ib_mad_post_receive_mads()
    d3edf648f398 s390/qeth: fix error handling for isolation mode cmds
    9e89c2d5da87 ASoC: rockchip: Fix a reference count leak.
    4aeb21584e55 RDMA/cma: Protect bind_list and listen_list while finding matching cm id
    f0078dc6750f RDMA/qedr: Fix KASAN: use-after-free in ucma_event_handler+0x532
    66143ecb9e3c RDMA/rvt: Fix potential memory leak caused by rvt_alloc_rq
    d6fb7f457456 rxrpc: Fix handling of rwind from an ACK packet
    73cff44e66e3 ARM: dts: NSP: Correct FA2 mailbox node
    f1ee7d3a2c1a bpf: Don't return EINVAL from {get,set}sockopt when optlen > PAGE_SIZE
    0f3aa6c6d6ad devmap: Use bpf_map_area_alloc() for allocating hash buckets
    b93df0f6d7cd regmap: Fix memory leak from regmap_register_patch
    5f6b834e110b x86/resctrl: Fix a NULL vs IS_ERR() static checker warning in rdt_cdp_peer_get()
    99ab61cc8b75 ARM: dts: Fix duovero smsc interrupt for suspend
    07f7c547698b ARM: dts: am335x-pocketbeagle: Fix mmc0 Write Protect
    d909f9db0caa bpf, xdp, samples: Fix null pointer dereference in *_user code
    0608288c6caa samples/bpf: xdp_redirect_cpu: Set MAX_CPUS according to NR_CPUS
    b59ed5668c4e ASoC: fsl_ssi: Fix bclk calculation for mono channel
    3947dd237ef5 RDMA/siw: Fix pointer-to-int-cast warning in siw_rx_pbl()
    34f105349369 regualtor: pfuze100: correct sw1a/sw2 on pfuze3000
    1fa27418054f ASoC: qcom: common: set correct directions for dailinks
    47c7ae0ca9d7 ASoc: q6afe: add support to get port direction
    92444a57e365 efi/esrt: Fix reference count leak in esre_create_sysfs_entry.
    8c236ac4376a efi/tpm: Verify event log header before parsing
    e50cf858d118 ASoC: q6asm: handle EOS correctly
    41b2debf35ef xfrm: Fix double ESP trailer insertion in IPsec crypto offload.
    475a7b09b4bb ARM: OMAP2+: Fix legacy mode dss_reset
    527ddb339d6b bus: ti-sysc: Ignore clockactivity unless specified as a quirk
    1f5197a5ad97 bus: ti-sysc: Flush posted write on enable and disable
    21d511c6c9c2 IB/hfi1: Fix module use count flaw due to leftover module put calls
    2a4c0bf5c70e IB/mad: Fix use after free when destroying MAD agent
    588ad2b29ea3 loop: replace kill_bdev with invalidate_bdev
    d9a74e455070 cdc-acm: Add DISABLE_ECHO quirk for Microchip/SMSC chip
    d6522bc320d7 xhci: Return if xHCI doesn't support LPM
    14d46386226e xhci: Fix enumeration issue when setting max packet size for FS devices.
    c09be4f57956 xhci: Fix incorrect EP_STATE_MASK
    e615f58fa86c cifs/smb3: Fix data inconsistent when zero file range
    bd2f2ac0ab96 cifs/smb3: Fix data inconsistent when punch hole
    572a11131ad3 cifs: Fix cached_fid refcnt leak in open_shroot
    1f551a056b30 scsi: zfcp: Fix panic on ERP timeout for previously dismissed ERP action
    d3a251b84797 scsi: qla2xxx: Keep initiator ports after RSCN
    be8df027079b usb: cdns3: ep0: add spinlock for cdns3_check_new_setup
    a0668653be26 usb: cdns3: ep0: fix the test mode set incorrectly
    79175ae5f996 usb: cdns3: trace: using correct dir value
    25e1bb1e6c36 ALSA: usb-audio: Fix OOB access of mixer element list
    1cc2d29710c2 ALSA: usb-audio: add quirk for Samsung USBC Headset (AKG)
    0c4ff206043e ALSA: usb-audio: add quirk for Denon DCD-1500RE
    74a7ad9d975c ALSA: usb-audio: Add implicit feedback quirk for SSL2+.
    895ec8c86e13 usb: typec: tcpci_rt1711h: avoid screaming irq causing boot hangs
    fe2daefad98a usb: host: ehci-exynos: Fix error check in exynos_ehci_probe()
    c1e71a51c2f5 xhci: Poll for U0 after disabling USB2 LPM
    9d814bd14cff usb: host: xhci-mtk: avoid runtime suspend when removing hcd
    9200037a6ab6 USB: ehci: reopen solution for Synopsys HC bug
    ffeb58a0daf0 usb: add USB_QUIRK_DELAY_INIT for Logitech C922
    6b3eb8af48cb usb: dwc2: Postponed gadget registration to the udc class driver
    195c1d1dd8cf USB: ohci-sm501: Add missed iounmap() in remove
    2274a7421e73 binder: fix null deref of proc->context
    3621616af99b ALSA: usb-audio: Fix potential use-after-free of streams
    335add4ac891 fix a braino in "sparc32: fix register window handling in genregs32_[gs]et()"
    32e5a15f1084 net: sched: export __netdev_watchdog_up()
    9d3d40ec7dee btrfs: fix a block group ref counter leak after failure to remove block group
    8ae850cddf27 Revert "i2c: tegra: Fix suspending in active runtime PM state"
    052a7fdd86fb tcp_cubic: fix spurious HYSTART_DELAY exit upon drop in min RTT
    942315134313 sch_cake: fix a few style nits
    b1aa7e5fa163 sch_cake: don't call diffserv parsing code when it is not needed
    ea2628dd586d sch_cake: don't try to reallocate or unshare skb unconditionally
    3c6208267218 ip_tunnel: fix use-after-free in ip_tunnel_lookup()
    9baf076d797f net: phy: Check harder for errors in get_phy_id()
    568c5aaf6c2d ip6_gre: fix use-after-free in ip6gre_tunnel_lookup()
    35db638692db tg3: driver sleeps indefinitely when EEH errors exceed eeh_max_freezes
    fe3a5d8fc372 tcp: grow window for OOO packets only for SACK flows
    cb22ce3346f2 tcp: don't ignore ECN CWR on pure ACK
    dc43f7e807a8 sctp: Don't advertise IPv4 addresses if ipv6only is set on the socket
    fea864489c90 rxrpc: Fix notification call on completion of discarded calls
    6956830cf981 rocker: fix incorrect error handling in dma_rings_init
    a908f986ddf7 openvswitch: take into account de-fragmentation/gso_size in execute_check_pkt_len
    27b70214fc69 net: usb: ax88179_178a: fix packet alignment padding
    67571b1ab296 net: increment xmit_recursion level in dev_direct_xmit()
    97a1d2aa6cdd net: Fix the arp error in some cases
    742f2358b324 net: fix memleak in register_netdevice()
    9e693934cd59 net: Do not clear the sock TX queue in sk_set_socket()
    9f217d6dd796 net: core: reduce recursion limit value
    f32325b100ea net: bridge: enfore alignment for ethernet address
    57a976e676e1 mvpp2: ethtool rxtx stats fix
    fa0d7e09da1d mld: fix memory leak in ipv6_mc_destroy_dev()
    009b3e294a90 ibmveth: Fix max MTU limit
    f060107ccc97 geneve: allow changing DF behavior after creation
    ce06fcb6a66d enetc: Fix tx rings bitmap iteration range, irq handling
    b90ca32531bf block/bio-integrity: don't free 'buf' if bio_integrity_add_page() failed
    4e9688ad3d36 (tag: v5.4.49) Linux 5.4.49
    99705220b22c net: core: device_rename: Use rwsem instead of a seqcount
    e33765201db7 sched/rt, net: Use CONFIG_PREEMPTION.patch
    a6030d71e62d pwm: jz4740: Enhance precision in calculation of duty cycle
    d0da4be60288 net: octeon: mgmt: Repair filling of RX ring
    96d98372b53a e1000e: Do not wake up the system via WOL if device wakeup is disabled
    3d390370d78c kretprobe: Prevent triggering kretprobe from within kprobe_flush_task
    c19f0c3c9a8a kprobes: Fix to protect kick_kprobe_optimizer() by kprobe_mutex
    f4748ee4fa15 tracing/probe: Fix memleak in fetch_op_data operations
    7bb62d0cd8ac crypto: algboss - don't wait during notifier callback
    993e0d12f226 crypto: algif_skcipher - Cap recv SG list at ctx->used
    972f961c5930 Revert "drm/amd/display: disable dcn20 abm feature for bring up"
    021935185e2a drm/i915/icl+: Fix hotplug interrupt disabling after storm detection
    d814e4732cbe drm/amd/display: Use kvfree() to free coeff in build_regamma()
    50df31ea31cc drm/connector: notify userspace on hotplug after register complete
    35bd59b8b68c drm/i915: Whitelist context-local timestamp in the gen9 cmdparser
    962d0e0c091c drm/i915/gem: Avoid iterating an empty list
    a09489576fe5 drm/msm: Check for powered down HW in the devfreq callbacks
    536ffde7df46 drm/i915: Fix AUX power domain toggling across TypeC mode resets
    190f6c2d6e38 s390: fix syscall_get_error for compat processes
    2173a7ed6358 f2fs: avoid utf8_strncasecmp() with unstable name
    de3feefa3bfd f2fs: split f2fs_d_compare() from f2fs_match_name()
    9fec865dde6e net/mlx5: DR, Fix freeing in dr_create_rc_qp()
    859a0a9afee3 block: nr_sects_write(): Disable preemption on seqcount write
    120307746990 x86/boot/compressed: Relax sed symbol type regex for LLVM ld.lld
    bba1f4ac037c drm/amd/display: Use swap() where appropriate
    8f16bebbb171 drm/dp_mst: Increase ACT retry timeout to 3s
    ffa9206a62d3 ext4: avoid race conditions when remounting with options that change dax
    0804b23d2ff1 jbd2: clean __jbd2_journal_abort_hard() and __journal_abort_soft()
    ae3c09e346bd selinux: fix double free
    5471b5287cc7 drm/amdgpu: Replace invalid device ID with a valid device ID
    3031fb61096c drm/qxl: Use correct notify port address when creating cursor ring
    1f3f21d53fa8 drm/dp_mst: Reformat drm_dp_check_act_status() a bit
    8c315a220930 ext4: avoid utf8_strncasecmp() with unstable name
    779286d9babf ext4: fix partial cluster initialization when splitting extent
    bc615a290faf drm: encoder_slave: fix refcouting error for modules
    ef4f3b65d5a9 libata: Use per port sync for detach
    81344ae52c77 arm64: hw_breakpoint: Don't invoke overflow handler on uaccess watchpoints
    64183b459624 mvpp2: remove module bugfix
    b3dc33946a74 block: Fix use-after-free in blkdev_get()
    cb5fe511b11e scsi: ufs-bsg: Fix runtime PM imbalance on error
    7c7dd0507842 bnxt_en: Return from timer if interface is not in open state.
    13e6e75e68f3 afs: Fix the mapping of the UAEOVERFLOW abort code
    b7420726bc8a afs: Set error flag rather than return error from file status decode
    66f38da13198 afs: Always include dir in bulk status fetch from afs_do_lookup()
    4fd68a35f62d afs: Fix EOF corruption
    c8c19fcdabdb afs: afs_write_end() should change i_size under the right lock
    6a9fd8046fbd afs: Fix non-setting of mtime when writing into mmap
    7b307d292ab2 powerpc: Fix kernel crash in show_instructions() w/DEBUG_VIRTUAL
    f651e94899ed bcache: fix potential deadlock problem in btree_gc_coalesce
    889b69a9982b ext4: stop overwrite the errcode in ext4_setup_super
    aa7baef53057 perf stat: Fix NULL pointer dereference
    676634f1a831 perf report: Fix NULL pointer dereference in hists__fprintf_nr_sample_events()
    335d720bb4bd usb/ehci-platform: Set PM runtime as active on resume
    21a45a1427dd usb: host: ehci-platform: add a quirk to avoid stuck
    57a1cd87efb9 usb/xhci-plat: Set PM runtime as active on resume
    33a76c15c7c2 bpf: Fix memlock accounting for sock_hash
    93b675736542 iavf: fix speed reporting over virtchnl
    e7847db7aa6d xdp: Fix xsk_generic_xmit errno
    57f71bb57f7c nfs: set invalid blocks after NFSv4 writes
    d3caf0e49492 nvme-pci: use simple suspend when a HMB is enabled
    9777d12a8b23 net/filter: Permit reading NET in load_bytes_relative when MAC not set
    0eb4e1573ffd x86/idt: Keep spurious entries unset in system_vectors
    04ce5f6f0d3c scsi: acornscsi: Fix an error handling path in acornscsi_probe()
    f3f9ee422842 libbpf: Handle GCC noreturn-turned-volatile quirk
    ab482b587207 drm/sun4i: hdmi ddc clk: Fix size of m divider
    c7c658ef5159 tracing/probe: Fix bpf_task_fd_query() for kprobes and uprobes
    5bed77b0a2a0 bpf, sockhash: Synchronize delete from bucket list on map free
    0f97842057c7 bpf/sockmap: Fix kernel panic at __tcp_bpf_recvmsg
    ea8837b9435e ASoC: rt5645: Add platform-data for Asus T101HA
    ebc448eb2de5 ASoC: Intel: bytcr_rt5640: Add quirk for Toshiba Encore WT10-A tablet
    69367d9f1f0e ASoC: SOF: nocodec: conditionally set dpcm_capture/dpcm_playback flags
    7b31ec2a011f ASoC: core: only convert non DPCM link to DPCM link
    445a847a5507 afs: Fix memory leak in afs_put_sysnames()
    3b50b29a2056 f2fs: don't return vmalloc() memory from f2fs_kmalloc()
    37be9b71b748 selftests/net: in timestamping, strncpy needs to preserve null byte
    a98132826820 drivers/perf: hisi: Fix wrong value for all counters enable
    e1ee6238534e i2c: icy: Fix build with CONFIG_AMIGA_PCMCIA=n
    ad67536d48ba NTB: ntb_test: Fix bug when counting remote files
    abf918236a79 NTB: perf: Fix race condition when run with ntb_test
    50a79b96b951 NTB: perf: Fix support for hardware that doesn't have port numbers
    ec8490131670 NTB: perf: Don't require one more memory window than number of peers
    2b97e354e586 NTB: Revert the change to use the NTB device dev for DMA allocations
    e5cd9e1df0c9 NTB: ntb_tool: reading the link file should not end in a NULL byte
    25abac5c9ff7 ntb_tool: pass correct struct device to dma_alloc_coherent
    f167d8f7b341 ntb_perf: pass correct struct device to dma_alloc_coherent
    08cc0ec9ba86 net: marvell: Fix OF_MDIO config check
    fbaf0137df1e gfs2: fix use-after-free on transaction ail lists
    e782a45789f8 blktrace: fix endianness for blk_log_remap()
    545bafecc0f2 blktrace: fix endianness in get_pdu_int()
    d578f98fa7b3 blktrace: use errno instead of bi_status
    718d9a863eb3 selftests/vm/pkeys: fix alloc_random_pkey() to make it really random
    7fd599522823 include/linux/bitops.h: avoid clang shift-count-overflow warnings
    b7ce2e4538f6 lib/zlib: remove outdated and incorrect pre-increment optimization
    62378b65237e geneve: change from tx_error to tx_dropped on missing metadata
    7791ab20b8eb crypto: omap-sham - add proper load balancing support for multicore
    b73df5915d13 drm/amd/display: Revalidate bandwidth before commiting DC updates
    ca0cac3373fa nfsd: safer handling of corrupted c_type
    e585a8b54046 pinctrl: freescale: imx: Fix an error handling path in 'imx_pinctrl_probe()'
    d184d62ceb19 pinctrl: imxl: Fix an error handling path in 'imx1_pinctrl_core_probe()'
    bd410e6600b4 scsi: ufs: Don't update urgent bkops level when toggling auto bkops
    88d678348430 scsi: iscsi: Fix reference count leak in iscsi_boot_create_kobj
    08904df10d3a gfs2: Allow lock_nolock mount to specify jid=X
    9adcc852d552 nfsd4: make drc_slab global, not per-net
    807460787179 ceph: don't return -ESTALE if there's still an open file
    145565f722c9 drm/nouveau/disp/gm200-: fix NV_PDISP_SOR_HDMI2_CTRL(n) selection
    43ba1b177a49 openrisc: Fix issue with argument clobbering for clone/fork
    6de31dc168f0 rxrpc: Adjust /proc/net/rxrpc/calls to display call->debug_id not user_ID
    2e48a738dc15 mailbox: zynqmp-ipi: Fix NULL vs IS_ERR() check in zynqmp_ipi_mbox_probe()
    2d9c7e0ff9f4 rtc: rv3028: Add missed check for devm_regmap_init_i2c()
    f4fbb592d9d7 vfio/mdev: Fix reference count leak in add_mdev_supported_type
    1957ac8d1b4f ASoC: fsl_asrc_dma: Fix dma_chan leak when config DMA channel failed
    c75f1641ef58 extcon: adc-jack: Fix an error handling path in 'adc_jack_probe()'
    5ed5f8db9582 powerpc/4xx: Don't unmap NULL mbase
    838d3e75ba50 input: i8042 - Remove special PowerPC handling
    cde05d643e51 of: Fix a refcounting bug in __of_attach_node_sysfs()
    f9db526da547 NFSv4.1 fix rpc_call_done assignment for BIND_CONN_TO_SESSION
    5e85d78ed4ff net: sunrpc: Fix off-by-one issues in 'rpc_ntop6'
    ece3a3337c50 /dev/mem: Revoke mappings when a driver claims the region
    3302d17ef6ea misc: xilinx-sdfec: improve get_user_pages_fast() error handling
    24aa54a8b0ec clk: ast2600: Fix AHB clock divider for A1
    c66e72f1721a clk: sprd: return correct type of value for _sprd_pll_recalc_rate
    e5497842e253 KVM: PPC: Book3S: Fix some RCU-list locks
    fd1a1089aed8 KVM: PPC: Book3S HV: Ignore kmemleak false positives
    39983e188624 scsi: ufs-qcom: Fix scheduling while atomic issue
    4d33659ac379 clk: bcm2835: Fix return type of bcm2835_register_gate
    41324c48301d scsi: target: tcmu: Fix a use after free in tcmu_check_expired_queue_cmd()
    87b3dca712b4 ASoC: fix incomplete error-handling in img_i2s_in_probe.
    5578bf5ce0d8 powerpc/32s: Don't warn when mapping RO data ROX.
    9669bf039ff6 mfd: stmfx: Disable IRQ in suspend to avoid spurious interrupt
    d8d1b8b41783 mfd: stmfx: Fix stmfx_irq_init error path
    cf90dd9fb161 mfd: stmfx: Reset chip on resume as supply was disabled
    dc69fec9271a x86/apic: Make TSC deadline timer detection message visible
    af92e4a595e0 RDMA/iw_cxgb4: cleanup device debugfs entries on ULD remove
    4c8a62c93984 scripts: headers_install: Exit with error on config leak
    c707e18796c6 usb: gadget: Fix issue with config_ep_by_speed function
    84e1326ffc61 usb: gadget: fix potential double-free in m66592_probe.
    51ad579d64dd usb: gadget: lpc32xx_udc: don't dereference ep pointer before null check
    4a8c5f25c6bc USB: gadget: udc: s3c2410_udc: Remove pointless NULL check in s3c2410_udc_nuke
    0a560f102d80 usb: dwc2: gadget: move gadget resume after the core is in L0 state
    f1b9e29983ae watchdog: da9062: No need to ping manually before setting timeout
    4820050e8438 IB/cma: Fix ports memory leak in cma_configfs
    6e934217c943 PCI: amlogic: meson: Don't use FAST_LINK_MODE to set up link
    443ed62ef80d PCI: dwc: Fix inner MSI IRQ domain registration
    0bd8e62464e0 PCI/PTM: Inherit Switch Downstream Port PTM settings from Upstream Port
    f04479f8d519 dm zoned: return NULL if dmz_get_zone_for_reclaim() fails to find a zone
    96cd8d249a37 powerpc/64s/pgtable: fix an undefined behaviour
    a7ba81f26d70 arm64: tegra: Fix flag for 64-bit resources in 'ranges' property
    17232b92cf79 arm64: tegra: Fix ethernet phy-mode for Jetson Xavier
    d658c127fc41 fuse: copy_file_range should truncate cache
    c9ddb8dd12e1 fuse: fix copy_file_range cache issues
    ad7f78b7ce39 firmware: imx: scu: Fix possible memory leak in imx_scu_probe()
    95ea51b2690e scsi: target: tcmu: Userspace must not complete queued commands
    1503314a3354 RDMA/hns: Fix cmdq parameter of querying pf timer resource
    d09de58d2b65 RDMA/hns: Bugfix for querying qkey
    7d95cb8a4073 clk: samsung: exynos5433: Add IGNORE_UNUSED flag to sclk_i2s1
    fddd06f7490f fpga: dfl: afu: Corrected error handling levels
    7454c171a88c tty: n_gsm: Fix bogus i++ in gsm_data_kick
    4f01308480c5 USB: host: ehci-mxc: Add error handling in ehci_mxc_drv_probe()
    0e0332473790 ASoC: Intel: bytcr_rt5640: Add quirk for Toshiba Encore WT8-A tablet
    f1069001bba7 drm/msm/mdp5: Fix mdp5_init error path for failed mdp5_kms allocation
    fbf719e5da12 usb/ohci-platform: Fix a warning when hibernating
    8a67dae365e0 vfio-pci: Mask cap zero
    f5e28a0824ec powerpc/ps3: Fix kexec shutdown hang
    8f4372f4724d drivers: phy: sr-usb: do not use internal fsm for USB2 phy init
    1a588c7edcd0 powerpc/pseries/ras: Fix FWNMI_VALID off by one
    8240829fc38c powerpc/64s/exception: Fix machine check no-loss idle wakeup
    b1bc8753eefc ipmi: use vzalloc instead of kmalloc for user creation
    5c2207ba2394 habanalabs: increase timeout during reset
    828b192c57e8 PCI/PM: Assume ports without DLL Link Active train links in 100 ms
    c6737f3a1b01 HID: Add quirks for Trust Panora Graphic Tablet
    7961800651fa ALSA: usb-audio: Add duplex sound support for USB devices using implicit feedback
    860b8717f724 tty: n_gsm: Fix waking up upper tty layer when room available
    3a497f97a3b6 tty: n_gsm: Fix SOF skipping
    7fcc2ca6a3fb powerpc/64: Don't initialise init_task->thread.regs
    c7fab8a5c3ba PCI: Fix pci_register_host_bridge() device_register() error handling
    86e8dd9d249c clk: ti: composite: fix memory leak
    4536dbe64bd1 USB: ohci-sm501: fix error return code in ohci_hcd_sm501_drv_probe()
    c17e7243051a dlm: remove BUG() before panic()
    d40e6a98aa55 pinctrl: rockchip: fix memleak in rockchip_dt_node_to_map
    5248114b9bcf ASoC: ti: omap-mcbsp: Fix an error handling path in 'asoc_mcbsp_probe()'
    5acfef99644c ASoC: ux500: mop500: Fix some refcounted resources issues
    b0ccdd2fdd00 SoC: rsnd: add interrupt support for SSI BUSIF buffer
    f34a3697a8d4 scsi: mpt3sas: Fix double free warnings
    f20dfec03b82 scsi: target: loopback: Fix READ with data and sensebytes
    a798daf42a35 arm64: dts: msm8996: Fix CSI IRQ types
    6544b95bd789 ASoC: SOF: core: fix error return code in sof_probe_continue()
    79790202d4f3 power: supply: smb347-charger: IRQSTAT_D is volatile
    ad8b5b5faf9d power: supply: lp8788: Fix an error handling path in 'lp8788_charger_probe()'
    c1bcf01aea0e ALSA: firewire-lib: fix invalid assignment to union data for directional parameter
    3201bb03c8fd scsi: qla2xxx: Fix warning after FC target reset
    766c787e55ca PCI/ASPM: Allow ASPM on links to PCIe-to-PCI/PCI-X Bridges
    742f8ac8edd4 PCI: rcar: Fix incorrect programming of OB windows
    efb5f7b106ea drivers: base: Fix NULL pointer exception in __platform_driver_probe() if a driver developer is foolish
    33cf7944af54 serial: amba-pl011: Make sure we initialize the port.lock spinlock
    32a5bc992b6c i2c: pxa: fix i2c_pxa_scream_blue_murder() debug output
    9eb54d0e8962 PCI: v3-semi: Fix a memory leak in v3_pci_probe() error handling paths
    4d30daf901aa staging: sm750fb: add missing case while setting FB_VISUAL
    2428682e3f6c staging: wilc1000: Increase the size of wid_list array
    b14b7359535d usb: dwc3: gadget: Properly handle failed kick_transfer
    1bfa09147282 usb: dwc3: gadget: Properly handle ClearFeature(halt)
    e320bb0e01db HID: intel-ish-hid: avoid bogus uninitialized-variable warning
    cbec16266a35 soundwire: slave: don't init debugfs on device registration error
    a45fc52449d7 ASoC: max98373: reorder max98373_reset() in resume
    7377ba16b542 clk: meson: meson8b: Don't rely on u-boot to init all GP_PLL registers
    ea78361174c4 thermal/drivers/ti-soc-thermal: Avoid dereferencing ERR_PTR
    3296e566b0d2 gpio: pca953x: fix handling of automatic address incrementing
    dd47c98992d6 clk: meson: meson8b: Fix the vclk_div{1, 2, 4, 6, 12}_en gate bits
    ecb9a8068ba5 clk: meson: meson8b: Fix the polarity of the RESET_N lines
    1fa1d1ceb02f clk: meson: meson8b: Fix the first parent of vid_pll_in_sel
    9a624802e628 slimbus: ngd: get drvdata from correct device
    793e15fb6681 tty: hvc: Fix data abort due to race in hvc_open
    eb3e85b3375d s390/qdio: put thinint indicator after early error
    d7852661f9fd ALSA: usb-audio: Fix racy list management in output queue
    aba41867dd66 ALSA: usb-audio: Improve frames size computation
    3468bca1ea44 staging: gasket: Fix mapping refcnt leak when register/store fails
    b3b4dcdc2bb4 staging: gasket: Fix mapping refcnt leak when put attribute fails
    0c884f3236f3 firmware: qcom_scm: fix bogous abuse of dma-direct internals
    0c48b6df64c0 arm64: dts: qcom: fix pm8150 gpio interrupts
    2b5e027657d4 virtiofs: schedule blocking async replies in separate worker
    ff86bd6cca2e pinctrl: rza1: Fix wrong array assignment of rza1l_swio_entries
    cd3f4ed1c567 scsi: qedf: Fix crash when MFW calls for protocol stats while function is still probing
    a0a00156d50e gpio: dwapb: Append MODULE_ALIAS for platform driver
    02416142fdf4 RDMA/mlx5: Fix udata response upon SRQ creation
    7acbadd1aa29 ARM: dts: sun8i-h2-plus-bananapi-m2-zero: Fix led polarity
    ef0c0fbf1d4a arm64: dts: qcom: msm8916: remove unit name for thermal trip points
    f37623862ec5 scsi: qedi: Do not flush offload work if ARP not resolved
    0e5d7bff3b06 arm64: dts: mt8173: fix unit name warnings
    7bf3a213f79e staging: greybus: fix a missing-check bug in gb_lights_light_config()
    c970dcc085b8 x86/purgatory: Disable various profiling and sanitizing options
    a78c65cb4b67 apparmor: fix nnp subset test for unconfined
    af1f72ad18bb scsi: ibmvscsi: Don't send host info in adapter info MAD after LPM
    08d2ea2e236a scsi: sr: Fix sr_probe() missing deallocate of device minor
    8f73ac0b6434 bpf, sockhash: Fix memory leak when unlinking sockets in sock_hash_free
    efdb1bf81aab ASoC: meson: add missing free_irq() in error path
    390f1688fb46 f2fs: handle readonly filesystem in f2fs_ioc_shutdown()
    039a79ef0b1e apparmor: check/put label on apparmor_sk_clone_security()
    2a9b3e4667f5 net: dsa: lantiq_gswip: fix and improve the unsupported interface error
    88bc3e060390 apparmor: fix introspection of of task mode for unconfined tasks
    d782d6a142d5 mksysmap: Fix the mismatch of '.L' symbols in System.map
    d0af43b47418 NTB: Fix the default port and peer numbers for legacy drivers
    f0b8eead5b1c NTB: ntb_pingpong: Choose doorbells based on port number
    0ec407dfc1ec yam: fix possible memory leak in yam_init_driver
    a4d4b8437731 sparc32: mm: Don't try to free page-table pages if ctor() fails
    7f16ba366a66 pwm: img: Call pm_runtime_put() in pm_runtime_get_sync() failed case
    9b163c91620c powerpc/crashkernel: Take "mem=" option into account
    211836827af3 ASoC: qcom: q6asm-dai: kCFI fix
    117929a41db1 cifs: set up next DFS target before generic_ip_connect()
    c0c8c8b10567 RDMA/core: Fix several reference count leaks.
    3851967ff567 PCI: vmd: Filter resource type bits from shadow register
    e8cac2e3067e nfsd: Fix svc_xprt refcnt leak when setup callback client failed
    db686568ae52 powerpc/perf/hv-24x7: Fix inconsistent output values incase multiple hv-24x7 events run
    ecb9c4d344c9 IB/mlx5: Fix DEVX support for MLX5_CMD_OP_INIT2INIT_QP command
    a2fe8d88aeff clk: clk-flexgen: fix clock-critical handling
    6a70c943a26f scsi: vhost: Notify TCM about the maximum sg entries supported per command
    296cec70500b scsi: lpfc: Fix lpfc_nodelist leak when processing unsolicited event
    82ac4863030c clk: zynqmp: fix memory leak in zynqmp_register_clocks
    bee9cc351308 scsi: cxgb3i: Fix some leaks in init_act_open()
    4deddbf7db45 mfd: wm8994: Fix driver operation if loaded as modules
    8e52a1eef19b powerpc/ptdump: Add _PAGE_COHERENT flag
    805bae7592fa usb: gadget: core: sync interrupt before unbind the udc
    2ec338547c67 gpio: dwapb: Call acpi_gpiochip_free_interrupts() on GPIO chip de-registration
    02bdd581404d m68k/PCI: Fix a memory leak in an error handling path
    ec475f960e92 PCI: pci-bridge-emul: Fix PCIe bit conflicts
    ba5192db9672 scsi: hisi_sas: Do not reset phy timer to wait for stray phy up
    2b670bbfd8c0 RDMA/mlx5: Add init2init as a modify command
    cbd55ce91abf coresight: tmc: Fix TMC mode read in tmc_read_prepare_etb()
    c74ead459747 vfio/pci: fix memory leaks in alloc_perm_bits()
    24911d387b84 arm64: dts: fvp/juno: Fix node address fields
    6d79ba8094fa ps3disk: use the default segment boundary
    bc881cd5334c PCI: aardvark: Don't blindly enable ASPM L0s and don't write to read-only register
    492c50fe65a9 arm64: dts: fvp: Fix GIC child nodes
    376ef9d7ee4c ASoC: SOF: Do nothing when DSP PM callbacks are not set
    1cdae7bb4221 clk: renesas: cpg-mssr: Fix STBCR suspend/resume handling
    14c5e25d3b00 pinctrl: ocelot: Fix GPIO interrupt decoding on Jaguar2
    4e55b843fa61 arm64: dts: juno: Fix GIC child nodes
    7df82e1754df arm64: dts: armada-3720-turris-mox: fix SFP binding
    4ca96a5de812 arm64: dts: armada-3720-turris-mox: forbid SDR104 on SDIO for FCC purposes
    a86306dbefc3 dm mpath: switch paths in dm_blk_ioctl() code path
    08f396eb02c8 misc: fastrpc: fix potential fastrpc_invoke_ctx leak
    8d8991bb2bf0 misc: fastrpc: Fix an incomplete memory release in fastrpc_rpmsg_probe()
    c2ff1fcc2530 serial: 8250: Fix max baud limit in generic 8250 port
    9e6a9201b78b usblp: poison URBs upon disconnect
    cc9024f69ba7 clk: samsung: Mark top ISP and CAM clocks on Exynos542x as critical
    2b5e61da68e8 remoteproc: qcom_q6v5_mss: map/unmap mpss segments before/after use
    8a44731af689 i2c: pxa: clear all master action bits in i2c_pxa_stop_message()
    ceb63ec0ef6e f2fs: report delalloc reserve as non-free in statfs for project quota
    ca90f67ece5c iio: bmp280: fix compensation of humidity
    30bd1f36b6eb rtc: mc13xxx: fix a double-unlock issue
    91fce7922a75 powerpc/kasan: Fix stack overflow by increasing THREAD_SHIFT
    a6a0317bf9c2 Input: edt-ft5x06 - fix get_default register write access
    70a2296d4bab scsi: qla2xxx: Fix issue with adapter's stopping state
    5800b7f7d231 PCI: Allow pci_resize_resource() for devices on root bus
    956a2e737a2c ALSA: isa/wavefront: prevent out of bounds write in ioctl
    23337efa940c ALSA: hda/realtek - Introduce polarity for micmute LED GPIO
    66a177ae4ed0 arm64: dts: meson: fixup SCP sram nodes
    7631dc491a3f scsi: qedi: Check for buffer overflow in qedi_set_path()
    545b86efa0d0 scsi: core: free sgtables in case command setup fails
    bde2d5d443c4 ARM: dts: stm32: Add missing ethernet PHY reset on AV96
    38ede4d7736e ARM: integrator: Add some Kconfig selections
    a1359b9fdd8d ASoC: davinci-mcasp: Fix dma_chan refcnt leak when getting dma type
    8908c555e06e ARM: dts: renesas: Fix IOMMU device node names
    2c40fc80331b backlight: lp855x: Ensure regulators are disabled on probe failure
    53057bd4ac84 ASoC: fsl_esai: Disable exception interrupt before scheduling tasklet
    b543c3595188 clk: qcom: msm8916: Fix the address location of pll->config_reg
    7906a075c900 remoteproc: Fix IDR initialisation in rproc_alloc()
    8bd207bb1a25 iio: pressure: bmp280: Tolerate IRQ before registering
    2e714a547ef8 ASoC: SOF: imx8: Fix randbuild error
    dc570a1fb48c i2c: piix4: Detect secondary SMBus controller on AMD AM4 chipsets
    30e82a3edd94 ASoC: tegra: tegra_wm8903: Support nvidia, headset property
    7b139b714a5d clk: sunxi: Fix incorrect usage of round_down()
    8aa822a1305c power: supply: bq24257_charger: Replace depends on REGMAP_I2C with select
    67cb016870e2 (tag: v5.4.48) Linux 5.4.48
    8e38ea68da06 perf symbols: Fix kernel maps for kcore and eBPF
    807cc607f129 perf symbols: Fix debuginfo search for Ubuntu
    842645de05d5 perf probe: Check address correctness by map instead of _etext
    be781abe3ae8 perf probe: Fix to check blacklist address correctly
    a2e097910334 perf probe: Do not show the skipped events
    9660edf6729d f2fs: fix checkpoint=disable:%u%%
    1866b1493e2e w1: omap-hdq: cleanup to add missing newline for some dev_dbg
    2140d7d5d878 mtd: rawnand: tmio: Fix the probe error path
    ec851b26a3e5 mtd: rawnand: mtk: Fix the probe error path
    b5404756b54f mtd: rawnand: pasemi: Fix the probe error path
    44a9bf52ef80 mtd: rawnand: plat_nand: Fix the probe error path
    ab702f81e978 mtd: rawnand: sunxi: Fix the probe error path
    2d77d5575e09 mtd: rawnand: oxnas: Fix the probe error path
    2d6b0901b834 mtd: rawnand: socrates: Fix the probe error path
    3a54e242870b mtd: rawnand: orion: Fix the probe error path
    0b19623af5a6 mtd: rawnand: xway: Fix the probe error path
    ae7cf595e15b mtd: rawnand: ingenic: Fix the probe error path
    38abdd9bf77c mtd: rawnand: sharpsl: Fix the probe error path
    8d695fbaa5cb mtd: rawnand: diskonchip: Fix the probe error path
    1260c45ac55b mtd: rawnand: brcmnand: fix hamming oob layout
    ba4ffbb5592d mtd: rawnand: onfi: Fix redundancy detection check
    869a782420da mtd: rawnand: Fix nand_gpio_waitrdy()
    e5084eadf193 sunrpc: clean up properly in gss_mech_unregister()
    4a68a2e25e20 sunrpc: svcauth_gss_register_pseudoflavor must reject duplicate registrations.
    e4f7a7260737 kbuild: force to build vmlinux if CONFIG_MODVERSION=y
    1b0d830e0ce0 powerpc/64s: Save FSCR to init_task.thread.fscr after feature init
    b3b357d83079 powerpc/64s: Don't let DT CPU features set FSCR_DSCR
    1d9a4422c9ac powerpc/32: Disable KASAN with pages bigger than 16k
    4719cb8a16af powerpc/kasan: Fix shadow pages allocation failure
    002d22c4945a powerpc/kasan: Fix issues by lowering KASAN_SHADOW_END
    23e07a77aa7c powerpc/32s: Fix another build failure with CONFIG_PPC_KUAP_DEBUG
    c6077abc067f drivers/macintosh: Fix memleak in windfarm_pm112 driver
    1d5144d7dc5d ARM: dts: s5pv210: Set keep-power-in-suspend for SDHCI1 on Aries
    727111d44a59 ARM: dts: at91: sama5d2_ptc_ek: fix vbus pin
    1bfcafbb4d1e ARM: dts: exynos: Fix GPIO polarity for thr GalaxyS3 CM36651 sensor's bus
    8c7ca9ab5abc soc/tegra: pmc: Select GENERIC_PINCONF
    be20b99a86b3 ARM: tegra: Correct PL310 Auxiliary Control Register initialization
    b5d2f71b98b7 kernel/cpu_pm: Fix uninitted local in cpu_pm
    6d9cc26aa164 powerpc/fadump: Account for memory_limit while reserving memory
    6fd930da24e1 powerpc/fadump: consider reserved ranges while reserving memory
    3e9211d98803 powerpc/fadump: use static allocation for reserved memory ranges
    c81e34c4346f alpha: fix memory barriers so that they conform to the specification
    5018a0bd0964 dm crypt: avoid truncating the logical block size
    ee6fa4903f84 sparc64: fix misuses of access_process_vm() in genregs32_[sg]et()
    0dcbc7d6cd2d sparc32: fix register window handling in genregs32_[gs]et()
    f2f18147c7db gnss: sirf: fix error return code in sirf_probe()
    e75e551606f4 pinctrl: samsung: Save/restore eint_mask over suspend for EINT_TYPE GPIOs
    407933bbb385 pinctrl: samsung: Correct setting of eint wakeup mask on s5pv210
    8b28e5c35d32 power: supply: core: fix memory leak in HWMON error path
    6050811edffb power: supply: core: fix HWMON temperature labels
    0fd525d817ea power: vexpress: add suppress_bind_attrs to true
    7c71b9aa18a0 EDAC/amd64: Add AMD family 17h model 60h PCI IDs
    67712fa4a662 hwmon: (k10temp) Add AMD family 17h model 60h PCI match
    3046b09d45ec igb: Report speed and duplex as unknown when device is runtime suspended
    e6f91166fc37 clk: mediatek: assign the initial value to clk_init_data of mtk_mux
    adecd49745f8 media: ov5640: fix use of destroyed mutex
    3ef00d99199d b43_legacy: Fix connection problem with WPA3
    b74d369d2962 b43: Fix connection problem with WPA3
    5c039a9921b3 b43legacy: Fix case where channel status is corrupted
    eeb0cf8bb68e Bluetooth: hci_bcm: fix freeing not-requested IRQ
    4c79dd14c15d serial: 8250: Avoid error message on reprobe
    80462f7c296d media: cedrus: Program output format during each run
    6e688a315acf media: go7007: fix a miss of snd_card_free
    bda6ebf290fa carl9170: remove P2P_GO support
    cedbd8709cc1 e1000e: Relax condition to trigger reset for ME workaround
    0fedb80811f4 e1000e: Disable TSO for buffer overrun workaround
    f4cc36066a31 PCI: Program MPS for RCiEP devices
    e131e70e2144 ima: Set again build_ima_appraise variable
    2600136eaee9 ima: Remove redundant policy rule set in add_rules()
    70ce85319d45 x86/amd_nb: Add AMD family 17h model 60h PCI IDs
    44eec92cc4bf serial: 8250_pci: Move Pericom IDs to pci_ids.h
    3c8938fb19ed PCI: Add Loongson vendor ID
    9cfece5c0e2b x86/amd_nb: Add Family 19h PCI IDs
    b35415c0949a PCI: vmd: Add device id for VMD device 8086:9A0B
    3179b408c401 PCI: Add ACS quirk for Intel Root Complex Integrated Endpoints
    0e4528cdbaf0 PCI: Avoid FLR for AMD Starship USB 3.0
    cb5ac1a32552 PCI: Avoid FLR for AMD Matisse HD Audio & USB 3.0
    c41d7ca0061e PCI: Avoid Pericom USB controller OHCI/EHCI PME# defect
    fd8abb78b129 ext4: fix race between ext4_sync_parent() and rename()
    c316ebcf9f4b ext4: fix error pointer dereference
    319b553695ec ext4: fix EXT_MAX_EXTENT/INDEX to check for zeroed eh_max
    6de50456fe17 evm: Fix possible memory leak in evm_calc_hmac_or_hash()
    ce7f038f859d ima: Remove __init annotation from ima_pcrread()
    f387759c2d67 ima: Call ima_calc_boot_aggregate() in ima_eventdigest_init()
    64712383a186 ima: Directly assign the ima_default_policy pointer to ima_rules
    4ce29d9b1941 ima: Evaluate error in init_ima()
    5f7272bd228c ima: Switch to ima_hash_algo for boot aggregate
    0698eacdfc4f ima: Fix ima digest hash table key calculation
    13ae9eaae0cc mm: call cond_resched() from deferred_init_memmap()
    5386d93bc5b6 mm/pagealloc.c: call touch_nmi_watchdog() on max order boundaries in deferred init
    c388f173ed8a mm: initialize deferred pages with interrupts enabled
    a88d8aaf9b8b mm: thp: make the THP mapcount atomic against __split_huge_pmd_locked()
    e418045e25a9 powerpc/mm: Fix conditions to perform MMU specific management by blocks on PPC32.
    0ccfd7a531e8 btrfs: fix space_info bytes_may_use underflow during space cache writeout
    248cdf728895 btrfs: fix space_info bytes_may_use underflow after nocow buffered write
    8076bdd4fe00 btrfs: fix wrong file range cleanup after an error filling dealloc range
    c2c69ecb605f btrfs: fix error handling when submitting direct I/O bio
    05c5e98bf402 btrfs: force chunk allocation if our global rsv is larger than metadata
    f63545770fc4 btrfs: send: emit file capabilities after chown
    20f260ed536a btrfs: include non-missing as a qualifier for the latest_bdev
    fd9720b8e957 btrfs: free alien device after device add
    b008ae4cc74d string.h: fix incompatibility between FORTIFY_SOURCE and KASAN
    d6c2b4d246c5 kasan: stop tests being eliminated as dead code with FORTIFY_SOURCE
    c48a842d8ce7 selftests/bpf, flow_dissector: Close TAP device FD after the test
    e7b1564a24e6 bpf: Fix running sk_skb program types with ktls
    d9cd7b83942f bpf: Refactor sockmap redirect code so its easy to reuse
    215a256bc8dd bpf: Fix map permissions check
    0d55b7032ad1 libbpf: Fix perf_buffer__free() API for sparse allocs
    98545815cfcf platform/x86: asus_wmi: Reserve more space for struct bias_args
    4383a5dfbdc5 platform/x86: intel-vbtn: Only blacklist SW_TABLET_MODE on the 9 / "Laptop" chasis-type
    5f3cba4bc241 platform/x86: intel-hid: Add a quirk to support HP Spectre X2 (2015)
    176396ad0594 platform/x86: hp-wmi: Convert simple_strtoul() to kstrtou32()
    b77412359c1e cpuidle: Fix three reference count leaks
    cf3359869819 spi: dw: Return any value retrieved from the dma_transfer callback
    2c95fc879a2f mmc: sdhci-esdhc-imx: fix the mask for tuning start point
    7fe3a1c29869 iwlwifi: mvm: fix aux station leak
    ffa118a164e6 ixgbe: fix signed-integer-overflow warning
    99ea968e3766 ice: fix potential double free in probe unrolling
    62b2fbb9c463 mmc: via-sdmmc: Respect the cmd->busy_timeout from the mmc core
    3d6143663f21 staging: greybus: sdio: Respect the cmd->busy_timeout from the mmc core
    8a7c5b83f846 mmc: sdhci-msm: Set SDHCI_QUIRK_MULTIBLOCK_READ_ACMD12 quirk
    62e7e4f5976c bcache: fix refcount underflow in bcache_device_free()
    d55960f7f6b7 MIPS: Fix IRQ tracing when call handle_fpe() and handle_msa_fpe()
    3f6482c0a486 PCI: Don't disable decoding when mmio_always_on is set
    fa99a4b3fb12 macvlan: Skip loopback packets in RX handler
    c6f1f12a8c3d btrfs: qgroup: mark qgroup inconsistent if we're inherting snapshot to a new qgroup
    1e42a1857bcf btrfs: improve global reserve stealing logic
    590aad883521 m68k: mac: Don't call via_flush_cache() on Mac IIfx
    ce066ce05e1b MIPS: tools: Fix resource leak in elf-entry.c
    87ef5086a3c2 x86/mm: Stop printing BRK addresses
    41b44325c9eb selftests/bpf: CONFIG_IPV6_SEG6_BPF required for test_seg6_loop.o
    5b8d09eeb4a6 drm/amdgpu: Sync with VM root BO when switching VM to CPU update mode
    b06a7dc9e5f6 drm/amd/powerpay: Disable gfxoff when setting manual mode on picasso and raven
    188e3e6ed902 crypto: stm32/crc32 - fix multi-instance
    d879598b8dae crypto: stm32/crc32 - fix run-time self test issue.
    8fe61a2027db crypto: stm32/crc32 - fix ext4 chksum BUG_ON()
    c79c643fca61 mips: Add udelay lpj numbers adjustment
    34a45e84edc5 mips: MAAR: Use more precise address mask
    9fa3b0bd9914 sched: Defend cfs and rt bandwidth quota against overflow
    fecf17b609a7 x86/boot: Correct relocation destination on old linkers
    7b3423eff20e kgdboc: Use a platform device to handle tty drivers showing up late
    39d7ce336ec5 mwifiex: Fix memory corruption in dump_station
    65f1c3e4e906 rtlwifi: Fix a double free in _rtl_usb_tx_urb_setup()
    916f41e40643 net/mlx5e: IPoIB, Drop multicast packets that this interface sent
    fa408bbe1007 veth: Adjust hard_start offset on redirect XDP frames
    894d9cd52466 iocost: don't let vrate run wild while there's no saturation signal
    7f5d77570b0c raid5: remove gfp flags from scribble_alloc()
    cd4013947eae md: don't flush workqueue unconditionally in md_open
    5deaa24167a6 mt76: avoid rx reorder buffer overflow
    095e7a6a326c drm/mcde: dsi: Fix return value check in mcde_dsi_bind()
    727093f432d1 net: qed*: Reduce RX and TX default ring count when running inside kdump kernel
    5099a9c22dbf wcn36xx: Fix error handling path in 'wcn36xx_probe()'
    dbf2fab3f540 ath10k: Remove msdu from idr when management pkt send fails
    671d8b8726a1 nvme-tcp: use bh_lock in data_ready
    a09fc96a3d54 nvme-pci: align io queue count with allocted nvme_queue in nvme_probe
    be7f2672c341 nvme: refine the Qemu Identify CNS quirk
    66ea23154df0 iwlwifi: avoid debug max amsdu config overwriting itself
    287a0f7a3393 platform/x86: intel-vbtn: Also handle tablet-mode switch on "Detachable" and "Portable" chassis-types
    708e0175edf5 platform/x86: intel-vbtn: Do not advertise switches to userspace if they are not there
    0ac5741007f1 platform/x86: intel-vbtn: Split keymap into buttons and switches parts
    4a091f1d273f platform/x86: intel-vbtn: Use acpi_evaluate_integer()
    b04c79255e8d xfs: fix duplicate verification from xfs_qm_dqflush()
    f69806af2a2f xfs: reset buffer write failure state on successful completion
    4f1a132115ef kgdb: Fix spurious true from in_dbg_master()
    fe99bb25c452 mips: cm: Fix an invalid error code of INTVN_*_ERR
    7bf491d01ea7 MIPS: Truncate link address into 32bit for 32bit kernel
    ec19b7a525aa Crypto/chcr: fix for ccm(aes) failed test
    984fc5f4e3b4 xfs: clean up the error handling in xfs_swap_extents
    0eeea4b8f0a9 libertas_tf: avoid a null dereference in pointer priv
    964de53149ab powerpc/spufs: fix copy_to_user while atomic
    dc091fc86216 net: allwinner: Fix use correct return type for ndo_start_xmit()
    8ca0e780b4e8 media: cec: silence shift wrapping warning in __cec_s_log_addrs()
    4f6762503fa2 drivers: net: davinci_mdio: fix potential NULL dereference in davinci_mdio_probe()
    b2083327ea3c selinux: fix error return code in policydb_read()
    86dced2417b7 net: lpc-enet: fix error return code in lpc_mii_init()
    7b88ccc137fb iocost_monitor: drop string wrap around numbers when outputting json
    5934e2270901 drivers/perf: hisi: Fix typo in events attribute array
    f7757368e0f0 sched/core: Fix illegal RCU from offline CPUs
    2e256dd5b055 exit: Move preemption fixup up, move blocking operations down
    338ff29604d9 lib/mpi: Fix 64-bit MIPS build with Clang
    4fbc334749e7 net: bcmgenet: Fix WoL with password after deep sleep
    d7b1ca9eebdf net: bcmgenet: set Rx mode before starting netif
    1dbb13ceedac selftests/bpf: Fix memory leak in extract_build_id()
    58ee4d253753 netfilter: nft_nat: return EOPNOTSUPP if type or flags are not supported
    d1a00c9bb1c7 dpaa2-eth: fix return codes used in ndo_setup_tc
    04ab099d1eb0 Drivers: hv: vmbus: Always handle the VMBus messages on CPU0
    51d2957b21b5 audit: fix a net reference leak in audit_list_rules_send()
    5b737a0ae101 Bluetooth: btbcm: Add 2 missing models to subver tables
    c5edfe811b4a ath10k: add flush tx packets for SDIO chip
    cc66b6bb3241 MIPS: Make sparse_init() using top-down allocation
    c3bc42b70ed1 media: platform: fcp: Set appropriate DMA parameters
    79d622a81322 media: dvb: return -EREMOTEIO on i2c transfer failure.
    189ca174b87d audit: fix a net reference leak in audit_send_reply()
    6315839f14b9 drm/mediatek: set dpi pin mode to gpio low to avoid leakage current
    878ca9ebf1a0 dt-bindings: display: mediatek: control dpi pins mode to avoid leakage
    4f8c52320202 e1000: Distribute switch variables for initialization
    0bf9805dfdae tools api fs: Make xxx__mountpoint() more scalable
    a17cc8a6abab regulator: qcom-rpmh: Fix typos in pm8150 and pm8150l
    22a734616824 brcmfmac: fix wrong location to get firmware feature
    90e5154c737c spi: Respect DataBitLength field of SpiSerialBusV2() ACPI resource
    42c22e4834c2 media: staging/intel-ipu3: Implement lock for stream on/off operations
    bfc0ee2b31f8 ath10k: fix kernel null pointer dereference
    76ecfcfefe3b staging: android: ion: use vmap instead of vm_map_ram
    3ec7b42f1747 x86: fix vmap arguments in map_irq_stack
    ece6218eea3a net: vmxnet3: fix possible buffer overflow caused by bad DMA value in vmxnet3_get_rss()
    af510d6fd690 x86/kvm/hyper-v: Explicitly align hcall param for kvm_hyperv_exit
    bd18ecbbc7aa spi: dw: Fix Rx-only DMA transfers
    999b59be5d20 Bluetooth: btmtkuart: Improve exception handling in btmtuart_probe()
    2daf747c2831 mmc: meson-mx-sdio: trigger a soft reset after a timeout or CRC error
    804664580662 ice: Fix for memory leaks and modify ICE_FREE_CQ_BUFS
    f9b545956421 ice: Fix memory leak
    f503e7fe3099 batman-adv: Revert "disable ethtool link speed detection when auto negotiation off"
    8cf93ef213f9 ARM: 8978/1: mm: make act_mm() respect THREAD_SIZE
    2a005026102e btrfs: do not ignore error from btrfs_next_leaf() when inserting checksums
    3bb51c966b9f btrfs: account for trans_block_rsv in may_commit_transaction
    cb0ee3f03f0b media: dvbdev: Fix tuner->demod media controller link
    bffe2c8e2303 clocksource: dw_apb_timer_of: Fix missing clockevent timers
    7bd656984566 clocksource: dw_apb_timer: Make CPU-affiliation being optional
    e8ec0ae0f3cf spi: dw: Enable interrupts in accordance with DMA xfer mode
    a2683765887d mips: Fix cpu_has_mips64r1/2 activation for MIPS32 CPUs
    b1d2d3dd016f ACPI/IORT: Fix PMCG node single ID mapping handling
    c2ad0dc7b9e0 pmu/smmuv3: Clear IRQ affinity hint on device removal
    308c2095da30 kgdb: Prevent infinite recursive entries to the debugger
    1343e0a85941 kgdb: Disable WARN_CONSOLE_UNLOCKED for all kgdb
    5c79bf440d35 Bluetooth: Add SCO fallback for invalid LMP parameters error
    461b239e3a73 MIPS: Loongson: Build ATI Radeon GPU driver as module
    544a3a292d8e platform/x86: dell-laptop: don't register micmute LED if there is no token
    ece1e470af13 ixgbe: Fix XDP redirect on archs with PAGE_SIZE above 4K
    6eec65c9e283 lockdown: Allow unprivileged users to see lockdown status
    00f73938ef65 drm: rcar-du: Set primary plane zpos immutably at initializing
    e7aefaba39d2 block: reset mapping if failed to update hardware queue count
    b432540123f5 arm64: insn: Fix two bugs in encoding 32-bit logical immediates
    201219691a9a block: alloc map and request for new hardware queue
    fec6f8c0b221 ACPICA: Dispatcher: add status checks
    c916af516d82 spi: dw: Zero DMA Tx and Rx configurations on stack
    92fb6909b058 rtw88: fix an issue about leak system resources
    bd7662d6036e media: staging: ipu3: Fix stale list entries on parameter queue failure
    9a0c99419125 arm64: cacheflush: Fix KGDB trap detection
    12d4dac2be77 ath10k: remove the max_sched_scan_reqs value
    c573a13f72fb efi/libstub/x86: Work around LLVM ELF quirk build regression
    fa15b59b1ea2 net: ena: fix error returning in ena_com_get_hash_function()
    84c8498320d2 net: atlantic: make hw_get_regs optional
    9f664eda61a0 sched/fair: Refill bandwidth before scaling
    91517e951830 x86,smap: Fix smap_{save,restore}() alternatives
    6fc5d5834b37 spi: pxa2xx: Apply CS clk quirk to BXT
    269e7b43f2b4 libbpf: Fix memory leak and possible double-free in hashmap__clear
    072d23eef600 arm64/kernel: Fix range on invalidating dcache for boot page tables
    614722f1ffd2 drm/amdgpu: Init data to avoid oops while reading pp_num_states.
    d2a244e74808 spi: spi-mem: Fix Dual/Quad modes on Octal-capable devices
    07d45406db69 objtool: Ignore empty alternatives
    1121685ca1bd media: si2157: Better check for running tuner in init
    18b2a6f250cc media: vicodec: Fix error codes in probe function
    f9f8f0c24203 crypto: ccp -- don't "select" CONFIG_DMADEVICES
    68aeaeac683b media: imx: imx7-mipi-csis: Cleanup and fix subdev pad format handling
    ff41c7b3c7db media: staging: imgu: do not hold spinlock during freeing mmu page table
    22710f6c35a3 drm: bridge: adv7511: Extend list of audio sample rates
    30c5d951a557 ath10k: Fix the race condition in firmware dump work queue
    6fc5719b85ec drm/amdgpu: fix and cleanup amdgpu_gem_object_close v4
    f3ec5b536fc1 ACPI: GED: use correct trigger type field in _Exx / _Lxx handling
    fd8cd8ac940c (tag: v5.4.47) Linux 5.4.47
    d96ef8fa9534 KVM: arm64: Save the host's PtrAuth keys in non-preemptible context
    812857678847 KVM: arm64: Synchronize sysreg state on injecting an AArch32 exception
    85831981aa0e xen/pvcalls-back: test for errors when calling backend_connect()
    29ed45653bec block/floppy: fix contended case in floppy_queue_rq()
    9ec34f441ed4 mmc: sdio: Fix several potential memory leaks in mmc_sdio_init_card()
    55d805ab3691 mmc: sdio: Fix potential NULL pointer error in mmc_sdio_init_card()
    d3c4c5a4d3d8 ARM: dts: at91: sama5d2_ptc_ek: fix sdmmc0 node description
    5a05406e8c14 mmc: uniphier-sd: call devm_request_irq() after tmio_mmc_host_probe()
    1ccf2d6c5b8c mmc: tmio: Further fixup runtime PM management at remove
    e9614e0c525d mmc: mmci_sdmmc: fix DMA API warning overlapping mappings
    f5b13ef230dc mmc: sdhci-msm: Clear tuning done flag while hs400 tuning
    bfc12ff9050b agp/intel: Reinforce the barrier after GTT updates
    e81b05e535e8 perf: Add cond_resched() to task_function_call()
    e0544273b70c fat: don't allow to mount if the FAT length == 0
    c49a17f1f1f7 mm/slub: fix a memory leak in sysfs_slab_add()
    b21602a88ef1 drm/vkms: Hold gem object while still in-use
    9c09a772acb4 Smack: slab-out-of-bounds in vsscanf
    b5c8896bc14f ath9k: Fix general protection fault in ath9k_hif_usb_rx_cb
    db899f242e1a ath9x: Fix stack-out-of-bounds Write in ath9k_hif_usb_rx_cb
    3412e9437543 ath9k: Fix use-after-free Write in ath9k_htc_rx_msg
    3eb802924486 ath9k: Fix use-after-free Read in ath9k_wmi_ctrl_rx
    7f336346d001 ath9k: Fix use-after-free Read in htc_connect_service
    fe0957254640 selftests/ftrace: Return unsupported if no error_log file
    221b26e01d9d scsi: lpfc: Fix negation of else clause in lpfc_prep_node_fc4type
    387d51f0c16f scsi: megaraid_sas: TM command refire leads to controller firmware crash
    205b4c441b0e KVM: arm64: Make vcpu_cp1x() work on Big Endian hosts
    f9551b73717a KVM: arm64: Stop writing aarch32's CSSELR into ACTLR
    8c8238343f0f KVM: MIPS: Fix VPN2_MASK definition for variable cpu_vmbits
    94f4af1b73de KVM: MIPS: Define KVM_ENTRYHI_ASID to cpu_asid_mask(&boot_cpu_data)
    c6d2eb8e57b3 KVM: nVMX: Consult only the "basic" exit reason when routing nested exit
    021cd99a305a KVM: nSVM: leave ASID aside in copy_vmcb_control_area
    3c0bee0c0757 KVM: nSVM: fix condition for filtering async PF
    64b8f33b2e1e KVM: nVMX: Skip IBPB when switching between vmcs01 and vmcs02
    d181dc3667de video: fbdev: w100fb: Fix a potential double free.
    dc8897b8d3b4 video: vt8500lcdfb: fix fallthrough warning
    78e6964dce2a EDAC/skx: Use the mcmtr register to retrieve close_pg/bank_xor_enable
    cd266f8a5b1c cpufreq: Fix up cpufreq_boost_set_sw()
    943f3ae9b149 remoteproc: Fix and restore the parenting hierarchy for vdev
    81fb06cb6bd4 remoteproc: Fall back to using parent memory pool if no dedicated available
    12b24ba6ce56 proc: Use new_inode not new_inode_pseudo
    98a3dea7e276 ovl: initialize error in ovl_copy_xattr
    5650ce02d261 net/mlx5e: Fix repeated XSK usage on one channel
    b05f2b60213c net/mlx5: Fix fatal error handling during device load
    cd5d0278dcb1 net/mlx5: drain health workqueue in case of driver load error
    57bad9e291e3 selftests/net: in rxtimestamp getopt_long needs terminating null entry
    05e275d8742b dccp: Fix possible memleak in dccp_init and dccp_fini
    5ab6f11621a5 crypto: virtio: Fix dest length calculation in __virtio_crypto_skcipher_do_req()
    af03d5957152 crypto: virtio: Fix src/dst scatterlist calculation in __virtio_crypto_skcipher_do_req()
    2ef260d686b5 crypto: virtio: Fix use-after-free in virtio_crypto_skcipher_finalize_req()
    0070e73c9edc firmware: imx: scu: Fix corruption of header
    a1fd068c8922 firmware: imx-scu: Support one TX and one RX
    da24a76bdc81 firmware: imx: warn on unexpected RX
    9a20d6c32756 x86/{mce,mm}: Unmap the entire page if the whole page is affected and poisoned
    977b89e1aba0 crypto: drbg - fix error return code in drbg_alloc_state()
    6ebdf342d4c7 crypto: algapi - Avoid spurious modprobe on LOADED
    4a87772480aa crypto: cavium/nitrox - Fix 'nitrox_get_first_device()' when ndevlist is fully iterated
    1027dc04f557 gup: document and work around "COW can break either way" issue
    6ed11984edb1 PM: runtime: clk: Fix clk_pm_runtime_get() error path
    fc45cd292c5e spi: bcm-qspi: when tx/rx buffer is NULL set to 0
    0cd18337704f spi: bcm-qspi: Handle clock probe deferral
    3bb1e6eb7c5e spi: bcm2835aux: Fix controller unregister order
    496a5e5fd0e6 spi: bcm2835: Fix controller unregister order
    73d9bae0a584 spi: pxa2xx: Fix runtime PM ref imbalance on probe error
    1aec7b22a93f spi: pxa2xx: Fix controller unregister order
    824a4e3b9acf spi: Fix controller unregister order
    7753886c6dd7 spi: dw: Fix controller unregister order
    ffe5ebdf81a1 nilfs2: fix null pointer dereference at nilfs_segctor_do_construct()
    d4904b38ea45 lib/lzo: fix ambiguous encoding bug in lzo-rle
    07ffdf0d984b arm64: acpi: fix UBSAN warning
    286822392013 ACPI: PM: Avoid using power resources if there are none for D0
    75d6d0ad12f3 ACPI: GED: add support for _Exx / _Lxx handler methods
    040b4dcc1269 ACPI: CPPC: Fix reference count leak in acpi_cppc_processor_probe()
    e4cc99efbeb9 ACPI: sysfs: Fix reference count leak in acpi_sysfs_add_hotplug_profile()
    10a8c04c0b51 ALSA: usb-audio: Add vendor, product and profile name for HP Thunderbolt Dock
    969c9b50fdec ALSA: usb-audio: Fix inconsistent card PM state after resume
    1f5ab51e2e2f ALSA: pcm: fix snd_pcm_link() lockdep splat
    4f643b8c4773 ALSA: pcm: disallow linking stream to itself
    1900bf5e7fd7 ALSA: hda/realtek - add a pintbl quirk for several Lenovo machines
    13c18353c985 ALSA: fireface: fix configuration error for nominal sampling transfer frequency
    110d04acda5e ALSA: es1688: Add the missed snd_card_free()
    f7d57ba8d7b8 watchdog: imx_sc_wdt: Fix reboot on crash
    3003daa76bdf smb3: add indatalen that can be a non-zero value to calculation of credit charge in smb2 ioctl
    0470d6c3276d smb3: fix incorrect number of credits when ioctl MaxOutputResponse > 64K
    e1437d181d30 efi/efivars: Add missing kobject_put() in sysfs entry creation error path
    ab2df991e5e2 io_uring: use kvfree() in io_sqe_buffer_register()
    d4a13e671138 ASoC: max…