### PR TITLE
linux-fslc-imx: update to v5.4.78

### DIFF
--- a/recipes-kernel/linux/linux-fslc-imx_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_5.4.bb
@@ -28,7 +28,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v5.4.76
+#    tag: v5.4.78
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
@@ -79,14 +79,14 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
 SRCBRANCH = "5.4-2.2.x-imx"
-SRCREV = "19f584db29268ed166ed53bd34018a1666f9bdda"
+SRCREV = "fc26781f713f2fe79a50a5bb44ecb4b3d70af907"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.76"
+LINUX_VERSION = "5.4.78"
 
 # Local version indicates the branch name in the NXP kernel tree where patches are collected from.
 LOCALVERSION = "-imx-5.4.47-2.2.0"


### PR DESCRIPTION
Kernel repository has been upgraded to v5.4.78 from stable korg.

Following upstream commits are included in this version:
----
```
315443293a2d Linux 5.4.78
9fda2e762498 Convert trailing spaces and periods in path components
ebc24aeb8694 net: sch_generic: fix the missing new qdisc assignment bug
c5cf5c7b585c perf/core: Fix race in the perf_mmap_close() function
c6b1616f5472 perf scripting python: Avoid declaring function pointers with a visibility attribute
b74fe3186471 x86/speculation: Allow IBPB to be conditionally enabled on CPUs with always-on STIBP
6958fbd52e79 powerpc/603: Always fault when _PAGE_ACCESSED is not set
5af9d48acbee drm/i915: Correctly set SFC capability for video engines
6fcf4141b9a2 r8169: fix potential skb double free in an error path
78f6fac0814e tipc: fix memory leak in tipc_topsrv_start()
c59039a088bd net/x25: Fix null-ptr-deref in x25_connect
7e332a5c0e2c net: Update window_clamp if SOCK_RCVBUF is set
25786fb512f7 net: udp: fix UDP header access on Fast/frag0 UDP GRO
016e70d176ff net/af_iucv: fix null pointer dereference on shutdown
22ee23fe1cc9 IPv6: Set SIT tunnel hard_header_len to zero
98901bff58d9 swiotlb: fix "x86: Don't panic if can not alloc buffer for swiotlb"
2cd21fe5bcc4 pinctrl: amd: fix incorrect way to disable debounce filter
fa76dd3c1df3 pinctrl: amd: use higher precision for 512 RtcClk
c6a6168a31e1 drm/gma500: Fix out-of-bounds access to struct drm_device.vblank[]
974e3a7002a0 don't dump the threads that had been already exiting when zapped.
039c8dcd2b15 mmc: renesas_sdhi_core: Add missing tmio_mmc_host_free() at remove
e1d706eeeaf7 mmc: sdhci-of-esdhc: Handle pulse width detection erratum for more SoCs
2a6cba6d3d72 gpio: pcie-idio-24: Enable PEX8311 interrupts
7b6790ae3a94 gpio: pcie-idio-24: Fix IRQ Enable Register value
819bf3b0d969 gpio: pcie-idio-24: Fix irq mask when masking
68dae71b7cde selinux: Fix error return code in sel_ib_pkey_sid_slow()
33e53f2cac19 btrfs: fix potential overflow in cluster_pages_for_defrag on 32bit arch
9de4ffb70150 ocfs2: initialize ip_next_orphan
ac18b128cfd6 reboot: fix overflow parsing reboot cpu number
fa6265f8fb9e Revert "kernel/reboot.c: convert simple_strtoul to kstrtoint"
bd4d106f3122 mm/slub: fix panic in slab_alloc_node()
84778a43ae59 jbd2: fix up sparse warnings in checkpoint code
2192d905df0d futex: Don't enable IRQs unconditionally in put_pi_state()
761fb6829238 mei: protect mei_cl_mtu from null dereference
e2b2c390ec9e virtio: virtio_console: fix DMA memory allocation for rproc serial
57626d77ef1e xhci: hisilicon: fix refercence leak in xhci_histb_probe
cbad9668929c usb: cdc-acm: Add DISABLE_ECHO for Renesas USB Download mode
f988e9c85cfb uio: Fix use-after-free in uio_unregister_device()
1654bf2d9f0e thunderbolt: Add the missed ida_simple_remove() in ring_request_msix()
06c1895fe71b thunderbolt: Fix memory leak if ida_simple_get() fails in enumerate_services()
11c14da8d005 KVM: arm64: Don't hide ID registers from userspace
2033dd885297 btrfs: dev-replace: fail mount if we don't have replace item with target device
5af9630036ef btrfs: fix min reserved size calculation in merge_reloc_root
8266c23124c1 btrfs: ref-verify: fix memory leak in btrfs_ref_tree_mod
062c9b04f6eb ext4: unlock xattr_sem properly in ext4_inline_data_truncate()
a6ca4c7ec44c ext4: correctly report "not supported" for {usr,grp}jquota when !CONFIG_QUOTA
52e3a55bc253 erofs: derive atime instead of leaving it empty
09b0d47b7952 perf: Fix get_recursion_context()
70867a9dbf57 vrf: Fix fast path output packet handling with async Netfilter rules
2ab9c76986e4 cosa: Add missing kfree in error path of cosa_write
c0a6cc9e11f4 of/address: Fix of_node memory leak in of_dma_is_coherent
f10d238aad93 xfs: fix a missing unlock on error in xfs_fs_map_blocks
0e2ad69bd4b5 lan743x: fix "BUG: invalid wait context" when setting rx mode
b45f52a20879 xfs: fix brainos in the refcount scrubber's rmap fragment processor
7cbf708b1b9a xfs: fix rmap key and record comparison functions
3bd97b33be41 xfs: set the unwritten bit in rmap lookup flags in xchk_bmap_get_rmapextents
08e213bef291 xfs: fix flags argument to rmap lookup when converting shared file rmaps
a8ee686597fb igc: Fix returning wrong statistics
81dcfdb9a015 nbd: fix a block_device refcount leak in nbd_release
c602ad2b52dc bpf: Zero-fill re-used per-cpu map element
dfcb33773877 SUNRPC: Fix general protection fault in trace_rpc_xdr_overflow()
b9e8f9d139bd net/mlx5: Fix deletion of duplicate rules
e74e514c8cca pinctrl: aspeed: Fix GPI only function problem.
d2e61c5202e6 bpf: Don't rely on GCC __attribute__((optimize)) to disable GCSE
443ae3655f8c ARM: 9019/1: kprobes: Avoid fortify_panic() when copying optprobe template
c0be7a34c889 pinctrl: intel: Set default bias in case no particular value given
88ccabbd2066 mfd: sprd: Add wakeup capability for PMIC IRQ
58953e87343d tick/common: Touch watchdog in tick_unfreeze() on all CPUs
3322f7289e50 spi: bcm2835: remove use of uninitialized gpio flags variable
572e545d80ea tpm_tis: Disable interrupts on ThinkPad T490s
713a3a94bee0 i2c: sh_mobile: implement atomic transfers
37a048d790c3 riscv: Set text_offset correctly for M-Mode
6d8b43376990 selftests: proc: fix warning: _GNU_SOURCE redefined
ab10b7def421 amd/amdgpu: Disable VCN DPG mode for Picasso
4faa1fabc645 i2c: mediatek: move dma reset before i2c reset
b66c7cdedd1e vfio/pci: Bypass IGD init in case of -ENODEV
c6be53caf1c8 vfio: platform: fix reference leak in vfio_platform_open
4d6f536e34d6 s390/smp: move rcu_cpu_starting() earlier
984d77507439 iommu/amd: Increase interrupt remapping table limit to 512 entries
a889cd3d350d nvme-tcp: avoid repeated request completion
9d14f5225dbb nvme-rdma: avoid repeated request completion
531b55cce9cd nvme-tcp: avoid race between time out and tear down
d0e888a20dfd nvme-rdma: avoid race between time out and tear down
0ca279c859d7 nvme: introduce nvme_sync_io_queues
c473b3e56c1d scsi: mpt3sas: Fix timeouts observed while reenabling IRQ
b61e157d9f64 scsi: scsi_dh_alua: Avoid crash during alua_bus_detach()
bf1cedc12f58 tracing: Fix the checking of stackidx in __ftrace_trace_stack
e57c04697030 cfg80211: regulatory: Fix inconsistent format argument
a3f0db0d2320 cfg80211: initialize wdev data earlier
67bb2e4d41de mac80211: fix use of skb payload instead of header
c1cbb64c100d drm/amd/pm: do not use ixFEATURE_STATUS for checking smc running
48083640a47b drm/amd/pm: perform SMC reset on suspend/hibernation
f449b902badb drm/amdgpu: perform srbm soft reset always on SDMA resume
7f6df0b085ce scsi: hpsa: Fix memory leak in hpsa_init_one()
325455358e54 gfs2: check for live vs. read-only file system in gfs2_fitrim
edeff05a1f10 gfs2: Add missing truncate_inode_pages_final for sd_aspace
99dcfc517d17 gfs2: Free rd_bits later in gfs2_clear_rgrpd to fix use-after-free
42eaa22aaf2e ALSA: hda: Reinstate runtime_allow() for all hda controllers
0a4c091673ca ALSA: hda: Separate runtime and system suspend
9b7e6b670df7 selftests: pidfd: fix compilation errors due to wait.h
9110e2f2633d selftests/ftrace: check for do_sys_openat2 in user-memory test
1737ea0c5775 usb: gadget: goku_udc: fix potential crashes in probe
e60490354191 opp: Reduce the size of critical section in _opp_table_kref_release()
fe2dc1093c61 usb: dwc3: pci: add support for the Intel Alder Lake-S
e22142a9a2a9 ASoC: cs42l51: manage mclk shutdown delay
0fc0befe0bfa ASoC: qcom: sdm845: set driver name correctly
b668352c4aad ath9k_htc: Use appropriate rs_datalen type
42501604363f KVM: x86: don't expose MSR_IA32_UMWAIT_CONTROL unconditionally
d2cef3bae14b KVM: arm64: ARM_SMCCC_ARCH_WORKAROUND_1 doesn't return SMCCC_RET_NOT_REQUIRED
213e1238cacc random32: make prandom_u32() output unpredictable
327af342ca9b tpm: efi: Don't create binary_bios_measurements file for an empty log
0685eb84ad56 xfs: fix scrub flagging rtinherit even if there is no rt device
2f6cbef32718 xfs: flush new eof page on truncate to avoid post-eof corruption
66ce8bfad6f6 can: flexcan: flexcan_remove(): disable wakeup completely
0b657367309e can: flexcan: remove FLEXCAN_QUIRK_DISABLE_MECR quirk for LS1021A
56c56af0a3a1 can: peak_canfd: pucan_handle_can_rx(): fix echo management when loopback is on
a23ee9956612 can: peak_usb: peak_usb_get_ts_time(): fix timestamp wrapping
44b2c4beff8a can: peak_usb: add range checking in decode operations
d6c34afab0ed can: xilinx_can: handle failure cases of pm_runtime_get_sync
51920ca7519c can: ti_hecc: ti_hecc_probe(): add missed clk_disable_unprepare() in error path
b9c4a9a07c4a can: j1939: j1939_sk_bind(): return failure if netdev is down
0ab4c839409a can: j1939: swap addr and pgn in the send example
5bde65abe166 can: can_create_echo_skb(): fix echo skb generation: always use skb_clone()
183f1af506fe can: dev: __can_get_echo_skb(): fix real payload length return value for RTR frames
ab46748bf988 can: dev: can_get_echo_skb(): prevent call to kfree_skb() in hard IRQ context
3d0954767918 can: rx-offload: don't call kfree_skb() from IRQ context
e201588fad54 afs: Fix warning due to unadvanced marshalling pointer
9946509a027b iommu/vt-d: Fix a bug for PDP check in prq_event_thread
2825a5bf3ca5 ALSA: hda: prevent undefined shift in snd_hdac_ext_bus_get_link()
22901751d269 perf tools: Add missing swap for ino_generation
b36f78fd48e9 perf trace: Fix segfault when trying to trace events by cgroup
d261d0bd9066 powerpc/eeh_cache: Fix a possible debugfs deadlock
1c8fe343a79d netfilter: ipset: Update byte and packet counters regardless of whether they match
ad017cf5dace netfilter: nf_tables: missing validation from the abort path
56907fa27b94 netfilter: use actual socket sk rather than skb sk when routing harder
6234710dc634 xfs: set xefi_discard when creating a deferred agfl free log intent item
933f911136e2 ASoC: codecs: wcd9335: Set digital gain range correctly
5cb904da85ed net: xfrm: fix a race condition during allocing spi
4e438ca1b629 hv_balloon: disable warning when floor reached
bb2b60242c8e genirq: Let GENERIC_IRQ_IPI select IRQ_DOMAIN_HIERARCHY
bb8c6bd53cc0 ASoC: Intel: kbl_rt5663_max98927: Fix kabylake_ssp_fixup function
a8ec66026dd8 btrfs: reschedule when cloning lots of extents
0ee771e96954 btrfs: sysfs: init devices outside of the chunk_mutex
c58fa93b1409 btrfs: tracepoints: output proper root owner for trace_find_free_extent()
e24516cf62f9 usb: dwc3: gadget: Reclaim extra TRBs after request completion
ab031673e2ab usb: dwc3: gadget: Continue to process pending requests
504cfb5e3bca PCI: qcom: Make sure PCIe is reset before init for rev 2.1.0
9dfbc2f82ac8 KVM: arm64: Force PTE mapping on fault resulting in a device mapping
95fda70d3955 nbd: don't update block size after device is started
160777b19b86 time: Prevent undefined behaviour in timespec64_to_ns()
5a39fb2f22fd drm/i915/gem: Flush coherency domains on first set-domain-ioctl
2544d06afd8d Linux 5.4.77
19f6d91bdad4 powercap: restrict energy meter to root access
```

-- andrey