### PR TITLE
mesa: Re-enable dri driver swrast for NXP BSP

### DIFF
--- a/recipes-graphics/mesa/mesa_%.bbappend
+++ b/recipes-graphics/mesa/mesa_%.bbappend
@@ -18,8 +18,10 @@ python () {
 PACKAGECONFIG_append_use-mainline-bsp = " gallium etnaviv kmsro freedreno"
 
 # For NXP BSP, enable OSMesa for parts with DRM
+# Also enable swrast for its dri driver
 PACKAGECONFIG_remove_use-nxp-bsp_imxdrm = "gallium"
 PACKAGECONFIG_append_use-nxp-bsp_imxdrm = " osmesa"
+DRIDRIVERS_use-nxp-bsp_imxdrm = "swrast"
 
 BACKEND = \
     "${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'wayland', \


### PR DESCRIPTION
Seems swrast won't disable hardware acceleration and is still needed to prevent
a build break in xserver-xorg.

```
| Package dri was not found in the pkg-config search path.
| Perhaps you should add the directory containing `dri.pc'
| to the PKG_CONFIG_PATH environment variable
| No package 'dri' found
```

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>