### PR TITLE
imx-base.inc: add imx-boot as a dependency for mx8m machines

### DIFF
--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -366,6 +366,7 @@ WKS_FILE_DEPENDS ?= " \
 "
 
 WKS_FILE_DEPENDS_append_mx8 = " imx-boot"
+WKS_FILE_DEPENDS_append_mx8m = " imx-boot"
 
 SOC_DEFAULT_WKS_FILE ?= "imx-uboot-bootpart.wks.in"
 SOC_DEFAULT_WKS_FILE_mx8m ?= "imx-imx-boot-bootpart.wks.in"


### PR DESCRIPTION
`imx-boot` is required to be provided as a dependency for `mx8m` machines in order to provide a boot container, which WIC is expecting to include into the final image.

Since the only dependency for WIC present in the layer now is targeting mx8 machine and _MACHINEOVERRIDES_EXTENDER_FILTER_OUT_ removes it when `use-mainline-bsp` is set - it leaves no 'imx-boot' container in the path of creating WIC file, and build for mx8m machines fails.

Append _WKS_FILE_DEPENDS_ to include `imx-boot` for `mx8m`, as it is required to be present regardless of the BSP flavor chosen.

Fixes: e2589ccb ("imx-base.inc: Avoid adding 'imx-boot' as dependency for all SoCs")
Signed-off-by: Andrey Zhizhikin <andrey.z@gmail.com>