### PR TITLE
linux-fslc-imx: update to v5.4.62

### DIFF
--- a/recipes-kernel/linux/linux-fslc-imx_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_5.4.bb
@@ -28,7 +28,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v5.4.61
+#    tag: v5.4.62
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
@@ -72,14 +72,14 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
 SRCBRANCH = "5.4-2.1.x-imx"
-SRCREV = "eedc0de7de8b12af3b56cbe960105ddfc0f1e17c"
+SRCREV = "e176f4c52f8071238edbc93c858a94c3362c8b22"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.61"
+LINUX_VERSION = "5.4.62"
 
 # Local version indicates the branch name in the NXP kernel tree where patches are collected from.
 LOCALVERSION = "-imx_5.4.24_2.1.0"


### PR DESCRIPTION
Kernel repository has been upgraded up to and including v5.4.62 tag from
stable korg.

Tracking information is updated with the new stable tag.

Signed-off-by: Andrey Zhizhikin <andrey.z@gmail.com>