### PR TITLE
imx-mkimage: Reorder inheriting native class

### DIFF
--- a/recipes-bsp/imx-mkimage/imx-mkimage_git.bb
+++ b/recipes-bsp/imx-mkimage/imx-mkimage_git.bb
@@ -8,7 +8,7 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6"
 SECTION = "BSP"
 
-inherit native deploy
+inherit deploy native
 
 CFLAGS = "-O2 -Wall -std=c99 -I ${STAGING_INCDIR} -L ${STAGING_LIBDIR}"
 


### PR DESCRIPTION
Fixes
imx-mkimage-git: imx-mkimage: native/nativesdk class is not inherited last, this can result in unexpected behaviour.  [native-last]

Signed-off-by: Khem Raj <raj.khem@gmail.com>