### PR TITLE
weston-imx: remove also xwayland from package config

### DIFF
--- a/recipes-graphics/wayland/weston_8.0.0.imx.bb
+++ b/recipes-graphics/wayland/weston_8.0.0.imx.bb
@@ -144,7 +144,7 @@ PACKAGECONFIG_OPENGL              = "opengl"
 PACKAGECONFIG_OPENGL_imxgpu2d     = ""
 PACKAGECONFIG_OPENGL_imxgpu3d     = "opengl"
 
-PACKAGECONFIG_remove = "wayland x11"
+PACKAGECONFIG_remove = "wayland x11 xwayland"
 PACKAGECONFIG_append = " ${@bb.utils.filter('DISTRO_FEATURES', '${PACKAGECONFIG_OPENGL}', d)}"
 
 PACKAGECONFIG_remove_imxfbdev = "kms"


### PR DESCRIPTION
Commit [5a5c5dd23ea0173ef16073c3c651aec89b5a67c1] removes x11 and
wayland from PACKAGECONFIG, but when wayland with X11 distro is used -
this leaves the xwayland package config option enabled.

Without x11 and wayland in PACKAGECONFIG, xwayland cannot be enabled so
remove this config option as well.

Signed-off-by: Andrey Zhizhikin <andrey.z@gmail.com>