### PR TITLE
imx-seco: Upgrade to 3.7.1

### DIFF
--- a/recipes-bsp/imx-seco/imx-seco-libs_git.bb
+++ b/recipes-bsp/imx-seco/imx-seco-libs_git.bb
@@ -8,9 +8,9 @@ LIC_FILES_CHKSUM = "file://EULA.txt;md5=228c72f2a91452b8a03c4cab30f30ef9"
 
 DEPENDS = "zlib"
 
-SRCBRANCH = "imx_5.4.24_2.1.0"
+SRCBRANCH = "imx_5.4.47_2.2.0"
 SRC_URI = "git://github.com/NXP/imx-seco-libs.git;protocol=https;branch=${SRCBRANCH}"
-SRCREV = "a4faaa474e49fa0d3668db466739834fe45a6767"
+SRCREV = "5932c1e5240eb36c3cddc7bcbdc7abd9bd8b562c"
 
 S = "${WORKDIR}/git"
 
@@ -20,5 +20,4 @@ do_install () {
 	oe_runmake DESTDIR=${D} install
 }
 
-COMPATIBLE_MACHINE = "(mx8)"
-COMPATIBLE_MACHINE_mx8m = "(^$)"
+COMPATIBLE_MACHINE = "(mx8qm|mx8qxp|mx8qxpc0|mx8phantomdxl|mx8dxl)"

--- a/recipes-bsp/imx-seco/imx-seco_3.7.1.bb
+++ b/recipes-bsp/imx-seco/imx-seco_3.7.1.bb
@@ -4,14 +4,14 @@ SUMMARY = "NXP i.MX SECO firmware"
 DESCRIPTION = "NXP IMX SECO firmware"
 SECTION = "base"
 LICENSE = "Proprietary"
-LIC_FILES_CHKSUM = "file://COPYING;md5=228c72f2a91452b8a03c4cab30f30ef9"
+LIC_FILES_CHKSUM = "file://COPYING;md5=983e4c77621568488dd902b27e0c2143"
 
 inherit fsl-eula-unpack use-imx-security-controller-firmware deploy
 
 SRC_URI = "${FSL_MIRROR}/${BP}.bin;fsl-eula=true"
 
-SRC_URI[md5sum] = "22a47e14e3f2e713b4b1b2b7ff768b11"
-SRC_URI[sha256sum] = "52ba07633e0f8707d8c26724b5cd03ef96444c8de1e0e134acac50acacf3e7dd"
+SRC_URI[md5sum] = "29d563790bf46629a083ba031a7de46d"
+SRC_URI[sha256sum] = "b09f63139df6c4dfef3533570cd60b22eb4c48eed05f314268178e80b8de40fc"
 
 do_compile[noexec] = "1"
 


### PR DESCRIPTION
Simplify the compatibility rule, all mx8 except mx8m supports SECO.
Otherwise, some machines on the list are not upstream.

Signed-off-by: Cristinel Panfir <cristinel.panfir@nxp.com>