### PR TITLE
imx-vpu-hantro: fix compilation issues with -fcommon

### DIFF
--- a/recipes-bsp/imx-vpu-hantro/imx-vpu-hantro/0001-decoder_sw-resolve-compilation-error-with-fcommon.patch
+++ b/recipes-bsp/imx-vpu-hantro/imx-vpu-hantro/0001-decoder_sw-resolve-compilation-error-with-fcommon.patch
@@ -1,0 +1,54 @@
+From 5bfb24738c47003fd04a86bfd5a49f8c6354ed23 Mon Sep 17 00:00:00 2001
+From: Andrey Zhizhikin <andrey.zhizhikin@leica-geosystems.com>
+Date: Fri, 28 Aug 2020 07:46:35 +0000
+Subject: [PATCH] decoder_sw: resolve compilation error with -fcommon
+
+-fcommon is enabled by default in gcc10 compiler, which results in
+following build errors:
+
+decoder_sw/software/source/inc/decapicommon.h:272: multiple definition
+of `DecPicCodingType'; decoder_sw/software/linux/dwl/dwl_linux.o:
+decoder_sw/software/source/inc/decapicommon.h:272: first defined here
+
+decoder_sw/software/source/inc/dwl.h:94: multiple definition of
+`DWLInitParam'; decoder_sw/software/linux/dwl/dwl_linux.o:
+decoder_sw/software/source/inc/dwl.h:94: first defined here
+
+Drop multiple enum name definitions, which solves above compilation
+issues.
+
+Signed-off-by: Andrey Zhizhikin <andrey.zhizhikin@leica-geosystems.com>
+---
+ decoder_sw/software/source/inc/decapicommon.h | 2 +-
+ decoder_sw/software/source/inc/dwl.h          | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/decoder_sw/software/source/inc/decapicommon.h b/decoder_sw/software/source/inc/decapicommon.h
+index 0f02092..fc8cccf 100755
+--- a/decoder_sw/software/source/inc/decapicommon.h
++++ b/decoder_sw/software/source/inc/decapicommon.h
+@@ -269,7 +269,7 @@ enum DecPicCodingType {
+   DEC_PIC_TYPE_D           = 3,
+   DEC_PIC_TYPE_FI          = 4,
+   DEC_PIC_TYPE_BI          = 5
+-} DecPicCodingType;
++};
+ 
+ /* Output picture pixel format types for raster scan or down scale output */
+ enum DecPicturePixelFormat {
+diff --git a/decoder_sw/software/source/inc/dwl.h b/decoder_sw/software/source/inc/dwl.h
+index 6991f03..fd357b3 100755
+--- a/decoder_sw/software/source/inc/dwl.h
++++ b/decoder_sw/software/source/inc/dwl.h
+@@ -91,7 +91,7 @@ struct DWLLinearMem {
+ /* DWLInitParam is used to pass parameters when initializing the DWL */
+ struct DWLInitParam {
+   u32 client_type;
+-} DWLInitParam;
++};
+ 
+ /* Hardware configuration description, same as in top API */
+ typedef struct DecHwConfig DWLHwConfig;
+-- 
+2.17.1
+

--- a/recipes-bsp/imx-vpu-hantro/imx-vpu-hantro_1.18.0.bb
+++ b/recipes-bsp/imx-vpu-hantro/imx-vpu-hantro_1.18.0.bb
@@ -8,6 +8,7 @@ PROVIDES = "virtual/imxvpu"
 
 SRC_URI = " \
     ${FSL_MIRROR}/${BPN}-${PV}.bin;fsl-eula=true \
+    file://0001-decoder_sw-resolve-compilation-error-with-fcommon.patch \
 "
 SRC_URI[md5sum] = "78034de7ed74363eb793d29894bba5e3"
 SRC_URI[sha256sum] = "bebd82649d00d6dd8236b77b8677b1cc6ac46dc474200502df7797a75dc8f568"


### PR DESCRIPTION
GCC 10.2 is recently configured to include -fcommon per default, which
results in compilation error with multiple definitions of enum names.

Intoduce a patch which corrects double-defined enum names and resolves
compilation of the component.

Signed-off-by: Andrey Zhizhikin <andrey.zhizhikin@leica-geosystems.com>
Cc: Tom Hochstein <tom.hochstein@nxp.com>