### PR TITLE
[master-next]: linux-fslc-imx: update to v5.4.76

### DIFF
--- a/recipes-kernel/linux/linux-fslc-imx_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_5.4.bb
@@ -28,7 +28,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v5.4.75
+#    tag: v5.4.76
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
@@ -79,14 +79,14 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
 SRCBRANCH = "5.4-2.2.x-imx"
-SRCREV = "4bca0fec0e84f43539060e608867297533b0e09c"
+SRCREV = "19f584db29268ed166ed53bd34018a1666f9bdda"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.75"
+LINUX_VERSION = "5.4.76"
 
 # Local version indicates the branch name in the NXP kernel tree where patches are collected from.
 LOCALVERSION = "-imx-5.4.47-2.2.0"


### PR DESCRIPTION
Kernel repository has been upgraded to _v5.4.76_ from stable korg.

Following conflicts were resolved during merge:
----
- drivers/tty/serial/fsl_lpuart.c:
Fix merge conflict of upstream patches [86875e1d6426] and [8febdfb5973d],
which contradicted with patch [cde0cb39c0e8e] from NXP.


Following upstream commits are included in this version:
----
```
ec9c6b417e27 Linux 5.4.76
c3d60c695712 arm64: dts: marvell: espressobin: Add ethernet switch aliases
b7f7474b3921 perf/core: Fix a memory leak in perf_event_parse_addr_filter()
21ab13af8c50 xfs: flush for older, xfs specific ioctls
258d01b1577e PM: runtime: Resume the device earlier in __device_release_driver()
37f75c6aa8dd PM: runtime: Drop pm_runtime_clean_up_links()
874dfb5c6aa3 PM: runtime: Drop runtime PM references to supplier on link removal
fbfca92c7840 ARC: stack unwinding: avoid indefinite looping
d61edc06002f drm/panfrost: Fix a deadlock between the shrinker and madvise path
b9d91fa92164 usb: mtu3: fix panic in mtu3_gadget_stop()
b0d03a1bdb3c USB: Add NO_LPM quirk for Kingston flash drive
290fcf3e0c0c usb: dwc3: ep0: Fix delay status handling
86875e1d6426 tty: serial: fsl_lpuart: LS1021A has a FIFO size of 16 words, like LS1028A
8febdfb5973d tty: serial: fsl_lpuart: add LS1028A support
d5d3cca9d61f USB: serial: option: add Telit FN980 composition 0x1055
7f7be9341b86 USB: serial: option: add LE910Cx compositions 0x1203, 0x1230, 0x1231
b7f74775c2bb USB: serial: option: add Quectel EC200T module support
9d34dbab6ef4 USB: serial: cyberjack: fix write-URB completion race
62c4b2b21e3b serial: txx9: add missing platform_driver_unregister() on error in serial_txx9_init
085fc4784e4b serial: 8250_mtk: Fix uart_get_baud_rate warning
b33a1039564c s390/pkey: fix paes selftest failure with paes and pkey static build
beeb658cfd35 fork: fix copy_process(CLONE_PARENT) race with the exiting ->real_parent
642181fe3567 vt: Disable KD_FONT_OP_COPY
cfd9d7137759 Revert "coresight: Make sysfs functional on topologies with per core sink"
8ee6a0f25457 arm64/smp: Move rcu_cpu_starting() earlier
eceb94287dbf drm/nouveau/gem: fix "refcount_t: underflow; use-after-free"
7d0de6f87257 drm/nouveau/nouveau: fix the start/end range for migration
4dab0fd40323 usb: cdns3: gadget: suspicious implicit sign extension
937753df482c ACPI: NFIT: Fix comparison to '-ENXIO'
16476c2b26ca drm/vc4: drv: Add error handding for bind
a04cec1dd293 nvmet: fix a NULL pointer dereference when tracing the flush command
8c9c03432500 nvme-rdma: handle unexpected nvme completion data length
2fd9e60760ef vsock: use ns_capable_noaudit() on socket create
2149aa583068 scsi: ibmvscsi: Fix potential race after loss of transport
1247f4e29188 drm/amdgpu: add DID for navi10 blockchain SKU
fd4fb5080725 scsi: core: Don't start concurrent async scan on same host
3c52715ceaae blk-cgroup: Pre-allocate tree node on blkg_conf_prep
f77756ea6641 blk-cgroup: Fix memleak on error path
914fc5524261 drm/sun4i: frontend: Fix the scaler phase on A33
f743f73f42a7 drm/sun4i: frontend: Reuse the ch0 phase for RGB formats
6d7b41a67687 drm/sun4i: frontend: Rework a bit the phase data
147e3743cf7a of: Fix reserved-memory overlap detection
6e02c29e4ac4 x86/kexec: Use up-to-dated screen_info copy to fill boot params
3283d4d78412 arm64: dts: meson: add missing g12 rng clock
69e0e917c7c8 ARM: dts: sun4i-a10: fix cpu_alert temperature
2716e78a6486 futex: Handle transient "ownerless" rtmutex state correctly
ec5f524e0293 tracing: Fix out of bounds write in get_trace_buf
9f6883fce694 spi: bcm2835: fix gpio cs level inversion
f352cca84625 regulator: defer probe when trying to get voltage from unresolved supply
a69af5baed80 ftrace: Handle tracing when switching between context
3058420f40fb ftrace: Fix recursion check for NMI test
cfaf010cf345 mtd: spi-nor: Don't copy self-pointing struct around
aef59b5e5bdf ring-buffer: Fix recursion protection transitions between interrupt context
2cd71743e7ff gfs2: Wake up when sd_glock_disposal becomes zero
d2286457bd83 mm: always have io_remap_pfn_range() set pgprot_decrypted()
1b8490d6b809 kthread_worker: prevent queuing delayed work from timer_fn when it is being canceled
b1d16be4f2f4 lib/crc32test: remove extra local_irq_disable/enable
c1f729c7dec0 mm: mempolicy: fix potential pte_unmap_unlock pte error
f7c2913d606b ALSA: usb-audio: Add implicit feedback quirk for MODX
26a871cf86cb ALSA: usb-audio: Add implicit feedback quirk for Qu-16
a46e830d017e ALSA: usb-audio: add usb vendor id as DSD-capable for Khadas devices
65457e345f3c ALSA: usb-audio: Add implicit feedback quirk for Zoom UAC-2
72ce616ed55a ALSA: hda/realtek - Enable headphone for ASUS TM420
f7d0f7242405 ALSA: hda/realtek - Fixed HP headset Mic can't be detected
61402d61a2af Fonts: Replace discarded const qualifier
e5ea79bb19f8 sfp: Fix error handing in sfp_probe()
9b5458effeee sctp: Fix COMM_LOST/CANT_STR_ASSOC err reporting on big-endian platforms
26ffb8916059 powerpc/vnic: Extend "failover pending" window
92e65059beda net: usb: qmi_wwan: add Telit LE910Cx 0x1230 composition
8e3c047f814b ip_tunnel: fix over-mtu packet send fail without TUNNEL_DONT_FRAGMENT flags
ac343efb572c ionic: check port ptr before use
6ef3bcc25a3e gianfar: Account for Tx PTP timestamp in the skb headroom
5b66a5b6a9e2 gianfar: Replace skb_realloc_headroom with skb_cow_head for PTP
7bf7b7c385a1 chelsio/chtls: fix always leaking ctrl_skb
14d755a4815e chelsio/chtls: fix memory leaks caused by a race
57bb59f9d8fb cadence: force nonlinear buffers to be cloned
1695fca8a923 ptrace: fix task_join_group_stop() for the case when current is traced
76e5bba75a63 tipc: fix use-after-free in tipc_bcast_get_mode
ca16a42f5f0d arm64: Change .weak to SYM_FUNC_START_WEAK_PI for arch/arm64/lib/mem*.S
d94589900d98 arm64: lib: Use modern annotations for assembly functions
3e7050661d95 arm64: asm: Add new-style position independent function annotations
840d8c9b3e5f linkage: Introduce new macros for assembler symbols
1ca84322ab5b ASoC: Intel: Skylake: Add alternative topology binary name
e05dfcff26e9 drm/i915: Drop runtime-pm assert from vgpu io accessors
d321f127eb51 drm/i915/gt: Delay execlist processing for tgl
5bcd18bf8082 drm/i915: Break up error capture compression loops with cond_resched()
```

-- andrey