### PR TITLE
tsntool: update to b74987c

### DIFF
--- a/recipes-extended/tsntool/tsntool_git.bb
+++ b/recipes-extended/tsntool/tsntool_git.bb
@@ -8,7 +8,7 @@ DEPENDS = "cjson libnl readline"
 inherit pkgconfig
 
 SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/tsntool;protocol=https;nobranch=1"
-SRCREV = "ca2d8fb348bb54960d706177108c43ae213e0063"
+SRCREV = "b74987c855fb5605d2e384d355d101c68c4d6eaf"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Changes:
b74987c tsntool: fix define some_msg in the .h file for compile error
1bd1321 cnc: fix Qbv input gate state hex value
1e76457 libtsn:tsntool: align dscpset qos/dpl field with correct nla_policy
28429eb cnc.py: correct the name of basetime in sgi for sysrepo-tsn v0.2
2618ef7 libtsn:tsntool: fix dscp parameter input
297c7c3 tsntool: fix parameter input of help and queue

Signed-off-by: Ting Liu <ting.liu@nxp.com>