### PR TITLE
As promised - Update linux-fslc-qoriq to v5.4.58

### DIFF
--- a/recipes-kernel/linux/linux-fslc-qoriq_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc-qoriq_5.4.bb
@@ -10,8 +10,8 @@ require recipes-kernel/linux/linux-qoriq.inc
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
-LINUX_VERSION = "5.4.51"
+LINUX_VERSION = "5.4.58"
 
 SRCBRANCH = "5.4.y+qoriq+fslc"
-SRCREV = "c34b53c0927fcefcdea3be16cc1fb9fdcbedbe40"
+SRCREV = "ba11ffe3d1285be7645e40ab027b9c33974023f3"
 SRC_URI := "git://github.com/Freescale/linux-fslc.git;branch=${SRCBRANCH}"


### PR DESCRIPTION
This updates QorIQ FSLC kernel to 5.4.58 which contains:

cad17feaf0d0 Linux 5.4.58
512570b17807 nfsd: Fix NFSv4 READ on RDMA when using readv
df6aeb5235e9 ima: move APPRAISE_BOOTPARAM dependency on ARCH_POLICY to runtime
fb264505b395 tcp: apply a floor of 1 for RTT samples from TCP timestamps
848e15a8c8f6 selftests/net: relax cpu affinity requirement in msg_zerocopy test
b8f2d34f6bb5 Revert "vxlan: fix tos value before xmit"
daff7f09f341 openvswitch: Prevent kernel-infoleak in ovs_ct_put_key()
ba729a97ae54 net: thunderx: use spin_lock_bh in nicvf_set_rx_mode_task()
786a9368be8c net: gre: recompute gre csum for sctp over gre tunnels
5d791d36a49b hv_netvsc: do not use VF device if link is down
3a82f4bfd20a dpaa2-eth: Fix passing zero to 'PTR_ERR' warning
5a963aa72107 appletalk: Fix atalk_proc_init() return path
3787b5a3ac67 net: lan78xx: replace bogus endpoint lookup
31489ed8c20c vxlan: Ensure FDB dump is performed under RCU
106b415d5139 rxrpc: Fix race between recvmsg and sendmsg on immediate call failure
6f9354702ca5 net: ethernet: mtk_eth_soc: fix MTU warnings
bd68177f26e4 ipv6: Fix nexthop refcnt leak when creating ipv6 route info
89c12bc36262 ipv6: fix memory leaks on IPV6_ADDRFORM path
9b37a7bcdd8a ipv4: Silence suspicious RCU usage warning
4913f71e64ab PCI: tegra: Revert tegra124 raw_violation_fixup
ceff42e6c1fc Revert "powerpc/kasan: Fix shadow pages allocation failure"
11e64146dc69 xattr: break delegations in {set,remove}xattr
6059000e145f Drivers: hv: vmbus: Ignore CHANNELMSG_TL_CONNECT_RESULT(23)
3429579045f1 tools lib traceevent: Fix memory leak in process_dynamic_array_len
414f10532c14 atm: fix atm_dev refcnt leaks in atmtcp_remove_persistent
5414f27048e5 igb: reinit_locked() should be called with rtnl_lock
7c8a863ba3cb cfg80211: check vendor command doit pointer before use
83ea63708a29 firmware: Fix a reference count leak.
01fdcb848611 ALSA: hda: fix NULL pointer dereference during suspend
eb96e4f71f59 net: ethernet: mtk_eth_soc: Always call mtk_gmac0_rgmii_adjust() for mt7623
fd601f38f59d usb: hso: check for return value in hso_serial_common_create()
871b5a5a3be9 i2c: slave: add sanity check when unregistering
fa0195d83a49 i2c: slave: improve sanity check when registering
4bba72b72c36 drm/drm_fb_helper: fix fbdev with sparc64
8e6af828a332 nvme-pci: prevent SK hynix PC400 from using Write Zeroes command
802df1e3f40c drm/nouveau/fbcon: zero-initialise the mode_cmd2 structure
5955ccb5a46d drm/nouveau/fbcon: fix module unload when fbcon init has failed for some reason
e0c47a51fc62 net/9p: validate fds in p9_fd_open
fe6402e0e66c leds: 88pm860x: fix use-after-free on unbind
3564cddefb5b leds: lm3533: fix use-after-free on unbind
385c1ae9ddb9 leds: da903x: fix use-after-free on unbind
bde8f23c030c leds: lm36274: fix use-after-free on unbind
635f8fcc2ee3 leds: wm831x-status: fix use-after-free on unbind
9a53e8bd59d9 mtd: properly check all write ioctls for permissions
8c3215a0426c vgacon: Fix for missing check in scrollback handling
1ae21e97d5d3 scripts: add dummy report mode to add_namespace.cocci
5f5fb7cea828 Smack: fix use-after-free in smk_write_relabel_self()
c5665cafbedd binder: Prevent context manager from incrementing ref 0
da47eae4e165 omapfb: dss: Fix max fclk divider for omap36xx
b78763e0a247 Bluetooth: Prevent out-of-bounds read in hci_inquiry_result_with_rssi_evt()
70d1e884edc4 Bluetooth: Prevent out-of-bounds read in hci_inquiry_result_evt()
c26eaaf547b7 Bluetooth: Fix slab-out-of-bounds read in hci_extended_inquiry_result_evt()
a8b8b535c588 Staging: rtl8188eu: rtw_mlme: Fix uninitialized variable authmode
af707d9d7f44 staging: rtl8712: handle firmware load failure
6a7626c4798d staging: android: ashmem: Fix lockdep warning for write operation
4d81a7bdd3b2 ALSA: seq: oss: Serialize ioctls
3ebdc7b61906 ALSA: hda/ca0132 - Fix AE-5 microphone selection commands.
b8ce0756b312 ALSA: hda/ca0132 - Fix ZxR Headphone gain control get value.
87775770635a ALSA: hda/ca0132 - Add new quirk ID for Recon3D.
1d05ad79e1dd ALSA: hda/realtek: Add alc269/alc662 pin-tables for Loongson-3 laptops
864468a7a63b Revert "ALSA: hda: call runtime_allow() for all hda controllers"
e8053c68337e io_uring: Fix use-after-free in io_sq_wq_submit_work()
a4d61e66ee4a io_uring: prevent re-read of sqe->opcode
67afa25456d0 usb: xhci: Fix ASMedia ASM1142 DMA addressing
e7ad225ba4ef usb: xhci: define IDs for various ASMedia host controllers
7173ac5c07bb USB: iowarrior: fix up report size handling for some devices
68a2350376b1 perf/core: Fix endless multiplex timer
aabba1b10075 USB: serial: qcserial: add EM7305 QDL product ID
d9939285fc81 Linux 5.4.57
ca7ace8fd26d bpf: sockmap: Require attach_bpf_fd when detaching a program
9fe975acb53f selftests: bpf: Fix detach from sockmap tests
c77610435355 ext4: fix direct I/O read error
6330b0cb2ace arm64: Workaround circular dependency in pointer_auth.h
f06d60ff794a random32: move the pseudo-random 32-bit definitions to prandom.h
c131009987f2 random32: remove net_rand_state from the latent entropy gcc plugin
7471f3228e7a random: fix circular include dependency on arm64 after addition of percpu.h
50bf89625bba ARM: percpu.h: fix build error
c15a77bdda2c random32: update the net random state on interrupt and activity
1b940bbc5c55 Linux 5.4.56
df35e878d0a5 perf bench: Share some global variables to fix build with gcc 10
702d1b287fd2 perf env: Do not return pointers to local variables
73d2d6b421df perf tests bp_account: Make global variable static
39568546706f x86/i8259: Use printk_deferred() to prevent deadlock
01ac46c6baf0 KVM: LAPIC: Prevent setting the tscdeadline timer if the lapic is hw disabled
fd412846a6ec KVM: arm64: Don't inherit exec permission across page-table levels
1aff51292ee8 drivers/net/wan: lapb: Corrected the usage of skb_cow
f88c909dc28c RISC-V: Set maximum number of mapped pages correctly
e3043abb5baa xen-netfront: fix potential deadlock in xennet_remove()
a7b488d65d39 cxgb4: add missing release on skb in uld_send()
5f4e6b874b57 x86/stacktrace: Fix reliable check for empty user task stacks
32344d2993b0 x86/unwind/orc: Fix ORC for newly forked tasks
a14d6a9ddf33 Revert "i2c: cadence: Fix the hold bit setting"
df366abb9c8f net: ethernet: ravb: exit if re-initialization fails in tx timeout
ac7c3b8f34ec parisc: add support for cmpxchg on u8 pointers
a0ba41317c89 scsi: core: Run queue in case of I/O resource contention failure
0ac155dcf048 nfc: s3fwrn5: add missing release on skb in s3fwrn5_recv_frame
50c5f89637bc selftests: net: ip_defrag: modprobe missing nf_defrag_ipv6 support
78c7532b80c6 qed: Disable "MFW indication via attention" SPAM every 5 minutes
6e4620df9cbc selftests: fib_nexthop_multiprefix: fix cleanup() netns deletion
5b235c1d9022 usb: hso: Fix debug compile warning on sparc32
cac2b7ad0915 vxlan: fix memleak of fdb
1df0000b30cd perf tools: Fix record failure when mixed with ARM SPE event
568995fb61e7 net/mlx5e: fix bpf_prog reference count leaks in mlx5e_alloc_rq
e68b7b9b03fb net: gemini: Fix missing clk_disable_unprepare() in error path of gemini_ethernet_port_probe()
1158aa743a0b net: nixge: fix potential memory leak in nixge_probe()
9acd96f14a49 Bluetooth: fix kernel oops in store_pending_adv_report
3bb2f52ad9e7 arm64: csum: Fix handling of bad packets
8a90b436a0c9 arm64/alternatives: move length validation inside the subsection
4a50753aacb5 mac80211: mesh: Free pending skb when destroying a mpath
3f15e3e62c80 mac80211: mesh: Free ie data when leaving mesh
fe58e3dd6e11 bpf: Fix map leak in HASH_OF_MAPS map
43c390b751ba ibmvnic: Fix IRQ mapping disposal in error path
ea559138b331 mlxsw: core: Free EMAD transactions using kfree_rcu()
57f498ced731 mlxsw: core: Increase scope of RCU read-side critical section
0f424eda4705 mlx4: disable device on shutdown
c3883876d3f1 rhashtable: Fix unprotected RCU dereference in __rht_ptr
b1d629d32910 net: lan78xx: fix transfer-buffer memory leak
9db3040eb952 net: lan78xx: add missing endpoint sanity check
32ec4441cca1 net/mlx5e: Fix kernel crash when setting vf VLANID on a VF dev
475cbcef491a net/mlx5e: Modify uplink state on interface up/down
43608372b84d net/mlx5: Verify Hardware supports requested ptp function on a given pin
8901896f69d4 net/mlx5e: Fix error path of device attach
00bedd730d1f net/mlx5: E-switch, Destroy TSAR when fail to enable the mode
d70f9a3cc32c net: hns3: fix aRFS FD rules leftover after add a user FD rule
475b8d619268 net: hns3: fix a TX timeout issue
5fc02e8d1bfd sh: Fix validation of system call number
2f2674997dfb sh/tlb: Fix PGTABLE_LEVELS > 2
222dbeca05fb selftests/net: so_txtime: fix clang issues for target arch PowerPC
d817b2c8d3cf selftests/net: psock_fanout: fix clang issues for target arch PowerPC
22f84cce9527 selftests/net: rxtimestamp: fix clang issues for target arch PowerPC
831c904a0f68 nvme-tcp: fix possible hang waiting for icresp response
9a1d0084cbe1 ARM: dts: armada-38x: fix NETA lockup when repeatedly switching speeds
731e013e33b3 xfrm: Fix crash when the hold queue is used.
a4c902887f1d ARM: dts sunxi: Relax a bit the CMA pool allocation range
0307da686660 xfrm: policy: match with both mark and mask on user interfaces
bbb13adb07af net/x25: Fix null-ptr-deref in x25_disconnect
69cd304cfa5c net/x25: Fix x25_neigh refcnt leak when x25 disconnect
c2fd34d43110 libtraceevent: Fix build with binutils 2.35
2ec69499b758 rds: Prevent kernel-infoleak in rds_notify_queue_get()
6a9428427da1 drm: hold gem reference until object is no longer accessed
7eef3b463d88 drm/dbi: Fix SPI Type 1 (9-bit) transfer
8ea180f1c7ec drm/amdgpu: Prevent kernel-infoleak in amdgpu_info_ioctl()
f1b4bdde2bdc drm/amd/display: Clear dm_state for fast updates
22d3202e51a7 Revert "drm/amdgpu: Fix NULL dereference in dpm sysfs handlers"
cea6633d5382 virtio_balloon: fix up endian-ness for free cmd id
c2f787f904e0 ARM: dts: imx6qdl-icore: Fix OTG_ID pin and sdcard detect
b9274613114a ARM: dts: imx6sx-sdb: Fix the phy-mode on fec2
c4738c67a569 ARM: dts: imx6sx-sabreauto: Fix the phy-mode on fec2
3b7e4a5ba95d ARM: 8986/1: hw_breakpoint: Don't invoke overflow handler on uaccess watchpoints
b8fa0b037047 wireless: Use offsetof instead of custom macro.
d3472f74d229 9p/trans_fd: Fix concurrency del of req_list in p9_fd_cancelled/p9_read_work
96f105943cff vhost/scsi: fix up req type endian-ness
951117a2079b IB/rdmavt: Fix RQ counting issues causing use of an invalid RWQE
dc731d262811 ALSA: hda/hdmi: Fix keep_power assignment for non-component devices
6a67b05c6f30 ALSA: hda/realtek - Fixed HP right speaker no sound
09832a9e0b76 ALSA: hda/realtek: Fix add a "ultra_low_power" function for intel reference board (alc256)
e9f147c937a5 ALSA: hda/realtek: typo_fix: enable headset mic of ASUS ROG Zephyrus G14(GA401) series with ALC289
cd76d30f51fb ALSA: hda/realtek: enable headset mic of ASUS ROG Zephyrus G15(GA502) series with ALC289
6d84a8cf8a02 ALSA: usb-audio: Add implicit feedback quirk for SSL2
47e20933814f mm/filemap.c: don't bother dropping mmap_sem for zero size readahead
140210554274 PCI/ASPM: Disable ASPM on ASMedia ASM1083/1085 PCIe-to-PCI bridge
2ff65580d477 ath10k: enable transmit data ack RSSI for QCA9884
98cef10fbcca sunrpc: check that domain table is empty at module unload.
84da97713b91 media: rc: prevent memory leak in cx23888_ir_probe
ecfa7fa198fc crypto: ccp - Release all allocated memory if sha type is invalid
169b93899c7d Linux 5.4.55
909dbf09cd01 Revert "dpaa_eth: fix usage as DSA master, try 3"
4918285a6c7d PM: wakeup: Show statistics for deleted wakeup sources again
59242fa1d2ba regmap: debugfs: check count when read regmap file
df89c1ee034c udp: Improve load balancing for SO_REUSEPORT.
6735c126d272 udp: Copy has_conns in reuseport_grow().
86512c6938a9 sctp: shrink stream outq when fails to do addstream reconf
46e7c7efc30d sctp: shrink stream outq only when new outcnt < old outcnt
bbf6af4a938a AX.25: Prevent integer overflows in connect and sendmsg
182ffc66456b tcp: allow at most one TLP probe per flight
e2f904fd79a0 rxrpc: Fix sendmsg() returning EPIPE due to recvmsg() returning ENODATA
01c928350641 rtnetlink: Fix memory(net_device) leak when ->newlink fails
b7d3d6df72a8 qrtr: orphan socket in qrtr_release()
2bf797a8691a net: udp: Fix wrong clean up for IS_UDPLITE macro
274b40b6df6c net-sysfs: add a newline when printing 'tx_timeout' by sysfs
8d9f13dd400c ip6_gre: fix null-ptr-deref in ip6gre_init_net()
fbcd85cd11de drivers/net/wan/x25_asy: Fix to make it work
d109acd58052 dev: Defer free of skbs in flush_backlog
52aeeec1a635 AX.25: Prevent out-of-bounds read in ax25_sendmsg()
2f1624faf647 AX.25: Fix out-of-bounds read in ax25_connect()
58a12e3368db Linux 5.4.54
c15d59b94511 ath9k: Fix regression with Atheros 9271
e6eb815beccc ath9k: Fix general protection fault in ath9k_hif_usb_rx_cb
6d4448ca54bc dm integrity: fix integrity recalculation that is improperly skipped
2ca71b807383 ASoC: topology: fix tlvs in error handling for widget_dmixer
a4fd00dd8299 ASoC: topology: fix kernel oops on route addition error
e60e53e685d9 ASoC: qcom: Drop HAS_DMA dependency to fix link failure
8f64dc9e1d49 ASoC: rt5670: Add new gpio1_is_ext_spk_en quirk and enable it on the Lenovo Miix 2 10
697bd3e4aa4b x86, vmlinux.lds: Page-align end of ..page_aligned sections
c89af82f64a0 parisc: Add atomic64_set_release() define to avoid CPU soft lockups
d1bab3cf71dd drm/amd/powerplay: fix a crash when overclocking Vega M
33ab3f2dc444 drm/amdgpu: Fix NULL dereference in dpm sysfs handlers
c3de96686db9 mmc: sdhci-of-aspeed: Fix clock divider calculation
615f44e04792 io-mapping: indicate mapping failure
40c5836b4a48 khugepaged: fix null-pointer dereference due to race
95750e1edbcd mm: memcg/slab: fix memory leak at non-root kmem_cache destroy
db949f60d983 mm/memcg: fix refcount error while moving and swapping
549bfc142706 mm/mmap.c: close race between munmap() and expand_upwards()/downwards()
5835e6d5988f Makefile: Fix GCC_TOOLCHAIN_DIR prefix for Clang cross compilation
23e8b741c8a1 vt: Reject zero-sized screen buffer size.
028b478f2231 fbdev: Detect integer underflow at "struct fbcon_ops"->clear_margins.
bf331efc8ea4 /dev/mem: Add missing memory barriers for devmem_inode
3c52751df236 serial: 8250_mtk: Fix high-speed baud rates clamping
af811869db06 serial: 8250: fix null-ptr-deref in serial8250_start_tx()
fb8d832978bb serial: tegra: fix CREAD handling for PIO
c76a1dacc28d staging: comedi: addi_apci_1564: check INSN_CONFIG_DIGITAL_TRIG shift
178a09b0fb0d staging: comedi: addi_apci_1500: check INSN_CONFIG_DIGITAL_TRIG shift
7ee8d78bc12b staging: comedi: ni_6527: fix INSN_CONFIG_DIGITAL_TRIG support
747558b1c737 staging: comedi: addi_apci_1032: check INSN_CONFIG_DIGITAL_TRIG shift
c9afe420c53a staging: wlan-ng: properly check endpoint types
a44c859323c2 tty: xilinx_uartps: Really fix id assignment
f32718cfa5db iwlwifi: mvm: don't call iwl_mvm_free_inactive_queue() under RCU
3e84602475f7 Revert "cifs: Fix the target file was deleted when rename failed."
86894c3797ed usb: xhci: Fix ASM2142/ASM3142 DMA addressing
1d91547f2fc8 usb: xhci-mtk: fix the failure of bandwidth allocation
93f1e16af4a5 binder: Don't use mmput() from shrinker function.
35728cac176a RISC-V: Upgrade smp_mb__after_spinlock() to iorw,iorw
5345ede4acde drivers/perf: Prevent forced unbinding of PMU drivers
0821295b23cc asm-generic/mmiowb: Allow mmiowb_set_pending() when preemptible()
90e78ec7d725 x86: math-emu: Fix up 'cmp' insn for clang ias
679fe09188c1 arm64: Use test_tsk_thread_flag() for checking TIF_SINGLESTEP
7fc7942f52cf drivers/perf: Fix kernel panic when rmmod PMU modules during perf sampling
347f735ca82b ALSA: hda/realtek - fixup for yet another Intel reference board
30a17b51d80d hwmon: (scmi) Fix potential buffer overflow in scmi_hwmon_probe()
76361edb5559 platform/x86: asus-wmi: allow BAT1 battery name
41a7fdf90ce2 platform/x86: ISST: Add new PCI device ids
ace6e8b448b9 hwmon: (nct6775) Accept PECI Calibration as temperature source for NCT6798D
6627a265c598 drm/amdgpu: fix preemption unit test
ffb5604d2043 drm/amdgpu/gfx10: fix race condition for kiq
c04a48251314 hwmon: (adm1275) Make sure we are reading enough data for different chips
a2a380bd4575 usb: cdns3: trace: fix some endian issues
103a90ad4e64 usb: cdns3: ep0: fix some endian issues
89fe6eba178d usb: gadget: udc: gr_udc: fix memleak on error handling path in gr_ep_init()
74ec2cc5bfff usb: dwc3: pci: add support for the Intel Jasper Lake
c4c6363b8e68 usb: dwc3: pci: add support for the Intel Tiger Lake PCH -H variant
4f5eb2735fa3 Input: elan_i2c - only increment wakeup count on touch
186d3fe73e27 Input: synaptics - enable InterTouch for ThinkPad X1E 1st gen
460c0dafea92 dmaengine: ioat setting ioat timeout as module parameter
493aed3263ca dmaengine: fsl-edma: fix wrong tcd endianness for big-endian cpu
6a3015ae35f5 hwmon: (aspeed-pwm-tacho) Avoid possible buffer overflow
01d7bd8903d8 regmap: dev_get_regmap_match(): fix string comparison
bbc0b6e18405 spi: mediatek: use correct SPI_CFG2_REG MACRO
126a0ab6b83b ARM: dts: n900: remove mmc1 card detect gpio
80fed4024c39 Input: add `SW_MACHINE_COVER`
db886ec71fe4 dmaengine: tegra210-adma: Fix runtime PM imbalance on error
5cbe437d5968 HID: apple: Disable Fn-key key-re-mapping on clone keyboards
2c179ece3bfb HID: steam: fixes race in handling device list.
5d273c566f7b HID: alps: support devices with report id 2
08696a4ac9f6 HID: i2c-hid: add Mediacom FlexBook edge13 to descriptor override
9ab9cfcc2d8f scripts/gdb: fix lx-symbols 'gdb.error' while loading modules
22508bc315eb scripts/decode_stacktrace: strip basepath from all paths
1e63d569fd2d serial: exar: Fix GPIO configuration for Sealevel cards based on XR17V35X
a86abef1558a geneve: fix an uninitialized value in geneve_changelink()
89b4f204ba43 bonding: check return value of register_netdevice() in bond_newlink()
93bb40b79e84 i2c: i2c-qcom-geni: Fix DMA transfer race
58637b3027db i2c: rcar: always clear ICSAR to avoid side effects
e8b86b4d87e3 enetc: Remove the mdio bus on PF probe bailout
9f2c2928b939 nfsd4: fix NULL dereference in nfsd/clients display code
a44625dc0bd3 Revert "PCI/PM: Assume ports without DLL Link Active train links in 100 ms"
9e3e96aa9a2e net: ethernet: ave: Fix error returns in ave_init
eb2c32de1ce6 ipvs: fix the connection sync failed in some cases
592614918431 qed: suppress false-positives interrupt error messages on HW init
641bd96bd0ac qed: suppress "don't support RoCE & iWARP" flooding on HW init
8d416c038a91 netdevsim: fix unbalaced locking in nsim_create()
99a5e865cbe4 net: dsa: microchip: call phy_remove_link_mode during probe
4997b311c01e net: hns3: fix error handling for desc filling
107ea66643bd net: ag71xx: add missed clk_disable_unprepare in error path of probe
34e93385c416 ionic: fix up filter locks and debug msgs
42f5c49f7bbb ionic: use offset for ethtool regs data
eac87543368c mlxsw: destroy workqueue when trap_register in mlxsw_emad_init
9b52f23ad648 bonding: check error value of register_netdevice() immediately
d11a27411c65 net: smc91x: Fix possible memory leak in smc_drv_probe()
a2cdb4ebd84e drm: sun4i: hdmi: Fix inverted HPD result
988e5d2179e4 ieee802154: fix one possible memleak in adf7242_probe
7bf93c95a9b9 net: dp83640: fix SIOCSHWTSTAMP to update the struct with actual configuration
e2e31a0bf7a1 ASoC: Intel: bytcht_es8316: Add missed put_device()
613e7c52aaaa RDMA/mlx5: Use xa_lock_irq when access to SRQ table
d0d394c71604 ax88172a: fix ax88172a_unbind() failures
ad49d766612e vsock/virtio: annotate 'the_virtio_vsock' RCU pointer
f826efa1c381 hippi: Fix a size used in a 'pci_free_consistent()' in an error handling path
570b1c92cb48 fpga: dfl: fix bug in port reset handshake
c73188295841 fpga: dfl: pci: reduce the scope of variable 'ret'
57393e695a10 bnxt_en: Fix completion ring sizing with TPA enabled.
9cc322773b20 bnxt_en: Fix race when modifying pause settings.
38a66f3cdab4 btrfs: fix page leaks after failure to lock page for delalloc
b04805a7e8a5 btrfs: fix mount failure caused by race with umount
e333df0e4ac6 btrfs: fix double free on ulist after backref resolution failure
f668e822950d ASoC: rt5670: Correct RT5670_LDO_SEL_MASK
0f87dabe4415 ALSA: info: Drop WARN_ON() from buffer NULL sanity check
aad343d571ae ALSA: hda/realtek: Fixed ALC298 sound bug by adding quirk for Samsung Notebook Pen S
ee2f6a6b39be uprobes: Change handle_swbp() to send SIGTRAP with si_code=SI_KERNEL, to fix GDB regression
ee08663380ff btrfs: reloc: clear DEAD_RELOC_TREE bit for orphan roots to prevent runaway balance
044ca910276b btrfs: reloc: fix reloc root leak and NULL pointer dereference
cb1225707041 SUNRPC reverting d03727b248d0 ("NFSv4 fix CLOSE not waiting for direct IO compeletion")
02140e85d8e4 drm/amd/display: Check DMCU Exists Before Loading
722c6e954c90 dmabuf: use spinlock to access dmabuf->name
44838b956304 ARM: dts: imx6qdl-gw551x: fix audio SSI
593221ce16af ARM: dts: imx6qdl-gw551x: Do not use 'simple-audio-card,dai-link'
36f735554572 irqdomain/treewide: Keep firmware node unconditionally allocated
8676732c3337 fuse: fix weird page warning
96002e7485be drivers/firmware/psci: Fix memory leakage in alloc_init_cpu_groups()
d0e40e510aa7 dm: use bio_uninit instead of bio_disassociate_blkg
0ff9fce4abee scsi: dh: Add Fujitsu device to devinfo and dh lists
3959567d870d scsi: mpt3sas: Fix error returns in BRM_status_show
0c1337e94a54 drm/nouveau/i2c/g94-: increase NV_PMGR_DP_AUXCTL_TRANSACTREQ timeout
fb50c5cf2105 net: sky2: initialize return of gm_phy_read
b4397143da53 ALSA: hda/hdmi: fix failures at PCM open on Intel ICL and later
e50116e51281 drivers/net/wan/lapbether: Fixed the value of hard_header_len
0eced7636001 scsi: mpt3sas: Fix unlock imbalance
0edfdefc0a9c xtensa: update *pos in cpuinfo_op.next
df5b65f5df3e xtensa: fix __sync_fetch_and_{and,or}_4 declarations
806ffec1a93a scsi: scsi_transport_spi: Fix function pointer check
65c835ebe2cd mac80211: allow rx of mesh eapol frames with default rx key
f55550d566e4 pinctrl: amd: fix npins for uart0 in kerncz_groups
de0d953ee787 gpio: arizona: put pm_runtime in case of failure
52083907ebfa gpio: arizona: handle pm_runtime_get_sync failure case
4f80cb2c787f soc: qcom: rpmh: Dirt can only make you dirtier, not cleaner
d811d29517d1 Linux 5.4.53
e6c19fa5b6c6 gpio: pca953x: disable regmap locking for automatic address incrementing
411c80267541 drm/i915/gvt: Fix two CFL MMIO handling caused by regression.
517708c47c66 iommu/vt-d: Make Intel SVM code 64-bit only
41389f739a5e ionic: export features for vlans to use
5d7e2852d7e6 spi: sprd: switch the sequence of setting WDG_LOAD_LOW and _HIGH
1245a1e0e1c3 rxrpc: Fix trace string
07253d24cda3 libceph: don't omit recovery_deletes in target_copy()
d2ccad3c9ce9 block: fix get_max_segment_size() overflow on 32bit arch
310d75f274d5 block: fix splitting segments on boundary masks
f2e57ed2f3f8 drm/i915/gt: Ignore irq enabling on the virtual engines
64a17e1da02a drm/amdgpu/sdma5: fix wptr overwritten in ->get_wptr()
9f8d3d2f79ba genirq/affinity: Handle affinity setting on inactive interrupts correctly
6aae92ed2c42 sched/fair: handle case of task_h_load() returning 0
b5b774918816 sched: Fix unreliable rseq cpu_id for new tasks
5c2450ac7c7a arm64: compat: Ensure upper 32 bits of x0 are zero on syscall return
ed766e740cc9 arm64: ptrace: Consistently use pseudo-singlestep exceptions
bdb71132992b arm64: ptrace: Override SPSR.SS when single-stepping is enabled
d3b7bacd1115 thermal/drivers/cpufreq_cooling: Fix wrong frequency converted from power
025cec59aa17 thermal: int3403_thermal: Downgrade error message
0ab6b541c6f8 misc: atmel-ssc: lock with mutex instead of spinlock
746930d17d14 dmaengine: fsl-edma-common: correct DSIZE_32BYTE
5f3fcbf5b57f dmaengine: mcf-edma: Fix NULL pointer exception in mcf_edma_tx_handler
9464956544be dmaengine: fsl-edma: Fix NULL pointer exception in fsl_edma_tx_handler
8fd0d8536805 intel_th: Fix a NULL dereference when hub driver is not loaded
55d7092cc8f5 intel_th: pci: Add Emmitsburg PCH support
905f20f4946a intel_th: pci: Add Tiger Lake PCH-H support
5c698cc5b6f4 intel_th: pci: Add Jasper Lake CPU support
c5ce2060f487 powerpc/pseries/svm: Fix incorrect check for shared_lppaca_size
93d1e96b98b2 powerpc/book3s64/pkeys: Fix pkey_access_permitted() for execute disable pkey
d6a76f8eee21 hwmon: (emc2103) fix unable to change fan pwm1_enable attribute
9125d5762590 riscv: use 16KB kernel stack on 64-bit
c28501385945 timer: Fix wheel index calculation on last level
6c2388e2a12b timer: Prevent base->clk from moving backward
e9506de7b305 scsi: megaraid_sas: Remove undefined ENABLE_IRQ_POLL macro
acd3901a62f6 uio_pdrv_genirq: fix use without device tree and no interrupt
17268122ba5e uio_pdrv_genirq: Remove warning when irq is not specified
97f1aecb80e9 Input: elan_i2c - add more hardware ID for Lenovo laptops
1fb81fe5e180 Input: i8042 - add Lenovo XiaoXin Air 12 to i8042 nomux list
62dd03054918 mei: bus: don't clean driver pointer
72648019cd52 Revert "zram: convert remaining CLASS_ATTR() to CLASS_ATTR_RO()"
4dd2ad686704 fuse: Fix parameter for FS_IOC_{GET,SET}FLAGS
e8f32a9f5aeb fuse: use ->reconfigure() instead of ->remount_fs()
f96ce4be463a fuse: ignore 'data' argument of mount(..., MS_REMOUNT)
09b696bd2149 ovl: fix unneeded call to ovl_change_flags()
93f75b0f0d3b ovl: relax WARN_ON() when decoding lower directory file handle
6270654c7de9 ovl: inode reference leak in ovl_is_inuse true case.
4996065307c8 ovl: fix regression with re-formatted lower squashfs
2cd065b91681 serial: mxs-auart: add missed iounmap() in probe failure and remove
752641ba871a virtio: virtio_console: add missing MODULE_DEVICE_TABLE() for rproc serial
8f4c040f45b9 Revert "tty: xilinx_uartps: Fix missing id assignment to the console"
1bc2c30d861c virt: vbox: Fix guest capabilities mask check
78d85ca8300e virt: vbox: Fix VBGL_IOCTL_VMMDEV_REQUEST_BIG and _LOG req numbers to match upstream
cc894ec456c1 USB: serial: option: add Quectel EG95 LTE modem
4eaf06c9bd35 USB: serial: option: add GosunCn GM500 series
dcc1df3cdb04 USB: serial: ch341: add new Product ID for CH340
dff0a4f024fc USB: serial: cypress_m8: enable Simply Automated UPB PIM
18059e953e1f USB: serial: iuu_phoenix: fix memory corruption
72596d0b2acd usb: gadget: function: fix missing spinlock in f_uac1_legacy
01512075a387 usb: chipidea: core: add wakeup support for extcon
3dd890afedbf usb: dwc2: Fix shutdown callback in platform
4f0addeba0c0 USB: c67x00: fix use after free in c67x00_giveback_urb
bd422c7fb477 ALSA: hda/realtek - Enable Speaker for ASUS UX563
63d318f05e67 ALSA: hda/realtek - Enable Speaker for ASUS UX533 and UX534
e7bafe0c94cc ALSA: hda/realtek: Enable headset mic of Acer TravelMate B311R-31 with ALC256
4181b271908a ALSA: hda/realtek: enable headset mic of ASUS ROG Zephyrus G14(G401) series with ALC289
246b9693026a ALSA: hda/realtek - change to suitable link model for ASUS platform
71319db6f3b1 ALSA: usb-audio: Fix race against the error recovery URB submission
25fd7ee3baeb ALSA: line6: Sync the pending work cancel at disconnection
91a6d4049c58 ALSA: line6: Perform sanity check for each URB creation
212425802dc6 HID: quirks: Ignore Simply Automated UPB PIM
c0188ab5bc31 HID: quirks: Always poll Obins Anne Pro 2 keyboard
e93ab4628452 HID: magicmouse: do not set up autorepeat
bc94605df1f9 HID: logitech-hidpp: avoid repeated "multiplier = " log messages
7c4e6cfd922c slimbus: core: Fix mismatch in of_node_get/put
93b57bf835d2 clk: qcom: gcc: Add missing UFS clocks for SM8150
cb7b7928310f clk: qcom: gcc: Add GPU and NPU clocks for SM8150
cc490ea23f33 mtd: rawnand: oxnas: Release all devices in the _remove() path
f8a2658d0fd7 mtd: rawnand: oxnas: Unregister all devices on error
4682749ce329 mtd: rawnand: oxnas: Keep track of registered devices
8463054e3d4e mtd: rawnand: brcmnand: fix CS0 layout
ee73c81e386d mtd: rawnand: brcmnand: correctly verify erased pages
e9f5e16f3228 mtd: rawnand: timings: Fix default tR_max and tCCS_min timings
f1ad0fc9de60 mtd: rawnand: marvell: Fix probe error path
be953ad71ce9 mtd: rawnand: marvell: Use nand_cleanup() when the device is not yet registered
5f59ce425f78 mtd: rawnand: marvell: Fix the condition on a return code
eec70178983f RDMA/mlx5: Verify that QP is created with RQ or SQ
6b1aaceb0dab soc: qcom: rpmh-rsc: Allow using free WAKE TCS for active request
e65ee5ad8903 soc: qcom: rpmh-rsc: Clear active mode configuration for wake TCS
9e56b18ca5a3 soc: qcom: rpmh: Invalidate SLEEP and WAKE TCSes before flushing new data
9edb7370f893 soc: qcom: rpmh: Update dirty flag only when data changes
033f56f7d3d6 perf stat: Zero all the 'ena' and 'run' array slot stats for interval mode
c2e29cac6d89 PCI/PM: Call .bridge_d3() hook only if non-NULL
d950d2e79f0f habanalabs: Align protection bits configuration of all TPCs
d79e57db4544 apparmor: ensure that dfa state tables have entries
b7d9b78ab901 soc: qcom: socinfo: add missing soc_id sysfs entry
8eeebe37c64e arm: dts: mt7623: add phy-mode property for gmac2
742b79562142 copy_xstate_to_kernel: Fix typo which caused GDB regression
319c3c7980c7 regmap: debugfs: Don't sleep while atomic for fast_io regmaps
f62d7f91afa2 keys: asymmetric: fix error return code in software_key_query()
c5acd9395d41 arm64: dts: spcfpga: Align GIC, NAND and UART nodenames with dtschema
2e224b5d3149 ARM: dts: socfpga: Align L2 cache-controller nodename with dtschema
c8a4452da9f4 xprtrdma: fix incorrect header size calculations
a75a8aabb2f4 Revert "thermal: mediatek: fix register index error"
cc3188b3bab2 ARM: dts: Fix dcan driver probe failed on am437x platform
408ef501b894 fuse: don't ignore errors from fuse_writepages_fill()
9b810684b1da NFS: Fix interrupted slots by sending a solo SEQUENCE operation
dc92d84b371f clk: AST2600: Add mux for EMMC clock
0392f18139aa clk: mvebu: ARMADA_AP_CPU_CLK needs to select ARMADA_AP_CP_HELPER
36e6ac265fc0 staging: comedi: verify array index is correct before using it
62013d49bcf6 usb: gadget: udc: atmel: fix uninitialized read in debug printk
e435865c783f spi: spi-sun6i: sun6i_spi_transfer_one(): fix setting of clock rate
f979982feb03 dmaengine: dmatest: stop completed threads when running without set channel
e6b46f01d995 dmaengine: dw: Initialize channel before each transfer
a6fe5dde5343 iio: adc: ad7780: Fix a resource handling path in 'ad7780_probe()'
28be430bbf13 bus: ti-sysc: Do not disable on suspend for no-idle
47ba42786d14 bus: ti-sysc: Fix sleeping function called from invalid context for RTC quirk
5a23897f7a41 bus: ti-sysc: Fix wakeirq sleeping function called from invalid context
b2c7d6ce2d5e arm64: dts: meson-gxl-s805x: reduce initial Mali450 core frequency
cbd8c92a8d51 arm64: dts: meson: add missing gxl rng clock
1d08f59081e5 phy: sun4i-usb: fix dereference of pointer phy0 before it is null checked
684a5568df11 dmaengine: sh: usb-dmac: set tx_result parameters
f5c6ebd5146e soundwire: intel: fix memory leak with devm_kasprintf
7005a4885a29 iio:health:afe4404 Fix timestamp alignment and prevent data leak.
ba3788d243cf ALSA: usb-audio: Add registration quirk for Kingston HyperX Cloud Flight S
1510d8ab7bc9 bus: ti-sysc: Use optional clocks on for enable and wait for softreset bit
7637bba4c621 ACPI: video: Use native backlight on Acer TravelMate 5735Z
0a330aa202c9 Input: mms114 - add extra compatible for mms345l
75ff2767e85c ALSA: usb-audio: Add quirk for Focusrite Scarlett 2i2
695fcb612bf1 ALSA: usb-audio: Add registration quirk for Kingston HyperX Cloud Alpha S
18f2cbb28730 ACPI: video: Use native backlight on Acer Aspire 5783z
dc1e4db658a6 ALSA: usb-audio: Rewrite registration quirk handling
592b179fa149 mmc: sdhci: do not enable card detect interrupt for gpio cd type
e60b02922876 doc: dt: bindings: usb: dwc3: Update entries for disabling SS instances in park mode
54100aa32f66 ALSA: usb-audio: Create a registration quirk for Kingston HyperX Amp (0951:16d8)
35aef79e81a1 Input: goodix - fix touch coordinates on Cube I15-TC
9c16b5e8b5d9 ALSA: usb-audio: Add support for MOTU MicroBook IIc
d70a6425a6e2 bus: ti-sysc: Detect EDMA and set quirk flags for tptc
d09e12709acd arm64: dts: g12-common: add parkmode_disable_ss_quirk on DWC3 controller
234021eaddcb bus: ti-sysc: Detect display subsystem related devices
e7e98dd42aae bus: ti-sysc: Handle module unlock quirk needed for some RTC
e2c37939a795 bus: ti-sysc: Consider non-existing registers too when matching quirks
f7280837df83 bus: ti-sysc: Rename clk related quirks to pre_reset and post_reset quirks
69fbdbb4fa0c scsi: sr: remove references to BLK_DEV_SR_VENDOR, leave it enabled
23a609417361 drm/sun4i: tcon: Separate quirks for tcon0 and tcon1 on A20
de6d9aa5f7c1 ARM: at91: pm: add quirk for sam9x60's ulp1
4301497fdc68 HID: quirks: Remove ITE 8595 entry from hid_have_special_driver
1c96af59a904 mmc: mmci: Support any block sizes for ux500v2 and qcom variant
cf911ee9f49d ARM: OMAP2+: use separate IOMMU pdata to fix DRA7 IPU1 boot
3ea583b09537 ARM: OMAP2+: Add workaround for DRA7 DSP MStandby errata i879
8d158e3453eb ARM: OMAP4+: remove pdata quirks for omap4+ iommus
370cc95c00ae net: sfp: add some quirks for GPON modules
17918c99abc1 net: sfp: add support for module quirks
11a6ff1df31e Revert "usb/xhci-plat: Set PM runtime as active on resume"
4cf55dcd4fa4 Revert "usb/ehci-platform: Set PM runtime as active on resume"
add6b48ad376 Revert "usb/ohci-platform: Fix a warning when hibernating"
267516d7009e net: ethernet: mvneta: Add back interface mode validation
beee39d71e87 net: ethernet: mvneta: Do not error out in non serdes modes
131ab7a0cdb8 net: macb: call pm_runtime_put_sync on failure path
fefc7580af39 of: of_mdio: Correct loop scanning logic
3f2f3edcc075 net: dsa: bcm_sf2: Fix node reference count
cb2801017057 spi: spi-fsl-dspi: Fix lockup if device is shutdown during SPI transfer
baf22f66c9cf iio:health:afe4403 Fix timestamp alignment and prevent data leak.
5f8fe8ab4463 iio:pressure:ms5611 Fix buffer element alignment
5a6378911f22 iio:humidity:hts221 Fix alignment and data leak issues
74953efffb3d iio: pressure: zpa2326: handle pm_runtime_get_sync failure
4ecff6ee264f iio: mma8452: Add missed iio_device_unregister() call in mma8452_probe()
b4172e024d48 iio: core: add missing IIO_MOD_H2/ETHANOL string identifiers
ead750685280 iio: magnetometer: ak8974: Fix runtime PM imbalance on error
0b16921edc61 iio:humidity:hdc100x Fix alignment and data leak issues
7cc8cad2bef9 iio:magnetometer:ak8974: Fix alignment and data leak issues
4c7924060fe0 arm64/alternatives: don't patch up internal branches
77a181fba1e5 i2c: eg20t: Load module automatically if ID matches
27874115b059 gfs2: read-only mounts should grab the sd_freeze_gl glock
827139ad9db5 tpm_tis: extra chip->ops check on error path in tpm_tis_core_init
a8f13826f9c6 arm64/alternatives: use subsections for replacement sequences
91e81d2262e7 cifs: prevent truncation from long to int in wait_for_free_credits
43046f786714 dt-bindings: mailbox: zynqmp_ipi: fix unit address
ea9d6016b1a4 m68k: mm: fix node memblock init
560dbf34dec8 m68k: nommu: register start of the memory with memblock
c3adbd37c054 blk-mq-debugfs: update blk_queue_flag_name[] accordingly for new flags
9025a5589c03 thermal/drivers: imx: Fix missing of_node_put() at probe time
c4db485dd3f2 x86/fpu: Reset MXCSR to default in kernel_fpu_begin()
d2bfb9eb439c drm/exynos: fix ref count leak in mic_pre_enable
f886b67c6b28 drm/exynos: Properly propagate return value in drm_iommu_attach_device()
0885be75f1be drm/msm/dpu: allow initialization of encoder locks during encoder init
5d6891a5a627 drm/msm: fix potential memleak in error branch
f608a77e0cc9 arm64: arch_timer: Disable the compat vdso for cores affected by ARM64_WORKAROUND_1418040
86e3c7c70c63 arm64: arch_timer: Allow an workaround descriptor to disable compat vdso
71d65a3fc628 arm64: Introduce a way to disable the 32bit vdso
36d60eba862d ip: Fix SO_MARK in RST, ACK and ICMP packets
38b122c0af04 cgroup: Fix sock_cgroup_data on big-endian.
94886c86e833 cgroup: fix cgroup_sk_alloc() for sk_clone_lock()
171644727abf tcp: md5: allow changing MD5 keys in all socket states
8ee263bd11af tcp: md5: refine tcp_md5_do_add()/tcp_md5_hash_key() barriers
30d015f5ecd9 vlan: consolidate VLAN parsing code and limit max parsing depth
f40c3a8438fc tcp: md5: do not send silly options in SYNCOOKIES
1c8bad567b5d tcp: md5: add missing memory barriers in tcp_md5_do_add()/tcp_md5_hash_key()
f52293aefe18 tcp: make sure listeners don't initialize congestion-control state
7eec9f331223 tcp: fix SO_RCVLOWAT possible hangs under high mem pressure
9b7fd81cf9b6 sched: consistently handle layer3 header accesses in the presence of VLANs
aafe9dd13f42 net: usb: qmi_wwan: add support for Quectel EG95 LTE modem
edbde451bf3f net_sched: fix a memory leak in atm_tc_init()
d55dad8b1d89 net: dsa: microchip: set the correct number of ports
64d782212646 net: Added pointer check for dst->ops->neigh_lookup in dst_neigh_lookup_skb
a70a667736ed llc: make sure applications use ARPHRD_ETHER
73e42f4d2d13 l2tp: remove skb_dst_set() from l2tp_xmit_skb()
f8646548ee46 ipv6: Fix use of anycast address with loopback
75270f819666 ipv6: fib6_select_path can not use out path for nexthop objects
1418b60e998b ipv4: fill fl4_icmp_{type,code} in ping_v4_sendmsg
7b42410d3556 genetlink: remove genl_bind
aef7a9e21aa6 bridge: mcast: Fix MLD2 Report IPv6 payload length check
587ccf092e28 net: rmnet: fix lower interface leak
d06c17fcd7c0 net: atlantic: fix ip dst and ipv6 address filters
de93c1c104ac crypto: atmel - Fix build error of CRYPTO_AUTHENC
1f21bb70d7b1 crypto: atmel - Fix selection of CRYPTO_AUTHENC
c57b1153a58a Linux 5.4.52
1a70857590f7 s390/maccess: add no DAT mode to kernel_write
627d15eecb61 s390: Change s390_kernel_write() return type to match memcpy()
d64dc6118a0f pwm: jz4740: Fix build failure
d13a78d13d2c perf scripts python: exported-sql-viewer.py: Fix unexpanded 'Find' result
64e8b913c30b perf scripts python: exported-sql-viewer.py: Fix zero id in call tree 'Find' result
2038998170b0 perf scripts python: exported-sql-viewer.py: Fix zero id in call graph 'Find' result
e51a811c242e perf scripts python: export-to-postgresql.py: Fix struct.pack() int argument
299ffecbd530 dm writecache: reject asynchronous pmem devices
49a7ac29f6a0 blk-mq: consider non-idle request as "inflight" in blk_mq_rq_inflight()
2dfd182451d9 s390/mm: fix huge pte soft dirty copying
0d62bc7e960f s390/setup: init jump labels before command line parsing
e6de7cbbcacb ARC: elf: use right ELF_ARCH
854827a2697a ARC: entry: fix potential EFA clobber when TIF_SYSCALL_TRACE
37634f502b53 mmc: meson-gx: limit segments to 1 when dram-access-quirk is needed
b9fe45efa671 dm: use noio when sending kobject event
ede24894e8bf drm/amdgpu: don't do soft recovery if gpu_recovery=0
ef8164f03a86 drm/radeon: fix double free
026f830e0ba3 btrfs: fix double put of block group with nocow
808b2b3ea85a btrfs: fix fatal extent_buffer readahead vs releasepage race
5a046d75acf7 Revert "ath9k: Fix general protection fault in ath9k_hif_usb_rx_cb"
baef8d1027b0 bpf: Check correct cred for CAP_SYSLOG in bpf_dump_raw_ok()
e5541c6347b7 kprobes: Do not expose probe addresses to non-CAP_SYSLOG
314ac273f005 module: Do not expose section addresses to non-CAP_SYSLOG
0d5d9413a692 module: Refactor section attr into bin attribute
2a6c8d3d0dd0 kallsyms: Refactor kallsyms_show_value() to take cred
79aaeec71271 KVM: arm64: Fix kvm_reset_vcpu() return code being incorrect with SVE
a494529add3f KVM: x86: Mark CR4.TSD as being possibly owned by the guest
d29a79fa7559 KVM: x86: Inject #GP if guest attempts to toggle CR4.LA57 in 64-bit mode
3f108b168002 KVM: x86: bit 8 of non-leaf PDPEs is not reserved
388429498641 KVM: arm64: Annotate hyp NMI-related functions as __always_inline
b956ec9afc2e KVM: arm64: Stop clobbering x0 for HVC_SOFT_RESTART
a20aa35b839a KVM: arm64: Fix definition of PAGE_HYP_DEVICE
9b742b6a3b78 ALSA: hda/realtek: Enable headset mic of Acer Veriton N4660G with ALC269VC
8254cddab9a4 ALSA: hda/realtek: Enable headset mic of Acer C20-820 with ALC269VC
c6fbfa6dd96b ALSA: hda/realtek - Enable audio jacks of Acer vCopperbox with ALC269VC
615313fe4294 ALSA: hda/realtek - Fix Lenovo Thinkpad X1 Carbon 7th quirk subdevice id
92b598132eec ALSA: usb-audio: Add implicit feedback quirk for RTX6001
caead988fe61 ALSA: usb-audio: add quirk for MacroSilicon MS2109
02b2f10e5c9f ALSA: hda - let hs_mic be picked ahead of hp_mic
3496a18a1c3b ALSA: opl3: fix infoleak in opl3
4a215725dec7 IB/hfi1: Do not destroy link_wq when the device is shut down
607fbc27d75f IB/hfi1: Do not destroy hfi1_wq when the device is shut down
6a882fb7232d mlxsw: pci: Fix use-after-free in case of failed devlink reload
c9dcb4929ce2 mlxsw: spectrum_router: Remove inappropriate usage of WARN_ON()
f62f896a56a2 net: macb: fix call to pm_runtime in the suspend/resume functions
ad396c483dd5 net: macb: mark device wake capable when "magic-packet" property present
5d744ee94b49 net: macb: fix wakeup test in runtime suspend/resume routines
15442ef56405 bnxt_en: fix NULL dereference in case SR-IOV configuration fails
65fb9bbee611 net/mlx5e: Fix 50G per lane indication
ce27893535ca net/mlx5: Fix eeprom support for SFP module
f277e0be69d4 qed: Populate nvm-file attributes while reading nvm config partition.
e89b828ae357 IB/mlx5: Fix 50G per lane indication
97d6855ac57d cxgb4: fix all-mask IP address comparison
2a4c5ff12f42 nbd: Fix memory leak in nbd_add_socket
06cee3572ed5 arm64: kgdb: Fix single-step exception handling oops
9e8f4623e292 RDMA/siw: Fix reporting vendor_part_id
1c54d0d9c4e6 ALSA: compress: fix partial_drain completion state
175b5aa7b964 net: hns3: fix use-after-free when doing self test
ab8c4fd863f4 net: hns3: add a missing uninit debugfs when unload driver
5c0192d28513 smsc95xx: avoid memory leak in smsc95xx_bind
81ed1f9fd0b3 smsc95xx: check return value of smsc95xx_reset
3959bf65fe48 perf intel-pt: Fix PEBS sample for XMM registers
da4b6eff382b perf intel-pt: Fix recording PEBS-via-PT with registers
9ca67a453273 perf report TUI: Fix segmentation fault in perf_evsel__hists_browse()
2d15663304f5 netfilter: conntrack: refetch conntrack after nf_conntrack_update()
d9b8206e5323 net: dsa: microchip: set the correct number of ports
fd3a612d9828 IB/sa: Resolv use-after-free in ib_nl_make_request()
b0259e7056b1 net: cxgb4: fix return error value in t4_prep_fw
92002d59ecee net: mvneta: fix use of state->speed
4f412ae89e78 netfilter: ipset: call ip_set_free() instead of kfree()
b709a08bc4d7 bpf, sockmap: RCU dereferenced psock may be used outside RCU block
2000bb546525 bpf, sockmap: RCU splat with redirect and strparser error or TLS
4625f4d5e4bf drm/mediatek: Check plane visibility in atomic_update
a062088e675f nl80211: don't return err unconditionally in nl80211_start_ap()
d63806c30706 gpio: pca953x: Fix GPIO resource leak on Intel Galileo Gen 2
137e7782bddd gpio: pca953x: Override IRQ for one of the expanders on Galileo Gen 2
91f8d05b4b56 net: qrtr: Fix an out of bounds read qrtr_endpoint_post()
1128ed7e1dd0 sched/core: Check cpus_mask, not cpus_ptr in __set_cpus_allowed_ptr(), to fix mask corruption
4e9631a90830 x86/entry: Increase entry_stack size to a full page
010f93079a26 nvme-rdma: assign completion vector correctly
074ae0cd8407 block: release bip in a right way in error path
b1b252d8d9c5 usb: dwc3: pci: Fix reference count leak in dwc3_pci_resume_work
2485b6afadd7 scsi: mptscsih: Fix read sense data size
10533390da7c ARM: imx6: add missing put_device() call in imx6q_suspend_init()
15fa5dfaa4e8 cifs: update ctime and mtime during truncate
9c732cccb04b s390/kasan: fix early pgm check handler execution
a9c816494dc2 drm: panel-orientation-quirks: Use generic orientation-data for Acer S1003
fcab0d2f1b91 drm: panel-orientation-quirks: Add quirk for Asus T101HA panel
b7556e7ca381 iommu/vt-d: Don't apply gfx quirks to untrusted devices
1a570b8faea4 powerpc/kvm/book3s64: Fix kernel crash with nested kvm & DEBUG_VIRTUAL
4e4ddeee7aff ibmvnic: continue to init in CRQ reset returns H_CLOSED
ce4a93b9e607 i40e: protect ring accesses with READ- and WRITE_ONCE
2e5a3586ca27 ixgbe: protect ring accesses with READ- and WRITE_ONCE
203cfe694e9d net: ethernet: mvneta: Add 2500BaseX support for SoCs without comphy
996bd0778a37 net: ethernet: mvneta: Fix Serdes configuration for SoCs without comphy
8f23c0dcd096 spi: spidev: fix a potential use-after-free in spidev_release()
010de5718162 spi: spidev: fix a race between spidev_release and spidev_remove
44b6e192e05f ALSA: hda: Intel: add missing PCI IDs for ICL-H, TGL-H and EKL
04197a8184e7 ASoC: SOF: Intel: add PCI ID for CometLake-S
b1589bb5b04e drm: mcde: Fix display initialization problem
408ddca5c737 gpu: host1x: Detach driver on unregister
d78a975525f3 drm/tegra: hub: Do not enable orphaned window group
dbe5fef1c2b1 drm/ttm: Fix dma_fence refcnt leak when adding move fence
6bfa3b616c52 ARM: dts: omap4-droid4: Fix spi configuration and increase rate
3965fe7c0a77 perf/x86/rapl: Fix RAPL config variable bug
5f121ba6b625 perf/x86/rapl: Move RAPL support to common x86 code
14e8708fffee regmap: fix alignment issue
2ec3c8329aca spi: spi-fsl-dspi: Fix lockup if device is removed during SPI transfer
6b64220baf4a spi: spi-fsl-dspi: Adding shutdown hook
eb676bef0224 KVM: s390: reduce number of IO pins to 1

Signed-off-by: Jens Rehsack <sno@netbsd.org>