### PR TITLE
imx6sxsabreauto: Switch virtual/bootloader to u-boot-fslc

### DIFF
--- a/conf/machine/imx6sxsabreauto.conf
+++ b/conf/machine/imx6sxsabreauto.conf
@@ -12,8 +12,8 @@ require conf/machine/include/tune-cortexa9.inc
 KERNEL_DEVICETREE = "imx6sx-sabreauto.dtb"
 KERNEL_DEVICETREE_use-mainline-bsp = "imx6sx-sabreauto.dtb"
 
-PREFERRED_PROVIDER_u-boot = "u-boot-imx"
-PREFERRED_PROVIDER_virtual/bootloader = "u-boot-imx"
+PREFERRED_PROVIDER_u-boot = "u-boot-fslc"
+PREFERRED_PROVIDER_virtual/bootloader = "u-boot-fslc"
 
 UBOOT_CONFIG ??= "sd"
 UBOOT_CONFIG[sd] = "mx6sxsabreauto_config,sdcard"


### PR DESCRIPTION
The virtual/bootloader for this board used to be u-boot-imx which does
not include the board in COMPATIBLE_MACHINE any more, so the choice is
migrate to u-boot-fslc.

The error message:
   ERROR: Nothing PROVIDES 'virtual/bootloader' (but /media/daiane/TRIFORCE/yocto/dunfell/sources/poky/meta/recipes-core/images/core-image-minimal.bb DEPENDS on or otherwise requires it)
   u-boot-imx PROVIDES virtual/bootloader but was skipped: incompatible with machine imx6sxsabreauto (not in COMPATIBLE_MACHINE)

Signed-off-by: Daiane Angolini <daiane.angolini@nxp.com>