### PR TITLE
xf86-video-armada: Fix no more working SRC_URI

### DIFF
--- a/recipes-graphics/xorg-driver/xf86-video-armada_git.bb
+++ b/recipes-graphics/xorg-driver/xf86-video-armada_git.bb
@@ -28,7 +28,7 @@ SRCREV_FORMAT = "armada_etna"
 PV = "0.1+git${SRCPV}"
 
 SRC_URI = " \
-    git://git.arm.linux.org.uk/cgit/xf86-video-armada.git;branch=unstable-devel;protocol=http;name=armada \
+    git://git.armlinux.org.uk/cgit/xf86-video-armada.git;branch=unstable-devel;protocol=http;name=armada \
     git://github.com/etnaviv/etna_viv.git;protocol=https;name=etna;destsuffix=etna_viv \
     "
 


### PR DESCRIPTION
Hi,

apparrently the URL of xf86-video-armada has changed. Hope, it will stay like it is now for a while.

Kind Regards
Kay Bouché