### PR TITLE
gstreamer1.0-plugins-bad: fix vulkan compilation error

### DIFF
--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0001-vulkan-Drop-use-of-VK_RESULT_BEGIN_RANGE.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0001-vulkan-Drop-use-of-VK_RESULT_BEGIN_RANGE.patch
@@ -1,0 +1,51 @@
+From 54c700f9721ef218188803b48acae46e885626ee Mon Sep 17 00:00:00 2001
+From: "Jan Alexander Steffens (heftig)" <jan.steffens@ltnglobal.com>
+Date: Sat, 9 May 2020 19:59:46 +0200
+Subject: [PATCH] vulkan: Drop use of VK_RESULT_BEGIN_RANGE
+
+This was removed in Vulkan 1.2.140.
+
+> Shortly after 2020-04-24, we will be removing the automatically
+> generated `VK_*_BEGIN_RANGE`, `VK_*_END_RANGE`, and `VK_*_RANGE_SIZE`
+> tokens from the Vulkan headers. These tokens are currently defined for
+> some enumerated types, but are explicitly not part of the Vulkan API.
+> They existed only to support some Vulkan implementation internals,
+> which no longer require them. We will be accepting comments on this
+> topic in [#1230], but we strongly suggest any external projects using
+> these tokens immediately migrate away from them.
+
+[#1230]: https://github.com/KhronosGroup/Vulkan-Docs/issues/1230
+
+Part-of: <https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad/-/merge_requests/1603>
+
+Upstream-Status: Backport [https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad/-/commit/17850d7e87af93c6bd181d7c25903478c2254fa6]
+Signed-off-by: Andrey Zhizhikin <andrey.zhizhikin@leica-geosystems.com>
+---
+ ext/vulkan/vkerror.c | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/ext/vulkan/vkerror.c b/ext/vulkan/vkerror.c
+index 3fec27e4d..c91589d9b 100644
+--- a/ext/vulkan/vkerror.c
++++ b/ext/vulkan/vkerror.c
+@@ -27,7 +27,7 @@
+ #include "vkerror.h"
+ 
+ /* *INDENT-OFF* */
+-static const struct 
++static const struct
+ {
+   VkResult result;
+   const char *str;
+@@ -63,8 +63,6 @@ _vk_result_to_string (VkResult result)
+ 
+   if (result >= 0)
+     return NULL;
+-  if (result < VK_RESULT_BEGIN_RANGE)
+-    return "Unknown Error";
+ 
+   for (i = 0; i < G_N_ELEMENTS (vk_result_string_map); i++) {
+     if (result == vk_result_string_map[i].result)
+-- 
+2.17.1
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.16.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.16.imx.bb
@@ -19,6 +19,7 @@ SRC_URI = " \
     file://0001-meson-build-gir-even-when-cross-compiling-if-introsp.patch \
     file://opencv-resolve-missing-opencv-data-dir-in-yocto-buil.patch \
     file://0001-opencv-allow-compilation-against-4.4.x.patch \
+    file://0001-vulkan-Drop-use-of-VK_RESULT_BEGIN_RANGE.patch \
     file://fix-maybe-uninitialized-warnings-when-compiling-with-Os.patch \
     file://avoid-including-sys-poll.h-directly.patch \
     file://ensure-valid-sentinels-for-gst_structure_get-etc.patch \


### PR DESCRIPTION
VK_RESULT_BEGIN_RANGE has been removed in Vulkan headers, and corresponding patch has been introduced in GStreamer.

Backport patch from upstream GStreamer to NXP fork to address compilation error for Vulkan.

@thochstein Can you take attached patch internally and apply it to NXP fork? This would be required to compile with latest Vulkan headers.

-- andrey