### PR TITLE
Upgrade linux-fslc* kernel recipes with v5.4.51

### DIFF
--- a/recipes-kernel/linux/linux-fslc-imx_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_5.4.bb
@@ -28,7 +28,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v5.4.46
+#    tag: v5.4.51
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
@@ -69,14 +69,14 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
 SRCBRANCH = "5.4-1.0.0-imx"
-SRCREV = "53764182e42fddfa3f4c66b4307d17a27d69c1e5"
+SRCREV = "9fb52fae75909b9ca83b2a04e824f97d2df85302"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.46"
+LINUX_VERSION = "5.4.51"
 
 # Local version indicates the branch name in the NXP kernel tree where patches are collected from.
 LOCALVERSION = "-lf-5.4.y"

--- a/recipes-kernel/linux/linux-fslc_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc_5.4.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.46"
+LINUX_VERSION = "5.4.51"
 
 SRCBRANCH = "5.4.x+fslc"
-SRCREV = "38d6c3525e4f77a842ef2ce4196a4e2ce3a2ff69"
+SRCREV = "d051c7c9af6fa0bb57603ec927ea2674521167c8"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"


### PR DESCRIPTION
Kernel branches are updated to *v5.4.51* from stable korg.

Update both `linux-fslc` and `linux-fslc-imx` recipes to include the latest patchlevel applied.

-- andrey