### PR TITLE
optee-test_3.7.0.imx: fix optee-test build

### DIFF
--- a/recipes-security/optee-imx/optee-test_3.7.0.imx.bb
+++ b/recipes-security/optee-imx/optee-test_3.7.0.imx.bb
@@ -39,6 +39,13 @@ EXTRA_OEMAKE = " \
     OPTEE_OPENSSL_EXPORT=${STAGING_INCDIR}/ \
     -C ${S} O=${B} \
 "
+do_compile() {
+    cd ${S}
+    # Top level makefile doesn't seem to handle parallel make gracefully
+    oe_runmake xtest
+    oe_runmake ta
+}
+do_compile[cleandirs] = "${B}"
 
 do_install () {
 	install -d ${D}/usr/bin


### PR DESCRIPTION
Currently nothing is built for optee-test which means
do_install() fails copying xtest binary.

Align the do_compile() with upstream meta-arm optee-test recipe.
With this patch the build then completes OK.

Fixes: a66dc98
Signed-off-by: Peter Griffin <peter.griffin@linaro.org>
(cherry picked from commit 840176462b2ae175bc06322f32c21d5b117b673e)