### PR TITLE
imx-vpu-hantro-vc: set compatible to the soc, not a specific machine

### DIFF
--- a/recipes-bsp/imx-vpu-hantro-vc/imx-vpu-hantro-vc_1.1.0.bb
+++ b/recipes-bsp/imx-vpu-hantro-vc/imx-vpu-hantro-vc_1.1.0.bb
@@ -13,4 +13,4 @@ S = "${WORKDIR}/${BPN}-${PV}"
 SRC_URI[md5sum] = "5c254523ae4c44491ea838e84e9aee49"
 SRC_URI[sha256sum] = "c5dd1fbf8c9776d7a2844a225e0aa2e489aa24eaab8f55cb48a6e3184def235d"
 
-COMPATIBLE_MACHINE = "(imx8mpevk)"
+COMPATIBLE_MACHINE = "(mx8mp)"


### PR DESCRIPTION
Backport of PR #546