### PR TITLE
optee-test-qoriq: DEPENDS python3-pycryptodomex-native

### DIFF
--- a/recipes-security/optee/optee-test-qoriq_3.8.0.bb
+++ b/recipes-security/optee/optee-test-qoriq_3.8.0.bb
@@ -4,7 +4,7 @@ HOMEPAGE = "https://github.com/OP-TEE/optee_test"
 LICENSE = "BSD & GPLv2"
 LIC_FILES_CHKSUM = "file://${S}/LICENSE.md;md5=daa2bcccc666345ab8940aab1315a4fa"
 
-DEPENDS = "optee-client-qoriq optee-os-qoriq python3-pycryptodome-native"
+DEPENDS = "optee-client-qoriq optee-os-qoriq python3-pycryptodome-native python3-pycryptodomex-native"
 
 inherit python3native
 


### PR DESCRIPTION
Fix:
| /usr/include/optee/export-user_ta/scripts/sign_encrypt.py", line 131, in main
|     from Cryptodome.Signature import pss
| ModuleNotFoundError: No module named 'Cryptodome'

Signed-off-by: Ting Liu <ting.liu@nxp.com>