### PR TITLE
[master-next]: linux-fslc-imx: update to v5.4.79

### DIFF
--- a/recipes-kernel/linux/linux-fslc-imx_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_5.4.bb
@@ -28,7 +28,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v5.4.78
+#    tag: v5.4.79
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
@@ -79,14 +79,14 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
 SRCBRANCH = "5.4-2.2.x-imx"
-SRCREV = "fc26781f713f2fe79a50a5bb44ecb4b3d70af907"
+SRCREV = "b30710716dd9b979353862afcb2c092066a10402"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.78"
+LINUX_VERSION = "5.4.79"
 
 # Local version indicates the branch name in the NXP kernel tree where patches are collected from.
 LOCALVERSION = "-imx-5.4.47-2.2.0"


### PR DESCRIPTION
Kernel repository has been upgraded to _v5.4.79_ from stable korg.

Following upstream commits are included in this version:
----
```
fc8334619167 Linux 5.4.79
26c7d2883851 ACPI: GED: fix -Wformat
087c857e0131 KVM: x86: clflushopt should be treated as a no-op by emulation
7ae6f2df438d can: proc: can_remove_proc(): silence remove_proc_entry warning
1527ab7859b2 mac80211: always wind down STA state
df3305411447 Input: sunkbd - avoid use-after-free in teardown paths
cd61f14592df net: lantiq: Add locking for TX DMA channel
8cad37eb129f powerpc/8xx: Always fault when _PAGE_ACCESSED is not set
b57c75956e79 net/mlx5: Add retry mechanism to the command entry index allocation
7db82a5a4c15 net/mlx5: Fix a race when moving command interface to events mode
3fa9daaccce8 net/mlx5: poll cmd EQ in case of command timeout
42bb7b7b9654 net/mlx5: Use async EQ setup cleanup helpers for multiple EQs
b33905dc1ce5 MIPS: PCI: Fix MIPS build
01474e8cc342 selftests/powerpc: entry flush test
eb37345ed224 powerpc: Only include kup-radix.h for 64-bit Book3S
09495b5f7aab powerpc/64s: flush L1D after user accesses
b65458b6be80 powerpc/64s: flush L1D on kernel entry
bcf7f2d3fcec selftests/powerpc: rfi_flush: disable entry flush if present
```

-- andrey