### PR TITLE
libimxvpuapi2: Update to version 2.1.0

### DIFF
--- a/recipes-multimedia/libimxvpuapi/libimxvpuapi2_2.1.0.bb
+++ b/recipes-multimedia/libimxvpuapi/libimxvpuapi2_2.1.0.bb
@@ -8,7 +8,7 @@ DEPENDS = "virtual/imxvpu libimxdmabuffer"
 PV .= "+git${SRCPV}"
 
 SRCBRANCH ?= "master"
-SRCREV = "9a5e84af53e6765c4f0ea299df264a4e32a13ea7"
+SRCREV = "49cb1b34d759aa7a51269ca0f58fcc1f9647da5b"
 SRC_URI = "git://github.com/Freescale/libimxvpuapi.git;branch=${SRCBRANCH}"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
* introduce RGB and packed YUV formats since the Hantro encoder
  supports those
* remove hardware specific public headers since they only added
  tiled pixel formats; instead, migrate these tiled formats into
  ImxVpuApiColorFormat
* imx8 hantro decoder: reorder list of supported decoder color
  formats to favor 10 bit output
* imx8 hantro decoder: clear new framebuffer fields to zero
* imx8 hantro encoder: fix segfault caused by trying to unmap
  non existing staged raw frame

Signed-off-by: Carlos Rafael Giani <crg7475@mailbox.org>