### PR TITLE
firmware-nxp-wifi: remove packages existing in upstream

### DIFF
--- a/recipes-bsp/firmware-imx/firmware-nxp-wifi_1.0.bb
+++ b/recipes-bsp/firmware-imx/firmware-nxp-wifi_1.0.bb
@@ -1,6 +1,11 @@
 # Copyright 2020-2021 NXP
 
 SUMMARY = "Wi-Fi firmware redistributed by NXP"
+DESCRIPTION = "Additional Wi-Fi firmware redistributed by NXP, \
+which is not covered by linux-firmware package. Once package becomes \
+available as a part of linux-firmware - it can be dropped from this \
+recipe in favor of upstream."
+
 SECTION = "kernel"
 LICENSE = "Proprietary"
 LIC_FILES_CHKSUM = "file://cyw-wifi-bt/EULA.txt;md5=80c0478f4339af024519b3723023fe28"
@@ -13,6 +18,7 @@ S = "${WORKDIR}/git"
 inherit allarch
 
 CLEANBROKEN = "1"
+ALLOW_EMPTY_${PN} = "1"
 
 do_compile() {
 	:
@@ -22,37 +28,14 @@ do_install() {
     install -d ${D}${sysconfdir}/firmware
     install -d ${D}${nonarch_base_libdir}/firmware/brcm
 
-    # Install various flavors of Broadcom firmware provided by Murata
-    install -m 0644 cyw-wifi-bt/*_CYW*/brcmfmac* ${D}${nonarch_base_libdir}/firmware/brcm
-    install -m 0644 cyw-wifi-bt/*_CYW*/BCM*.hcd ${D}${sysconfdir}/firmware
+    # Install various flavors of Broadcom firmware provided by Murata:
+    # - bcm4359-pcie
+    install -m 0644 cyw-wifi-bt/*_CYW*/brcmfmac4359-pcie* ${D}${nonarch_base_libdir}/firmware/brcm
+    install -m 0644 cyw-wifi-bt/*_CYW*/BCM4349B1*.hcd ${D}${sysconfdir}/firmware
 }
 
 PACKAGES =+ " \
-    ${PN}-bcm4339 \
-    ${PN}-bcm43430 \
-    ${PN}-bcm43455 \
-    ${PN}-bcm4356-pcie \
     ${PN}-bcm4359-pcie \
-"
-
-FILES_${PN}-bcm4339 = " \
-    ${nonarch_base_libdir}/firmware/brcm/brcmfmac4339-sdio.* \
-    ${sysconfdir}/firmware/BCM4335C0.ZP.hcd \
-"
-
-FILES_${PN}-bcm43430 = " \
-    ${nonarch_base_libdir}/firmware/brcm/brcmfmac43430-sdio.* \
-    ${sysconfdir}/firmware/BCM43430A1.1DX.hcd \
-"
-
-FILES_${PN}-bcm43455 = " \
-    ${nonarch_base_libdir}/firmware/brcm/brcmfmac43455-sdio.* \
-    ${sysconfdir}/firmware/BCM4345C0.1MW.hcd \
-"
-
-FILES_${PN}-bcm4356-pcie = " \
-    ${nonarch_base_libdir}/firmware/brcm/brcmfmac4356-pcie.* \
-    ${sysconfdir}/firmware/BCM4354A2.1CX.hcd \
 "
 
 FILES_${PN}-bcm4359-pcie = " \
@@ -60,22 +43,4 @@ FILES_${PN}-bcm4359-pcie = " \
     ${sysconfdir}/firmware/BCM4349B1_*.hcd \
 "
 
-RCONFLICTS_${PN}-bcm4339 = "linux-firmware-bcm4339"
-RPROVIDES_${PN}-bcm4339 = "linux-firmware-bcm4339"
-RREPLACES_${PN}-bcm4339 = "linux-firmware-bcm4339"
-
-RCONFLICTS_${PN}-bcm43430 = "linux-firmware-bcm43430"
-RPROVIDES_${PN}-bcm43430 = "linux-firmware-bcm43430"
-RREPLACES_${PN}-bcm43430 = "linux-firmware-bcm43430"
-
-RCONFLICTS_${PN}-bcm43455 = "linux-firmware-bcm43455"
-RPROVIDES_${PN}-bcm43455 = "linux-firmware-bcm43455"
-RREPLACES_${PN}-bcm43455 = "linux-firmware-bcm43455"
-
-RCONFLICTS_${PN}-bcm4356-pcie = "linux-firmware-bcm4356-pcie"
-RPROVIDES_${PN}-bcm4356-pcie = "linux-firmware-bcm4356-pcie"
-RREPLACES_${PN}-bcm4356-pcie = "linux-firmware-bcm4356-pcie"
-
-RCONFLICTS_${PN}-bcm4359-pcie = "linux-firmware-bcm4359-pcie"
 RPROVIDES_${PN}-bcm4359-pcie = "linux-firmware-bcm4359-pcie"
-RREPLACES_${PN}-bcm4359-pcie = "linux-firmware-bcm4359-pcie"


### PR DESCRIPTION
linux-firmware package already has firmware for modules, provided in
this recipe.

Drop firmware packages for following modules:
- bcm4339
- bcm43430
- bcm43455
- bcm4356-pcie

Keep the bcm4359-pcie in the recipe as it is not yet made part of
linux-firmware package.

Add recipe description detailing the usage of this package and actions
to be taken once the firmware gets integrated upstream.

Signed-off-by: Andrey Zhizhikin <andrey.z@gmail.com>