### PR TITLE
xf86-video-imx-vivante: Remove trailing slash from S

### DIFF
--- a/recipes-graphics/xorg-driver/xf86-video-imx-vivante_6.4.0.p0.0.bb
+++ b/recipes-graphics/xorg-driver/xf86-video-imx-vivante_6.4.0.p0.0.bb
@@ -18,7 +18,7 @@ SRCBRANCH = "imx_exa_viv6_g2d"
 SRC_URI = "git://source.codeaurora.org/external/imx/xf86-video-imx-vivante.git;protocol=https;branch=${SRCBRANCH} \
            file://rc.autohdmi"
 
-S = "${WORKDIR}/git/"
+S = "${WORKDIR}/git"
 
 INITSCRIPT_PACKAGES = "xserver-xorg-extension-viv-autohdmi"
 INITSCRIPT_NAME = "rc.autohdmi"


### PR DESCRIPTION
Signed-off-by: Khem Raj <raj.khem@gmail.com>