### PR TITLE
opencv: Drop removal of v4l support

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-support/opencv/opencv_4.%.bbappend
+++ b/dynamic-layers/openembedded-layer/recipes-support/opencv/opencv_4.%.bbappend
@@ -1,3 +1,0 @@
-FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
-
-PACKAGECONFIG_remove_imxgpu2d = "v4l"


### PR DESCRIPTION
In the past, i.MX gstreamer camera didn't work well with OpenCV v4l,
so v4l was disabled. Now that i.MX gstreamer is no longer using
OpenCV, v4l support can be restored.

Fixes #475

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>