### PR TITLE
Introduce imx8mpevk machine support

### DIFF
--- a/conf/machine/imx8mpevk.conf
+++ b/conf/machine/imx8mpevk.conf
@@ -1,0 +1,66 @@
+#@TYPE: Machine
+#@NAME: NXP i.MX8MP Evaluation Kit and i.MX8MP Evaluation Kit
+#@SOC: i.MX8MP
+#@DESCRIPTION: Machine configuration for NXP i.MX8MP EVK
+#@MAINTAINER: Alexandru Palalau <ioan-alexandru.palalau@nxp.com>
+
+MACHINEOVERRIDES =. "mx8:mx8m:mx8mp:"
+
+require conf/machine/include/imx-base.inc
+require conf/machine/include/tune-cortexa53.inc
+
+IMX_DEFAULT_BSP = "nxp"
+
+MACHINE_FEATURES += " pci wifi bluetooth optee mrvl8997"
+
+KERNEL_DEVICETREE = " \
+	freescale/imx8mp-ab2.dtb \
+	freescale/imx8mp-evk-basler.dtb \
+	freescale/imx8mp-evk.dtb \
+	freescale/imx8mp-evk-dsp.dtb \
+	freescale/imx8mp-evk-flexcan2.dtb \
+	freescale/imx8mp-evk-inmate.dtb \
+	freescale/imx8mp-evk-jdi-wuxga-lvds-panel.dtb \
+	freescale/imx8mp-evk-it6263-lvds-dual-channel.dtb \
+	freescale/imx8mp-evk-ov2775.dtb \
+	freescale/imx8mp-evk-rm67191.dtb \
+	freescale/imx8mp-evk-root.dtb \
+	freescale/imx8mp-evk-rpmsg.dtb \
+	freescale/imx8mp-evk-sof-wm8960.dtb \
+"
+
+UBOOT_CONFIG ??= "sd"
+UBOOT_CONFIG[sd] = "imx8mp_evk_defconfig,sdcard"
+UBOOT_CONFIG[fspi] = "imx8mp_evk_defconfig"
+UBOOT_CONFIG[ecc] = "imx8mp_evk_inline_ecc_defconfig"
+UBOOT_CONFIG[mfgtool] = "imx8mp_evk_defconfig"
+SPL_BINARY = "spl/u-boot-spl.bin"
+
+# Set DDR FIRMWARE
+DDR_FIRMWARE_NAME = " \
+	lpddr4_pmu_train_1d_dmem_201904.bin \
+	lpddr4_pmu_train_1d_imem_201904.bin \
+	lpddr4_pmu_train_2d_dmem_201904.bin \
+	lpddr4_pmu_train_2d_imem_201904.bin \
+"
+
+# Set u-boot DTB
+UBOOT_DTB_NAME = "imx8mp-evk.dtb"
+
+# Set imx-mkimage boot target
+IMXBOOT_TARGETS = "${@bb.utils.contains('UBOOT_CONFIG', 'fspi', 'flash_evk_flexspi', 'flash_evk', d)}"
+
+# Set Serial console
+SERIAL_CONSOLES = "115200;ttymxc1"
+
+IMAGE_BOOTLOADER = "imx-boot"
+
+LOADADDR = ""
+UBOOT_SUFFIX = "bin"
+UBOOT_MAKE_TARGET = ""
+IMX_BOOT_SEEK = "32"
+
+OPTEE_BIN_EXT = "8mp"
+
+# Add additional firmware
+MACHINE_FIRMWARE_append = " linux-firmware-ath10k"

--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -53,6 +53,7 @@ UBOOT_ENTRYPOINT_mx7 = "0x80008000"
 UBOOT_ENTRYPOINT_mx7ulp = "0x60008000"
 UBOOT_ENTRYPOINT_mx8mm  = "0x40480000"
 UBOOT_ENTRYPOINT_mx8mn  = "0x40480000"
+UBOOT_ENTRYPOINT_mx8mp  = "0x40480000"
 UBOOT_ENTRYPOINT_mx8mq  = "0x40480000"
 UBOOT_ENTRYPOINT_vf = "0x80008000"
 
@@ -84,6 +85,7 @@ DEFAULTTUNE_vf     ?= "cortexa5thf-neon"
 
 DEFAULTTUNE_mx8mm  ?= "cortexa53-crypto"
 DEFAULTTUNE_mx8mn  ?= "cortexa53-crypto"
+DEFAULTTUNE_mx8mp  ?= "cortexa53-crypto"
 DEFAULTTUNE_mx8mq  ?= "cortexa53-crypto"
 DEFAULTTUNE_mx8qm  ?= "cortexa72-cortexa53-crypto"
 DEFAULTTUNE_mx8qxp ?= "cortexa35-crypto"
