### PR TITLE
imx-boot: fix upgrade to version 1.0 for custom dtbs

### DIFF
--- a/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
+++ b/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
@@ -136,10 +136,10 @@ do_compile() {
         if [ "$target" = "flash_linux_m4_no_v2x" ]; then
            # Special target build for i.MX 8DXL with V2X off
            bbnote "building ${SOC_TARGET} - ${REV_OPTION} V2X=NO ${target}"
-           make SOC=${SOC_TARGET} ${REV_OPTION} V2X=NO  flash_linux_m4
+           make SOC=${SOC_TARGET} dtbs=${UBOOT_DTB_NAME} ${REV_OPTION} V2X=NO  flash_linux_m4
         else
            bbnote "building ${SOC_TARGET} - ${REV_OPTION} ${target}"
-           make SOC=${SOC_TARGET} ${REV_OPTION} ${target}
+           make SOC=${SOC_TARGET} dtbs=${UBOOT_DTB_NAME} ${REV_OPTION} ${target}
         fi
         if [ -e "${BOOT_STAGING}/flash.bin" ]; then
             cp ${BOOT_STAGING}/flash.bin ${S}/${BOOT_CONFIG_MACHINE}-${target}


### PR DESCRIPTION
The dtbs argument wasn't carried from v0.2 to v1.0, ending up throwing
the following error for us (as using custom dtb):
| ./../scripts/dtb_check.sh imx8mm-evk.dtb evk.dtb
|  Can't find u-boot DTB file, please copy from u-boot
| soc.mak:138: recipe for target 'evk.dtb' failed
| make[1]: *** [evk.dtb] Error 254
| Makefile:22: recipe for target 'flash_evk' failed

Fixes: b98b3c88 "imx-mkimage: upgrade to version 1.0"

Signed-off-by: Gary Bisson <gary.bisson@boundarydevices.com>