### PR TITLE
ddr-phy: add support for lx2162aqds

### DIFF
--- a/recipes-bsp/ddr-phy/ddr-phy_git.bb
+++ b/recipes-bsp/ddr-phy/ddr-phy_git.bb
@@ -9,7 +9,7 @@ SRCREV = "fbc036b88acb6c06ffed02c898cbae9856ec75ba"
 
 S = "${WORKDIR}/git"
 
-REGLEX_lx2160a = "lx2160a"
+REGLEX = "lx2160a"
 
 DEPENDS += "atf-tools-native"
 
@@ -40,5 +40,5 @@ addtask deploy before do_populate_sysroot after do_install
 PACKAGES += "${PN}-image"
 FILES_${PN}-image += "/boot"
 
-COMPATIBLE_MACHINE = "(lx2160a)"
+COMPATIBLE_MACHINE = "(lx2160a|lx2162a)"
 PACKAGE_ARCH = "${MACHINE_ARCH}"


### PR DESCRIPTION
LX2162A is LX2160A based processor. They share the same ddr-phy binaries.
Remove override '_lx2160a' and add lx2162a into COMPATIBLE_MACHINE.

Signed-off-by: Ting Liu <ting.liu@nxp.com>