### PR TITLE
Consolidated Kernel update (v5.4.75)

### DIFF
--- a/recipes-kernel/linux/linux-fslc-imx_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_5.4.bb
@@ -28,7 +28,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v5.4.74
+#    tag: v5.4.75
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
@@ -38,6 +38,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 3. Critical patches (SHA(s))
 # ------------------------------------------------------------------------------
+#    391a7c6dfd13 irq-imx-irqsteer: fix compile error if CONFIG_PM_SLEEP is not set
 #    b3d088d2f8fa fbdev: fix fbinfo flag dropped upstream
 #    c874333fa0be arm64: dts: imx8mp: Add fallback compatible to ocotp node
 #    55abb34c9faf arm64: dts: imx8m: change ocotp node name on i.MX8M SoCs
@@ -72,14 +73,14 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
 SRCBRANCH = "5.4-2.1.x-imx"
-SRCREV = "70d1232fdbe28e4c765c4cfc3cc5c7580959d5e0"
+SRCREV = "ad4c64e47c85a8e6d16ab61aa45d4bd4b645228d"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.74"
+LINUX_VERSION = "5.4.75"
 
 # Local version indicates the branch name in the NXP kernel tree where patches are collected from.
 LOCALVERSION = "-imx-5.4.24-2.1.0"

--- a/recipes-kernel/linux/linux-fslc_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc_5.4.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.74"
+LINUX_VERSION = "5.4.75"
 
 SRCBRANCH = "5.4.x+fslc"
-SRCREV = "edb45473faf9e9f1762991a620785fb21bc9517b"
+SRCREV = "f999c12539ffe482350d5d4ccaf1255d965e1b4e"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"


### PR DESCRIPTION
Both kernel branches were updated to _v5.4.75_ from stable korg, recipe `SRCREV` are updated to point to that version now.

Upstream commits, resolved conflicts and additional patches are recorded in corresponding recipe commits.

_Cc:_ @MDoswaldSchiller

-- andrey