### PR TITLE
linux-fslc-qoriq: fix merge error

### DIFF
--- a/recipes-kernel/linux/linux-fslc-qoriq_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc-qoriq_5.4.bb
@@ -13,5 +13,5 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 LINUX_VERSION = "5.4.51"
 
 SRCBRANCH = "5.4.y+qoriq+fslc"
-SRCREV = "8221fcf6c01e7ed451510e2792c9f45422a4ca8c"
+SRCREV = "c34b53c0927fcefcdea3be16cc1fb9fdcbedbe40"
 SRC_URI := "git://github.com/Freescale/linux-fslc.git;branch=${SRCBRANCH}"


### PR DESCRIPTION
Fix merge error introduced while fixing conflict merging 5.4.48:
    d1a00c9bb1c7 dpaa2-eth: fix return codes used in ndo_setup_tc

Signed-off-by: Jens Rehsack <sno@netbsd.org>