### PR TITLE
fsl-kernel-localversion.bbclass: add preconfigure after do_kernel_met…

### DIFF
--- a/classes/fsl-kernel-localversion.bbclass
+++ b/classes/fsl-kernel-localversion.bbclass
@@ -40,4 +40,4 @@ do_preconfigure() {
 		printf "%s%s" +g $head > ${S}/.scmversion
 	fi
 }
-addtask preconfigure before do_configure after do_unpack do_patch
+addtask preconfigure before do_configure after do_unpack do_patch do_kernel_metadata


### PR DESCRIPTION
…adata

do_preconfigure task should run after do_kernel_metadata, or else there
might be no ${WORKDIR}/defconfig present when KBUILD_DEFCONFIG is being
set rather than defconfig added in SRC_URI.

Signed-off-by: Ming Liu <liu.ming50@gmail.com>