### PR TITLE
gstreamer1.0-plugins-bad: Remove un-necessary opencv dependency

### DIFF
--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.16.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.16.imx.bb
@@ -3,9 +3,7 @@ require recipes-multimedia/gstreamer/gstreamer1.0-plugins-common.inc
 DEPENDS_append_imxgpu2d = " virtual/libg2d"
 DEPENDS_append_mx8 = " libdrm"
 
-PACKAGECONFIG_append_mx6q = " opencv"
-PACKAGECONFIG_append_mx6qp = " opencv"
-PACKAGECONFIG_append_mx8 = " opencv kms"
+PACKAGECONFIG_append_mx8 = " kms"
 
 DEFAULT_PREFERENCE = "-1"
 


### PR DESCRIPTION
OpenCV is no longer required, so remove it from PACKAGECONFIG.

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>