### PR TITLE
imx-boot: add back LD_LIBRARY_PATH exporting

### DIFF
--- a/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
+++ b/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
@@ -126,6 +126,9 @@ compile_mx8x() {
     fi
 }
 do_compile() {
+    # mkimage_uboot requires libssl.so.1.1 from ${STAGING_LIBDIR_NATIVE}
+    export LD_LIBRARY_PATH=${STAGING_LIBDIR_NATIVE}:$LD_LIBRARY_PATH
+
     # mkimage for i.MX8
     # Copy TEE binary to SoC target folder to mkimage
     if ${DEPLOY_OPTEE}; then


### PR DESCRIPTION
It was dropped by commit 65100fad:
[ imx-mkimage: upgrade to version 1.0 ]

after that, the following error was observed again:
| ./mkimage_uboot -E -p 0x3000 -f u-boot.its u-boot.itb
| ./mkimage_uboot: error while loading shared libraries: libssl.so.1.1: cannot open shared object file: No such file or directory

Signed-off-by: Ming Liu <liu.ming50@gmail.com>