### PR TITLE
mc-utils: add support for lx2162a

### DIFF
--- a/recipes-bsp/mc-utils/mc-utils_git.bb
+++ b/recipes-bsp/mc-utils/mc-utils_git.bb
@@ -18,8 +18,10 @@ MC_CFG ?= ""
 MC_CFG_ls1088a = "ls1088a"
 MC_CFG_ls2088a = "ls2088a"
 MC_CFG_lx2160a = "lx2160a"
+MC_CFG_lx2162aqds = "lx2162aqds"
 
 MC_FLAVOUR ?= "RDB"
+MC_FLAVOUR_lx2162a = ""
 
 do_compile () {
 	oe_runmake -C config 


### PR DESCRIPTION
mc-utils has different folder structure for lx2162a.
Set MC_CFG and MC_FLAVOUR for it.

Signed-off-by: Ting Liu <ting.liu@nxp.com>