### PR TITLE
[dunfell]: waffle: revert "waffle: fix patch fuzz QA warning"

### DIFF
--- a/recipes-graphics/waffle/waffle/0001-meson-Add-missing-wayland-dependency-on-EGL.patch
+++ b/recipes-graphics/waffle/waffle/0001-meson-Add-missing-wayland-dependency-on-EGL.patch
@@ -1,4 +1,4 @@
-From 87fc7761cff5931a58984c7f7e78f421a0660e0e Mon Sep 17 00:00:00 2001
+From 932c21d2851fe79bf4fe55d3b613f71f65762adb Mon Sep 17 00:00:00 2001
 From: Tom Hochstein <tom.hochstein@nxp.com>
 Date: Wed, 22 Apr 2020 13:40:04 -0500
 Subject: [PATCH] meson: Add missing wayland dependency on EGL
@@ -9,13 +9,12 @@ missing dependency.
 Upstream-Status: Pending
 
 Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>
-
 ---
  meson.build | 6 ++++--
  1 file changed, 4 insertions(+), 2 deletions(-)
 
 diff --git a/meson.build b/meson.build
-index ca8b127..efb51f4 100644
+index 957737c..4ebb022 100644
 --- a/meson.build
 +++ b/meson.build
 @@ -65,6 +65,7 @@ dep_gl = _dep_null
@@ -28,7 +27,7 @@ index ca8b127..efb51f4 100644
  dep_udev = _dep_null
 @@ -90,7 +91,8 @@ else
    dep_wayland_client = dependency(
-     'wayland-client', version : '>= 1.10', required : get_option('wayland'),
+     'wayland-client', version : '>= 1.0', required : get_option('wayland'),
    )
 -  dep_wayland_egl = dependency(
 +  dep_wayland_egl = dependency('egl', required : get_option('wayland'))
@@ -45,3 +44,6 @@ index ca8b127..efb51f4 100644
    build_glx = dep_gl.found()
    build_gbm = dep_gbm.found() and dep_udev.found()
    build_surfaceless = dep_egl.found()
+-- 
+2.17.1
+

--- a/recipes-graphics/waffle/waffle/0002-meson-Separate-surfaceless-option-from-x11.patch
+++ b/recipes-graphics/waffle/waffle/0002-meson-Separate-surfaceless-option-from-x11.patch
@@ -1,7 +1,7 @@
-From 12ac4372cc6a66e83b61f8510bdaa4f11c72113d Mon Sep 17 00:00:00 2001
+From 451381a61ad0c96e870da2325fc188eaa3d91fec Mon Sep 17 00:00:00 2001
 From: Tom Hochstein <tom.hochstein@nxp.com>
 Date: Wed, 22 Apr 2020 14:08:36 -0500
-Subject: [PATCH] meson: Separate surfaceless option from x11
+Subject: [PATCH 2/2] meson: Separate surfaceless option from x11
 
 Allow surfaceless build separate from the x11 option.
 Also require gbm for surfaceless build.
@@ -9,13 +9,12 @@ Also require gbm for surfaceless build.
 Upstream-Status: Pending
 
 Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>
-
 ---
  meson.build | 5 ++++-
  1 file changed, 4 insertions(+), 1 deletion(-)
 
 diff --git a/meson.build b/meson.build
-index efb51f4..0ee3ee5 100644
+index 4ebb022..0705f61 100644
 --- a/meson.build
 +++ b/meson.build
 @@ -72,6 +72,7 @@ dep_udev = _dep_null
@@ -42,3 +41,6 @@ index efb51f4..0ee3ee5 100644
  endif
  
  dep_bash = dependency('bash-completion', required : false)
+-- 
+2.17.1
+


### PR DESCRIPTION
Current waffle release present on the dunfell branch in upstream is
1.6.0, while master upstream version is 1.6.1.

Due to this version mismatch, patches applied on master do not apply
clean on dunfell release.

Revert commit [81262efe6e9eb8ac0ed345abccbf80233707dcc3] which resolved
patch fuzz when waffle 1.6.1 is built, and keep the old versions of
patch files which are matching waffle 1.6.0.

Signed-off-by: Andrey Zhizhikin <andrey.zhizhikin@leica-geosystems.com>