### PR TITLE
imx-atf: fix build with -fno-common

### DIFF
--- a/recipes-bsp/imx-atf/imx-atf/0001-imx-Fix-multiple-definition-of-ipc_handle.patch
+++ b/recipes-bsp/imx-atf/imx-atf/0001-imx-Fix-multiple-definition-of-ipc_handle.patch
@@ -1,0 +1,45 @@
+From 8c433aa6c6b2eaed4084233beea99ee3fb0b652f Mon Sep 17 00:00:00 2001
+From: Samuel Holland <samuel@sholland.org>
+Date: Wed, 4 Dec 2019 02:45:58 -0600
+Subject: [PATCH] imx: Fix multiple definition of ipc_handle
+
+This is not conforming C and does not compile with -fno-common.
+
+Upstream-Status: Backport
+
+Signed-off-by: Samuel Holland <samuel@sholland.org>
+Change-Id: I6535954cc567d6efa06919069b91e3f50975b073
+---
+ plat/imx/common/include/sci/sci_ipc.h | 2 +-
+ plat/imx/common/sci/ipc.c             | 2 ++
+ 2 files changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/plat/imx/common/include/sci/sci_ipc.h b/plat/imx/common/include/sci/sci_ipc.h
+index 7cb109206..d2c3bba1c 100644
+--- a/plat/imx/common/include/sci/sci_ipc.h
++++ b/plat/imx/common/include/sci/sci_ipc.h
+@@ -63,7 +63,7 @@ void sc_ipc_read(sc_ipc_t ipc, void *data);
+  */
+ void sc_ipc_write(sc_ipc_t ipc, const void *data);
+ 
+-sc_ipc_t ipc_handle;
++extern sc_ipc_t ipc_handle;
+ 
+ #endif /* SC_IPC_H */
+ 
+diff --git a/plat/imx/common/sci/ipc.c b/plat/imx/common/sci/ipc.c
+index 68b0b8ef0..3169b7e0b 100644
+--- a/plat/imx/common/sci/ipc.c
++++ b/plat/imx/common/sci/ipc.c
+@@ -11,6 +11,8 @@
+ 
+ #include "imx8_mu.h"
+ 
++sc_ipc_t ipc_handle;
++
+ #include <bakery_lock.h>
+ DEFINE_BAKERY_LOCK(sc_ipc_bakery_lock);
+ #define sc_ipc_lock_init()	bakery_lock_init(&sc_ipc_bakery_lock)
+-- 
+2.28.0
+

--- a/recipes-bsp/imx-atf/imx-atf_2.0.bb
+++ b/recipes-bsp/imx-atf/imx-atf_2.0.bb
@@ -10,6 +10,7 @@ PV .= "+git${SRCPV}"
 SRCBRANCH = "lf-5.4.y"
 SRC_URI = "git://source.codeaurora.org/external/imx/imx-atf.git;protocol=https;branch=${SRCBRANCH} \
            file://0001-Allow-BUILD_STRING-to-be-set-in-.revision-file.patch \
+           file://0001-imx-Fix-multiple-definition-of-ipc_handle.patch \
 "
 SRCREV = "7b3389d49815f1e3f7942bd312a27ee665bd2e33"
 


### PR DESCRIPTION
Backport patch required to fix build with -fno-common.

Similar to #468, but for master (older imx-atf).

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>