### PR TITLE
[gatesgarth] Provide u-boot-mfgtool and linux-mfgtool for fslc distros

### DIFF
--- a/recipes-bsp/u-boot/u-boot-fslc-mfgtool_2020.04.bb
+++ b/recipes-bsp/u-boot/u-boot-fslc-mfgtool_2020.04.bb
@@ -1,0 +1,8 @@
+# Copyright (C) 2014 O.S. Systems Software LTDA.
+# Copyright (C) 2014-2016 Freescale Semiconductor
+# Copyright 2017-2019 NXP
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/u-boot-fslc:"
+
+require u-boot-fslc_${PV}.bb
+require u-boot-mfgtool.inc

--- a/recipes-kernel/linux/linux-fslc-mfgtool_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc-mfgtool_5.4.bb
@@ -1,0 +1,15 @@
+# Copyright (C) 2014-2018 O.S. Systems Software LTDA.
+# Copyright (C) 2014-2016 Freescale Semiconductor
+
+SUMMARY = "Produces a Manufacturing Tool compatible Linux Kernel"
+DESCRIPTION = "Linux Kernel provided and supported by the Freescale Community \
+that produces a Manufacturing Tool compatible Linux Kernel to be used in updater \
+environment"
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/linux-fslc:"
+require linux-fslc_${PV}.bb
+require linux-mfgtool.inc
+
+KERNEL_IMAGE_BASE_NAME[vardepsexclude] = "DATETIME"
+MODULE_IMAGE_BASE_NAME[vardepsexclude] = "DATETIME"
+do_package[vardepsexclude] = "DATETIME"


### PR DESCRIPTION
This makes `u-boot-fslc` and `linux-fslc` support the NXP mfgtool.