### PR TITLE
imx-atf: fix build with -fno-common

### DIFF
--- a/recipes-bsp/imx-atf/imx-atf/0001-imx-Fix-missing-inclusion-of-cdefs.h.patch
+++ b/recipes-bsp/imx-atf/imx-atf/0001-imx-Fix-missing-inclusion-of-cdefs.h.patch
@@ -1,0 +1,62 @@
+From e8bb1c2caa19fa224090eca0793586857199af9e Mon Sep 17 00:00:00 2001
+From: Samuel Holland <samuel@sholland.org>
+Date: Wed, 4 Dec 2019 02:48:37 -0600
+Subject: [PATCH] imx: Fix missing inclusion of cdefs.h
+
+This was found by compiling with -fno-common:
+
+./build/picopi/release/bl2/imx_snvs.o:(.bss.__packed+0x0): multiple definition of `__packed';
+./build/picopi/release/bl2/imx_caam.o:(.bss.__packed+0x0): first defined here
+
+__packed was intended to be the attribute macro from cdefs.h, not an
+object of the structure type.
+
+Upstream-Status: Backport
+
+Signed-off-by: Samuel Holland <samuel@sholland.org>
+Change-Id: Id02fac3f098be2d71c35c6b4a18012515532f32a
+---
+ plat/imx/common/include/imx_caam.h | 3 ++-
+ plat/imx/common/include/imx_snvs.h | 3 ++-
+ 2 files changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/plat/imx/common/include/imx_caam.h b/plat/imx/common/include/imx_caam.h
+index 335bd0f8b..61005b51c 100644
+--- a/plat/imx/common/include/imx_caam.h
++++ b/plat/imx/common/include/imx_caam.h
+@@ -1,5 +1,5 @@
+ /*
+- * Copyright (c) 2018, ARM Limited and Contributors. All rights reserved.
++ * Copyright (c) 2018-2019, ARM Limited and Contributors. All rights reserved.
+  *
+  * SPDX-License-Identifier: BSD-3-Clause
+  */
+@@ -7,6 +7,7 @@
+ #ifndef IMX_CAAM_H
+ #define IMX_CAAM_H
+ 
++#include <cdefs.h>
+ #include <stdint.h>
+ #include <arch.h>
+ #include <imx_regs.h>
+diff --git a/plat/imx/common/include/imx_snvs.h b/plat/imx/common/include/imx_snvs.h
+index 0b3d1085f..565c451dd 100644
+--- a/plat/imx/common/include/imx_snvs.h
++++ b/plat/imx/common/include/imx_snvs.h
+@@ -1,11 +1,12 @@
+ /*
+- * Copyright (C) 2018, ARM Limited and Contributors. All rights reserved.
++ * Copyright (C) 2018-2019, ARM Limited and Contributors. All rights reserved.
+  *
+  * SPDX-License-Identifier: BSD-3-Clause
+  */
+ #ifndef IMX_SNVS_H
+ #define IMX_SNVS_H
+ 
++#include <cdefs.h>
+ #include <stdint.h>
+ 
+ #include <arch.h>
+-- 
+2.28.0
+

--- a/recipes-bsp/imx-atf/imx-atf/0001-imx-Fix-multiple-definition-of-ipc_handle.patch
+++ b/recipes-bsp/imx-atf/imx-atf/0001-imx-Fix-multiple-definition-of-ipc_handle.patch
@@ -1,0 +1,44 @@
+From 2338329e35254c1b8a887409d930ca76d9612093 Mon Sep 17 00:00:00 2001
+From: Samuel Holland <samuel@sholland.org>
+Date: Wed, 4 Dec 2019 02:45:58 -0600
+Subject: [PATCH] imx: Fix multiple definition of ipc_handle
+
+This is not conforming C and does not compile with -fno-common.
+
+Upstream-Status: Backport
+
+Signed-off-by: Samuel Holland <samuel@sholland.org>
+Change-Id: I6535954cc567d6efa06919069b91e3f50975b073
+---
+ plat/imx/common/include/sci/sci_ipc.h | 2 +-
+ plat/imx/common/sci/ipc.c             | 2 ++
+ 2 files changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/plat/imx/common/include/sci/sci_ipc.h b/plat/imx/common/include/sci/sci_ipc.h
+index cc8e47b28..1e3e53247 100755
+--- a/plat/imx/common/include/sci/sci_ipc.h
++++ b/plat/imx/common/include/sci/sci_ipc.h
+@@ -63,6 +63,6 @@ void sc_ipc_read(sc_ipc_t ipc, void *data);
+  */
+ void sc_ipc_write(sc_ipc_t ipc, const void *data);
+ 
+-sc_ipc_t ipc_handle;
++extern sc_ipc_t ipc_handle;
+ 
+ #endif /* SCI_IPC_H */
+diff --git a/plat/imx/common/sci/ipc.c b/plat/imx/common/sci/ipc.c
+index f329482fe..bf35a5ead 100755
+--- a/plat/imx/common/sci/ipc.c
++++ b/plat/imx/common/sci/ipc.c
+@@ -11,6 +11,8 @@
+ 
+ #include "imx8_mu.h"
+ 
++sc_ipc_t ipc_handle;
++
+ #include <lib/bakery_lock.h>
+ DEFINE_BAKERY_LOCK(sc_ipc_bakery_lock);
+ #define sc_ipc_lock_init()	bakery_lock_init(&sc_ipc_bakery_lock)
+-- 
+2.28.0
+

--- a/recipes-bsp/imx-atf/imx-atf_2.2.bb
+++ b/recipes-bsp/imx-atf/imx-atf_2.2.bb
@@ -9,6 +9,8 @@ PV .= "+git${SRCPV}"
 
 SRCBRANCH = "imx_5.4.24_2.1.0"
 SRC_URI = "git://source.codeaurora.org/external/imx/imx-atf.git;protocol=https;branch=${SRCBRANCH} \
+           file://0001-imx-Fix-missing-inclusion-of-cdefs.h.patch \
+           file://0001-imx-Fix-multiple-definition-of-ipc_handle.patch \
 "
 SRCREV = "b0a00f22b09c13572d3e87902a1069dee34763bd"
 


### PR DESCRIPTION
Backport fixes required to fix build with -fno-common. Build failure
found when building for a imx8qx based target.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>