### PR TITLE
Add i.MX vulkan driver to image explicitly

### DIFF
--- a/recipes-graphics/vulkan/vulkan-loader_%.bbappend
+++ b/recipes-graphics/vulkan/vulkan-loader_%.bbappend
@@ -1,0 +1,3 @@
+# The i.MX implementation is dynamically loaded, so it requires an
+# explicit runtime dependency.
+RRECOMMENDS_${PN}_append_imxgpu = " libvulkan-imx"


### PR DESCRIPTION
The i.MX vulkan driver libvulkan-imx is dynamically loaded, so bitbake won't add it
to the image implicitly, and a missing library error at runtime is the result.

Add the driver explicitly.

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>