### PR TITLE
Update linux-fslc-qoriq to v5.4.63

### DIFF
--- a/recipes-kernel/linux/linux-fslc-qoriq_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc-qoriq_5.4.bb
@@ -10,8 +10,8 @@ require recipes-kernel/linux/linux-qoriq.inc
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
-LINUX_VERSION = "5.4.58"
+LINUX_VERSION = "5.4.63"
 
 SRCBRANCH = "5.4.y+qoriq+fslc"
-SRCREV = "ba11ffe3d1285be7645e40ab027b9c33974023f3"
+SRCREV = "183ad8ea350bd55b9eb3904b9c9b586e1556ed19"
 SRC_URI := "git://github.com/Freescale/linux-fslc.git;branch=${SRCBRANCH}"


### PR DESCRIPTION
This updates QorIQ FSLC kernel to 5.4.63+perf fix which contains:

183ad8ea350b perf cs-etm: Move definition of 'traceid_list' global variable from header file
e32f4fa1b24d Linux 5.4.63
5153710a5ecc scsi: target: tcmu: Optimize use of flush_dcache_page
bb9949fdfddd scsi: target: tcmu: Fix size in calls to tcmu_flush_dcache_range
6d2e274f60fc sdhci: tegra: Remove SDHCI_QUIRK_DATA_TIMEOUT_USES_SDCLK for Tegra186
0176db2f2ad5 sdhci: tegra: Remove SDHCI_QUIRK_DATA_TIMEOUT_USES_SDCLK for Tegra210
eda97e9d90db arm64: tegra: Add missing timeout clock to Tegra210 SDMMC
5cd8c5979e72 arm64: tegra: Add missing timeout clock to Tegra186 SDMMC nodes
ef8b5f333780 arm64: tegra: Add missing timeout clock to Tegra194 SDMMC nodes
9d806d68bf97 dt-bindings: mmc: tegra: Add tmclk for Tegra210 and later
d2ac42e61ecd KVM: arm64: Set HCR_EL2.PTW to prevent AT taking synchronous exception
ffad02f9e3ea KVM: arm64: Survive synchronous exceptions caused by AT instructions
1744237ca047 KVM: arm64: Add kvm_extable for vaxorcism code
538caddbe635 drm/etnaviv: fix TS cache flushing on GPUs with BLT engine
80743b4bde09 drm/sched: Fix passing zero to 'PTR_ERR' warning v2
6cadd1e2d8c5 perf record/stat: Explicitly call out event modifiers in the documentation
4bae1afed432 HID: core: Sanitize event code and type when mapping input
667514df10a0 HID: core: Correctly handle ReportSize being zero
933cf1c2c075 Linux 5.4.62
54ee77961e79 io_uring: Fix NULL pointer dereference in io_sq_wq_submit_work()
44cf62d388fb ALSA: usb-audio: Update documentation comment for MS2109 quirk
851d0813ab80 HID: hiddev: Fix slab-out-of-bounds write in hiddev_ioctl_usage()
c98b6ebd9b55 kbuild: fix broken builds because of GZIP,BZIP2,LZOP variables
37432a83faab kbuild: add variables for compression tools
47a41f65afb6 kheaders: explain why include/config/autoconf.h is excluded from md5sum
7caddaa9f88b kheaders: remove the last bashism to allow sh to run it
18f48708c3f5 kheaders: optimize header copy for in-tree builds
a1d0c6e2f334 kheaders: optimize md5sum calculation for in-tree builds
eb914bae6e17 kheaders: remove unneeded 'cat' command piped to 'head' / 'tail'
376810e5e9e1 fbmem: pull fbcon_update_vcs() out of fb_set_var()
6a862aa31ec3 usb: dwc3: gadget: Handle ZLP for sg requests
7c8b5685662b usb: dwc3: gadget: Fix handling ZLP
4bc5d90a7dce usb: dwc3: gadget: Don't setup more than requested
f8e4c5297fcd drm/i915: Fix cmd parser desc matching with masks
73992639ec78 usb: storage: Add unusual_uas entry for Sony PSZ drives
2add73c8c00d USB: cdc-acm: rework notification_buffer resizing
e2e02f260496 USB: gadget: u_f: Unbreak offset calculation in VLAs
4f529c4d1e43 USB: gadget: f_ncm: add bounds checks to ncm_unwrap_ntb()
f47ab852bea3 USB: gadget: u_f: add overflow checks to VLA macros
2534d3dec376 usb: host: ohci-exynos: Fix error handling in exynos_ohci_probe()
de24343880a6 USB: Ignore UAS for JMicron JMS567 ATA/ATAPI Bridge
ca29a2a53953 USB: quirks: Ignore duplicate endpoint on Sound Devices MixPre-D
20b3564c6748 USB: quirks: Add no-lpm quirk for another Raydium touchscreen
b32ec919ee37 usb: uas: Add quirk for PNY Pro Elite
ad0bc424fc0a USB: yurex: Fix bad gfp argument
3623dab2959e drm/amd/pm: correct the thermal alert temperature limit settings
85ca6f199c77 drm/amd/pm: correct Vega20 swctf limit setting
9afabefd42fc drm/amd/pm: correct Vega12 swctf limit setting
60cffee2d951 drm/amd/pm: correct Vega10 swctf limit setting
2809cf7f6eba drm/amd/powerplay: Fix hardmins not being sent to SMU for RV
20700b352d10 drm/amdgpu/gfx10: refine mgcg setting
8fc7a66619e1 drm/amdgpu: Fix buffer overflow in INFO ioctl
1adf8c19f974 x86/hotplug: Silence APIC only after all interrupts are migrated
47c8387a963e irqchip/stm32-exti: Avoid losing interrupts due to clearing pending bits by mistake
927aa9a10f12 genirq/matrix: Deal with the sillyness of for_each_cpu() on UP
70957a10e1db crypto: af_alg - Work around empty control messages without MSG_MORE
aca10ab0568a device property: Fix the secondary firmware node handling in set_primary_fwnode()
df2a6a4a9d68 powerpc/perf: Fix crashes with generic_compat_pmu & BHRB
b260fb2a02b5 PM: sleep: core: Fix the handling of pending runtime resume requests
7ded78a8c89e arm64: vdso32: make vdso32 install conditional
3b7087e07730 xhci: Always restore EP_SOFT_CLEAR_TOGGLE even if ep reset failed
02166fea639f xhci: Do warm-reset when both CAS and XDEV_RESUME are set
3ac8545b29ae usb: host: xhci: fix ep context print mismatch in debugfs
4d3e2a3a0c64 XEN uses irqdesc::irq_data_common::handler_data to store a per interrupt XEN data pointer which contains XEN specific information.
6623c19042b6 writeback: Fix sync livelock due to b_dirty_time processing
cb0c74450072 writeback: Avoid skipping inode writeback
8eab2b531fd3 writeback: Protect inode->i_io_list with inode->i_lock
2e76a3a1667c serial: 8250: change lock order in serial8250_do_startup()
f53ebc7c2922 serial: 8250_exar: Fix number of ports for Commtech PCIe cards
fbb55ec82dd6 serial: stm32: avoid kernel warning on absence of optional IRQ
64a05aadf936 serial: pl011: Don't leak amba_ports entry on driver register error
0806b49bba20 serial: pl011: Fix oops on -EPROBE_DEFER
daae6b962a13 serial: samsung: Removes the IRQ not found warning
7c57237d74a0 vt_ioctl: change VT_RESIZEX ioctl to check for error return from vc_resize()
adb76f3f7732 vt: defer kfree() of vc_screenbuf in vc_do_resize()
db1bb352cc08 USB: lvtest: return proper error code in probe
96e41fc29e8a fbcon: prevent user font height or width change from causing potential out-of-bounds access
cd1d270e3e4f btrfs: detect nocow for swap after snapshot delete
eb576fc43a43 btrfs: fix space cache memory leak after transaction abort
1d08edc70154 btrfs: check the right error variable in btrfs_del_dir_entries_in_log
8a3509486f08 btrfs: reset compression level for lzo on remount
b1a83ee0cbbf blk-mq: order adding requests to hctx->dispatch and checking SCHED_RESTART
c2035d1e55aa HID: i2c-hid: Always sleep 60ms after I2C_HID_PWR_ON commands
db4542b6617b block: loop: set discard granularity and alignment for block device backed loop
f09dbec9c0c6 block: fix get_max_io_size()
2f4b202eb1b1 arm64: Allow booting of late CPUs affected by erratum 1418040
82b05f0838aa arm64: Move handling of erratum 1418040 into C code
7d44b707aaff powerpc/perf: Fix soft lockups due to missed interrupt accounting
9c0305c0cfa2 net: gianfar: Add of_node_put() before goto statement
c656534e5c45 macvlan: validate setting of multiple remote source MAC addresses
19f669a3609c Revert "scsi: qla2xxx: Fix crash on qla2x00_mailbox_command"
48765b780ace scsi: qla2xxx: Fix null pointer access during disconnect from subsystem
36a139cf4146 scsi: qla2xxx: Check if FW supports MQ before enabling
88274626d110 scsi: qla2xxx: Fix login timeout
37528b3ee9e1 scsi: ufs: Clean up completed request without interrupt notification
a39ba0fdcdfd scsi: ufs: Improve interrupt handling for shared interrupts
d895b0be701c scsi: ufs: Fix possible infinite loop in ufshcd_hold
1778bebd06b4 scsi: fcoe: Fix I/O path allocation
a8d26145e112 selftests: disable rp_filter for icmp_redirect.sh
957066143e6c ASoC: wm8994: Avoid attempts to read unreadable registers
1d63737b0777 s390/cio: add cond_resched() in the slow_eval_known_fn() loop
2a8c6149a49a ALSA: hda/realtek: Add model alc298-samsung-headphone
021a98a87864 can: j1939: transport: j1939_xtp_rx_dat_one(): compare own packets to detect corruptions
3803312a3c55 netfilter: avoid ipv6 -> nf_defrag_ipv6 module dependency
35238963c972 drm/amd/display: Switch to immediate mode for updating infopackets
b92b415fa7b7 drm/amd/powerplay: correct UVD/VCE PG state on custom pptable uploading
73a0e6280a32 drm/amd/powerplay: correct Vega20 cached smu feature state
d2da80e0a3e7 spi: stm32: always perform registers configuration prior to transfer
2844685c661a spi: stm32: fix stm32_spi_prepare_mbr in case of odd clk_rate
a6daa863d15e spi: stm32: fix fifo threshold level in case of short transfer
3c15a3c4b155 spi: stm32h7: fix race condition at end of transfer
a08e95e83e6f fs: prevent BUG_ON in submit_bh_wbc()
28a56c26a00d ext4: correctly restore system zone info when remount fails
8e63c86f6580 ext4: handle error of ext4_setup_system_zone() on remount
e579635669da ext4: handle option set by mount flags correctly
3a53d012bd26 jbd2: abort journal if free a async write error metadata buffer
1b36d4fa4b66 ext4: handle read only external journal device
2e7312ddaf62 ext4: don't BUG on inconsistent journal feature
40827caf954c jbd2: make sure jh have b_transaction set in refile/unfile_buffer
e4351ad44d7e spi: stm32: clear only asserted irq flags on interrupt
d63728afe947 usb: gadget: f_tcm: Fix some resource leaks in some error paths
262f5fbad941 i2c: rcar: in slave mode, clear NACK earlier
883ed72723ef i2c: core: Don't fail PRP0001 enumeration when no ID table exist
2fc8fa50ebee null_blk: fix passing of REQ_FUA flag in null_handle_rq
88994acafd96 nvme: multipath: round-robin: fix single non-optimized path case
97f30414a2e0 nvme-fc: Fix wrong return value in __nvme_fc_init_request()
05c608f630b9 blkcg: fix memleak for iolatency
872a2b3182ee blk-mq: insert request not through ->queue_rq into sw/scheduler queue
9054d5844092 hwmon: (nct7904) Correct divide by 0
1475314530bb bfq: fix blkio cgroup leakage v4
2295664518c3 block: Fix page_is_mergeable() for compound pages
3e9eb1e893ba drm/msm/adreno: fix updating ring fence
effd3b89f7e5 block: virtio_blk: fix handling single range discard request
cc3a73f245cb block: respect queue limit of max discard segment
8f409e764c4b media: gpio-ir-tx: improve precision of transmitted signal due to scheduling
6ba04701b801 ALSA: usb-audio: Add capture support for Saffire 6 (USB 1.1)
5861e84d7145 cpufreq: intel_pstate: Fix EPP setting via sysfs in active mode
1b7b2d45b31e PCI: qcom: Add missing reset for ipq806x
ea552383a9d5 PCI: qcom: Change duplicate PCI reset to phy reset
29ecf28be997 PCI: qcom: Add missing ipq806x clocks in PCIe driver
6d11320bed41 EDAC/{i7core,sb,pnd2,skx}: Fix error event severity
87cc96bb11b9 EDAC: skx_common: get rid of unused type var
3bf42b2e8d67 EDAC: sb_edac: get rid of unused vars
75aaa8fa7672 mm/vunmap: add cond_resched() in vunmap_pmd_range
a2038eb833a5 drm/amd/display: Fix dmesg warning from setting abm level
8522b1bec88e drm/amd/display: Add additional config guards for DCN
992e51ff0e4b drm/amd/display: Trigger modesets on MST DSC connectors
b730fb14434f drm/ingenic: Fix incorrect assumption about plane->index
8dc47d858fea gpu/drm: ingenic: Use the plane's src_[x,y] to configure DMA length
302b9e189962 cma: don't quit at first error when activating reserved areas
aed14b1b5c0e mm/cma.c: switch to bitmap_zalloc() for cma bitmap allocation
965d3d5ce355 mm: fix kthread_use_mm() vs TLB invalidate
72574434da87 mm/shuffle: don't move pages between zones and don't read garbage memmaps
483b956a16a0 btrfs: only commit delayed items at fsync if we are logging a directory
3eddcc71fe8a btrfs: only commit the delayed inode when doing a full fsync
d5f5b15d3ea4 btrfs: factor out inode items copy loop from btrfs_log_inode()
a0cfda9cb3a1 s390/numa: set node distance to LOCAL_DISTANCE
67f8b390b15e drm/xen-front: Fix misused IS_ERR_OR_NULL checks
02611bcaafe5 drm/xen: fix passing zero to 'PTR_ERR' warning
fe376f1b12d2 PM / devfreq: rk3399_dmc: Fix kernel oops when rockchip,pmu is absent
b7cca731b486 PM / devfreq: rk3399_dmc: Disable devfreq-event device when fails
a0f69c6f5e0b PM / devfreq: rk3399_dmc: Add missing of_node_put()
961bfe1277ae usb: cdns3: gadget: always zeroed TRB buffer when enable endpoint
2c0000f409ec sched/uclamp: Fix a deadlock when enabling uclamp static key
88435320ebc1 sched/uclamp: Protect uclamp fast path code with static key
93709d8ade00 Revert "ath10k: fix DMA related firmware crashes on multiple devices"
da56eb03ea94 arm64: Fix __cpu_logical_map undefined issue
12a9bec2bd4e efi: provide empty efi_enter_virtual_mode implementation
b2defeb19bff brcmfmac: Set timeout value when configuring power save
7aac56d8b0ee USB: sisusbvga: Fix a potential UB casued by left shifting a negative value
e77f71c6341a powerpc/spufs: add CONFIG_COREDUMP dependency
653ae33b030b KVM: arm64: Fix symbol dependency in __hyp_call_panic_nvhe
a84a6eb935ba media: davinci: vpif_capture: fix potential double free
6b0010ed7140 hugetlbfs: prevent filesystem stacking of hugetlbfs
c67c6e1f54aa EDAC/ie31200: Fallback if host bridge device is already initialized
41191f8c57a1 scsi: fcoe: Memory leak fix in fcoe_sysfs_fcf_del()
a002274db527 ceph: do not access the kiocb after aio requests
01540d5e7c1b ceph: fix potential mdsc use-after-free crash
9da791b5410e scsi: iscsi: Do not put host in iscsi_set_flashnode_param()
050292f138a3 btrfs: make btrfs_qgroup_check_reserved_leak take btrfs_inode
1f52b85f6c79 btrfs: file: reserve qgroup space after the hole punch range is locked
7d6689df48de locking/lockdep: Fix overflow in presentation of average lock-time
2adf6ec63db2 drm/nouveau: Fix reference count leak in nouveau_connector_detect
19e81f6325a9 drm/nouveau: fix reference count leak in nv50_disp_atomic_commit
d23d52e38cc9 drm/nouveau/drm/noveau: fix reference count leak in nouveau_fbcon_open
45e30390f50f f2fs: fix use-after-free issue
4cba87943046 HID: quirks: add NOGET quirk for Logitech GROUP
6734eeb6c2f0 cec-api: prevent leaking memory through hole in structure
bd4593030332 ALSA: hda: Add support for Loongson 7A1000 controller
f4107f633a29 mips/vdso: Fix resource leaks in genvdso.c
71e7e02c0590 rtlwifi: rtl8192cu: Prevent leaking urb
3a84491364e1 ARM: dts: ls1021a: output PPS signal on FIPER2
4410fd0c378e PCI: Fix pci_create_slot() reference count leak
201838142c52 omapfb: fix multiple reference count leaks due to pm_runtime_get_sync
22d859fe1bdc f2fs: fix error path in do_recover_data()
110c5a5a6854 selftests/powerpc: Purge extra count_pmc() calls of ebb selftests
0450a50c914e scsi: target: Fix xcopy sess release leak
774cc7c882f8 xfs: Don't allow logging of XFS_ISTALE inodes
40b450375c80 scsi: lpfc: Fix shost refcount mismatch when deleting vport
815060a8ec2a drm/amdgpu/display: fix ref count leak when pm_runtime_get_sync fails
8290f9d4695f drm/amdgpu: fix ref count leak in amdgpu_display_crtc_set_config
3753eff4c69a drm/amd/display: fix ref count leak in amdgpu_drm_ioctl
c911da7b6673 drm/amdgpu: fix ref count leak in amdgpu_driver_open_kms
40d0bf2b6e99 drm/radeon: fix multiple reference count leak
9c88b27ac444 drm/amdkfd: Fix reference count leaks.
1174ed705dda iommu/iova: Don't BUG on invalid PFNs
f0a066af0f37 mfd: intel-lpss: Add Intel Tiger Lake PCH-H PCI IDs
d98ea48810e6 scsi: target: tcmu: Fix crash on ARM during cmd completion
ab2d90e58ae1 blktrace: ensure our debugfs dir exists
fc93c091de22 media: pci: ttpci: av7110: fix possible buffer overflow caused by bad DMA value in debiirq()
1dc0ed18219a powerpc/xive: Ignore kmemleak false positives
88eb00cb39ce arm64: dts: qcom: msm8916: Pull down PDM GPIOs during sleep
d8cc881483d8 mfd: intel-lpss: Add Intel Emmitsburg PCH PCI IDs
fd5908860a17 ASoC: tegra: Fix reference count leaks.
7d60cd2a6e08 ASoC: img-parallel-out: Fix a reference count leak
8150a0e3d796 ASoC: img: Fix a reference count leak in img_i2s_in_set_fmt
a53f67368c98 ALSA: hda/hdmi: Use force connectivity quirk on another HP desktop
348da2f8566b ALSA: hda/realtek: Fix pin default on Intel NUC 8 Rugged
bcf40820b4fd ALSA: pci: delete repeated words in comments
b45944e2b39e ALSA: hda/hdmi: Add quirk to force connectivity
266d21a57093 ipvlan: fix device features
e1334c4f4aec net/sched: act_ct: Fix skb double-free in tcf_ct_handle_fragments() error flow
97a74349cf82 net: ena: Make missed_tx stat incremental
6c2e795f95cd tipc: fix uninit skb->data in tipc_nl_compat_dumpit()
d429362b3de4 net/smc: Prevent kernel-infoleak in __smc_diag_dump()
4d2fe0addc38 net: sctp: Fix negotiation of the number of data streams.
4ef63e365466 net: qrtr: fix usage of idr in port assignment to socket
4ae9ebf9e8ea net: nexthop: don't allow empty NHA_GROUP
6ed89176755c net: Fix potential wrong skb->protocol in skb_vlan_untag()
b5e34120b06a gre6: Fix reception with IP6_TNL_F_RCV_DSCP_COPY
730443f4c48a binfmt_flat: revert "binfmt_flat: don't offset the data start"
669fc3b38ce2 powerpc/64s: Don't init FSCR_DSCR in __init_FSCR()
6576d69aac94 Linux 5.4.61
d316d52742c4 KVM: arm64: Only reschedule if MMU_NOTIFIER_RANGE_BLOCKABLE is not set
e1818ffcca0e KVM: Pass MMU notifier range flags to kvm_unmap_hva_range()
744fde53ec32 xen: don't reschedule in preemption off sections
d6bca2a8f064 mm/hugetlb: fix calculation of adjust_range_if_pmd_sharing_possible
42694912aaf1 do_epoll_ctl(): clean the failure exits up a bit
b158e91610c7 epoll: Keep a reference on files added to the check list
5167f194da69 efi: add missed destroy_workqueue when efisubsys_init fails
13b1fc60ecb0 powerpc/pseries: Do not initiate shutdown when system is running on UPS
dafae068886a net: dsa: b53: check for timeout
83236e697f79 hv_netvsc: Fix the queue_mapping in netvsc_vf_xmit()
2dd00ae408a9 net: gemini: Fix missing free_netdev() in error path of gemini_ethernet_port_probe()
f4adc6430d74 net: ena: Prevent reset after device destruction
f4ed9ede3441 bonding: fix active-backup failover for current ARP slave
542a493c8c5e ARM64: vdso32: Install vdso32 from vdso_install
278eb88ab206 afs: Fix NULL deref in afs_dynroot_depopulate()
140ac9370b16 RDMA/bnxt_re: Do not add user qps to flushlist
dc0d58e281a6 Fix build error when CONFIG_ACPI is not set/enabled:
7cc9812be1c7 efi: avoid error message when booting under Xen
d3ca317cf62a kconfig: qconf: fix signal connection to invalid slots
51d85e70e3ad kconfig: qconf: do not limit the pop-up menu to the first row
da1069e4e727 Revert "scsi: qla2xxx: Disable T10-DIF feature with FC-NVMe during probe"
6e2aa034d777 kvm: x86: Toggling CR4.PKE does not load PDPTEs in PAE mode
46713f3d61b3 kvm: x86: Toggling CR4.SMAP does not load PDPTEs in PAE mode
667a59aa55fb vfio/type1: Add proper error unwind for vfio_iommu_replay()
503176f5dc07 ASoC: intel: Fix memleak in sst_media_open
8aeb112d58c0 ASoC: msm8916-wcd-analog: fix register Interrupt offset
e9849a60facb s390/ptrace: fix storage key handling
d35f24bc566d s390/runtime_instrumentation: fix storage key handling
cc215d206881 bonding: fix a potential double-unregister
8a49739f58f5 can: j1939: add rxtimer for multipacket broadcast session
d7ab964b6ba9 can: j1939: abort multipacket broadcast session when timeout occurs
d0dc3d2c71e2 can: j1939: cancel rxtimer on multipacket broadcast session complete
5159a0a5164b can: j1939: fix support for multipacket broadcast message
5dc0c1c12094 bonding: show saner speed for broadcast mode
1b9dee25ad25 net: fec: correct the error path for regulator disable in probe
c0e04d08e544 i40e: Fix crash during removing i40e driver
e2a8d4423640 i40e: Set RX_ONLY mode for unicast promiscuous on VLAN
154ccf69feca can: j1939: transport: add j1939_session_skb_find_by_offset() function
3bfd1398de6a can: j1939: transport: j1939_simple_recv(): ignore local J1939 messages send not by J1939 stack
ff723ef6b7b6 can: j1939: fix kernel-infoleak in j1939_sk_sock2sockaddr_can()
6e0bc946cbee bpf: sock_ops sk access may stomp registers when dst_reg = src_reg
ece9ca5840e0 ASoC: q6routing: add dummy register read/write function
aaa6e691b983 ASoC: q6afe-dai: mark all widgets registers as SND_SOC_NOPM
233d6f2ab120 spi: stm32: fixes suspend/resume management
666d1d1a0584 netfilter: nf_tables: nft_exthdr: the presence return value should be little-endian
3473fa198178 ext4: don't allow overlapping system zones
ea54176e5821 ext4: fix potential negative array index in do_split()
2585402c5799 fs/signalfd.c: fix inconsistent return codes for signalfd4
e4f952b031c1 alpha: fix annotation of io{read,write}{16,32}be()
538c74a9cb26 xfs: Fix UBSAN null-ptr-deref in xfs_sysfs_init
4591461ea9f2 tools/testing/selftests/cgroup/cgroup_util.c: cg_read_strcmp: fix null pointer dereference
10b2bb101f06 media: camss: fix memory leaks on error handling paths in probe
05724341d9db virtio_ring: Avoid loop when vq is broken in virtqueue_poll
34f8368f6634 scsi: libfc: Free skb in fc_disc_gpn_id_resp() for valid cases
28850b8043cc cpufreq: intel_pstate: Fix cpuinfo_max_freq when MSR_TURBO_RATIO_LIMIT is 0
cca58a166920 swiotlb-xen: use vmalloc_to_page on vmalloc virt addresses
2bd8ba398fad ceph: fix use-after-free for fsc->mdsc
2524bb04d81b jffs2: fix UAF problem
04aeb884e8a5 drm/ttm: fix offset in VMAs with a pg_offs in ttm_bo_vm_access
711f5688bb97 xfs: fix inode quota reservation checks
8fe5e38acbe7 svcrdma: Fix another Receive buffer leak
7aca2f7d1710 m68knommu: fix overwriting of bits in ColdFire V3 cache control
1a718d4caa1a MIPS: Fix unable to reserve memory for Crash kernel
5594a54c520b Input: psmouse - add a newline when printing 'proto' by sysfs
06d4d9acd7d8 media: vpss: clean up resources in init
f948f1d02237 rtc: goldfish: Enable interrupt in set_alarm() when necessary
85ad0d5f3d69 media: budget-core: Improve exception handling in budget_register()
62b8c76d061f scsi: target: tcmu: Fix crash in tcmu_flush_dcache_range on ARM
59d587cc3640 scsi: ufs: Add DELAY_BEFORE_LPM quirk for Micron devices
10e99c3003d5 opp: Enable resources again if they were disabled earlier
52d322f91954 kthread: Do not preempt current task if it is going to call schedule()
504fe0ab2412 drm/amd/display: fix pow() crashing when given base 0
1f3cfa9338c3 drm/amd/display: Fix EDID parsing after resume from suspend
6f3bff30f1cb drm/amdgpu/display: use GFP_ATOMIC in dcn20_validate_bandwidth_internal
f45ab6e7d957 scsi: zfcp: Fix use-after-free in request timeout handlers
b4062a49ad4a jbd2: add the missing unlock_buffer() in the error path of jbd2_write_superblock()
2bc54ba65fdc ext4: fix checking of directory entry validity for inline directories
59af0759bd46 RDMA/hfi1: Correct an interlock issue for TID RDMA WRITE request
0cfb9320d00c mm, page_alloc: fix core hung in free_pcppages_bulk()
5663159e2930 mm: include CMA pages in lowmem_reserve at boot
e9e3ec03e6ae uprobes: __replace_page() avoid BUG in munlock_vma_page()
fa2e0d4e4a4c kernel/relay.c: fix memleak on destroy relay channel
19a77c937a19 romfs: fix uninitialized memory leak in romfs_dev_read()
3e538c536f01 spi: Prevent adding devices below an unregistering controller
143df6b3584a can: j1939: socket: j1939_sk_bind(): make sure ml_priv is allocated
60be1488a3ae can: j1939: transport: j1939_session_tx_dat(): fix use-after-free read in j1939_tp_txtimer()
055c65c7e7dd ALSA: hda/realtek: Add quirk for Samsung Galaxy Book Ion
4fe52a85eeb4 ALSA: hda/realtek: Add quirk for Samsung Galaxy Flex Book
84bfb4b10d6f btrfs: add wrapper for transaction abort predicate
745148367b04 btrfs: return EROFS for BTRFS_FS_STATE_ERROR cases
de88b7e2f02f btrfs: don't show full path of bind mounts in subvol=
038580b1f58b btrfs: export helpers for subvolume name/id resolution
b40753984979 bcache: avoid nr_stripes overflow in bcache_device_init()
9f4f7c08d50b khugepaged: adjust VM_BUG_ON_MM() in __khugepaged_enter()
9a05b774af30 khugepaged: khugepaged_test_exit() check mmget_still_valid()
8043d5ee9168 perf probe: Fix memory leakage when the probe point is not found
888d9b829c25 gfs2: Never call gfs2_block_zero_range with an open transaction
18a640d3b570 gfs2: Improve mmap write vs. punch_hole consistency
e42c75ef3477 drm/vgem: Replace opencoded version of drm_gem_dumb_map_offset()
62353048e2d4 kbuild: support LLVM=1 to switch the default tools to Clang/LLVM
c7d8f67db126 kbuild: replace AS=clang with LLVM_IAS=1
244d9026768d kbuild: remove AS variable
fed06097acce kbuild: remove PYTHON2 variable
fa84d9f31599 x86/boot: kbuild: allow readelf executable to be specified
c173511a12e4 net: wan: wanxl: use $(M68KCC) instead of $(M68KAS) for rebuilding firmware
c7c239c947be net: wan: wanxl: use allow to pass CROSS_COMPILE_M68k for rebuilding firmware
f781285d09a9 Documentation/llvm: fix the name of llvm-size
97eab9af0036 Documentation/llvm: add documentation on building w/ Clang/LLVM
77fcb48939fc Linux 5.4.60
53a856c5a6af drm/amd/display: dchubbub p-state warning during surface planes switch
4287c18a7d8f drm/amdgpu: Fix bug where DPM is not enabled after hibernate and resume
915ad46bdd4a drm: fix drm_dp_mst_port refcount leaks in drm_dp_mst_allocate_vcpi
f9f53b7c6a81 drm: Added orientation quirk for ASUS tablet model T103HAF
aeec14061d53 drm/panfrost: Use kvfree() to free bo->sgts
a202b42b94bc arm64: dts: marvell: espressobin: add ethernet alias
0f1c938ef82d khugepaged: retract_page_tables() remember to test exit
e47e00559893 sh: landisk: Add missing initialization of sh_io_port_base
64d358a9adb5 perf/x86/rapl: Fix missing psys sysfs attributes
5c90739d36ce tools build feature: Quote CC and CXX for their arguments
45989801d7cf perf bench mem: Always memset source before memcpy
306df54b5b8a ALSA: echoaudio: Fix potential Oops in snd_echo_resume()
8bc48c35a983 crypto: algif_aead - fix uninitialized ctx->init
a23269976109 mfd: dln2: Run event handler loop under spinlock
315b5cbe1aee i2c: iproc: fix race between client unreg and isr
8620d18575af test_kmod: avoid potential double free in trigger_config_run_type()
3457ba1acec2 fs/ufs: avoid potential u32 multiplication overflow
ba40d33e36b2 fs/minix: remove expected error message in block_to_path()
d91005b645d1 fs/minix: fix block limit check for V1 filesystems
6def476496a5 fs/minix: set s_maxbytes correctly
75cf7f895f56 nfs: Fix getxattr kernel panic and memory overflow
d09d6dca89e9 net: qcom/emac: add missed clk_disable_unprepare in error path of emac_clks_phase1_init
35b5e689abd9 drm/vmwgfx: Fix two list_for_each loop exit tests
95922cdab4ad drm/vmwgfx: Use correct vmw_legacy_display_unit pointer
1d8dce52a008 recordmcount: Fix build failure on non arm64
f41600c55789 Input: sentelic - fix error return when fsp_reg_write fails
8d7633b5aff9 x86/tsr: Fix tsc frequency enumeration bug on Lightning Mountain SoC
8645225c7180 md-cluster: Fix potential error pointer dereference in resize_bitmaps()
3fcd24040f55 watchdog: initialize device before misc_register
9340d8bfec94 nfs: nfs_file_write() should check for writeback errors
da14c05ad875 scsi: lpfc: nvmet: Avoid hang / use-after-free again when destroying targetport
c9220ff3b9cc openrisc: Fix oops caused when dumping stack
a6d5c5a398d6 libnvdimm/security: ensure sysfs poll thread woke up and fetch updated attr
dfb5d727d721 libnvdimm/security: fix a typo
0c51d8f5c83e clk: bcm2835: Do not use prediv with bcm2711's PLLs
1896dfc97c90 ubifs: Fix wrong orphan node deletion in ubifs_jnl_update|rename
7dccbf1111bf nfs: ensure correct writeback errors are returned on close()
9153e0d43710 i2c: rcar: avoid race when unregistering slave
4f69483568d6 tools build feature: Use CC and CXX from parent
3d0808f3c7d9 pwm: bcm-iproc: handle clk_get_rate() return
ba2c4d0e720b clk: clk-atlas6: fix return value check in atlas6_clk_init()
c7bd131f4335 clk: qcom: gcc-sdm660: Fix up gcc_mss_mnoc_bimc_axi_clk
422a01fc23d2 i2c: rcar: slave: only send STOP event when we have been addressed
043bc80399a8 iommu/vt-d: Enforce PASID devTLB field mask
99d1472ba802 clk: qcom: clk-alpha-pll: remove unused/incorrect PLL_CAL_VAL
f66d0154ed2f clk: qcom: gcc: fix sm8150 GPU and NPU clocks
a31ac4101981 iommu/omap: Check for failure of a call to omap_iommu_dump_ctx
34c920e2c858 selftests/powerpc: ptrace-pkey: Don't update expected UAMOR value
cf5078181528 selftests/powerpc: ptrace-pkey: Update the test to mark an invalid pkey correctly
e4a6919c9908 selftests/powerpc: ptrace-pkey: Rename variables to make it easier to follow code
ea777df6b8b9 clk: actions: Fix h_clk for Actions S500 SoC
0e0a146f978e dm rq: don't call blk_mq_queue_stopped() in dm_stop_queue()
386f82040c84 gpu: ipu-v3: image-convert: Wait for all EOFs before completing a tile
0f77e95efd75 gpu: ipu-v3: image-convert: Combine rotate/no-rotate irq handlers
e0a684edf6d7 crypto: caam - Remove broken arc4 support
64563d1dca80 mmc: renesas_sdhi_internal_dmac: clean up the code for dma complete
b638533ec6fa RDMA/counter: Allow manually bind QPs with different pids to same counter
e5a9bb4f1243 RDMA/counter: Only bind user QPs in auto mode
cf304df99fac devres: keep both device name and resource name in pretty name
ddd3934f7b39 crypto: af_alg - Fix regression on empty requests
9705f53eb01a USB: serial: ftdi_sio: clean up receive processing
aeefe7d15cf1 USB: serial: ftdi_sio: make process-packet buffer unsigned
8cab023c03aa selftests/bpf: test_progs use another shell exit on non-actions
de624fbac3eb selftests/bpf: Test_progs indicate to shell on non-actions
95c736a29105 IB/uverbs: Set IOVA on IB MR in uverbs layer
ea1cdb1bb80b media: rockchip: rga: Only set output CSC mode for RGB input
5f51ca677cd2 media: rockchip: rga: Introduce color fmt macros and refactor CSC mode logic
0f334b668455 RDMA/ipoib: Fix ABBA deadlock with ipoib_reap_ah()
5412efa6285a RDMA/ipoib: Return void from ipoib_ib_dev_stop()
ab67471562ad platform/chrome: cros_ec_ishtp: Fix a double-unlock issue
617da16f5ab9 mtd: rawnand: fsl_upm: Remove unused mtd var
e1f2606892f2 octeontx2-af: change (struct qmem)->entry_sz from u8 to u16
368caae37037 mfd: arizona: Ensure 32k clock is put on driver unbind and error
cf368b876f44 crypto: algif_aead - Only wake up when ctx->more is zero
bb0bba78d365 pinctrl: ingenic: Properly detect GPIO direction when configured for IRQ
974ca069d531 orangefs: get rid of knob code...
1752ab50e825 drm/imx: imx-ldb: Disable both channels for split mode in enc->disable()
988fcef346a3 remoteproc: qcom_q6v5_mss: Validate modem blob firmware size before load
babd6a4c3336 remoteproc: qcom_q6v5_mss: Validate MBA firmware size before load
73ba6991e981 remoteproc: qcom: q6v5: Update running state before requesting stop
55052ac61cb8 perf intel-pt: Fix duplicate branch after CBR
8214e74b662d perf intel-pt: Fix FUP packet state
169015f464d0 module: Correctly truncate sysfs sections output
54f44e3af24b pseries: Fix 64 bit logical memory block panic
37e3a1c08e2d ceph: handle zero-length feature mask in session messages
8953e8cb0d6a ceph: set sec_context xattr on symlink creation
12badd382453 watchdog: f71808e_wdt: clear watchdog timeout occurred flag
0f35915a0feb watchdog: f71808e_wdt: remove use of wrong watchdog_info option
4699d95a715b watchdog: f71808e_wdt: indicate WDIOF_CARDRESET support in watchdog_info.options
43e172e31bad tracing: Move pipe reference to trace array instead of current_tracer
9aab8b2b0f8f tracing: Use trace_sched_process_free() instead of exit() for pid tracing
bd23940da2d1 tracing/hwlat: Honor the tracing_cpumask
1424f0aa18dc kprobes: Fix NULL pointer dereference at kprobe_ftrace_handler
3a1208574658 ftrace: Setup correct FTRACE_FL_REGS flags for module
b47215b3749a mm/memory_hotplug: fix unpaired mem_hotplug_begin/done
aeeddba9b498 mm/page_counter.c: fix protection usage propagation
bd99ff4dc92b ocfs2: change slot number type s16 to u16
a6b238cac6d3 khugepaged: collapse_pte_mapped_thp() protect the pmd lock
687d366d0db1 khugepaged: collapse_pte_mapped_thp() flush the right range
8cdf68355312 ext2: fix missing percpu_counter_inc
6c7b42c8f01d MIPS: qi_lb60: Fix routing to audio amplifier
59909e23020f MIPS: CPU#0 is not hotpluggable
d3c9e815006e driver core: Avoid binding drivers to dead devices
0cf746d8b052 mac80211: fix misplaced while instead of if
c573e8673dc1 bcache: fix overflow in offset_to_stripe()
42dd8cc9e499 bcache: allocate meta data pages as compound pages
391b5d39faea md/raid5: Fix Force reconstruct-write io stuck in degraded raid5
28163868530b net/compat: Add missing sock updates for SCM_RIGHTS
6ea125ec644b net: stmmac: dwmac1000: provide multicast filter fallback
e92a02e47e16 net: ethernet: stmmac: Disable hardware multicast filter
eca5084aabdf media: vsp1: dl: Fix NULL pointer dereference on unbind
28bbbc45054c pinctrl: ingenic: Enhance support for IRQ_TYPE_EDGE_BOTH
9ba5f37fa353 powerpc: Fix circular dependency between percpu.h and mmu.h
9de20a6c4dd6 powerpc: Allow 4224 bytes of stack expansion for the signal frame
2150c25b76fb powerpc/ptdump: Fix build failure in hashpagetable.c
7a991df9e5cb cifs: Fix leak when handling lease break for cached root fid
545771537ec4 xtensa: fix xtensa_pmu_setup prototype
d1e2ec2e0b7d xtensa: add missing exclusive access state management
5efb3f91403c iio: dac: ad5592r: fix unbalanced mutex unlocks in ad5592r_read_raw()
1a5e5b3b7571 dt-bindings: iio: io-channel-mux: Fix compatible string in example code
ab58cc033124 arm64: perf: Correct the event index in sysfs
8c1431221374 btrfs: fix return value mixup in btrfs_get_extent
d256992d5105 btrfs: make sure SB_I_VERSION doesn't get unset by remount
5bed3387c8a1 btrfs: fix memory leaks after failure to lookup checksums during inode logging
f1d21b2688d9 btrfs: inode: fix NULL pointer dereference if inode doesn't need compression
7bbf647dbb5a btrfs: only search for left_info if there is no right_info in try_merge_free_space
38c8255af7d7 btrfs: fix messages after changing compression level by remount
242747612209 btrfs: fix race between page release and a fast fsync
ee6373070108 btrfs: don't WARN if we abort a transaction with EROFS
d8848f4c2555 btrfs: sysfs: use NOFS for device creation
e0e51f4fc488 btrfs: avoid possible signal interruption of btrfs_drop_snapshot() on relocation tree
2f29a31f394e btrfs: add missing check for nocow and compression inode flags
38ab14b1e27c btrfs: relocation: review the call sites which can be interrupted by signal
ae3f93cafd6f btrfs: move the chunk_mutex in btrfs_read_chunk_tree
98f55cd49671 btrfs: open device without device_list_mutex
3d3452920cac btrfs: don't traverse into the seed devices in show_devname
8bc3a5d8c2ae btrfs: remove no longer needed use of log_writers for the log root tree
938051408905 btrfs: stop incremening log_batch for the log root tree when syncing log
0ddf373adb42 btrfs: ref-verify: fix memory leak in add_block_entry
c16ba06f5204 btrfs: don't allocate anonymous block device for user invisible roots
d2731ac13ca5 btrfs: free anon block device right after subvolume deletion
207659ef151c btrfs: allow use of global block reserve for balance item deletion
7a6fc7c21962 PCI: qcom: Add support for tx term offset for rev 2.1.0
5956d3847502 PCI: qcom: Define some PARF params needed for ipq8064 SoC
588d5cbf4de7 PCI: Add device even if driver attach failed
d7caf80700f2 PCI: Mark AMD Navi10 GPU rev 0x00 ATS as broken
ae86233204ba PCI: hotplug: ACPI: Fix context refcounting in acpiphp_grab_context()
72ba9d544e60 genirq/PM: Always unlock IRQ descriptor in rearm_wake_irq()
a11f42496ac8 genirq/affinity: Make affinity setting if activated opt-in
582ee2cb6f90 smb3: warn on confusing error scenario with sec=krb5
f61e1c3638dd Linux 5.4.59
5de0b5247cba io_uring: Fix NULL pointer dereference in loop_rw_iter()
4db28111b2a3 s390/gmap: improve THP splitting
756a70b6dcc3 s390/dasd: fix inability to use DASD with DIAG driver
dccc66daeba5 xen/gntdev: Fix dmabuf import with non-zero sgt offset
8e41ac0bfdfd xen/balloon: make the balloon wait interruptible
ee4c180d93d0 xen/balloon: fix accounting in alloc_xenballooned_pages error path
db1f4c745a91 fs/minix: reject too-large maximum file size
8c7e720a165b fs/minix: don't allow getting deleted inodes
a5305f119907 fs/minix: check return value of sb_getblk()
5be9072b8121 bitfield.h: don't compile-time validate _val in FIELD_FIT
3e95a74f4c27 crypto: cpt - don't sleep of CRYPTO_TFM_REQ_MAY_SLEEP was not specified
28bd8f392f4a crypto: ccp - Fix use of merged scatterlists
3c660aa47304 crypto: qat - fix double free in qat_uclo_create_batch_init_list
d9add5d7d94b crypto: hisilicon - don't sleep of CRYPTO_TFM_REQ_MAY_SLEEP was not specified
17f9ba7229c4 pstore: Fix linking when crypto API disabled
1a2e558c8b30 tpm: Unify the mismatching TPM space buffer sizes
169d55c486f8 ALSA: usb-audio: add quirk for Pioneer DDJ-RB
a3ec61c84d85 irqdomain/treewide: Free firmware node after domain removal
35e1338bddcd ARM: 8992/1: Fix unwind_frame for clang-built kernels
cd17453fa96f parisc: mask out enable and reserved bits from sba imask
0d3897a7f527 parisc: Implement __smp_store_release and __smp_load_acquire barriers
8dfab4662001 parisc: Do not use an ordered store in pa_tlb_lock()
638e45c39f30 Revert "parisc: Revert "Release spinlocks using ordered store""
431d999bd098 Revert "parisc: Use ldcw instruction for SMP spinlock release barrier"
7612ce180e30 Revert "parisc: Drop LDCW barrier in CAS code when running UP"
15f7b186916d erofs: fix extended inode could cross boundary
a8e9efb55323 mtd: rawnand: qcom: avoid write to unavailable register
7ebb8fd40256 spi: spidev: Align buffers for DMA
e02c77edd9b0 include/asm-generic/vmlinux.lds.h: align ro_after_init
7e270e86b1b3 cpufreq: dt: fix oops on armada37xx
613a374f3fd6 cpufreq: Fix locking issues with governors
6d1e56826ea8 NFS: Don't return layout segments that are in use
046922d3248d NFS: Don't move layouts to plh_return_segs list while in use
3c512bd3dbbb io_uring: set ctx sq/cq entry count earlier
c6d2ddf1a30d drm/ttm/nouveau: don't call tt destroy callback on alloc failure.
86f95b631490 media: media-request: Fix crash if memory allocation fails
06d8ba514949 9p: Fix memory leak in v9fs_mount
10de419977bf ALSA: usb-audio: work around streaming quirk for MacroSilicon MS2109
1d2c4954e82b ALSA: usb-audio: fix overeager device match for MacroSilicon MS2109
d5f647e3a72a ALSA: usb-audio: Creative USB X-Fi Pro SB1095 volume knob support
8555fd99c111 ALSA: hda - fix the micmute led status for Lenovo ThinkCentre AIO
1f0e0ad76eae USB: serial: cp210x: enable usb generic throttle/unthrottle
3a8d1ca7204e USB: serial: cp210x: re-enable auto-RTS on open
378737e1eee2 net: initialize fastreuse on inet_inherit_port
dcedddbc7b20 net: refactor bind_bucket fastreuse into helper
8a337428a5af vmxnet3: use correct tcp hdr length when packet is encapsulated
e07d0ccd7fde tcp: correct read of TFO keys on big endian systems
49a5b473bc66 net/tls: Fix kmap usage
7bedf1d86298 net: Set fput_needed iff FDPUT_FPUT is set
47f873ac267b net: phy: fix memory leak in device-create error path
0b305f259ca9 net/nfc/rawsock.c: add CAP_NET_RAW check.
02618095ab45 net: Fix potential memory leak in proto_register()
f6c5d9f3361a drivers/net/wan/lapbether: Added needed_headroom and a skb->len check
de236de3df57 af_packet: TPACKET_V3: fix fill status rwlock imbalance
5ef739b7a5be crypto: aesni - add compatibility with IAS
c44efee6e432 x86/fsgsbase/64: Fix NULL deref in 86_fsgsbase_read_task
18d1bb497364 SUNRPC: Fix ("SUNRPC: Add "@len" parameter to gss_unwrap()")
789be9705ed1 svcrdma: Fix page leak in svc_rdma_recv_read_chunk()
fa6bd08869c5 pinctrl-single: fix pcs_parse_pinconf() return value
50abf1b9ad10 ocfs2: fix unbalanced locking
ba8a72193346 dlm: Fix kobject memleak
41e8b5afde8e net: thunderx: initialize VF's mailbox mutex before first usage
3084ecb02357 fsl/fman: fix eth hash table allocation
2997cea07f9e fsl/fman: check dereferencing null pointer
158ccb4f03b5 fsl/fman: fix unreachable code
a405fb3ffdab fsl/fman: fix dereference null return value
e9b3249a3df6 fsl/fman: use 32-bit unsigned integer
8c68da19fd02 net: spider_net: Fix the size used in a 'dma_free_coherent()' call
dc66a35ffee6 liquidio: Fix wrong return value in cn23xx_get_pf_num()
eb4afeaf861f net: ethernet: aquantia: Fix wrong return value
fe8571b4d5ac net/mlx5: Delete extra dump stack that gives nothing
87a43dac39c2 net/mlx5: DR, Change push vlan action sequence
a4301de4be41 tools, bpftool: Fix wrong return value in do_dump()
94bc0ab6043f tools, build: Propagate build failures from tools/build/Makefile.build
2684577dd9bc wl1251: fix always return 0 error
3bec3e41db0d rtw88: coex: only skip coex triggered by BT info
1b7546010b01 rtw88: fix short GI capability based on current bandwidth
ff1ecaf751d7 rtw88: fix LDPC field for RA info
fef9f09078b0 ice: Graceful error handling in HW table calloc failure
2fd47ea1e063 s390/qeth: don't process empty bridge port events
b8ae2bf5ccc6 ASoC: fsl_sai: Fix value of FSL_SAI_CR1_RFW_MASK
115da6e650ab ASoC: meson: axg-tdm-formatters: fix sclk inversion
0cc88bf69411 ASoC: meson: axg-tdmin: fix g12a skew
a9d54ebf8db0 ASoC: meson: axg-tdm-interface: fix link fmt setup
5299edbfc19a selftests/powerpc: Fix online CPU selection
5412751327e8 cpufreq: ap806: fix cpufreq driver needs ap cpu clk
0df3fad9c17f PCI: Release IVRS table in AMD ACS quirk
07783db29f89 RDMA/netlink: Remove CAP_NET_RAW check when dump a raw QP
04cf65b784d2 selftests/powerpc: Fix CPU affinity for child process
3e95f258a143 powerpc/boot: Fix CONFIG_PPC_MPC52XX references
69a797a04517 powerpc/32s: Fix CONFIG_BOOK3S_601 uses
09c2050239fb selftests/powerpc: Squash spurious errors due to device removal
5f56aa0b1fec xfs: fix inode allocation block res calculation precedence
5c0fd1e61b5a net: dsa: rtl8366: Fix VLAN set-up
8cd2a4878787 net: dsa: rtl8366: Fix VLAN semantics
495b9d0dd071 Bluetooth: hci_serdev: Only unregister device if it was registered
ba5c28f78461 Bluetooth: hci_h5: Set HCI_UART_RESET_ON_INIT to correct flags
8d91c73c13f1 power: supply: check if calc_soc succeeded in pm860x_init_battery
b2b8438ed831 Smack: prevent underflow in smk_set_cipso()
674992659a97 Smack: fix another vsscanf out of bounds
3a2cd06a3d93 RDMA/core: Fix return error value in _ib_modify_qp() to negative
16416a158743 PCI: cadence: Fix updating Vendor ID and Subsystem Vendor ID register
845601756341 macintosh/via-macii: Access autopoll_devs when inside lock
a88f86763cbc net: dsa: mv88e6xxx: MV88E6097 does not support jumbo configuration
f6f75b1756f7 scsi: mesh: Fix panic after host or bus reset
b41e8798f288 scsi: megaraid_sas: Clear affinity hint
1d7e19cf79f4 usb: gadget: f_uac2: fix AC Interface Header Descriptor wTotalLength
b2c2b88b0496 usb: dwc2: Fix error path in gadget registration
b8f3c361ca2c MIPS: OCTEON: add missing put_device() call in dwc3_octeon_device_init()
db2eabff57cc phy: armada-38x: fix NETA lockup when repeatedly switching speeds
2bf9418b7b11 mt76: mt7615: fix potential memory leak in mcu message handler
54c9afe415dc powerpc/perf: Fix missing is_sier_aviable() during build
53eeba79c152 coresight: tmc: Fix TMC mode read in tmc_read_unprepare_etb()
6482f5119946 thermal: ti-soc-thermal: Fix reversed condition in ti_thermal_expose_sensor()
c30281c4b28f usb: core: fix quirks_param_set() writing to a const pointer
92581069807b USB: serial: iuu_phoenix: fix led-activity helpers
278b532dfeaf spi: lantiq-ssc: Fix warning by using WQ_MEM_RECLAIM
7e206d89e1c7 gpu: ipu-v3: Restore RGB32, BGR32
e66ffe919ed4 drm/imx: tve: fix regulator_disable error path
1a279871012d drm/imx: fix use after free
44ae76d01d95 powerpc/book3s64/pkeys: Use PVR check instead of cpu feature
6112c341ba3a phy: renesas: rcar-gen3-usb2: move irq registration to init
e82e9db82faf PCI/ASPM: Add missing newline in sysfs 'policy'
c537bd0732ea ASoC: meson: fixes the missed kfree() for axg_card_add_tdm_loopback
2698fab03884 staging: rtl8192u: fix a dubious looking mask before a shift
209207562934 ima: Have the LSM free its audit rule
7ecfbee3b9c3 RDMA/rxe: Prevent access to wr->next ptr afrer wr is posted to send queue
4cf66d70b5ef RDMA/qedr: SRQ's bug fixes
978bef91cad7 powerpc/vdso: Fix vdso cpu truncation
7beea356fabb powerpc/rtas: don't online CPUs for partition suspend
936e927ece9b kernfs: do not call fsnotify() with name without a parent
b7fc8591cae4 mwifiex: Prevent memory corruption handling keys
0c0d30eaf31c scsi: scsi_debug: Add check for sdebug_max_queue during module init
6a292c4bc027 drm/bridge: sil_sii8620: initialize return of sii8620_readb
8ffa0cf2b662 phy: exynos5-usbdrd: Calibrating makes sense only for USB2.0 PHY
36f9ed95ec52 drm: panel: simple: Fix bpc for LG LB070WV8 panel
d25c81232007 leds: core: Flush scheduled work for system suspend
adbb26e2d44e kobject: Avoid premature parent object freeing in kobject_cleanup()
59f69f1edb56 drm/stm: repair runtime power management
cc5f55c46a71 PCI: Fix pci_cfg_wait queue locking problem
8fbefed6c3a0 RDMA/rxe: Skip dgid check in loopback mode
6093eae667d6 xfs: fix reflink quota reservation accounting error
2c5170b451b7 xfs: don't eat an EIO/ENOSPC writeback error when scrubbing data fork
deaf69f5b028 media: cros-ec-cec: do not bail on device_init_wakeup failure
951a21261577 media: exynos4-is: Add missed check for pinctrl_lookup_state()
210ab36cdaa9 media: firewire: Using uninitialized values in node_probe()
0c122fc90d02 ipvs: allow connection reuse for unconfirmed conntrack
45a769a10126 scsi: eesox: Fix different dev_id between request_irq() and free_irq()
76189426da56 scsi: powertec: Fix different dev_id between request_irq() and free_irq()
691081c0558a RDMA/core: Fix bogus WARN_ON during ib_unregister_device_queued()
67642ac2ac0b iavf: Fix updating statistics
8d5ce7e06ff8 iavf: fix error return code in iavf_init_get_resources()
f27a965b042f staging: vchiq_arm: Add a matching unregister call
87a30aa61f60 drm/radeon: fix array out-of-bounds read and write issues
db377d8caf08 cxl: Fix kobject memleak
835c6f7c0a94 drm/mipi: use dcs write for mipi_dsi_dcs_set_tear_scanline
6f2b14006d44 scsi: cumana_2: Fix different dev_id between request_irq() and free_irq()
d92cc98b7423 ASoC: Intel: bxt_rt298: add missing .owner field
a1773c8b04a4 ASoC: SOF: nocodec: add missing .owner field
d85cebc8656f media: omap3isp: Add missed v4l2_ctrl_handler_free() for preview_init_entities()
8fe0119f5c63 media: marvell-ccic: Add missed v4l2_async_notifier_cleanup()
79962a7a1dd1 media: cxusb-analog: fix V4L2 dependency
a728697b74b7 Bluetooth: btmtksdio: fix up firmware download sequence
ecab4ef93ce6 Bluetooth: btusb: fix up firmware download sequence
6db3579dd3a4 leds: lm355x: avoid enum conversion warning
cc51ca361059 clk: bcm63xx-gate: fix last clock availability
8bfd16c687cf drm/arm: fix unintentional integer overflow on left shift
018192e85860 drm/etnaviv: Fix error path on failure to enable bus clk
8080ccd31233 iio: improve IIO_CONCENTRATION channel type description
b4a09e491d38 ath10k: Acquire tx_lock in tx error paths
d9411fcc9a48 video: pxafb: Fix the function used to balance a 'dma_alloc_coherent()' call
703a2e85a3a8 console: newport_con: fix an issue about leak related system resources
e95d33905a4e video: fbdev: sm712fb: fix an issue about iounmap for a wrong address
d9e13b0c26cf btmrvl: Fix firmware filename for sd8997 chipset
671f14a14471 btmrvl: Fix firmware filename for sd8977 chipset
89b09156ed41 mwifiex: Fix firmware filename for sd8997 chipset
be9903c9ebe4 mwifiex: Fix firmware filename for sd8977 chipset
e3b04e1b5b03 agp/intel: Fix a memory leak on module initialisation failure
7669b6beb4fd drm/bridge: ti-sn65dsi86: Clear old error bits before AUX transfers
1a981f4d6c97 drm/gem: Fix a leak in drm_gem_objects_lookup()
167708cbebd3 drm/msm: ratelimit crtc event overflow error
1e8d2186551b ACPICA: Do not increment operation_region reference counts for field units
ca6654d7da59 bcache: fix super block seq numbers comparision in register_cache_set()
db9b14ae4b6a dyndbg: fix a BUG_ON in ddebug_describe_flags
8fb05790b55b usb: bdc: Halt controller on suspend
296184490e2c bdc: Fix bug causing crash after multiple disconnects
77d7ce9ccb33 usb: gadget: net2280: fix memory leak on probe error handling paths
7404ce0f639c mmc: sdhci-pci-o2micro: Bug fix for O2 host controller Seabird1
d000795c9f25 ionic: update eid test for overflow
691ae7c87ff7 gpu: host1x: debug: Fix multiple channels emitting messages simultaneously
ff3fde9d4519 iwlegacy: Check the return value of pcie_capability_read_*()
ef62e5411db2 platform/x86: asus-nb-wmi: add support for ASUS ROG Zephyrus G14 and G15
ce3ae44103ca brcmfmac: set state of hanger slot to FREE when flushing PSQ
1c53aefa2866 brcmfmac: To fix Bss Info flag definition Bug
29dd5e5309b1 brcmfmac: keep SDIO watchdog running when console_interval is non-zero
5908a17b247d bpf: Fix fds_example SIGSEGV error
4360d9b560bd drm/amd/powerplay: fix compile error with ARCH=arc
fae763f1357b drm/amdgpu/display bail early in dm_pp_get_static_clocks
87834546ea2c mm/mmap.c: Add cond_resched() for exit_mmap() CPU stalls
ae3033d38596 irqchip/irq-mtk-sysirq: Replace spinlock with raw_spinlock
d17931fbe9dd drm/radeon: disable AGP by default
238e32468e0d drm/debugfs: fix plain echo to connector "force" attribute
df91fe834bd4 drm/msm: Fix a null pointer access in msm_gem_shrinker_count()
fae8ff2dfd8d drm: msm: a6xx: fix gpu failure after system resume
0e76c2ffb8f0 usb: mtu3: clear dual mode of u3port when disable device
e633add66d17 btrfs: fix lockdep splat from btrfs_dump_space_info
7795eb18ce7d mmc: sdhci-cadence: do not use hardware tuning for SD mode
3b69bcd45426 drm/nouveau: fix multiple instances of reference count leaks
db0a2e4857dd drm/nouveau: fix reference count leak in nouveau_debugfs_strap_peek
20e7c4456069 drm/etnaviv: fix ref count leak via pm_runtime_get_sync
274f4e9c575a arm64: dts: hisilicon: hikey: fixes to comply with adi, adv7533 DT binding
454a00e9ed83 drm/nouveau/kms/nv50-: Fix disabling dithering
d72c0f225a2f md-cluster: fix wild pointer of unlock_all_bitmaps()
2ac7df0910e5 bus: ti-sysc: Add missing quirk flags for usb_host_hs
6754d2a86c43 video: fbdev: neofb: fix memory leak in neo_scan_monitor()
9ca426693563 video: fbdev: savage: fix memory leak on error handling path in probe
8b8d17d9ff8a crypto: aesni - Fix build with LLVM_IAS=1
cab45cfa00b8 drm/radeon: Fix reference count leaks caused by pm_runtime_get_sync
2f04f5bcf6d9 drm/amdgpu: avoid dereferencing a NULL pointer
6402b231824f fs/btrfs: Add cond_resched() for try_release_extent_mapping() stalls
a6619810135b loop: be paranoid on exit and prevent new additions / removals
0e656b7e85c3 Bluetooth: add a mutex lock to avoid UAF in do_enale_set
f8b0407f6a5f soc: qcom: rpmh-rsc: Set suppress_bind_attrs flag
94fd6f72a826 drm/tilcdc: fix leak & null ref in panel_connector_get_modes
86f305a9aca0 nvme-multipath: do not fall back to __nvme_find_path() for non-optimized paths
f0a8c0254fde nvme-multipath: fix logic for non-optimized paths
4e8691ba0e78 nvme-rdma: fix controller reset hang during traffic
b98a96662a4e nvme-tcp: fix controller reset hang during traffic
6f01de256dd0 md: raid0/linear: fix dereference before null check on pointer mddev
0f09c88f207c seccomp: Fix ioctl number for SECCOMP_IOCTL_NOTIF_ID_VALID
7915a3c04139 irqchip/ti-sci-inta: Fix return value about devm_ioremap_resource()
2f53a4b54e25 iocost: Fix check condition of iocg abs_vdebt
3f4f3b350a8a ARM: socfpga: PM: add missing put_device() call in socfpga_setup_ocram_self_refresh()
9600bdd6924a spi: rockchip: Fix error in SPI slave pio read
0b1799662a61 io_uring: fix sq array offset calculation
afa16b50e2aa regulator: fix memory leak on error path of regulator_register()
80242590651c recordmcount: only record relocation of type R_AARCH64_CALL26 on arm64.
3a17c7bfe705 tpm: Require that all digests are present in TCG_PCR_EVENT2 structures
b1fe27d227c6 spi: lantiq: fix: Rx overflow error in full duplex mode
e22730350d9e ARM: dts: sunxi: bananapi-m2-plus-v1.2: Fix CPU supply voltages
acbe4a1dc54c ARM: dts: sunxi: bananapi-m2-plus-v1.2: Add regulator supply to all CPU cores
cd9f5d2b3999 ARM: at91: pm: add missing put_device() call in at91_pm_sram_init()
1b3cb69fd559 ARM: dts: gose: Fix ports node name for adv7612
e21665164e99 ARM: dts: gose: Fix ports node name for adv7180
4361bec62bda platform/x86: intel-vbtn: Fix return value check in check_acpi_dev()
ed48a02d4cbd platform/x86: intel-hid: Fix return value check in check_acpi_dev()
78448034fafb m68k: mac: Fix IOP status/control register writes
b8ad79dde63f m68k: mac: Don't send IOP message until channel is idle
38702b9081c9 clk: scmi: Fix min and max rate when registering clocks with discrete rates
047187eb0a3f sched/uclamp: Fix initialization of struct uclamp_rq
4d7115d29201 arm64: dts: exynos: Fix silent hang after boot on Espresso
420acbfdd64b firmware: arm_scmi: Fix SCMI genpd domain probing
0155cd348be2 ARM: exynos: MCPM: Restore big.LITTLE cpuidle support
489ee1f21993 crypto: ccree - fix resource leak on error path
6a291f9c21e4 blktrace: fix debugfs use after free
34108464f808 arm64: dts: qcom: msm8916: Replace invalid bias-pull-none property
f2b639b2aa21 crc-t10dif: Fix potential crypto notify dead-lock
c73eec04e666 EDAC: Fix reference count leaks
192b8516c99c arm64: dts: rockchip: fix rk3399-puma gmac reset gpio
da9dfd06dbaa arm64: dts: rockchip: fix rk3399-puma vcc5v0-host gpio
066f85458d9c arm64: dts: rockchip: fix rk3368-lion gmac reset gpio
e8eb09e542c1 sched: correct SD_flags returned by tl->sd_flags()
b8d9908c9d3d sched/fair: Fix NOHZ next idle balance
072d1300f1ce x86/mce/inject: Fix a wrong assignment of i_mce.status
a36ff7a40d11 clk: qcom: clk-rpmh: Wait for completion when enabling clocks
a02df82a59c3 fs/io_uring.c: Fix uninitialized variable is referenced in io_submit_sqe
bd1584865c12 nvme: add a Identify Namespace Identification Descriptor list quirk
039b66468fc4 HID: input: Fix devices that return multiple bytes in battery report
16d2fb138f98 tracepoint: Mark __tracepoint_string's __used

Signed-off-by: Jens Rehsack <sno@netbsd.org>