### PR TITLE
Consolidated Kernel update (v5.4.71)

### DIFF
--- a/recipes-kernel/linux/linux-fslc-imx_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_5.4.bb
@@ -28,7 +28,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v5.4.70
+#    tag: v5.4.71
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
@@ -73,17 +73,17 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
 SRCBRANCH = "5.4-2.1.x-imx"
-SRCREV = "2d1241e38347784c5328fc45e790c435c78b4583"
+SRCREV = "4236f3c63f99cbd22601f4158f8a6166688af5b3"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.70"
+LINUX_VERSION = "5.4.71"
 
 # Local version indicates the branch name in the NXP kernel tree where patches are collected from.
-LOCALVERSION = "-imx_5.4.24_2.1.0"
+LOCALVERSION = "-imx-5.4.24-2.1.0"
 
 DEFAULT_PREFERENCE = "1"
 

--- a/recipes-kernel/linux/linux-fslc_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc_5.4.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.70"
+LINUX_VERSION = "5.4.71"
 
 SRCBRANCH = "5.4.x+fslc"
-SRCREV = "ae0ee2e5c5fbb23eadc2fa87b629bdfca3da7f57"
+SRCREV = "d4f3dcb65f2e93e3d2112feba5ff6d6f143e97be"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"


### PR DESCRIPTION
Both kernel branches were updated to _v5.4.71_ from stable korg, recipe `SRCREV` are updated to point to that version now.

`linux-fslc` received a separate patch to address VPU FW loading during probing.

`linux-fslc-imx` has updated versioning scheme recorded in `LOCALVERSION` to address build errors due to incompatible symbols were used (Fixes: #521).

-- andrey