### PR TITLE
gstreamer1.0-plugins-base: add additional patches

### DIFF
--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base/0001-glupload-Add-VideoMetas-and-GLSyncMeta-to-the-raw-up.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base/0001-glupload-Add-VideoMetas-and-GLSyncMeta-to-the-raw-up.patch
@@ -1,0 +1,87 @@
+From 8d32de090554cf29fe359f83aa46000ba658a693 Mon Sep 17 00:00:00 2001
+From: Thibault Saunier <tsaunier@igalia.com>
+Date: Fri, 27 Sep 2019 11:10:43 -0300
+Subject: [PATCH] glupload: Add VideoMetas and GLSyncMeta to the raw uploaded
+ buffers
+
+This is done by reusing `gst_gl_memory_setup_buffer` avoiding to
+duplicate code.
+
+Without a VideoMeta, mapping those buffers lead to GstBuffer mapping the
+buffer in system memory even when specifying the GL flags (through the
+buffer merging mechanism) making the result totally broken.
+
+Part-of: https://gitlab.freedesktop.org/gstreamer/gst-plugins-base/-/merge_requests/444
+Upstream-Status: Backport [8d32de090554cf29fe359f83aa46000ba658a693]
+
+Signed-off-by: Zan Dobersek <zdobersek@igalia.com>
+---
+ gst-libs/gst/gl/gstglupload.c  | 32 +++++++++++---------------------
+ tests/check/libs/gstglupload.c |  2 ++
+ 2 files changed, 13 insertions(+), 21 deletions(-)
+
+diff --git a/gst-libs/gst/gl/gstglupload.c b/gst-libs/gst/gl/gstglupload.c
+index bc6db7e0a..67ec4f4e9 100644
+--- a/gst-libs/gst/gl/gstglupload.c
++++ b/gst-libs/gst/gl/gstglupload.c
+@@ -1293,33 +1293,23 @@ _raw_data_upload_perform (gpointer impl, GstBuffer * buffer,
+       (raw->upload->context));
+ 
+   /* FIXME Use a buffer pool to cache the generated textures */
+-  /* FIXME: multiview support with separated left/right frames? */
+   *outbuf = gst_buffer_new ();
+-  for (i = 0; i < n_mem; i++) {
+-    GstGLBaseMemory *tex;
+-
+-    raw->params->parent.wrapped_data = raw->in_frame->frame.data[i];
+-    raw->params->plane = i;
+-    raw->params->tex_format =
+-        gst_gl_format_from_video_info (raw->upload->context, in_info, i);
+-
+-    tex =
+-        gst_gl_base_memory_alloc (allocator,
+-        (GstGLAllocationParams *) raw->params);
+-    if (!tex) {
+-      gst_buffer_unref (*outbuf);
+-      *outbuf = NULL;
+-      GST_ERROR_OBJECT (raw->upload, "Failed to allocate wrapped texture");
+-      return GST_GL_UPLOAD_ERROR;
+-    }
++  raw->params->parent.context = raw->upload->context;
++  if (gst_gl_memory_setup_buffer ((GstGLMemoryAllocator *) allocator, *outbuf,
++          raw->params, NULL, raw->in_frame->frame.data, n_mem)) {
+ 
+-    _raw_upload_frame_ref (raw->in_frame);
+-    gst_buffer_append_memory (*outbuf, (GstMemory *) tex);
++    for (i = 0; i < n_mem; i++)
++      _raw_upload_frame_ref (raw->in_frame);
++    gst_buffer_add_gl_sync_meta (raw->upload->context, *outbuf);
++  } else {
++    GST_ERROR_OBJECT (raw->upload, "Failed to allocate wrapped texture");
++    gst_buffer_unref (*outbuf);
++    return GST_GL_UPLOAD_ERROR;
+   }
+   gst_object_unref (allocator);
+-
+   _raw_upload_frame_unref (raw->in_frame);
+   raw->in_frame = NULL;
++
+   return GST_GL_UPLOAD_DONE;
+ }
+ 
+diff --git a/tests/check/libs/gstglupload.c b/tests/check/libs/gstglupload.c
+index 74bff2b83..eff2f18ba 100644
+--- a/tests/check/libs/gstglupload.c
++++ b/tests/check/libs/gstglupload.c
+@@ -281,6 +281,8 @@ GST_START_TEST (test_upload_data)
+   res = gst_gl_upload_perform_with_buffer (upload, inbuf, &outbuf);
+   fail_unless (res == GST_GL_UPLOAD_DONE, "Failed to upload buffer");
+   fail_unless (GST_IS_BUFFER (outbuf));
++  fail_unless (gst_buffer_get_video_meta (outbuf));
++  fail_unless (gst_buffer_get_gl_sync_meta (outbuf));
+ 
+   res = gst_buffer_map (outbuf, &map_info, GST_MAP_READ | GST_MAP_GL);
+   fail_if (res == FALSE, "Failed to map gl memory");
+-- 
+2.28.0
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base/0001-meson-viv-fb-code-must-link-against-libg2d.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base/0001-meson-viv-fb-code-must-link-against-libg2d.patch
@@ -1,0 +1,44 @@
+From 8153e86dac04076fb80fc272c8374d4ba019fa3c Mon Sep 17 00:00:00 2001
+From: Zan Dobersek <zdobersek@igalia.com>
+Date: Wed, 4 Nov 2020 14:02:10 +0100
+Subject: [PATCH] meson: viv-fb code must link against libg2d
+
+Find the libg2d library and link against it, if necessary, avoiding
+linking errors for couple of libg2d symbols.
+
+Upstream-Status: Pending
+
+Signed-off-by: Zan Dobersek <zdobersek@igalia.com>
+---
+ gst-libs/gst/gl/meson.build | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/gst-libs/gst/gl/meson.build b/gst-libs/gst/gl/meson.build
+index 6f6c6866d..fb6a9aabf 100644
+--- a/gst-libs/gst/gl/meson.build
++++ b/gst-libs/gst/gl/meson.build
+@@ -818,9 +818,11 @@ if need_win_gbm != 'no'
+ endif
+ 
+ if need_platform_egl != 'no' and need_win_viv_fb != 'no'
+-  if egl_dep.found() and cc.has_function ('fbGetDisplay', dependencies : egl_dep)
++  g2d_dep = cc.find_library('g2d', required : false)
++  if egl_dep.found() and g2d_dep.found() and cc.has_function ('fbGetDisplay', dependencies : egl_dep)
+     if cc.has_function ('glTexDirectVIV', dependencies : gles2_dep)
+       enabled_gl_winsys += 'viv-fb'
++      gl_winsys_deps += [g2d_dep]
+       glconf.set10('GST_GL_HAVE_WINDOW_VIV_FB', 1)
+       glconf.set10('GST_GL_HAVE_VIV_DIRECTVIV', 1)
+       glconf.set10('GST_GL_HAVE_PHYMEM', 1)
+@@ -834,6 +836,8 @@ if need_platform_egl != 'no' and need_win_viv_fb != 'no'
+       ]
+       gl_cpp_args += ['-DEGL_API_FB']
+     endif
++  else
++    g2d_dep = unneeded_dep
+   endif
+ endif
+ 
+-- 
+2.28.0
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.16.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.16.imx.bb
@@ -14,6 +14,8 @@ SRC_URI = "${GST1.0-PLUGINS-BASE_SRC};branch=${SRCBRANCH} \
            file://0005-viv-fb-Make-sure-config.h-is-included.patch \
            file://0009-glimagesink-Downrank-to-marginal.patch \
            file://0001-gst-libs-gst-gl-wayland-fix-meson-build.patch \
+           file://0001-glupload-Add-VideoMetas-and-GLSyncMeta-to-the-raw-up.patch \
+           file://0001-meson-viv-fb-code-must-link-against-libg2d.patch \
            "
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Add a pair of patches that's to be applied over the iMX flavor of the
gstreamer1.0-plugins-base codebase.

First patch comes from upstream, and it fixes glupload behavior by avoiding
mapping the GL buffers into CPU memory. It's only applicable to the current
MM_04.05.05_2005_L5.4.24 branch that is based on the upstream 1.16.1 release,
since the patch itself is already present in 1.16.2.
https://gitlab.freedesktop.org/gstreamer/gst-plugins-base/-/merge_requests/444

Second patch is a fix for Meson builds that enable the viv-fb GL winsys.
When enabled, the GL plugins library should also link against libg2d since
the viv-fb code is using g2d allocators.

Signed-off-by: Zan Dobersek <zdobersek@igalia.com>