### PR TITLE
secure-obj: DEPENDS python3-pycryptodomex-native

### DIFF
--- a/recipes-extended/secure-obj/secure-obj.inc
+++ b/recipes-extended/secure-obj/secure-obj.inc
@@ -4,7 +4,7 @@ LICENSE = "BSD"
 DEPENDS = "openssl optee-os-qoriq optee-client-qoriq"
 RDEPENDS_${PN} = "bash libcrypto libssl"
 
-DEPENDS += "python3-pycryptodome-native"
+DEPENDS += "python3-pycryptodomex-native"
 
 inherit python3native
 


### PR DESCRIPTION
Fix:
| File "/usr/include/optee/export-user_ta/scripts/sign_encrypt.py", line 131, in main
|   from Cryptodome.Signature import pss
| ModuleNotFoundError: No module named 'Cryptodome'

Signed-off-by: Ting Liu <ting.liu@nxp.com>