### PR TITLE
[master] imx-base.inc: Always use the NXP bootloader when using the NXP BSP

### DIFF
--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -20,8 +20,8 @@ MACHINEOVERRIDES =. "use-${IMX_DEFAULT_BSP}-bsp:"
 
 # Set specific make target and binary suffix
 IMX_DEFAULT_BOOTLOADER = "u-boot-fslc"
-IMX_DEFAULT_BOOTLOADER_mx8 = "u-boot-imx"
 IMX_DEFAULT_BOOTLOADER_use-mainline-bsp = "u-boot-fslc"
+IMX_DEFAULT_BOOTLOADER_use-nxp-bsp = "u-boot-imx"
 
 PREFERRED_PROVIDER_u-boot ??= "${IMX_DEFAULT_BOOTLOADER}"
 PREFERRED_PROVIDER_u-boot-tools-native ??= "${IMX_DEFAULT_BOOTLOADER}-tools-native"


### PR DESCRIPTION
The NXP BSP should always use `u-boot-imx`. This also includes i.MX8 boards, which makes that line unnecessary. Fixes #601.
This should make NXP distros buildable on SoC's other than the i.MX8.