### PR TITLE
imx-atf/mkimage: allow to use mainline bsp for all imx8 machines

### DIFF
--- a/conf/machine/imx8mqevk.conf
+++ b/conf/machine/imx8mqevk.conf
@@ -48,6 +48,7 @@ ATF_PLATFORM = "imx8mq"
 
 # Set imx-mkimage boot target
 IMXBOOT_TARGETS = "flash_evk flash_evk_no_hdmi flash_dp_evk"
+IMX_BOOT_SOC_TARGET = "iMX8M"
 
 # Set Serial console
 SERIAL_CONSOLES = "115200;ttymxc0"

--- a/conf/machine/imx8mqevk.conf
+++ b/conf/machine/imx8mqevk.conf
@@ -43,6 +43,9 @@ DDR_FIRMWARE_NAME = "lpddr4_pmu_train_1d_imem.bin lpddr4_pmu_train_1d_dmem.bin l
 # Set u-boot DTB
 UBOOT_DTB_NAME = "imx8mq-evk.dtb"
 
+# Set ATF platform name
+ATF_PLATFORM = "imx8mq"
+
 # Set imx-mkimage boot target
 IMXBOOT_TARGETS = "flash_evk flash_evk_no_hdmi flash_dp_evk"
 

--- a/conf/machine/imx8qmmek.conf
+++ b/conf/machine/imx8qmmek.conf
@@ -59,6 +59,7 @@ ATF_PLATFORM = "imx8qm"
 IMXBOOT_TARGETS = \
     "${@bb.utils.contains('UBOOT_CONFIG',         'sd', 'flash', \
                                                         'flash_flexspi', d)}"
+IMX_BOOT_SOC_TARGET = "iMX8QM"
 
 BOARD_TYPE = "mek"
 

--- a/conf/machine/imx8qmmek.conf
+++ b/conf/machine/imx8qmmek.conf
@@ -53,6 +53,9 @@ IMX_BOOT_SEEK = "33"
 WKS_FILE_DEPENDS_append = " firmware-imx-8"
 IMAGE_BOOT_FILES += "hdmitxfw.bin hdmirxfw.bin dpfw.bin"
 
+# Set ATF platform name
+ATF_PLATFORM = "imx8qm"
+
 IMXBOOT_TARGETS = \
     "${@bb.utils.contains('UBOOT_CONFIG',         'sd', 'flash', \
                                                         'flash_flexspi', d)}"

--- a/conf/machine/imx8qxpmek.conf
+++ b/conf/machine/imx8qxpmek.conf
@@ -59,6 +59,7 @@ IMXBOOT_TARGETS = \
     "${@bb.utils.contains('UBOOT_CONFIG',   'sd', 'flash', \
         bb.utils.contains('UBOOT_CONFIG', 'fspi', 'flash_flexspi', \
                                                   'UNKNOWN', d), d)}"
+IMX_BOOT_SOC_TARGET = "iMX8QX"
 
 BOARD_TYPE = "mek"
 

--- a/conf/machine/imx8qxpmek.conf
+++ b/conf/machine/imx8qxpmek.conf
@@ -52,6 +52,9 @@ UBOOT_CONFIG[fspi] = "imx8qxp_mek_fspi_defconfig"
 
 IMX_BOOT_SEEK = "32"
 
+# Set ATF platform name
+ATF_PLATFORM = "imx8qx"
+
 IMXBOOT_TARGETS = \
     "${@bb.utils.contains('UBOOT_CONFIG',   'sd', 'flash', \
         bb.utils.contains('UBOOT_CONFIG', 'fspi', 'flash_flexspi', \

--- a/recipes-bsp/imx-atf/imx-atf_2.2.bb
+++ b/recipes-bsp/imx-atf/imx-atf_2.2.bb
@@ -21,12 +21,6 @@ inherit deploy
 BOOT_TOOLS = "imx-boot-tools"
 
 ATF_PLATFORM ??= "INVALID"
-ATF_PLATFORM_mx8qm   = "imx8qm"
-ATF_PLATFORM_mx8x    = "imx8qx"
-ATF_PLATFORM_mx8mq   = "imx8mq"
-ATF_PLATFORM_mx8dx   = "imx8dx"
-ATF_PLATFORM_imx8dxlevk = "imx8dxl"
-ATF_PLATFORM_mx8dxlevk-phantom = "imx8qx"
 
 EXTRA_OEMAKE += " \
     CROSS_COMPILE="${TARGET_PREFIX}" \

--- a/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
+++ b/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
@@ -39,12 +39,6 @@ do_compile[depends] += " \
 SC_FIRMWARE_NAME ?= "scfw_tcm.bin"
 
 ATF_MACHINE_NAME ?= "bl31-${ATF_PLATFORM}.bin"
-ATF_MACHINE_NAME_mx8qm = "bl31-imx8qm.bin"
-ATF_MACHINE_NAME_mx8x  = "bl31-imx8qx.bin"
-ATF_MACHINE_NAME_mx8mq = "bl31-imx8mq.bin"
-ATF_MACHINE_NAME_mx8phantomdxl = "bl31-imx8qx.bin"
-ATF_MACHINE_NAME_mx8dxl = "bl31-imx8dxl.bin"
-ATF_MACHINE_NAME_mx8dx = "bl31-imx8dx.bin"
 ATF_MACHINE_NAME_append = "${@bb.utils.contains('MACHINE_FEATURES', 'optee', '-optee', '', d)}"
 
 UBOOT_NAME = "u-boot-${MACHINE}.bin-${UBOOT_CONFIG}"
@@ -53,12 +47,6 @@ BOOT_CONFIG_MACHINE = "${BOOT_NAME}-${MACHINE}-${UBOOT_CONFIG}.bin"
 TOOLS_NAME ?= "mkimage_imx8"
 
 IMX_BOOT_SOC_TARGET       ?= "INVALID"
-IMX_BOOT_SOC_TARGET_mx8qm  = "iMX8QM"
-IMX_BOOT_SOC_TARGET_mx8x   = "iMX8QX"
-IMX_BOOT_SOC_TARGET_mx8mq  = "iMX8M"
-IMX_BOOT_SOC_TARGET_mx8dxl = "iMX8DXL"
-IMX_BOOT_SOC_TARGET_mx8phantomdxl = "iMX8QX"
-IMX_BOOT_SOC_TARGET_mx8dx  = "iMX8DX"
 
 DEPLOY_OPTEE = "${@bb.utils.contains('MACHINE_FEATURES', 'optee', 'true', 'false', d)}"
 


### PR DESCRIPTION
This series unifies all imx8 platforms, requiring to set both ATF_PLATFORM & IMX_BOOT_SOC_TARGET in the machine conf files.
Note that I don't believe mainline bsp works for any other platform than i.MX8MQ at this stage because of this:
```
BOOT_STAGING       = "${S}/${IMX_BOOT_SOC_TARGET}"
```
=> that doesn't work for iMX8MM/N/P I believe