### PR TITLE
Consolidated kernel update (v5.4.62)

### DIFF
--- a/recipes-kernel/linux/linux-fslc-imx_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_5.4.bb
@@ -28,7 +28,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v5.4.61
+#    tag: v5.4.62
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
@@ -44,6 +44,9 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 3. Critical patches (SHA(s))
 # ------------------------------------------------------------------------------
+#    fd34d250e9a5 arm64: dts: imx8m: change ocotp node name on i.MX8M SoCs
+#    4e0a3bc7b1af arm64: dts: imx8mn: Use "fsl,imx8mm-ocotp" as ocotp's fallback compatible
+#    66af62de926c arm64: dts: imx8mm: Remove incorrect fallback compatible for ocotp
 #    19be176e9eed perf cs-etm: Move definition of 'traceid_list' global variable from header file
 #    d40fb1b86571 libtraceevent: Fix build with binutils 2.35
 #    0296957500a0 arm: imx: include i.MX6SX DDR freq implementation for i.MX6UL
@@ -75,14 +78,14 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
 SRCBRANCH = "5.4-1.0.0-imx"
-SRCREV = "cd91bed8782ac945568ae453b538a69bfdb0b247"
+SRCREV = "530e2b37943dfbd5044e37c963b67946834c4973"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.61"
+LINUX_VERSION = "5.4.62"
 
 # Local version indicates the branch name in the NXP kernel tree where patches are collected from.
 LOCALVERSION = "-lf-5.4.y"

--- a/recipes-kernel/linux/linux-fslc_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc_5.4.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.61"
+LINUX_VERSION = "5.4.62"
 
 SRCBRANCH = "5.4.x+fslc"
-SRCREV = "5070f8007d964a8bb219b9c7886fc23ffff3fdc5"
+SRCREV = "dc538a401d932f1d07515fdd409c2f5a0629f44e"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"


### PR DESCRIPTION
Both kernel branches were updated to *v5.4.62* from stable korg, recipe `SRCREV` are updated to point to that version now.

`linux-fslc-imx` also included 3 patches cherry-picked from upstream, which solves the UUID readout in `soc` driver for *imx8mnevk*.

-- andrey