### PR TITLE
kernel-module-imx-gpu-viv+fslc: Update to version 6.4.0.p2.4-based

### DIFF
--- a/recipes-kernel/kernel-modules/kernel-module-imx-gpu-viv_6.4.0.p2.0+fslc.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-imx-gpu-viv_6.4.0.p2.0+fslc.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e"
 
 PV .= "+git${SRCPV}"
 
-SRCREV = "86354002bea77acd9ce1812712e9d8485b377ec8"
+SRCREV = "bc26daca3f330f1f037e5387d9219e135455a303"
 SRC_URI = "git://github.com/Freescale/kernel-module-imx-gpu-viv.git;protocol=https"
 
 S = "${WORKDIR}/git"

--- a/recipes-kernel/kernel-modules/kernel-module-imx-gpu-viv_6.4.0.p2.4+fslc.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-imx-gpu-viv_6.4.0.p2.4+fslc.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e"
 
 PV .= "+git${SRCPV}"
 
-SRCREV = "bc26daca3f330f1f037e5387d9219e135455a303"
+SRCREV = "f2e8483fbda59bf2482f77efb0804c014848f749"
 SRC_URI = "git://github.com/Freescale/kernel-module-imx-gpu-viv.git;protocol=https"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
This includes the following changes:
$ git log --oneline --no-decorate 8635400..bc26dac
bc26dac Merge tag 'upstream/6.4.0.p2.0'
dda8c30 Import 6.4.0.p2.0 original version
4cc1368 Merge tag 'upstream/6.4.0.p1.0'
7107f31 Merge tag 'upstream/6.2.4.p4.8'
d227cbd Merge tag 'upstream/6.2.4.p4.4'
40956c2 Merge tag 'upstream/6.2.4.p4.2'
5e6d5e1 Merge tag 'upstream/6.2.4.p4.0'
c7092f8 Merge tag 'upstream/6.2.4.p2.3'
b271b25 Import 6.4.0.p1.0 original version
34db06d Import 6.2.4.p4.8 original version
3d22560 Import 6.2.4.p4.4 original version
fc72ef3 Import 6.2.4.p4.2 original version
7a474fd Import 6.2.4.p4.0 original version
011ecb2 Import 6.2.4.p2.3 original version
40c717b Merge tag 'upstream/6.2.4.p1.8' into boundary/master
1477635 Import 6.2.4.p1.8 original version
ce51d6a Merge tag 'upstream/6.2.4.p1.6'
ea7cfb0 Import 6.2.4.p1.6 original version

Signed-off-by: Gary Bisson <gary.bisson@boundarydevices.com>