### PR TITLE
linux-fslc-qoriq: update to LSDK-20.12 & 5.4.92

### DIFF
--- a/recipes-kernel/linux/linux-fslc-qoriq_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc-qoriq_5.4.bb
@@ -10,8 +10,8 @@ require recipes-kernel/linux/linux-qoriq.inc
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
-LINUX_VERSION = "5.4.64"
+LINUX_VERSION = "5.4.92"
 
 SRCBRANCH = "5.4.y+qoriq+fslc"
-SRCREV = "4c04c442c0e91e7cf01f830aca524f09b5613f29"
+SRCREV = "11d4722c637a77c6e1c9a8eeec091f1588f6b3f3"
 SRC_URI := "git://github.com/Freescale/linux-fslc.git;branch=${SRCBRANCH}"


### PR DESCRIPTION
*   11d4722c637a Merge pull request #232 from rehsack/5.4.y+qoriq+fslc
|\
| * f3ccdf75e260 staging: fsl-dpaa2/mac: remove unused variable
| * 322847164405 staging: fsl-dpaa2/mac: mark configurable function __maybe_unused
| * e78b4629dad4 rtc: pcf2127: apply upstream fix of initialisation
| *   a7595c24be7a Merge tag 'v5.4.92' into 5.4.y+qoriq+fslc
| |\
| | * 09f983f0c7fc Linux 5.4.92
| | * e2d69319b713 spi: cadence: cache reference clock rate during probe
| | * d04c7938d0f8 mac80211: check if atf has been disabled in __ieee80211_schedule_txq
| | * d46996cb4b16 mac80211: do not drop tx nulldata packets on encrypted links
| | * 56e8947bcf81 tipc: fix NULL deref in tipc_link_xmit()
| | * 55bac51762c3 net, sctp, filter: remap copy_from_user failure error
| | * 52e0b20c8c57 rxrpc: Fix handling of an unsupported token type in rxrpc_read()
| | * 5c466480d7d4 net: avoid 32 x truesize under-estimation for tiny skbs
| | * f6499a78e581 net: sit: unregister_netdevice on newlink's error path
| | * a3870cf8a7a2 net: stmmac: Fixed mtu channged by cache aligned
| | * c213d85cae39 rxrpc: Call state should be read with READ_ONCE() under some circumstances
| | * 6d57b582fb35 net: dcb: Accept RTM_GETDCB messages carrying set-like DCB commands
| | * d52f5929d997 net: dcb: Validate netlink message in DCB handler
| | * 814e04776211 esp: avoid unneeded kmap_atomic call
| | * 0ff06dd1b949 rndis_host: set proper input size for OID_GEN_PHYSICAL_MEDIUM request
| | * c897c10e4334 net: mvpp2: Remove Pause and Asym_Pause support
| | * 18c29e175e30 mlxsw: core: Increase critical threshold for ASIC thermal zone
| | * 7680783452ce mlxsw: core: Add validation of transceiver temperature thresholds
| | * ff6d4e8da7c6 net: ipv6: Validate GSO SKB before finish IPv6 processing
| | * b41352a93c16 net: skbuff: disambiguate argument and member for skb_list_walk_safe helper
| | * aa350dbe3a1e net: introduce skb_list_walk_safe for skb segment walking
| | * 760e9fd4f7ab netxen_nic: fix MSI/MSI-x interrupts
| | * 982e763ea3c3 udp: Prevent reuseport_select_sock from reading uninitialized socks
| | * bd4793843c85 bpf: Fix helper bpf_map_peek_elem_proto pointing to wrong callback
| | * 79ce12cfa56a bpf: Don't leak memory in bpf getsockopt when optlen == 0
| | * 4aef760c28e8 nfsd4: readdirplus shouldn't return parent of export
| | * 9b72d5ba50f1 spi: npcm-fiu: Disable clock in probe error path
| | * 6ef67f59263e spi: npcm-fiu: simplify the return expression of npcm_fiu_probe()
| | * fa6de8d82d9c scsi: lpfc: Make lpfc_defer_acc_rsp static
| | * e82b58aa6471 scsi: lpfc: Make function lpfc_defer_pt2pt_acc static
| | * 5e6b88828526 elfcore: fix building with clang
| | * ac29c052654f xen/privcmd: allow fetching resource sizes
| | * dd113b79ee7e compiler.h: Raise minimum version of GCC to 5.1 for arm64
| | * 24cea7d70516 usb: ohci: Make distrust_firmware param default to false
| * | 369f5e340a61 Merge tag 'v5.4.91' into 5.4.y+qoriq+fslc
| |\|
| | * d26b3110041a Linux 5.4.91
| | * 516bd00e5ac1 netfilter: nft_compat: remove flush counter optimization
| | * 935114863364 netfilter: nf_nat: Fix memleak in nf_nat_init
| | * 49fc6d92b484 netfilter: conntrack: fix reading nf_conntrack_buckets
| | * 548e4168e68d ALSA: firewire-tascam: Fix integer overflow in midi_port_work()
| | * 68e67535e26b ALSA: fireface: Fix integer overflow in transmit_midi_msg()
| | * 2c3d03cdbd39 dm: eliminate potential source of excessive kernel log noise
| | * a34294774a32 net: sunrpc: interpret the return value of kstrtou32 correctly
| | * 8b5107a74db3 iommu/vt-d: Fix unaligned addresses for intel_flush_svm_range_dev()
| | * c2226680343d mm, slub: consider rest of partial list if acquire_slab() fails
| | * cd9e901fe2fc drm/i915/dsi: Use unconditional msleep for the panel_on_delay when there is no reset-deassert MIPI-sequence
| | * 9269296721b5 IB/mlx5: Fix error unwinding when set_has_smi_cap fails
| | * 40a782293545 RDMA/mlx5: Fix wrong free of blue flame register on error
| | * e8c8d2319bd7 bnxt_en: Improve stats context resource accounting with RDMA driver loaded.
| | * 3bcf35a7c05f RDMA/usnic: Fix memleak in find_free_vf_and_create_qp_grp
| | * da834a9bdc23 RDMA/restrack: Don't treat as an error allocation ID wrapping
| | * 986fdc7685fa ext4: fix superblock checksum failure when setting password salt
| | * 38992092b54e NFS: nfs_igrab_and_active must first reference the superblock
| | * 6b3ae2030db9 NFS/pNFS: Fix a leak of the layout 'plh_outstanding' counter
| | * aa2399f55eff pNFS: Stricter ordering of layoutget and layoutreturn
| | * 78c2ab7f5265 pNFS: Mark layout for return if return-on-close was not sent
| | * 7d1241ae1dce pNFS: We want return-on-close to complete when evicting the inode
| | * 69d121ca892c NFS4: Fix use-after-free in trace_event_raw_event_nfs4_set_lock
| | * c70f6e0ac9f9 nvme-tcp: fix possible data corruption with bio merges
| | * 55a102004376 ASoC: Intel: fix error code cnl_set_dsp_D0()
| | * 2392a54de8ba ASoC: meson: axg-tdmin: fix axg skew offset
| | * 973900cd4614 ASoC: meson: axg-tdm-interface: fix loopback
| | * 08eb8a735c11 dump_common_audit_data(): fix racy accesses to ->d_name
| | * d443cefd9f73 perf intel-pt: Fix 'CPU too large' error
| | * 221dee1d0d4e ARM: picoxcell: fix missing interrupt-parent properties
| | * ba74e0f222c7 drm/msm: Call msm_init_vram before binding the gpu
| | * 0251d3eb4480 ACPI: scan: add stub acpi_create_platform_device() for !CONFIG_ACPI
| | * bfdd0a3b86c3 usb: typec: Fix copy paste error for NVIDIA alt-mode description
| | * 644baa95db2b drm/amdgpu: fix a GPU hang issue when remove device
| | * 596b3423fddc nvmet-rdma: Fix list_del corruption on queue establishment failure
| | * 4cb77b877fcc nvme-pci: mark Samsung PM1725a as IGNORE_DEV_SUBNQN
| | * 242793c7ef2f selftests: fix the return value for UDP GRO test
| | * 5fc06b706432 net: ethernet: fs_enet: Add missing MODULE_LICENSE
| | * 15a8491cdcd4 misdn: dsp: select CONFIG_BITREVERSE
| | * 635a658de303 arch/arc: add copy_user_page() to <asm/page.h> to fix build error on ARC
| | * bc68af1fdcac bfq: Fix computation of shallow depth
| | * 2abc54579d1b lib/raid6: Let $(UNROLL) rules work with macOS userland
| | * 1d05b91ab72e hwmon: (pwm-fan) Ensure that calculation doesn't discard big period values
| | * 1229d433960c habanalabs: Fix memleak in hl_device_reset
| | * 93aef8e6cc08 habanalabs: register to pci shutdown callback
| | * 79df21218d63 ethernet: ucc_geth: fix definition and size of ucc_geth_tx_global_pram
| | * 331a6438ebfd regulator: bd718x7: Add enable times
| | * d5f996bea464 btrfs: fix transaction leak and crash after RO remount caused by qgroup rescan
| | * c8dd8af4b35f netfilter: ipset: fixes possible oops in mtype_resize
| | * ca2fc0dc1cec ARC: build: move symlink creation to arch/arc/Makefile to avoid race
| | * 6265a0f2410f ARC: build: add boot_targets to PHONY
| | * 217d8ba22bce ARC: build: add uImage.lzma to the top-level target
| | * b9128252b9ee ARC: build: remove non-existing bootpImage from KBUILD_IMAGE
| | * 5349b17c3df5 dm integrity: fix flush with external metadata device
| | * c553300f1453 cifs: fix interrupted close commands
| | * d17a9571e392 smb3: remove unused flag passed into close functions
| | * 55a4dff288af ext4: don't leak old mountpoint samples
| | * 2003c669df4c ext4: fix bug for rename with RENAME_WHITEOUT
| | * 425faacff213 drm/i915/backlight: fix CPU mode backlight takeover on LPT
| | * 72eb9fc82aea btrfs: tree-checker: check if chunk item end overflows
| | * 82a948fc67ea r8152: Add Lenovo Powered USB-C Travel Hub
| | * ad5f19c7e9ce dm integrity: fix the maximum number of arguments
| | * 5caac6317daf dm snapshot: flush merged data before committing metadata
| | * 2017b99ec205 dm raid: fix discard limits for raid1
| | * 4335af6c62fc mm/hugetlb: fix potential missing huge page size info
| | * c64366620d91 ACPI: scan: Harden acpi_device_add() against device ID overflows
| | * bc0b70f1d28c RDMA/ocrdma: Fix use after free in ocrdma_dealloc_ucontext_pd()
| | * f7a97dc302be MIPS: relocatable: fix possible boot hangup with KASLR enabled
| | * f5c2f7970683 MIPS: boot: Fix unaligned access with CONFIG_MIPS_RAW_APPENDED_DTB
| | * a650107de374 mips: lib: uncached: fix non-standard usage of variable 'sp'
| | * bda45bbc8e03 mips: fix Section mismatch in reference
| | * aeb64ef1f429 tracing/kprobes: Do the notrace functions check without kprobes on ftrace
| | * 984f57e4258c x86/hyperv: check cpu mask after interrupt has been disabled
| | * 1a202b9b9d23 ASoC: dapm: remove widget from dirty list on free
| | * 82d1a5f6f2e5 btrfs: prevent NULL pointer dereference in extent_io_tree_panic
| | * bb562e6e0358 kbuild: enforce -Werror=return-type
| * | e9c382e5394f Merge tag 'v5.4.90' into 5.4.y+qoriq+fslc
| |\|
| | * ceed81a883dc Linux 5.4.90
| | * 6f484096196b regmap: debugfs: Fix a reversed if statement in regmap_debugfs_init()
| | * bbb2fee395e9 net: drop bogus skb with CHECKSUM_PARTIAL and offset beyond end of trimmed packet
| | * bd0051a5cb05 block: fix use-after-free in disk_part_iter_next
| | * c5fe50e18fcb KVM: arm64: Don't access PMCR_EL0 when no PMU is available
| | * f595e44b161a net: mvpp2: disable force link UP during port init procedure
| | * 5b8d3c3a9fcb regulator: qcom-rpmh-regulator: correct hfsmps515 definition
| | * 3582406b9c04 wan: ds26522: select CONFIG_BITREVERSE
| | * 480c5e9c7e4c regmap: debugfs: Fix a memory leak when calling regmap_attach_dev
| | * c3c774886790 net/mlx5e: Fix two double free cases
| | * ce74b5a0689d net/mlx5e: Fix memleak in mlx5e_create_l2_table_groups
| | * a2b2ae3812e5 bpftool: Fix compilation failure for net.o with older glibc
| | * 2992e3371a3a iommu/intel: Fix memleak in intel_irq_remapping_alloc
| | * 006319327d21 lightnvm: select CONFIG_CRC32
| | * 46c15eeb0a8a block: rsxx: select CONFIG_CRC32
| | * 4834a984e456 wil6210: select CONFIG_CRC32
| | * b28378bc91d0 qed: select CONFIG_CRC32
| | * cc196d4604c9 dmaengine: xilinx_dma: fix mixed_enum_type coverity warning
| | * d0eaf8a8eff8 dmaengine: xilinx_dma: fix incompatible param warning in _child_probe()
| | * e6f247a5f927 dmaengine: xilinx_dma: check dma_async_device_register return value
| | * c15556cb344a dmaengine: mediatek: mtk-hsdma: Fix a resource leak in the error handling path of the probe function
| | * 55503711adff i2c: i801: Fix the i2c-mux gpiod_lookup_table not being properly terminated
| | * 12e8bcaef61a spi: stm32: FIFO threshold level - fix align packet size
| | * 9ff4796e6fd9 cpufreq: powernow-k8: pass policy rather than use cpufreq_cpu_get()
| | * 4dd15f9bc881 can: kvaser_pciefd: select CONFIG_CRC32
| | * 82adac5ad13b can: m_can: m_can_class_unregister(): remove erroneous m_can_clk_stop()
| | * 3b68980596fb can: tcan4x5x: fix bittiming const, use common bittiming from m_can driver
| | * b77e0283efdc dmaengine: dw-edma: Fix use after free in dw_edma_alloc_chunk()
| | * f6dd8c259ab8 i2c: sprd: use a specific timeout to avoid system hang up issue
| | * 8d0cadc2ea64 ARM: OMAP2+: omap_device: fix idling of devices during probe
| | * 003280bd8845 HID: wacom: Fix memory leakage caused by kfifo_alloc
| | * 6f367fb1b7ee iio: imu: st_lsm6dsx: fix edge-trigger interrupts
| | * 87ea51c90280 vmlinux.lds.h: Add PGO and AutoFDO input sections
| | * 099340d3e758 exfat: Month timestamp metadata accidentally incremented
| | * bb039d45ebc5 x86/resctrl: Don't move a task to the same resource group
| | * 628af07fc5cd x86/resctrl: Use an IPI instead of task_work_add() to update PQR_ASSOC MSR
| | * 96fb3d28c885 chtls: Fix chtls resources release sequence
| | * fac9b53cfacb chtls: Added a check to avoid NULL pointer dereference
| | * 38768ea1127d chtls: Replace skb_dequeue with skb_peek
| | * dcce456b2843 chtls: Fix panic when route to peer not configured
| | * 44bed66b2be9 chtls: Remove invalid set_tcb call
| | * 266ee00f402b chtls: Fix hardware tid leak
| | * ed62af62da41 net/mlx5e: ethtool, Fix restriction of autoneg with 56G
| | * cf59803ce4b3 net/mlx5: Use port_num 1 instead of 0 when delete a RoCE address
| | * 3008c639c081 net: dsa: lantiq_gswip: Exclude RMII from modes that report 1 GbE
| | * fc1c907da5a1 s390/qeth: fix L2 header access in qeth_l3_osa_features_check()
| | * e6931e3eb084 nexthop: Unlink nexthop group entry in error path
| | * 3cecab93f271 nexthop: Fix off-by-one error in error path
| | * f03b81e61ef5 octeontx2-af: fix memory leak of lmac and lmac->name
| | * 12e10b12124c net: ip: always refragment ip defragmented packets
| | * 41bfd4111257 net: fix pmtu check in nopmtudisc mode
| | * 98fc9692ac3d tools: selftests: add test for changing routes with PTMU exceptions
| | * 7694654168bb net: ipv6: fib: flush exceptions when purging route
| | * 1cba7e270b16 net/sonic: Fix some resource leaks in error handling paths
| | * 37e6368a8de6 net: vlan: avoid leaks on register_vlan_dev() failures
| | * 4ff0737ebc76 net: stmmac: dwmac-sun8i: Balance internal PHY power
| | * 5698f0921c9b net: stmmac: dwmac-sun8i: Balance internal PHY resource references
| | * fa020a28896c net: hns3: fix a phy loopback fail issue
| | * bddaf51d116c net: hns3: fix the number of queues actually used by ARQ
| | * d73f7e757526 net: cdc_ncm: correct overhead in delayed_ndp_size
| | * 5597557244d4 vfio iommu: Add dma available capability
| | * 335104082c21 x86/asm/32: Add ENDs to some functions and relabel with SYM_CODE_*
| * | f0f641b434af Merge tag 'v5.4.89' into 5.4.y+qoriq+fslc
| |\|
| | * a829146c3fdc Linux 5.4.89
| | * 485e21729b1e scsi: target: Fix XCOPY NAA identifier lookup
| | * 7795afa0d7a9 KVM: x86: fix shift out of bounds reported by UBSAN
| | * a9d49da7edf8 x86/mtrr: Correct the range check before performing MTRR type lookups
| | * a798b367a066 netfilter: nft_dynset: report EOPNOTSUPP on missing set feature
| | * 5e401ea71676 netfilter: xt_RATEEST: reject non-null terminated string from userspace
| | * 1dd6a790c220 netfilter: ipset: fix shift-out-of-bounds in htable_bits()
| | * e0281bb5a82d netfilter: x_tables: Update remaining dereference to RCU
| | * 828f2a20f946 drm/i915: clear the gpu reloc batch
| | * ef8133b1b47e dmabuf: fix use-after-free of dmabuf's file->f_inode
| | * 284be2b993ca Revert "device property: Keep secondary firmware node secondary by type"
| | * 64d06c7f2fa2 btrfs: send: fix wrong file path when there is an inode with a pending rmdir
| | * 0cb0b876f17f ALSA: hda/realtek: Add two "Intel Reference board" SSID in the ALC256.
| | * 02e59692a6b1 ALSA: hda/realtek: Enable mute and micmute LED on HP EliteBook 850 G7
| | * d63a96f45c4f ALSA: hda/realtek - Fix speaker volume control on Lenovo C940
| | * 30fd9778cf8f ALSA: hda/conexant: add a new hda codec CX11970
| | * 121944484cc4 ALSA: hda/via: Fix runtime PM for Clevo W35xSS
| | * a5c7a456680f kvm: check tlbs_dirty directly
| | * 10dcb79ec79e x86/mm: Fix leak of pmd ptlock
| | * d3e5db486fd8 USB: serial: keyspan_pda: remove unused variable
| | * bcffe2de9dde usb: gadget: configfs: Fix use-after-free issue with udc_name
| | * 276828221852 usb: gadget: configfs: Preserve function ordering after bind failure
| | * b2bd36f54495 usb: gadget: Fix spinlock lockup on usb_function_deactivate
| | * ce507b55db29 USB: gadget: legacy: fix return error code in acm_ms_bind()
| | * 7f875ea9883c usb: gadget: u_ether: Fix MTU size mismatch with RX packet size
| | * b89a5f39c2b5 usb: gadget: function: printer: Fix a memory leak for interface descriptor
| | * 692ab0726460 usb: gadget: f_uac2: reset wMaxPacketSize
| | * 7ac84fa85ba2 usb: gadget: select CONFIG_CRC32
| | * 77a804dd6b46 ALSA: usb-audio: Fix UBSAN warnings for MIDI jacks
| | * 5c263f16822f USB: usblp: fix DMA to stack
| | * 41f15da2abd9 USB: yurex: fix control-URB timeout handling
| | * 175f7a5fa7e6 USB: serial: option: add Quectel EM160R-GL
| | * 1a59feb52dc4 USB: serial: option: add LongSung M5710 module support
| | * ac48b1dacb07 USB: serial: iuu_phoenix: fix DMA from stack
| | * 8a051eaae708 usb: uas: Add PNY USB Portable SSD to unusual_uas
| | * a7b81d0d2e07 usb: usbip: vhci_hcd: protect shift size
| | * f7cc27eb358d USB: xhci: fix U1/U2 handling for hardware with XHCI_INTEL_HOST quirk set
| | * ea472d839133 usb: chipidea: ci_hdrc_imx: add missing put_device() call in usbmisc_get_init_data()
| | * a37a0667e1e0 usb: dwc3: ulpi: Use VStsDone to detect PHY regs access completion
| | * 5b8e1be9e0c1 USB: cdc-wdm: Fix use after free in service_outstanding_interrupt().
| | * 5445502a344b USB: cdc-acm: blacklist another IR Droid device
| | * eeae1d95ce4e usb: gadget: enable super speed plus
| | * 70cf59b8ffb4 staging: mt7621-dma: Fix a resource leak in an error handling path
| | * c511f27e130e powerpc: Handle .text.{hot,unlikely}.* in linker script
| | * 867c10a03f84 crypto: asym_tpm: correct zero out potential secrets
| | * ff7397add935 crypto: ecdh - avoid buffer overflow in ecdh_set_secret()
| | * 9e60056b1f53 video: hyperv_fb: Fix the mmap() regression for v5.4.y and older
| | * 84d488719b27 Bluetooth: revert: hci_h5: close serdev device and free hu in h5_close
| | * 3417067b3111 kbuild: don't hardcode depmod path
| | * 3f2a28930a7e net/sched: sch_taprio: ensure to reset/destroy all child qdiscs
| | * c41ea30c3839 ionic: account for vlan tag len in rx buffer len
| | * 5c6eb887e192 vhost_net: fix ubuf refcount incorrectly when sendmsg fails
| | * 8f64957fda12 net: usb: qmi_wwan: add Quectel EM160R-GL
| | * 12ab7b627d43 CDC-NCM: remove "connected" log message
| | * 171a2bce9d6c net: dsa: lantiq_gswip: Fix GSWIP_MII_CFG(p) register access
| | * c0883010d3b3 net: dsa: lantiq_gswip: Enable GSWIP_MII_CFG_EN also for internal PHYs
| | * 07f26fc52b45 r8169: work around power-saving bug on some chip versions
| | * 106ca9ca9acc net: hdlc_ppp: Fix issues when mod_timer is called while timer is running
| | * 2b8aa896b151 erspan: fix version 1 check in gre_parse_header()
| | * 606f5412ad86 net: hns: fix return value check in __lb_other_process()
| | * e40b5fc79110 net: sched: prevent invalid Scell_log shift count
| | * b16f883e71f3 ipv4: Ignore ECN bits for fib lookups in fib_compute_spec_dst()
| | * a018c071de14 net: mvpp2: fix pkt coalescing int-threshold configuration
| | * 443a71031e49 tun: fix return value when the number of iovs exceeds MAX_SKB_FRAGS
| | * c076e1198554 net: ethernet: ti: cpts: fix ethtool output when no ptp_clock registered
| | * 8602c20a9160 net-sysfs: take the rtnl lock when accessing xps_rxqs_map and num_tc
| | * 1f6b04a2b282 net-sysfs: take the rtnl lock when storing xps_rxqs
| | * 67ed54a63f43 net-sysfs: take the rtnl lock when accessing xps_cpus_map and num_tc
| | * fb14db9508c0 net-sysfs: take the rtnl lock when storing xps_cpus
| | * e43ec45d45af net: ethernet: Fix memleak in ethoc_probe
| | * 56dc7908ed85 net/ncsi: Use real net-device for response handler
| | * dffef999e484 virtio_net: Fix recursive call to cpus_read_lock()
| | * 5404192a8721 qede: fix offload for IPIP tunnel packets
| | * 8009f6bb13a3 net: ethernet: mvneta: Fix error handling in mvneta_probe
| | * 6d003fe7fe87 ibmvnic: continue fatal error reset after passive init
| | * 3d16088a9668 net: mvpp2: Fix GoP port 3 Networking Complex Control configurations
| | * 8548c9679939 atm: idt77252: call pci_disable_device() on error path
| | * 2a006b4fa5cc ethernet: ucc_geth: set dev->max_mtu to 1518
| | * c2ca14cc6f55 ethernet: ucc_geth: fix use-after-free in ucc_geth_remove()
| | * af99cae96fdc net: systemport: set dev->max_mtu to UMAC_MAX_MTU_SIZE
| | * 8dd98d5d2ba4 net: mvpp2: prs: fix PPPoE with ipv6 packet parse
| | * 73445f29575a net: mvpp2: Add TCAM entry to drop flow control pause frames
| | * a5a6dc4dc293 iavf: fix double-release of rtnl_lock
| | * 6aba31a7c72e i40e: Fix Error I40E_AQ_RC_EINVAL when removing VFs
| | * 9ea03f6890ce proc: fix lookup in /proc/net subdirectories after setns(2)
| | * d2942e958f26 proc: change ->nlink under proc_subdir_lock
| | * 59b10c8a59a1 depmod: handle the case of /sbin/depmod without /sbin in PATH
| | * 663a0bcb3fa5 lib/genalloc: fix the overflow when size is too big
| | * 19e0cf8fc481 scsi: scsi_transport_spi: Set RQF_PM for domain validation commands
| | * eb3e975ac2a3 scsi: ide: Do not set the RQF_PREEMPT flag for sense requests
| | * 4ae3573c571e scsi: ufs-pci: Ensure UFS device is in PowerDown mode for suspend-to-disk ->poweroff()
| | * 5f9c3d640505 scsi: ufs: Fix wrong print message in dev_err()
| | * 515dc635eb76 workqueue: Kick a worker based on the actual activation of delayed works
| * | ffe4a8bdd0c7 Merge tag 'v5.4.88' into 5.4.y+qoriq+fslc
| |\|
| | * f3a4c8d50145 Linux 5.4.88
| | * 0a49aaf4df29 mwifiex: Fix possible buffer overflows in mwifiex_cmd_802_11_ad_hoc_start
| | * 117433236ae2 exec: Transform exec_update_mutex into a rw_semaphore
| | * d390fc97df62 rwsem: Implement down_read_interruptible
| | * 1b75a263fbd9 rwsem: Implement down_read_killable_nested
| | * 71b8355ba667 perf: Break deadlock involving exec_update_mutex
| | * 732251cabeb3 fuse: fix bad inode
| | * 06c672dd61b5 iio:imu:bmi160: Fix alignment and data leak issues
| | * 7a736f41013e kdev_t: always inline major/minor helper functions
| | * 61a0d8e437bb dmaengine: at_hdmac: add missing kfree() call in at_dma_xlate()
| | * 20d5ee563bfd dmaengine: at_hdmac: add missing put_device() call in at_dma_xlate()
| | * f2a0b7677444 dmaengine: at_hdmac: Substitute kzalloc with kmalloc
| | * 4d3ba541bede Revert "mtd: spinand: Fix OOB read"
| | * da5b4cf021b9 Revert "drm/amd/display: Fix memory leaks in S3 resume"
| * | 5b3d5fd162f1 Merge tag 'v5.4.87' into 5.4.y+qoriq+fslc
| |\|
| | * b3f656a592f3 Linux 5.4.87
| | * 41ae3e574ccf dm verity: skip verity work if I/O error when system is shutting down
| | * 8b3c00977264 ALSA: pcm: Clear the full allocated memory at hw_params
| | * 480abac78e03 tick/sched: Remove bogus boot "safety" check
| | * 1dab82dd202d um: ubd: Submit all data segments atomically
| | * d32747bb687d fs/namespace.c: WARN if mnt_count has become negative
| | * 9f4e8026d202 module: delay kobject uevent until after module init call
| | * 86db71810a27 f2fs: avoid race condition for shrinker count
| | * dbe184f6be1e NFSv4: Fix a pNFS layout related use-after-free race when freeing the inode
| | * d52faa7fb12f i3c master: fix missing destroy_workqueue() on error in i3c_master_register
| | * 22f815627c64 powerpc: sysdev: add missing iounmap() on error in mpic_msgr_probe()
| | * a95049c51417 rtc: pl031: fix resource leak in pl031_probe
| | * e2926630f653 quota: Don't overflow quota file offsets
| | * 1842dde0dd13 module: set MODULE_STATE_GOING state when a module fails to load
| | * 569da7c3d9a3 rtc: sun6i: Fix memleak in sun6i_rtc_clk_init
| | * 642c2d74c365 fcntl: Fix potential deadlock in send_sig{io, urg}()
| | * 5b2f1ad6b12b bfs: don't use WARNING: string when it's just info.
| | * 3a2a5e197a84 ALSA: rawmidi: Access runtime->avail always in spinlock
| | * 8d2204a05391 ALSA: seq: Use bool for snd_seq_queue internal flags
| | * 4250fe65b2e6 f2fs: fix shift-out-of-bounds in sanity_check_raw_super()
| | * 28a29e3a658a media: gp8psk: initialize stats at power control logic
| | * 750627d36f84 misc: vmw_vmci: fix kernel info-leak by initializing dbells in vmci_ctx_get_chkpt_doorbells()
| | * 01be033cc127 reiserfs: add check for an invalid ih_entry_count
| | * 18e1101b0ee9 Bluetooth: hci_h5: close serdev device and free hu in h5_close
| | * b726f8602207 scsi: cxgb4i: Fix TLS dependency
| | * 57ba2c7a50bf cgroup: Fix memory leak when parsing multiple source parameters
| | * 8ddf02859c69 of: fix linker-section match-table corruption
| | * 8ec95e308418 null_blk: Fix zone size initialization
| | * 7c3d8d73bafd tools headers UAPI: Sync linux/const.h with the kernel headers
| | * 376c3111413c uapi: move constants from <linux/kernel.h> to <linux/const.h>
| | * af07e4dd0783 scsi: block: Fix a race in the runtime power management code
| | * 9ce7ac5ed53b jffs2: Fix NULL pointer dereference in rp_size fs option parsing
| | * 3a83e289e4b7 jffs2: Allow setting rp_size to zero during remounting
| | * ee78e7d93e35 powerpc/bitops: Fix possible undefined behaviour with fls() and fls64()
| | * 7cb6087b4536 KVM: x86: reinstate vendor-agnostic check on SPEC_CTRL cpuid bits
| | * 3d4a05894500 KVM: SVM: relax conditions for allowing MSR_IA32_SPEC_CTRL accesses
| | * d77c1ab54c9e KVM: x86: avoid incorrect writes to host MSR_IA32_SPEC_CTRL
| | * 11459136a107 ext4: don't remount read-only with errors=continue on reboot
| | * 6b0a4f603d5b btrfs: fix race when defragmenting leads to unnecessary IO
| | * 30aea96ff142 vfio/pci: Move dummy_resources_list init in vfio_pci_probe()
| | * 29c2d3e91e3d fscrypt: remove kernel-internal constants from UAPI header
| | * 34f000524d33 fscrypt: add fscrypt_is_nokey_name()
| | * eddc69467e39 f2fs: prevent creating duplicate encrypted filenames
| | * 6fe20a5204a6 ubifs: prevent creating duplicate encrypted filenames
| | * 3ebfed353afd ext4: prevent creating duplicate encrypted filenames
| | * faa72d97c3e3 thermal/drivers/cpufreq_cooling: Update cpufreq_state only if state has changed
| | * d3076d054f3e md/raid10: initialize r10_bio->read_slot before use.
| | * c71c512f4a65 net/sched: sch_taprio: reset child qdiscs before freeing them
| * | 729143265a92 Merge tag 'v5.4.86' into 5.4.y+qoriq+fslc
| |\|
| | * dfce803cd87d Linux 5.4.86
| | * 8302bd9afd4b x86/CPU/AMD: Save AMD NodeId as cpu_die_id
| | * 6001db0272da Revert: "ring-buffer: Remove HAVE_64BIT_ALIGNED_ACCESS"
| | * 33afcf723a0e rtc: ep93xx: Fix NULL pointer dereference in ep93xx_rtc_read_time
| | * 7e0f7a293608 regulator: axp20x: Fix DLDO2 voltage control register mask for AXP22x
| | * be23b04074b1 PCI: Fix pci_slot_release() NULL pointer dereference
| | * b1f9419d5e6c platform/x86: intel-vbtn: Allow switch events on Acer Switch Alpha 12
| | * c16b5849352c libnvdimm/namespace: Fix reaping of invalidated block-window-namespace labels
| | * 68d139a97415 xenbus/xenbus_backend: Disallow pending watch messages
| | * d3eaea062b51 xen/xenbus: Count pending messages for each watch
| | * c45b0a8d2a68 xen/xenbus/xen_bus_type: Support will_handle watch callback
| | * 7da6db982e53 xen/xenbus: Add 'will_handle' callback support in xenbus_watch_path()
| | * eac0c12e329d xen/xenbus: Allow watches discard events before queueing
| | * 8f3f6de44f7c xen-blkback: set ring->xenblkd to NULL after kthread_stop()
| | * 383c60c16dd8 dma-buf/dma-resv: Respect num_fences when initializing the shared fence list.
| | * b16a6a46e0b2 device-dax/core: Fix memory leak when rmmod dax.ko
| | * f3ede933fbc7 clk: tegra: Do not return 0 on failure
| | * f133bfbe1201 clk: mvebu: a3700: fix the XTAL MODE pin to MPP1_9
| | * ca4fd0284cb3 clk: ingenic: Fix divider calculation with div tables
| | * 13e6b6259e6d pinctrl: sunxi: Always call chained_irq_{enter, exit} in sunxi_pinctrl_irq_handler
| | * 2fb550de7563 md/cluster: fix deadlock when node is doing resync job
| | * 7523d147087b md/cluster: block reshape with remote resync job
| | * 27b58f6adad8 iio:adc:ti-ads124s08: Fix alignment and data leak issues.
| | * 2d7229c037d1 iio:adc:ti-ads124s08: Fix buffer being too long.
| | * d6ea1d559027 iio:imu:bmi160: Fix too large a buffer.
| | * 91b7b231f5e7 iio:pressure:mpl3115: Force alignment of buffer
| | * 9607d22e71d1 iio:magnetometer:mag3110: Fix alignment and data leak issues.
| | * 71a326dcd2a8 iio:light:st_uvis25: Fix timestamp alignment and prevent data leak.
| | * c18fc255187f iio:light:rpr0521: Fix timestamp alignment and prevent data leak.
| | * 860ab67cd81e iio: adc: rockchip_saradc: fix missing clk_disable_unprepare() on error in rockchip_saradc_resume
| | * 0fa2b43b0a2a iio: buffer: Fix demux update
| | * 82af6e44b7d4 scsi: lpfc: Re-fix use after free in lpfc_rq_buf_free()
| | * 7ec7630548dc scsi: lpfc: Fix invalid sleeping context in lpfc_sli4_nvmet_alloc()
| | * 6822575cf204 scsi: qla2xxx: Fix crash during driver load on big endian machines
| | * 1b26af7e4c7f mtd: rawnand: meson: fix meson_nfc_dma_buffer_release() arguments
| | * c5f3e5ca8116 mtd: rawnand: qcom: Fix DMA sync on FLASH_STATUS register read
| | * 2aea2b22b6f9 mtd: parser: cmdline: Fix parsing of part-names with colons
| | * 4290a73c9d67 mtd: spinand: Fix OOB read
| | * b22739509dcb soc: qcom: smp2p: Safely acquire spinlock without IRQs
| | * ddcb518dee78 spi: atmel-quadspi: Fix AHB memory accesses
| | * 96f7bd39f56f spi: atmel-quadspi: Disable clock in probe error path
| | * 8f295baae53d spi: mt7621: Don't leak SPI master in probe error path
| | * 0818aab8a82b spi: mt7621: Disable clock in probe error path
| | * cad189512c38 spi: synquacer: Disable clock in probe error path
| | * 4051e5b7741b spi: st-ssc4: Fix unbalanced pm_runtime_disable() in probe error path
| | * 3c0e28f2881e spi: sc18is602: Don't leak SPI master in probe error path
| | * 819f9edaaeb9 spi: rb4xx: Don't leak SPI master in probe error path
| | * c5491ac11559 spi: pic32: Don't leak DMA channels in probe error path
| | * 3ea835ac604b spi: mxic: Don't leak SPI master in probe error path
| | * 0da7709f5ea3 spi: gpio: Don't leak SPI master in probe error path
| | * ee1d2aef1c13 spi: fsl: fix use of spisel_boot signal on MPC8309
| | * 614f2529c8ea spi: davinci: Fix use-after-free on unbind
| | * c6b9bfb0c477 spi: atmel-quadspi: Fix use-after-free on unbind
| | * bd6d736dbf36 spi: spi-sh: Fix use-after-free on unbind
| | * 17360c3af129 spi: pxa2xx: Fix use-after-free on unbind
| | * c5ae864c148c drm/i915: Fix mismatch between misplaced vma check and vma insert
| | * 1e684ad37047 drm/dp_aux_dev: check aux_dev before use in drm_dp_aux_dev_get_by_minor()
| | * e1b1f10c3404 drm/amd/display: Fix memory leaks in S3 resume
| | * b966771b0d69 platform/x86: mlx-platform: remove an unused variable
| | * cbeb61258186 jfs: Fix array index bounds check in dbAdjTree
| | * 8ee70b6db882 jffs2: Fix ignoring mounting options problem during remounting
| | * 00e45efaf9ff jffs2: Fix GC exit abnormally
| | * ea1e4ba032c5 ubifs: wbuf: Don't leak kernel memory to flash
| | * 32825fe72cb3 SMB3: avoid confusing warning message on mount to Azure
| | * f22f743a2af2 ceph: fix race in concurrent __ceph_remove_cap invocations
| | * a7b014b54c16 um: Remove use of asprinf in umid.c
| | * 26d72a8460dc ima: Don't modify file descriptor mode on the fly
| | * a89b91fcb07c powerpc/powernv/memtrace: Fix crashing the kernel when enabling concurrently
| | * 45bf367c8550 powerpc/powernv/memtrace: Don't leak kernel memory to user space
| | * 59334d821e8a powerpc/powernv/npu: Do not attempt NPU2 setup on POWER8NVL NPU
| | * c7f66ad880a9 powerpc/mm: Fix verification of MMU_FTR_TYPE_44x
| | * 32e29541b5aa powerpc/8xx: Fix early debug when SMC1 is relocated
| | * 15c9e56b41d0 powerpc/xmon: Change printk() to pr_cont()
| | * c7b89d0d7186 powerpc/feature: Add CPU_FTR_NOEXECUTE to G2_LE
| | * 0f157acd436c powerpc/rtas: Fix typo of ibm,open-errinjct in RTAS filter
| | * 30a58a3f7c85 powerpc: Fix incorrect stw{, ux, u, x} instructions in __set_pte_at
| | * 3ee6a2bc1428 xprtrdma: Fix XDRBUF_SPARSE_PAGES support
| | * 2504e407a39f ARM: dts: at91: sama5d2: fix CAN message ram offset and size
| | * 789246b9afe8 ARM: dts: pandaboard: fix pinmux for gpio user button of Pandaboard ES
| | * 6ee6e4e5a4cf KVM: arm64: Introduce handling of AArch32 TTBCR2 traps
| | * 8635f0fe06c5 ext4: fix deadlock with fs freezing and EA inodes
| | * c90a5f4851a8 ext4: fix a memory leak of ext4_free_data
| | * e21d630a2c0d btrfs: trim: fix underflow in trim length to prevent access beyond device boundary
| | * 1d11ed122f6f btrfs: do not shorten unpin len for caching block groups
| | * af7414836d88 USB: serial: keyspan_pda: fix write unthrottling
| | * 7dae22ba62b2 USB: serial: keyspan_pda: fix tx-unthrottle use-after-free
| | * f99817ab5821 USB: serial: keyspan_pda: fix write-wakeup use-after-free
| | * a07b690e1976 USB: serial: keyspan_pda: fix stalled writes
| | * 0f13247fabaf USB: serial: keyspan_pda: fix write deadlock
| | * ebd9857a5bd4 USB: serial: keyspan_pda: fix dropped unthrottle interrupts
| | * 89fb2b91a9da USB: serial: digi_acceleport: fix write-wakeup deadlocks
| | * 08c24438fb10 USB: serial: mos7720: fix parallel-port state restore
| | * 6eab3f646b1a cpuset: fix race between hotplug work and later CPU offline
| | * 066d115fdd29 EDAC/amd64: Fix PCI component registration
| | * f4ce4a53c4e4 EDAC/i10nm: Use readl() to access MMIO registers
| | * f9189a3bb5f9 crypto: arm/aes-ce - work around Cortex-A57/A72 silion errata
| | * 36a58bda87cd crypto: ecdh - avoid unaligned accesses in ecdh_set_secret()
| | * f26f0e7770a1 powerpc/perf: Exclude kernel samples while counting events in user space.
| | * 8096a2c6b9f6 perf/x86/intel: Fix rtm_abort_event encoding on Ice Lake
| | * aa3cce9ceff0 perf/x86/intel: Add event constraint for CYCLE_ACTIVITY.STALLS_MEM_ANY
| | * 1e3de428d155 staging: comedi: mf6x4: Fix AI end-of-conversion detection
| | * ee0bcb1721a5 ASoC: cx2072x: Fix doubly definitions of Playback and Capture streams
| | * 5fbf84689f11 binder: add flag to clear buffer on txn complete
| | * a7c256a9fd18 s390/dasd: fix list corruption of lcu list
| | * 9c40d69a3be2 s390/dasd: fix list corruption of pavgroup group list
| | * 042683917f4b s390/dasd: prevent inconsistent LCU device data
| | * c8acd8d55bb9 s390/dasd: fix hanging device offline processing
| | * 3038bbd1bb33 s390/kexec_file: fix diag308 subcode when loading crash kernel
| | * c185f13918b4 s390/smp: perform initial CPU reset also for SMT siblings
| | * 48d3f12869ef ALSA: core: memalloc: add page alignment for iram
| | * cd3ff2a46d9c ALSA: usb-audio: Disable sample read check if firmware doesn't give back
| | * b1e3c2fb0fbe ALSA: usb-audio: Add VID to support native DSD reproduction on FiiO devices
| | * 58cb166b1f8a ALSA: hda/realtek: Apply jack fixup for Quanta NL3
| | * b61b2aa91f2b ALSA: hda/realtek: Add quirk for MSI-GP73
| | * 89d429ed2cdf ALSA/hda: apply jack fixup for the Acer Veriton N4640G/N6640G/N2510G
| | * 0bf907442c5f ALSA: pcm: oss: Fix a few more UBSAN fixes
| | * 11cd11af4058 ALSA: hda/realtek - Add supported for more Lenovo ALC285 Headset Button
| | * da723248c5f8 ALSA: hda/realtek - Enable headset mic of ASUS Q524UQK with ALC255
| | * 010a784a1a27 ALSA: hda/realtek - Enable headset mic of ASUS X430UN with ALC256
| | * 0fc8e6b85680 ALSA: hda/realtek: make bass spk volume adjustable on a yoga laptop
| | * 52d09e0cdb78 ALSA: hda/ca0132 - Fix AE-5 rear headphone pincfg.
| | * 1ca2437530e5 ALSA: hda: Fix regressions on clear and reconfig sysfs
| | * 2c6c6001d077 ACPI: PNP: compare the string length in the matching_id()
| | * 772dd826a44b Revert "ACPI / resources: Use AE_CTRL_TERMINATE to terminate resources walks"
| | * b9d93a666656 PM: ACPI: PCI: Drop acpi_pm_set_bridge_wakeup()
| | * 670b1b7e0d53 ALSA: hda/ca0132 - Change Input Source enum strings.
| | * 8f827adb9bbc Input: cyapa_gen6 - fix out-of-bounds stack access
| | * 98c956a6d9f7 media: ipu3-cio2: Make the field on subdev format V4L2_FIELD_NONE
| | * f05ac76139e6 media: ipu3-cio2: Validate mbus format in setting subdev format
| | * 44cb512a020e media: ipu3-cio2: Serialise access to pad format
| | * a47bc844f436 media: ipu3-cio2: Return actual subdev format
| | * 7dc40e1f8044 media: ipu3-cio2: Remove traces of returned buffers
| | * d7e6b7b6a7f7 media: netup_unidvb: Don't leak SPI master in probe error path
| | * 0bfbb8393e51 media: sunxi-cir: ensure IR is handled when it is continuous
| | * 124dc7d4f4b6 media: gspca: Fix memory leak in probe
| | * f97b54c8152d vfio/pci/nvlink2: Do not attempt NPU2 setup on POWER8NVL NPU
| | * df308380cbf3 Input: goodix - add upside-down quirk for Teclast X98 Pro tablet
| | * 070bd3a8ac55 initramfs: fix clang build failure
| | * f252a9953249 Input: cros_ec_keyb - send 'scancodes' in addition to key events
| | * 2686041cef06 drm/amdkfd: Fix leak in dmabuf import
| | * dc06432d9304 drm/amd/display: Prevent bandwidth overflow
| | * ca49d919d79c lwt: Disable BH too in run_lwt_bpf()
| | * b8dfee234581 fix namespaced fscaps when !CONFIG_SECURITY
| | * 5350b833bb0a cfg80211: initialize rekey_data
| | * ec15d0700709 ARM: sunxi: Add machine match for the Allwinner V3 SoC
| | * d629b50f9fdc perf probe: Fix memory leak when synthesizing SDT probes
| | * cbcb176b6016 kconfig: fix return value of do_error_if()
| | * 6e8beb020d5c clk: sunxi-ng: Make sure divider tables have sentinel
| | * 3cdeedf801b5 clk: s2mps11: Fix a resource leak in error handling paths in the probe function
| | * ef56621a579a clk: at91: sam9x60: remove atmel,osc-bypass support
| | * e01dfcc08b55 virtio_ring: Fix two use after free bugs
| | * 2d65ff873d06 virtio_net: Fix error code in probe()
| | * 5f70910832c7 virtio_ring: Cut and paste bugs in vring_create_virtqueue_packed()
| | * 372f06cd6b89 qlcnic: Fix error code in probe
| | * c16e42c93241 perf record: Fix memory leak when using '--user-regs=?' to list registers
| | * ceadde18f69a pwm: lp3943: Dynamically allocate PWM chip base
| | * 6bf2ef4bd38d pwm: zx: Add missing cleanup in error path
| | * d4515a24a802 clk: ti: Fix memleak in ti_fapll_synth_setup
| | * 572eba1ce574 watchdog: coh901327: add COMMON_CLK dependency
| | * 2b1575e28906 watchdog: qcom: Avoid context switch in restart handler
| | * fad88d462596 libnvdimm/label: Return -ENXIO for no slot in __blk_label_update
| | * b6c680755d22 net: korina: fix return value
| | * 19e73c9ff0bf net: allwinner: Fix some resources leak in the error handling path of the probe and in the remove function
| | * 226bcdbb4a60 net: bcmgenet: Fix a resource leak in an error handling path in the probe functin
| | * efc570073cbe lan743x: fix rx_napi_poll/interrupt ping-pong
| | * 9f5b56b5a71d checkpatch: fix unescaped left brace
| | * b32c5e0ae6f7 mm: don't wake kswapd prematurely when watermark boosting is disabled
| | * c3bf90c6aac5 sparc: fix handling of page table constructor failure
| | * 6ef298e1cebd powerpc/ps3: use dma_mapping_error()
| | * d864e7e8270a nfc: s3fwrn5: Release the nfc firmware
| | * 7a3d6a5dfc78 RDMA/cma: Don't overwrite sgid_attr after device is released
| | * 2d01f3d75013 sunrpc: fix xs_read_xdr_buf for partial pages receive
| | * 4acbc03e4fed um: chan_xterm: Fix fd leak
| | * 1bbd5678c0b4 um: tty: Fix handling of close in tty lines
| | * 1355bbe3a717 um: Monitor error events in IRQ controller
| | * a37d283825a4 ubifs: Fix error return code in ubifs_init_authentication()
| | * d4dbcfb7e158 watchdog: Fix potential dereferencing of null pointer
| | * 4e091ff107be watchdog: sprd: check busy bit before new loading rather than after that
| | * 4c8cffffc926 watchdog: sprd: remove watchdog disable from resume fail path
| | * 4a4b31e8b5a7 watchdog: sirfsoc: Add missing dependency on HAS_IOMEM
| | * 4d5aea30c1cd watchdog: armada_37xx: Add missing dependency on HAS_IOMEM
| | * 849270acd7b6 irqchip/alpine-msi: Fix freeing of interrupts on allocation error path
| | * aca4d1bd7e19 ASoC: wm_adsp: remove "ctl" from list on error in wm_adsp_create_control()
| | * 297e48ccf166 mac80211: don't set set TDLS STA bandwidth wider than possible
| | * d07972d764e8 crypto: atmel-i2c - select CONFIG_BITREVERSE
| | * f71984fc4482 extcon: max77693: Fix modalias string
| | * a4fd2da3e85e mtd: rawnand: gpmi: Fix the random DMA timeout issue
| | * 86f6e53642fa mtd: rawnand: meson: Fix a resource leak in init
| | * 5e8715b2383a mtd: rawnand: gpmi: fix reference count leak in gpmi ops
| | * 9c5b041ba20a clk: tegra: Fix duplicated SE clock entry
| | * 1ba196a73c45 remoteproc: qcom: Fix potential NULL dereference in adsp_init_mmio()
| | * 6f597c451e07 remoteproc: qcom: fix reference leak in adsp_start
| | * f61bce4bc833 remoteproc: q6v5-mss: fix error handling in q6v5_pds_enable
| | * 9b54e31fd08f RDMA/core: Do not indicate device ready when device enablement fails
| | * e6323070bdc7 can: m_can: m_can_config_endisable(): remove double clearing of clock stop request bit
| | * 6daf2d466380 erofs: avoid using generic_block_bmap
| | * 35e2bec96488 iwlwifi: mvm: hook up missing RX handlers
| | * 857b1403c3e5 s390/cio: fix use-after-free in ccw_device_destroy_console
| | * be4d879cb7c4 bus: fsl-mc: fix error return code in fsl_mc_object_allocate()
| | * 9b4f327c0746 platform/chrome: cros_ec_spi: Don't overwrite spi::mode
| | * 070c57885ec3 x86/kprobes: Restore BTF if the single-stepping is cancelled
| | * 353b19562a03 nfs_common: need lock during iterate through the list
| | * 48ed3e57ad58 nfsd: Fix message level for normal termination
| | * b4ac244716f3 speakup: fix uninitialized flush_lock
| | * 989d52723643 usb: oxu210hp-hcd: Fix memory leak in oxu_create
| | * 2addd726083f usb: ehci-omap: Fix PM disable depth umbalance in ehci_hcd_omap_probe
| | * 3f72486cecec powerpc/mm: sanity_check_fault() should work for all, not only BOOK3S
| | * a696ed262e83 ASoC: amd: change clk_get() to devm_clk_get() and add missed checks
| | * 972db497be45 drm/mediatek: avoid dereferencing a null hdmi_phy on an error message
| | * ef55a3c384cc powerpc/pseries/hibernation: remove redundant cacheinfo update
| | * c4115721d1f0 powerpc/pseries/hibernation: drop pseries_suspend_begin() from suspend ops
| | * 570697132c2c platform/x86: mlx-platform: Fix item counter assignment for MSN2700, MSN24xx systems
| | * a247efe47743 scsi: fnic: Fix error return code in fnic_probe()
| | * 0e724f2e80ba seq_buf: Avoid type mismatch for seq_buf_init
| | * 0b93626d3965 scsi: pm80xx: Fix error return in pm8001_pci_probe()
| | * 79e14f1c323c scsi: qedi: Fix missing destroy_workqueue() on error in __qedi_probe
| | * 172bb906202f arm64: dts: meson: g12a: x96-max: fix PHY deassert timing requirements
| | * 13f4c61d2f5c ARM: dts: meson: fix PHY deassert timing requirements
| | * 154105c0ba56 arm64: dts: meson: fix PHY deassert timing requirements
| | * 62b240d2644e Bluetooth: btmtksdio: Add the missed release_firmware() in mtk_setup_firmware()
| | * 097c4d9921b2 Bluetooth: btusb: Add the missed release_firmware() in btusb_mtk_setup_firmware()
| | * 3d3caa8e971d cpufreq: scpi: Add missing MODULE_ALIAS
| | * 6e34c9478fe5 cpufreq: loongson1: Add missing MODULE_ALIAS
| | * 3e3feeb0d2ba cpufreq: sun50i: Add missing MODULE_DEVICE_TABLE
| | * ef802b5a5e26 cpufreq: st: Add missing MODULE_DEVICE_TABLE
| | * 742697643c94 cpufreq: qcom: Add missing MODULE_DEVICE_TABLE
| | * c9d204c02825 cpufreq: mediatek: Add missing MODULE_DEVICE_TABLE
| | * f3754eec127d cpufreq: highbank: Add missing MODULE_DEVICE_TABLE
| | * e32836221017 cpufreq: ap806: Add missing MODULE_DEVICE_TABLE
| | * 3b6ba2fe6524 clocksource/drivers/arm_arch_timer: Correct fault programming of CNTKCTL_EL1.EVNTI
| | * b4219894d154 clocksource/drivers/arm_arch_timer: Use stable count reader in erratum sne
| | * e223cf39b928 phy: renesas: rcar-gen3-usb2: disable runtime pm in case of failure
| | * 675b3ba9cc96 dm ioctl: fix error return code in target_message
| | * d863d76536df ASoC: jz4740-i2s: add missed checks for clk_get()
| | * 1b760dc9d967 net/mlx5: Properly convey driver version to firmware
| | * a64822872957 MIPS: Don't round up kernel sections size for memblock_add()
| | * 33eeb395515d memstick: r592: Fix error return in r592_probe()
| | * e39b37d6a2ce arm64: dts: rockchip: Fix UART pull-ups on rk3328
| | * 33892a3797f1 pinctrl: falcon: add missing put_device() call in pinctrl_falcon_probe()
| | * 08e22710601a bpf: Fix bpf_put_raw_tracepoint()'s use of __module_address()
| | * e02d218aa63d ARM: dts: at91: sama5d2: map securam as device
| | * da8890329599 iio: hrtimer-trigger: Mark hrtimer to expire in hard interrupt context
| | * d903b80e1abc clocksource/drivers/cadence_ttc: Fix memory leak in ttc_setup_clockevent()
| | * 742d5de6c2fc clocksource/drivers/orion: Add missing clk_disable_unprepare() on error path
| | * 40f9ac2b0295 powerpc/64: Fix an EMIT_BUG_ENTRY in head_64.S
| | * 4968cc5ed0c0 powerpc/perf: Fix crash with is_sier_available when pmu is not set
| | * b0483a32d163 media: saa7146: fix array overflow in vidioc_s_audio()
| | * bfdf000e5dd9 hwmon: (ina3221) Fix PM usage counter unbalance in ina3221_write_enable
| | * a0f07c9ad72d vfio-pci: Use io_remap_pfn_range() for PCI IO memory
| | * 5ac81a4e5fa3 selftests/seccomp: Update kernel config
| | * 0588b8a03469 NFS: switch nfsiod to be an UNBOUND workqueue.
| | * 1094bd2edaa2 lockd: don't use interval-based rebinding over TCP
| | * cbb0a57326b8 net: sunrpc: Fix 'snprintf' return value check in 'do_xprt_debugfs'
| | * a0842124422e NFSv4: Fix the alignment of page data in the getdeviceinfo reply
| | * 73892eef6d9e SUNRPC: xprt_load_transport() needs to support the netid "rdma6"
| | * 2823b8979375 NFSv4.2: condition READDIR's mask for security label based on LSM state
| | * 04e9c169810c SUNRPC: rpc_wake_up() should wake up tasks in the correct order
| | * a3ac7dd8b16b ath10k: Release some resources in an error handling path
| | * 6b6edd2c072b ath10k: Fix an error handling path
| | * e856abba7fca ath10k: Fix the parsing error in service available event
| | * f4935d3c7b57 platform/x86: dell-smbios-base: Fix error return code in dell_smbios_init
| | * 3d64e8ce592b ARM: dts: at91: at91sam9rl: fix ADC triggers
| | * 09347a537cc7 soc: amlogic: canvas: add missing put_device() call in meson_canvas_get()
| | * 8424a5b661ca arm64: dts: meson-sm1: fix typo in opp table
| | * f4951cb10668 arm64: dts: meson: fix spi-max-frequency on Khadas VIM2
| | * 49b563bfdd66 PCI: iproc: Fix out-of-bound array accesses
| | * 4ef5a46d2964 PCI: Fix overflow in command-line resource alignment requests
| | * 048b98083c27 PCI: Bounds-check command-line resource alignment requests
| | * 72577f162cae arm64: dts: qcom: c630: Polish i2c-hid devices
| | * a554b68baf27 arm64: dts: ls1028a: fix ENETC PTP clock input
| | * a85f3e7cb717 genirq/irqdomain: Don't try to free an interrupt that has no mapping
| | * 2f00dcc6ce7a power: supply: bq24190_charger: fix reference leak
| | * e230e193c966 power: supply: axp288_charger: Fix HP Pavilion x2 10 DMI matching
| | * 8e9678d9d131 arm64: dts: rockchip: Set dr_mode to "host" for OTG on rk3328-roc-cc
| | * 11f007a5583d arm64: dts: armada-3720-turris-mox: update ethernet-phy handle name
| | * 5a551ef11669 ARM: dts: Remove non-existent i2c1 from 98dx3236
| | * 15305a5b103d HSI: omap_ssi: Don't jump to free ID in ssi_add_controller()
| | * ec30659ea631 slimbus: qcom-ngd-ctrl: Avoid sending power requests without QMI
| | * 76170933d3da media: max2175: fix max2175_set_csm_mode() error code
| | * 5873beee8744 mips: cdmm: fix use-after-free in mips_cdmm_bus_discover
| | * 51795c385f73 media: imx214: Fix stop streaming
| | * ceff135b9d93 samples: bpf: Fix lwt_len_hist reusing previous BPF map
| | * 4dc1360203c4 platform/x86: mlx-platform: Remove PSU EEPROM from MSN274x platform configuration
| | * 3432883ae896 platform/x86: mlx-platform: Remove PSU EEPROM from default platform configuration
| | * c14a740743f7 media: siano: fix memory leak of debugfs members in smsdvb_hotplug
| | * 6b93d6c5a888 arm64: tegra: Fix DT binding for IO High Voltage entry
| | * b0f1878c2d88 dmaengine: mv_xor_v2: Fix error return code in mv_xor_v2_probe()
| | * 46f8c7961168 cw1200: fix missing destroy_workqueue() on error in cw1200_init_common
| | * f2e7f608b274 rsi: fix error return code in rsi_reset_card()
| | * f7a6e378fc17 qtnfmac: fix error return code in qtnf_pcie_probe()
| | * d2b95947720d orinoco: Move context allocation after processing the skb
| | * e39908568b40 mmc: pxamci: Fix error return code in pxamci_probe
| | * 65f0d3c81c9f ARM: dts: at91: sama5d3_xplained: add pincontrol for USB Host
| | * c2aab53d1be5 ARM: dts: at91: sama5d4_xplained: add pincontrol for USB Host
| | * 8ce91557023e memstick: fix a double-free bug in memstick_check
| | * 4279ff6deaf3 RDMA/cxgb4: Validate the number of CQEs
| | * d3ff603c2e38 clk: meson: Kconfig: fix dependency for G12A
| | * 2fbd2b0dd7d1 Input: omap4-keypad - fix runtime PM error handling
| | * ff3a152243f8 drivers: soc: ti: knav_qmss_queue: Fix error return code in knav_queue_probe
| | * e16e8cde2bb1 soc: ti: Fix reference imbalance in knav_dma_probe
| | * 475b489b0713 soc: ti: knav_qmss: fix reference leak in knav_queue_probe
| | * 82b9934e1e7a spi: fix resource leak for drivers without .remove callback
| | * 70e19fccf680 crypto: omap-aes - Fix PM disable depth imbalance in omap_aes_probe
| | * c549355105d9 crypto: crypto4xx - Replace bitwise OR with logical OR in crypto4xx_build_pd
| | * 3e08a61b2f94 EDAC/mce_amd: Use struct cpuinfo_x86.cpu_die_id for AMD NodeId
| | * 0789349204a6 powerpc/feature: Fix CPU_FTRS_ALWAYS by removing CPU_FTRS_GENERIC_32
| | * 90b39366d834 powerpc: Avoid broken GCC __attribute__((optimize))
| | * 8f6e6ec101dd selftests/bpf: Fix broken riscv build
| | * 6f8c6e70738a spi: mxs: fix reference leak in mxs_spi_probe
| | * 5df04553ee8c usb/max3421: fix return error code in max3421_probe()
| | * e6405aad3592 Input: ads7846 - fix unaligned access on 7845
| | * 920c379029f9 Input: ads7846 - fix integer overflow on Rt calculation
| | * c7ac50927300 Input: ads7846 - fix race that causes missing releases
| | * 86398df4b283 drm/omap: dmm_tiler: fix return error code in omap_dmm_probe()
| | * e8cd88c3ab00 video: fbdev: atmel_lcdfb: fix return error code in atmel_lcdfb_of_init()
| | * 953379fb7ba3 media: solo6x10: fix missing snd_card_free in error handling case
| | * c64d2e159829 scsi: core: Fix VPD LUN ID designator priorities
| | * efb57c87d8d8 ASoC: meson: fix COMPILE_TEST error
| | * 2c06ac46f81c media: v4l2-fwnode: Return -EINVAL for invalid bus-type
| | * d8d35c1ea883 media: mtk-vcodec: add missing put_device() call in mtk_vcodec_init_enc_pm()
| | * c8adf58057b6 media: mtk-vcodec: add missing put_device() call in mtk_vcodec_release_dec_pm()
| | * c5c403db137f media: mtk-vcodec: add missing put_device() call in mtk_vcodec_init_dec_pm()
| | * 06a3c11c173b media: tm6000: Fix sizeof() mismatches
| | * 1638c7e3985b staging: gasket: interrupt: fix the missed eventfd_ctx_put() in gasket_interrupt.c
| | * aa1d8b959455 staging: greybus: codecs: Fix reference counter leak in error handling
| | * 5daf659fdf47 crypto: qat - fix status check in qat_hal_put_rel_rd_xfer()
| | * 38017f2c06cf MIPS: BCM47XX: fix kconfig dependency bug for BCM47XX_BCMA
| | * 9e779e6fae58 RDMa/mthca: Work around -Wenum-conversion warning
| | * 648b9dd270ff ASoC: arizona: Fix a wrong free in wm8997_probe
| | * 7e8200d44200 spi: sprd: fix reference leak in sprd_spi_remove
| | * c786bc725d8c ASoC: wm8998: Fix PM disable depth imbalance on error
| | * 06fa588c7921 selftest/bpf: Add missed ip6ip6 test back
| | * dab5973ada6b mwifiex: fix mwifiex_shutdown_sw() causing sw reset failure
| | * 404aadf45c71 spi: bcm63xx-hsspi: fix missing clk_disable_unprepare() on error in bcm63xx_hsspi_resume
| | * 769c2fecefd1 spi: tegra114: fix reference leak in tegra spi ops
| | * 47595d68cee2 spi: tegra20-sflash: fix reference leak in tegra_sflash_resume
| | * f9e5e84eb49f spi: tegra20-slink: fix reference leak in slink ops of tegra20
| | * 0a3196271b40 spi: mt7621: fix missing clk_disable_unprepare() on error in mt7621_spi_probe
| | * a2cf358aacf5 spi: spi-ti-qspi: fix reference leak in ti_qspi_setup
| | * 25b5a48adabf Bluetooth: hci_h5: fix memory leak in h5_close
| | * 5cf3c2e7892e Bluetooth: Fix null pointer dereference in hci_event_packet()
| | * d92b81fad01c arm64: dts: exynos: Correct psci compatible used on Exynos7
| | * da8d84637522 arm64: dts: exynos: Include common syscon restart/poweroff for Exynos7
| | * 8f14da44523c brcmfmac: Fix memory leak for unpaired brcmf_{alloc/free}
| | * 5c5b92c1d6ab spi: stm32: fix reference leak in stm32_spi_resume
| | * c807042f2d58 selinux: fix inode_doinit_with_dentry() LABEL_INVALID error handling
| | * ae54a6d99478 ASoC: pcm: DRAIN support reactivation
| | * 009a982ea25b spi: spi-mem: fix reference leak in spi_mem_access_start
| | * 68ad1bd244bd drm/msm/dsi_pll_10nm: restore VCO rate during restore_state
| | * 0a8f14baed8e f2fs: call f2fs_get_meta_page_retry for nat page
| | * 311da238f2f7 spi: img-spfi: fix reference leak in img_spfi_resume
| | * 4e20cee19c2e powerpc/64: Set up a kernel stack for secondaries before cpu_restore()
| | * 3988d96589d9 drm/amdgpu: fix build_coefficients() argument
| | * a4110e76e550 ARM: dts: aspeed: tiogapass: Remove vuart
| | * 129df833e15c ASoC: sun4i-i2s: Fix lrck_period computation for I2S justified mode
| | * 9edff753ade7 crypto: inside-secure - Fix sizeof() mismatch
| | * 7044a69699f3 crypto: talitos - Fix return type of current_desc_hdr()
| | * 8a73ee0a0a1e crypto: talitos - Endianess in current_desc_hdr()
| | * b9b8429042bd drm/amdgpu: fix incorrect enum type
| | * 52f525f2bdc7 sched: Reenable interrupts in do_sched_yield()
| | * 35975f2e83a5 sched/deadline: Fix sched_dl_global_validate()
| | * a3ec54b95c1a x86/apic: Fix x2apic enablement without interrupt remapping
| | * b7ec74246c32 ARM: p2v: fix handling of LPAE translation in BE mode
| | * 0a72e7286c67 x86/mm/ident_map: Check for errors from ident_pud_init()
| | * 0fd78ab5ef71 RDMA/rxe: Compute PSN windows correctly
| | * 35f18561616f ARM: dts: aspeed: s2600wf: Fix VGA memory region location
| | * 4aae08a71e68 selinux: fix error initialization in inode_doinit_with_dentry()
| | * de49a51e7938 rtc: pcf2127: fix pcf2127_nvmem_read/write() returns
| | * 57df1b39d990 RDMA/bnxt_re: Set queue pair state when being queried
| | * e11c7d39fa7e Revert "i2c: i2c-qcom-geni: Fix DMA transfer race"
| | * 4b3ee79fbe77 soc: qcom: geni: More properly switch to DMA mode
| | * d3bed198333a soc: mediatek: Check if power domains can be powered on at boot time
| | * fcb0be5ba2e9 soc: renesas: rmobile-sysc: Fix some leaks in rmobile_init_pm_domains()
| | * 38cded30497a arm64: dts: renesas: cat875: Remove rxc-skew-ps from ethernet-phy node
| | * 14be28959f69 arm64: dts: renesas: hihope-rzg2-ex: Drop rxc-skew-ps from ethernet-phy node
| | * c2712546a6e0 drm/tve200: Fix handling of platform_get_irq() error
| | * f61e9dbb56ba drm/mcde: Fix handling of platform_get_irq() error
| | * 29f34feb3860 drm/aspeed: Fix Kconfig warning & subsequent build errors
| | * 37028b8bc53d drm/gma500: fix double free of gma_connector
| | * de630248e740 md: fix a warning caused by a race between concurrent md_ioctl()s
| | * 054be9aed847 crypto: af_alg - avoid undefined behavior accessing salg_name
| | * 5a225303a68f media: msi2500: assign SPI bus number dynamically
| | * 01182045346a quota: Sanity-check quota file headers on load
| | * df95ea1228cc Bluetooth: Fix slab-out-of-bounds read in hci_le_direct_adv_report_evt()
| | * cda2f222e7e4 serial_core: Check for port state when tty is in error state
| | * 863cab3017bc HID: i2c-hid: add Vero K147 to descriptor override
| | * fd819f54065c scsi: megaraid_sas: Check user-provided offsets
| | * 152631f0273f coresight: etb10: Fix possible NULL ptr dereference in etb_enable_perf()
| | * 4c461e8d0e88 coresight: tmc-etr: Fix barrier packet insertion for perf buffer
| | * e81884d45a70 coresight: tmc-etr: Check if page is valid before dma_map_page()
| | * ec13738c6ec6 coresight: tmc-etf: Fix NULL ptr dereference in tmc_enable_etf_sink_perf()
| | * d923c0ec1292 ARM: dts: exynos: fix USB 3.0 pins supply being turned off on Odroid XU
| | * 43598dbdcbf0 ARM: dts: exynos: fix USB 3.0 VBUS control and over-current pins on Exynos5410
| | * 2c6f6cd2cdfb ARM: dts: exynos: fix roles of USB 3.0 ports on Odroid XU
| | * 4202cbbd2c4d usb: chipidea: ci_hdrc_imx: Pass DISABLE_DEVICE_STREAMING flag to imx6ul
| | * 8e19cfae3bb0 USB: gadget: f_rndis: fix bitrate for SuperSpeed and above
| | * 8c124b35a53b usb: gadget: f_fs: Re-use SS descriptors for SuperSpeedPlus
| | * 3389281e0e6e USB: gadget: f_midi: setup SuperSpeed Plus descriptors
| | * 0ddb1d96a5db USB: gadget: f_acm: add support for SuperSpeed Plus
| | * 9ad41aa399db USB: serial: option: add interface-number sanity check to flag handling
| | * 57e22590c41b usb: mtu3: fix memory corruption in mtu3_debugfs_regset()
| | * 80cb94507054 soc/tegra: fuse: Fix index bug in get_process_id
| | * 037c65990d76 kbuild: avoid split lines in .mod files
| | * a803ea15b0dc perf/x86/intel: Check PEBS status correctly
| | * 12db619c91d7 drm/amd/display: Init clock value by current vbios CLKs
| | * c137a880ae6c iwlwifi: pcie: add one missing entry for AX210
| | * e124c5afaf88 dm table: Remove BUG_ON(in_interrupt())
| | * 8a89abb26e30 scsi: mpt3sas: Increase IOCInit request timeout to 30s
| | * cd14a53938e0 vxlan: Copy needed_tailroom from lowerdev
| | * 0b9ce087f75b vxlan: Add needed_headroom for lower device
| | * 230290dca255 arm64: syscall: exit userspace before unmasking exceptions
| | * 34c07547dbe5 habanalabs: put devices before driver removal
| | * be063ce1004c drm/tegra: sor: Disable clocks on error in tegra_sor_init()
| | * 9b6ebb202bbb kernel/cpu: add arch override for clear_tasks_mm_cpumask() mm handling
| | * d8baf15b2196 drm/tegra: replace idr_init() by idr_init_base()
| | * 76812738841c net: mvpp2: add mvpp2_phylink_to_port() helper
| | * 6aa270eb2f90 selftests: fix poll error in udpgro.sh
| | * 0e2b048ffe44 ixgbe: avoid premature Rx buffer reuse
| | * 75bbe7bd9003 i40e: avoid premature Rx buffer reuse
| | * b05fdd74ffb7 i40e: optimise prefetch page refcount
| | * 405bfd36f072 i40e: Refactor rx_bi accesses
| | * 6935f5385f75 RDMA/cm: Fix an attempt to use non-valid pointer when cleaning timewait
| | * 2107658d6d62 selftests/bpf/test_offload.py: Reset ethtool features after failed setting
| | * 3b79aea56dff netfilter: nft_ct: Remove confirmation check for NFT_CT_ID
| | * 0a652b181d75 gpio: eic-sprd: break loop when getting NULL device resource
| | * 2ebb2df149d4 Revert "gpio: eic-sprd: Use devm_platform_ioremap_resource()"
| | * 64795af3bdc7 afs: Fix memory leak when mounting with multiple source parameters
| | * 6581512f0afc netfilter: nft_dynset: fix timeouts later than 23 days
| | * 810bc556e347 netfilter: nft_compat: make sure xtables destructors have run
| | * b17244cebb24 netfilter: x_tables: Switch synchronization to RCU
| | * 22faec182eec pinctrl: aspeed: Fix GPIO requests on pass-through banks
| | * f7e6636831df blk-mq: In blk_mq_dispatch_rq_list() "no budget" is a reason to kick
| | * 4f3e3fa6239d block: factor out requeue handling from dispatch code
| | * 9e54ca3d4f9d block: Simplify REQ_OP_ZONE_RESET_ALL handling
| | * 71e0f9c5c3df clk: renesas: r9a06g032: Drop __packed for portability
| | * 43a373488e92 can: softing: softing_netdev_open(): fix error handling
| | * 36f460d51ac5 xsk: Replace datagram_poll by sock_poll_wait
| | * 50ae52e07d2b xsk: Fix xsk_poll()'s return type
| | * 369ed255958f scsi: bnx2i: Requires MMU
| | * e190d1b3c4d2 gpio: mvebu: fix potential user-after-free on probe
| | * ec64dea576d5 gpio: zynq: fix reference leak in zynq_gpio functions
| | * 823f42bd6193 PM: runtime: Add pm_runtime_resume_and_get to deal with usage counter
| | * 74e38f86ab53 ARM: dts: imx6qdl-kontron-samx6i: fix I2C_PM scl pin
| | * f7fbde0f0b14 ARM: dts: imx6qdl-wandboard-revd1: Remove PAD_GPIO_6 from enetgrp
| | * 4b008707bac4 ARM: dts: sun7i: pcduino3-nano: enable RGMII RX/TX delay on PHY
| | * 76c475d5d788 ARM: dts: sun8i: v3s: fix GIC node memory range
| | * 9ebc986a2ea5 pinctrl: baytrail: Avoid clearing debounce value when turning it off
| | * e2556e022897 pinctrl: merrifield: Set default bias in case no particular value given
| | * 2ec85a7a5adf ARM: dts: sun8i: v40: bananapi-m2-berry: Fix ethernet node
| | * 9f69f6f85288 ARM: dts: sun8i: r40: bananapi-m2-berry: Fix dcdc1 regulator
| | * 389033996cec ARM: dts: sun7i: bananapi: Enable RGMII RX/TX delay on Ethernet PHY
| * | 9ee0c435c28b Merge tag 'v5.4.85' into 5.4.y+qoriq+fslc
| |\|
| | * 19d1c763e849 Linux 5.4.85
| | * 484ac6279ad2 x86/resctrl: Fix incorrect local bandwidth when mba_sc is enabled
| | * eb3f42cf5e67 x86/resctrl: Remove unused struct mbm_state::chunks_bw
| | * c4f909407015 membarrier: Explicitly sync remote cores when SYNC_CORE is requested
| | * a840e37ef800 Revert "selftests/ftrace: check for do_sys_openat2 in user-memory test"
| | * aa17a20d640d KVM: mmu: Fix SPTE encoding of MMIO generation upper half
| | * bb07f4c93e62 serial: 8250_omap: Avoid FIFO corruption caused by MDR1 access
| | * 14482dc42c28 ALSA: pcm: oss: Fix potential out-of-bounds shift
| | * c94a31c19225 USB: sisusbvga: Make console support depend on BROKEN
| | * 4ad8fc6cce01 USB: UAS: introduce a quirk to set no_write_same
| | * 397d0ae4cb90 xhci-pci: Allow host runtime PM as default for Intel Alpine Ridge LP
| | * 32c820e016b4 xhci: Give USB2 ports time to enter U3 in bus suspend
| | * 5828ae0c1920 ALSA: usb-audio: Fix control 'access overflow' errors from chmap
| | * e72a55ea7168 ALSA: usb-audio: Fix potential out-of-bounds shift
| | * 56339afa39e5 USB: add RESET_RESUME quirk for Snapscan 1212
| | * 52c2ada6fe5e USB: dummy-hcd: Fix uninitialized array use in init()
| | * 497993377bca ktest.pl: If size of log is too big to email, email error message
| | * a8d28a541500 net: stmmac: delete the eee_ctrl_timer after napi disabled
| | * ee08543f4598 net: stmmac: dwmac-meson8b: fix mask definition of the m250_sel mux
| | * 5ae78c6926cc net: ll_temac: Fix potential NULL dereference in temac_probe()
| | * 717a140a3635 net/mlx4_en: Handle TX error CQE
| | * d0363dcabbd1 lan743x: fix for potential NULL pointer dereference with bare card
| | * d4107a0f8802 net/mlx4_en: Avoid scheduling restart task if it is already running
| | * add880d788f0 tcp: fix cwnd-limited bug for TSO deferral where we send nothing
| | * 5189c070a0d7 tcp: select sane initial rcvq_space.space for big MSS
| | * 318d90218b21 net: stmmac: free tx skb buffer in stmmac_resume()
| | * d8d39e13668a bridge: Fix a deadlock when enabling multicast snooping
| | * cb327f83cf5e enetc: Fix reporting of h/w packet counters
| | * 408c8213ee97 udp: fix the proto value passed to ip_protocol_deliver_rcu for the segments
| | * f7a756fc7cb9 net: hns3: remove a misused pragma packed
| | * 2ef23e860e76 vrf: packets with lladdr src needs dst at input with orig_iif when needs strict
| | * cae90bd22cff net: bridge: vlan: fix error return code in __vlan_add()
| | * 2e6a15b0b3d4 mac80211: mesh: fix mesh_pathtbl_init() error path
| | * 1fe6b822b335 ipv4: fix error return code in rtm_to_fib_config()
| | * 8b4f08f28015 ptrace: Prevent kernel-infoleak in ptrace_get_syscall_info()
| * | 2cf5d2801f05 Merge tag 'v5.4.84' into 5.4.y+qoriq+fslc
| |\|
| | * 8a866bdbbac2 Linux 5.4.84
| | * c2c5dc84ac51 compiler.h: fix barrier_data() on clang
| | * 69dc72f058c9 mm/zsmalloc.c: drop ZSMALLOC_PGTABLE_MAPPING
| | * 3349f1e4cf6d x86/apic/vector: Fix ordering in vector assignment
| | * e3c1d51868f3 x86/membarrier: Get rid of a dubious optimization
| | * 6346ed69bc7c x86/mm/mem_encrypt: Fix definition of PMD_FLAGS_DEC_WP
| | * 258d646f006b scsi: be2iscsi: Revert "Fix a theoretical leak in beiscsi_create_eqs()"
| | * 7d5fc53439a1 proc: use untagged_addr() for pagemap_read addresses
| | * 6472d3ae6ef5 kbuild: avoid static_assert for genksyms
| | * 0cd7084a2a03 drm/i915/display/dp: Compute the correct slice count for VDSC on DP
| | * 60c1c68fae5e mmc: block: Fixup condition for CMD13 polling for RPMB requests
| | * 974aa59837ed pinctrl: amd: remove debounce filter setting in IRQ type setting
| | * 457f5289b7e7 Input: i8042 - add Acer laptops to the i8042 reset list
| | * cf596f3906e9 Input: cm109 - do not stomp on control URB
| | * d2d113aca34f ktest.pl: Fix incorrect reboot for grub2bls
| | * 181088e37b1d can: m_can: m_can_dev_setup(): add support for bosch mcan version 3.3.0
| | * 38b1dbc1229c platform/x86: touchscreen_dmi: Add info for the Irbis TW118 tablet
| | * 2fa99f6f8f60 platform/x86: intel-vbtn: Support for tablet mode on HP Pavilion 13 x360 PC
| | * 21aa2d1f2bfb platform/x86: acer-wmi: add automatic keyboard background light toggle key as KEY_LIGHTS_TOGGLE
| | * 010e6e816f54 platform/x86: thinkpad_acpi: Add BAT1 is primary battery quirk for Thinkpad Yoga 11e 4th gen
| | * 4778a11e0500 platform/x86: thinkpad_acpi: Do not report SW_TABLET_MODE on Yoga 11e
| | * eb5e28ffe39a arm64: tegra: Disable the ACONNECT for Jetson TX2
| | * c7e271337402 soc: fsl: dpio: Get the cpumask through cpumask_of(cpu)
| | * 37aa8318ed43 spi: spi-nxp-fspi: fix fspi panic by unexpected interrupts
| | * 864fbeab8c99 irqchip/gic-v3-its: Unconditionally save/restore the ITS state on suspend
| | * 47fac0ccf775 ibmvnic: skip tx timeout reset while in resetting
| | * c0450df6d0f7 interconnect: qcom: qcs404: Remove GPU and display RPM IDs
| | * adad2bc9f303 scsi: ufs: Make sure clk scaling happens only when HBA is runtime ACTIVE
| | * b184e9800867 ARC: stack unwinding: don't assume non-current task is sleeping
| | * 8ed74a012206 arm64: dts: broadcom: clear the warnings caused by empty dma-ranges
| | * acac3f7d7d22 powerpc: Drop -me200 addition to build flags
| | * 8012a30b9e16 iwlwifi: mvm: fix kernel panic in case of assert during CSA
| | * c90527770b88 iwlwifi: pcie: set LTR to avoid completion timeout
| | * d411a07d6c04 arm64: dts: rockchip: Assign a fixed index to mmc devices on rk3399 boards.
| | * 0e6cae4e8181 iwlwifi: pcie: limit memory read spin time
| | * 591afbc97c18 x86/lib: Change .weak to SYM_FUNC_START_WEAK for arch/x86/lib/mem*_64.S
| | * 018b05e0f05b Kbuild: do not emit debug info for assembly with LLVM_IAS=1
| * | 81b71b80bb2c Merge tag 'v5.4.83' into 5.4.y+qoriq+fslc
| |\|
| | * 2bff021f53b2 Linux 5.4.83
| | * 66a08d1d3bd8 Revert "geneve: pull IP header before ECN decapsulation"
| | * ed58971beb47 x86/insn-eval: Use new for_each_insn_prefix() macro to loop over prefixes bytes
| | * 423e1b08ce5c netfilter: nftables_offload: set address type in control dissector
| | * 13995410b616 netfilter: nf_tables: avoid false-postive lockdep splat
| | * f25fa580f99e Input: i8042 - fix error return code in i8042_setup_aux()
| | * b9df537e5fcd dm writecache: remove…