### PR TITLE
imx-gpu-viv: Restore virtual/opencl-icd to PROVIDES

### DIFF
--- a/recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc
+++ b/recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc
@@ -46,6 +46,7 @@ PROVIDES += " \
     opencl-icd-loader \
     virtual/egl \
     virtual/libopenvg \
+    virtual/opencl-icd \
     ${PROVIDES_OPENVX} \
     ${EXTRA_PROVIDES} \
 "


### PR DESCRIPTION
Since opencv depends on virtual/opencl-icd, restore virtual/opencl-icd to the
recipes provided so imx-gpu-viv is properly selected. Fixes:

```
ERROR: Nothing PROVIDES 'virtual/opencl-icd' (but /opt/work/upstream/sources/meta-openembedded/meta-oe/recipes-support/opencv/opencv_4.5.0.bb DEPENDS on or otherwise requires it). Close matches:
  virtual/libc
```

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>