### PR TITLE
Consolidated Kernel update (v5.4.78)

### DIFF
--- a/recipes-kernel/linux/linux-fslc-imx_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_5.4.bb
@@ -28,7 +28,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v5.4.76
+#    tag: v5.4.78
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
@@ -73,14 +73,14 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
 SRCBRANCH = "5.4-2.1.x-imx"
-SRCREV = "d96d648dcbbcdf5ecd69193772efe982aafb70d5"
+SRCREV = "bae12307563e19c20390f21bcbc9ab52874687c9"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.76"
+LINUX_VERSION = "5.4.78"
 
 # Local version indicates the branch name in the NXP kernel tree where patches are collected from.
 LOCALVERSION = "-imx-5.4.24-2.1.0"

--- a/recipes-kernel/linux/linux-fslc_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc_5.4.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.76"
+LINUX_VERSION = "5.4.78"
 
 SRCBRANCH = "5.4.x+fslc"
-SRCREV = "7409186c70249d0d5075ccab5886e4e5a8bb7fa1"
+SRCREV = "c50d1fa1c355b39f0f259d125bf98ff993d68f78"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"


### PR DESCRIPTION
Both kernel branches were updated to _v5.4.78_ from stable korg, recipe `SRCREV` are updated to point to that version now.

Upstream commits are recorded in corresponding recipe commits.

-- andrey