### PR TITLE
gstreamer1.0-plugins-base: allow enabling viv-fb as a supported GL wi…

### DIFF
--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.16.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.16.imx.bb
@@ -41,7 +41,7 @@ PACKAGECONFIG ??= " \
 
 OPENGL_APIS = 'opengl gles2'
 OPENGL_PLATFORMS = 'egl'
-OPENGL_WINSYS = 'x11 wayland gbm'
+OPENGL_WINSYS = 'x11 wayland gbm viv-fb'
 
 X11DEPENDS = "virtual/libx11 libsm libxrender libxv"
 X11ENABLEOPTS = "-Dx11=enabled -Dxvideo=enabled -Dxshm=enabled"
@@ -70,6 +70,7 @@ PACKAGECONFIG[egl]          = ",,virtual/egl"
 # OpenGL window systems (except for X11)
 PACKAGECONFIG[gbm]          = ",,virtual/libgbm libgudev libdrm"
 PACKAGECONFIG[wayland]      = ",,wayland-native wayland wayland-protocols libdrm"
+PACKAGECONFIG[viv-fb]       = ",,virtual/libgles2 virtual/libg2d"
 
 EXTRA_OEMESON += " \
     -Dgl-graphene=disabled \


### PR DESCRIPTION
…nsys

Add the viv-fb PACKAGECONFIG flag through which the corresponding GL winsys
support can be enabled in the GStreamer base plugins configuration. When
enabled, dependencies on the virtual libgles2 and libg2d targets are required.

Signed-off-by: Zan Dobersek <zdobersek@igalia.com>