### PR TITLE
Revert "weston-init: use g2d for i.MX8M Nano SoC"

### DIFF
--- a/recipes-graphics/wayland/weston-init.bbappend
+++ b/recipes-graphics/wayland/weston-init.bbappend
@@ -26,9 +26,6 @@ INI_UNCOMMENT_ASSIGNMENTS_append_mx8mq = " \
     \\[shell\\] \
     size=1920x1080 \
 "
-INI_UNCOMMENT_ASSIGNMENTS_append_mx8mn = " \
-    use-g2d=1 \
-"
 
 uncomment() {
     if ! (grep "^#$1" $2); then


### PR DESCRIPTION
8M Nano does not have 2D acceleration.

This reverts commit b3f51ab82838a67146d5b6fcf8f19d36c5efeb37.