### PR TITLE
imx8mp-evk: update ddr firmware version as required by imx-boot

### DIFF
--- a/conf/machine/imx8mp-evk.conf
+++ b/conf/machine/imx8mp-evk.conf
@@ -48,11 +48,12 @@ UBOOT_CONFIG[mfgtool] = "imx8mp_evk_defconfig"
 SPL_BINARY = "spl/u-boot-spl.bin"
 
 # Set DDR FIRMWARE
+DDR_FIRMWARE_VERSION = "202006"
 DDR_FIRMWARE_NAME = " \
-	lpddr4_pmu_train_1d_dmem_201904.bin \
-	lpddr4_pmu_train_1d_imem_201904.bin \
-	lpddr4_pmu_train_2d_dmem_201904.bin \
-	lpddr4_pmu_train_2d_imem_201904.bin \
+	lpddr4_pmu_train_1d_dmem_${DDR_FIRMWARE_VERSION}.bin \
+	lpddr4_pmu_train_1d_imem_${DDR_FIRMWARE_VERSION}.bin \
+	lpddr4_pmu_train_2d_dmem_${DDR_FIRMWARE_VERSION}.bin \
+	lpddr4_pmu_train_2d_imem_${DDR_FIRMWARE_VERSION}.bin \
 "
 
 # Set u-boot DTB


### PR DESCRIPTION
imx-boot update 5.4.70_2.3.0 requires a new version of ddr firmware to be deployed and used for imx8mp machine (201904 -> 202006).

This is introduced in commits of imx-boot git tree:
322a834 ("MLK-24860 iMX8MP: Use 202006 DDR4 firmware")
658c54a ("MLK-24788 iMX8MP: Update LPDDR4 Firmware to 202006 version")

Update ddr firmware name to include new version in machine config file.

@otavio I've separated the DDR firmware version into a variable for 2 reasons:
1. Ease of future version upgrades
2. This variable would be re-used to filter out version extension in boot container builds

-- andrey