@@ -103,6 +105,7 @@ MACHINEOVERRIDES_EXTENDER_mx7ulp = "imxfbdev:imxpxp:imxgpu:imxgpu2d:imxgpu3d"
 MACHINEOVERRIDES_EXTENDER_mx8qm  = "imxdrm:imxdpu:imxgpu:imxgpu2d:imxgpu3d"
 MACHINEOVERRIDES_EXTENDER_mx8mm  = "imxdrm:imxvpu:imxgpu:imxgpu2d:imxgpu3d"
 MACHINEOVERRIDES_EXTENDER_mx8mn  = "imxdrm:imxgpu:imxgpu3d"
+MACHINEOVERRIDES_EXTENDER_mx8mp  = "imxdrm:imxvpu:imxgpu:imxgpu2d:imxgpu3d"
 MACHINEOVERRIDES_EXTENDER_mx8mq  = "imxdrm:imxvpu:imxgpu:imxgpu3d"
 MACHINEOVERRIDES_EXTENDER_mx8qxp = "imxdrm:imxdpu:imxgpu:imxgpu2d:imxgpu3d"
 
@@ -126,6 +129,7 @@ MACHINEOVERRIDES_EXTENDER_FILTER_OUT_use-mainline-bsp = " \
     mx8qm \
     mx8mm \
     mx8mn \
+    mx8mp \
     mx8mq \
     mx8qxp \
 "
@@ -146,6 +150,7 @@ MACHINE_SOCARCH_SUFFIX_mx6ull = "-mx6ul"
 MACHINE_SOCARCH_SUFFIX_mx8qm  = "-mx8"
 MACHINE_SOCARCH_SUFFIX_mx8mm  = "-mx8mm"
 MACHINE_SOCARCH_SUFFIX_mx8mn  = "-mx8mn"
+MACHINE_SOCARCH_SUFFIX_mx8mp  = "-mx8mp"
 MACHINE_SOCARCH_SUFFIX_mx8mq  = "-mx8m"
 MACHINE_SOCARCH_SUFFIX_mx8qxp = "-mx8"
 MACHINE_SOCARCH_SUFFIX_use-mainline-bsp = "-imx"
@@ -226,6 +231,7 @@ MACHINE_FIRMWARE_append_mx6sll = " firmware-imx-epdc"
 MACHINE_FIRMWARE_append_mx6ull = " firmware-imx-epdc"
 MACHINE_FIRMWARE_append_mx53 = " firmware-imx-vpu-imx53 firmware-imx-sdma-imx53"
 MACHINE_FIRMWARE_append_mx51 = " firmware-imx-vpu-imx51 firmware-imx-sdma-imx51"
+MACHINE_FIRMWARE_append_mx8mp  = " firmware-imx-easrc-imx8mn firmware-imx-xcvr-imx8mp firmware-sof-imx"
 MACHINE_FIRMWARE_append_use-mainline-bsp = " linux-firmware-imx-sdma-imx6q linux-firmware-imx-sdma-imx7d firmware-imx-vpu-imx6q firmware-imx-vpu-imx6d"
 
 # FIXME: Needs addition of firmware-imx of official BSPs
@@ -260,14 +266,17 @@ MACHINE_EXTRA_RRECOMMENDS += " \
 "
 
 # GStreamer 1.0 plugins
-MACHINE_GSTREAMER_1_0_PLUGIN ?= ""
-MACHINE_GSTREAMER_1_0_PLUGIN_mx6dl ?= "gstreamer1.0-plugins-imx-meta"
-MACHINE_GSTREAMER_1_0_PLUGIN_mx6q ?= "gstreamer1.0-plugins-imx-meta"
-MACHINE_GSTREAMER_1_0_PLUGIN_mx6sl ?= "gstreamer1.0-plugins-imx-meta"
-MACHINE_GSTREAMER_1_0_PLUGIN_mx6sx ?= "gstreamer1.0-plugins-imx-meta"
-MACHINE_GSTREAMER_1_0_PLUGIN_mx6ul ?= "gstreamer1.0-plugins-imx-meta"
+MACHINE_GSTREAMER_1_0_PLUGIN        ?= ""
+MACHINE_GSTREAMER_1_0_PLUGIN_mx6dl  ?= "gstreamer1.0-plugins-imx-meta"
+MACHINE_GSTREAMER_1_0_PLUGIN_mx6q   ?= "gstreamer1.0-plugins-imx-meta"
+MACHINE_GSTREAMER_1_0_PLUGIN_mx6sl  ?= "gstreamer1.0-plugins-imx-meta"
+MACHINE_GSTREAMER_1_0_PLUGIN_mx6sx  ?= "gstreamer1.0-plugins-imx-meta"
+MACHINE_GSTREAMER_1_0_PLUGIN_mx6ul  ?= "gstreamer1.0-plugins-imx-meta"
 MACHINE_GSTREAMER_1_0_PLUGIN_mx6ull ?= "gstreamer1.0-plugins-imx-meta"
