### PR TITLE
imx-uuc: bump up revision from upstream

### DIFF
--- a/recipes-bsp/imx-uuc/imx-uuc_git.bb
+++ b/recipes-bsp/imx-uuc/imx-uuc_git.bb
@@ -12,7 +12,7 @@ PR = "r1"
 PV = "0.5.1+git${SRCPV}"
 
 SRC_URI = "git://github.com/NXPmicro/imx-uuc.git;protocol=https"
-SRCREV = "ebb7d34853133d92eff9766e370ea21e6d6d8f2b"
+SRCREV = "d6afb27e55d73d7ad08cd2dd51c784d8ec9694dc"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
This includes one commit from upstream:
d6afb27 Always use ipv6 address to mount rootfs

Signed-off-by: Andrey Zhizhikin <andrey.zhizhikin@leica-geosystems.com>