### PR TITLE
Consolidated Kernel update (v5.4.85 + v5.10.2)

### DIFF
--- a/recipes-kernel/linux/linux-fslc-imx_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_5.4.bb
@@ -28,7 +28,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v5.4.83
+#    tag: v5.4.85
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
@@ -79,14 +79,14 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
 SRCBRANCH = "5.4-2.2.x-imx"
-SRCREV = "95aec312c79e477bcbeb85c79f6e40aea06f4172"
+SRCREV = "350a71f471076717373c68fbe9dc5e6d3773bf57"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.83"
+LINUX_VERSION = "5.4.85"
 
 # Local version indicates the branch name in the NXP kernel tree where patches are collected from.
 LOCALVERSION = "-imx-5.4.47-2.2.0"

--- a/recipes-kernel/linux/linux-fslc_5.10.bb
+++ b/recipes-kernel/linux/linux-fslc_5.10.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.10-rc7"
+LINUX_VERSION = "5.10.2"
 
 SRCBRANCH = "5.10.x+fslc"
-SRCREV = "2b929f3dcf6caa89edb5c37f497b036d8964347f"
+SRCREV = "f263d1928d7d52dae2889284c20f303b569dd6ad"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"


### PR DESCRIPTION
Kernel branches were updated to include following versions for recipes from stable korg:
- `linux-fslc-imx`: _v5.4.85_
- `linux-fslc`: _v5.10.2_

Update recipe `SRCREV` to point to those versions now.

Upstream commits are recorded in corresponding recipe commit messages.

-- andrey