-MACHINE_GSTREAMER_1_0_PLUGIN_mx7d ?= "gstreamer1.0-plugins-imx-meta"
+MACHINE_GSTREAMER_1_0_PLUGIN_mx7d   ?= "gstreamer1.0-plugins-imx-meta"
+MACHINE_GSTREAMER_1_0_PLUGIN_mx8mm  ?= "imx-gst1.0-plugin"
+MACHINE_GSTREAMER_1_0_PLUGIN_mx8mn  ?= "imx-gst1.0-plugin"
+MACHINE_GSTREAMER_1_0_PLUGIN_mx8mp  ?= "imx-gst1.0-plugin"
 
 # Determines if the SoC has support for Vivante kernel driver
 SOC_HAS_VIVANTE_KERNEL_DRIVER_SUPPORT        = "0"

--- a/recipes-bsp/firmware-imx/firmware-sof-imx_1.5.0-1.bb
+++ b/recipes-bsp/firmware-imx/firmware-sof-imx_1.5.0-1.bb
@@ -1,0 +1,24 @@
+# Copyright (C) 2020 Mihai Lindner <mihai.lindner@nxp.com>
+# Released under the MIT license (see COPYING.MIT for the terms)
+
+DESCRIPTION = "Sound Open Firmware"
+HOMEPAGE = "https://www.sofproject.org"
+SECTION = "base"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENCE;md5=0f00d99239d922ffd13cabef83b33444"
+
+SRC_URI = "${FSL_MIRROR}/sof-imx-${PV}.tar.gz"
+SRC_URI[md5sum] = "c03aa6a07570b2e7b8f60ab859b8f24a"
+SRC_URI[sha256sum] = "d6fecb5f398ecce4fefb7f98a35c9c2741735ccc4668d676bcf53b1d4ebbe778"
+
+S = "${WORKDIR}/sof-imx-${PV}"
+
+inherit allarch
+
+do_install() {
+    # Install sof and sof-tplg folder
+    install -d ${D}${nonarch_base_libdir}/firmware/imx/
+    cp -r sof* ${D}${nonarch_base_libdir}/firmware/imx/
+}
+
+FILES_${PN} = "${nonarch_base_libdir}/firmware/imx"

--- a/recipes-bsp/imx-vpu-hantro-vc/imx-vpu-hantro-vc_1.1.0.bb
+++ b/recipes-bsp/imx-vpu-hantro-vc/imx-vpu-hantro-vc_1.1.0.bb
@@ -1,0 +1,16 @@
+# Copyright (C) 2019-2020 NXP
+
+DESCRIPTION = "i.MX VC8000E Encoder library"
+LICENSE = "Proprietary"
+LIC_FILES_CHKSUM = "file://COPYING;md5=228c72f2a91452b8a03c4cab30f30ef9"
+
+inherit fsl-eula-unpack
+
+SRC_URI = "${FSL_MIRROR}/${BP}.bin;fsl-eula=true"
+
+S = "${WORKDIR}/${BPN}-${PV}"
+
+SRC_URI[md5sum] = "5c254523ae4c44491ea838e84e9aee49"
+SRC_URI[sha256sum] = "c5dd1fbf8c9776d7a2844a225e0aa2e489aa24eaab8f55cb48a6e3184def235d"
+
+COMPATIBLE_MACHINE = "(imx8mpevk)"

--- a/recipes-graphics/wayland/weston-init.bbappend
+++ b/recipes-graphics/wayland/weston-init.bbappend
@@ -21,6 +21,9 @@ INI_UNCOMMENT_ASSIGNMENTS_append_mx7ulp = " \
 INI_UNCOMMENT_ASSIGNMENTS_append_mx8mm = " \
     use-g2d=1 \
 "
+INI_UNCOMMENT_ASSIGNMENTS_append_mx8mp = " \
+    use-g2d=1 \
+"
 INI_UNCOMMENT_ASSIGNMENTS_append_mx8mq = " \
     gbm-format=argb8888 \
     \\[shell\\] \

--- a/recipes-multimedia/libimxvpuapi/libimxvpuapi2_2.0.1.bb
+++ b/recipes-multimedia/libimxvpuapi/libimxvpuapi2_2.0.1.bb
@@ -18,6 +18,7 @@ inherit waf pkgconfig use-imx-headers
 IMX_PLATFORM_mx6 = "imx6"
 IMX_PLATFORM_mx8mq = "imx8m"
 IMX_PLATFORM_mx8mm = "imx8mm"
+IMX_PLATFORM_mx8mp = "imx8mm"
 
 EXTRA_OECONF = "--imx-platform=${IMX_PLATFORM} --libdir=${libdir} --imx-headers=${STAGING_INCDIR_IMX} --sysroot-path=${RECIPE_SYSROOT}"
 


### PR DESCRIPTION
This PR introduced a support for new _i.MX8M Plus_ SoC, which is introduced as a part of NXP `5.4.24-2.1.0` release.

There are few recipes, which are required for _imx8mpevk_ machine and are ported from NXP release.

This is a continuation of the #456 

@thochstein Can you please take a look at this PR and give our feedback if there are no missing pieces, which are required for _i.MX8M Plus_?

-- andrey