### PR TITLE
[dunfell]: Consolidated Kernel update (v5.4.83)

### DIFF
--- a/recipes-kernel/linux/linux-fslc-imx_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_5.4.bb
@@ -28,7 +28,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v5.4.82
+#    tag: v5.4.83
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
@@ -73,14 +73,14 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
 SRCBRANCH = "5.4-2.1.x-imx"
-SRCREV = "e7d7739c920d256d842d79959a3447f69d378050"
+SRCREV = "20467a016a344fd78faeacddfe5027441cc4f94f"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.82"
+LINUX_VERSION = "5.4.83"
 
 # Local version indicates the branch name in the NXP kernel tree where patches are collected from.
 LOCALVERSION = "-imx-5.4.24-2.1.0"

--- a/recipes-kernel/linux/linux-fslc_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc_5.4.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.82"
+LINUX_VERSION = "5.4.83"
 
 SRCBRANCH = "5.4.x+fslc"
-SRCREV = "38210f196c3250956c87d501b38b0b88f5cf5177"
+SRCREV = "77339af5b74db0c7ba34a1d8b8d25b4e6e44bb28"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"


### PR DESCRIPTION
Both kernel branches were updated to _v5.4.83_ from stable korg, recipe `SRCREV` are updated to point to that version now.

Upstream commits and resolved conflicts are recorded in corresponding recipe commit messages.

-- andrey