### PR TITLE
linux-fslc-imx: update to v5.4.56

### DIFF
--- a/recipes-kernel/linux/linux-fslc-imx_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_5.4.bb
@@ -28,7 +28,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v5.4.55
+#    tag: v5.4.56
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
@@ -70,14 +70,14 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
 SRCBRANCH = "5.4-1.0.0-imx"
-SRCREV = "84b7307a4801afd90732666a29ce61f748c452b4"
+SRCREV = "e6b34ea3ddd9a96ac7b657ac25fde1cf4b6145b6"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.55"
+LINUX_VERSION = "5.4.56"
 
 # Local version indicates the branch name in the NXP kernel tree where patches are collected from.
 LOCALVERSION = "-lf-5.4.y"


### PR DESCRIPTION
Kernel repository has been upgraded to the v5.4.56 tag from korg

Also includes a revert to the changes applied to pm-imx6 when
v5.4.52 was merged (fixing a build failure on iMX6-based devices).

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>