### PR TITLE
Dunfell: Cherry-pick mesa fixes for NXP BSP

### DIFF
--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -371,17 +371,17 @@ SOC_DEFAULT_WKS_FILE_mxs ?= "imx-uboot-mxs-bootpart.wks.in"
 
 WKS_FILE ?= "${SOC_DEFAULT_WKS_FILE}"
 
-# Certain machines override the default fsl u-boot with the
-# fslc u-boot. To restore the fsl u-boot, add use-fsl-bsp like this:
-#   MACHINEOVERRIDES_prepend_imx6ulevk = "use-fsl-bsp:"
-UBOOT_MAKE_TARGET_use-fsl-bsp_mx6 = "u-boot.imx"
-UBOOT_SUFFIX_use-fsl-bsp_mx6 = "imx"
-SPL_BINARY_use-fsl-bsp_mx6 = ""
-WKS_FILE_use-fsl-bsp_mx6 = "imx-uboot-bootpart.wks.in"
-UBOOT_MAKE_TARGET_use-fsl-bsp_mx7 = "u-boot.imx"
-UBOOT_SUFFIX_use-fsl-bsp_mx7 = "imx"
-SPL_BINARY_use-fsl-bsp_mx7 = ""
-WKS_FILE_use-fsl-bsp_mx7 = "imx-uboot-bootpart.wks.in"
+# Certain machines are set to use the mainline u-boot by default
+# to encourage syncronization with mainline. Undo that here for
+# machines that don't work with mainline.
+UBOOT_MAKE_TARGET_use-nxp-bsp_mx6 = "u-boot.imx"
+UBOOT_SUFFIX_use-nxp-bsp_mx6 = "imx"
+SPL_BINARY_use-nxp-bsp_mx6 = ""
+WKS_FILE_use-nxp-bsp_mx6 = "imx-uboot-bootpart.wks.in"
+UBOOT_MAKE_TARGET_use-nxp-bsp_mx7 = "u-boot.imx"
+UBOOT_SUFFIX_use-nxp-bsp_mx7 = "imx"
+SPL_BINARY_use-nxp-bsp_mx7 = ""
+WKS_FILE_use-nxp-bsp_mx7 = "imx-uboot-bootpart.wks.in"
 
 SERIAL_CONSOLES = "115200;ttymxc0"
 SERIAL_CONSOLES_mxs = "115200;ttyAMA0"

--- a/recipes-graphics/mesa/mesa_%.bbappend
+++ b/recipes-graphics/mesa/mesa_%.bbappend
@@ -17,17 +17,10 @@ python () {
 # Enable Etnaviv and Freedreno support
 PACKAGECONFIG_append_use-mainline-bsp = " gallium etnaviv kmsro freedreno"
 
-USE_OSMESA_ONLY ?= "no"
-
-# Etnaviv support state for i.MX8 is unknown, therefore only enable OSMesa and
-# disable Gallium for now. If you still want to enable Etnaviv, just set
-# USE_OSMESA_ONLY_mx8 = "no" in your bbappend.
-USE_OSMESA_ONLY_mx8 ?= "yes"
-
 # Enable OSMesa which also requires dri (classic) swrast
-PACKAGECONFIG_append = " ${@oe.utils.conditional('USE_OSMESA_ONLY', 'yes', ' osmesa', '', d)}"
-PACKAGECONFIG_remove = " ${@oe.utils.conditional('USE_OSMESA_ONLY', 'yes', 'gallium', '', d)}"
-DRIDRIVERS_append = "${@oe.utils.conditional('USE_OSMESA_ONLY', 'yes', 'swrast', '', d)}"
+PACKAGECONFIG_remove_use-nxp-bsp = "gallium"
+PACKAGECONFIG_append_use-nxp-bsp = " osmesa"
+DRIDRIVERS_use-nxp-bsp = "swrast"
 
 BACKEND = \
     "${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'wayland', \

--- a/recipes-graphics/mesa/mesa_%.bbappend
+++ b/recipes-graphics/mesa/mesa_%.bbappend
@@ -17,10 +17,9 @@ python () {
 # Enable Etnaviv and Freedreno support
 PACKAGECONFIG_append_use-mainline-bsp = " gallium etnaviv kmsro freedreno"
 
-# Enable OSMesa which also requires dri (classic) swrast
-PACKAGECONFIG_remove_use-nxp-bsp = "gallium"
-PACKAGECONFIG_append_use-nxp-bsp = " osmesa"
-DRIDRIVERS_use-nxp-bsp = "swrast"
+# For NXP BSP, enable OSMesa for parts with DRM
+PACKAGECONFIG_remove_use-nxp-bsp_imxdrm = "gallium"
+PACKAGECONFIG_append_use-nxp-bsp_imxdrm = " osmesa"
 
 BACKEND = \
     "${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'wayland', \

--- a/recipes-graphics/mesa/mesa_%.bbappend
+++ b/recipes-graphics/mesa/mesa_%.bbappend
@@ -17,10 +17,15 @@ python () {
 # Enable Etnaviv and Freedreno support
 PACKAGECONFIG_append_use-mainline-bsp = " gallium etnaviv kmsro freedreno"
 
-# For NXP BSP, enable OSMesa for parts with DRM
-# Also enable swrast for its dri driver
-PACKAGECONFIG_remove_use-nxp-bsp_imxdrm = "gallium"
-PACKAGECONFIG_append_use-nxp-bsp_imxdrm = " osmesa"
+# For NXP BSP, disable dri for parts without DRM.
+# Disable gallium and enable OSMesa for parts with DRM.
+# Also enable swrast for its dri driver for parts with DRM.
+PACKAGECONFIG_REMOVE_NXPBSP        = "dri"
+PACKAGECONFIG_APPEND_NXPBSP        = ""
+PACKAGECONFIG_REMOVE_NXPBSP_imxdrm = "gallium"
+PACKAGECONFIG_APPEND_NXPBSP_imxdrm = "osmesa"
+PACKAGECONFIG_remove_use-nxp-bsp   = "${PACKAGECONFIG_REMOVE_NXPBSP}"
+PACKAGECONFIG_append_use-nxp-bsp   = " ${PACKAGECONFIG_APPEND_NXPBSP}"
 DRIDRIVERS_use-nxp-bsp_imxdrm = "swrast"
 
 BACKEND = \

--- a/recipes-graphics/mesa/mesa_%.bbappend
+++ b/recipes-graphics/mesa/mesa_%.bbappend
@@ -18,8 +18,10 @@ python () {
 PACKAGECONFIG_append_use-mainline-bsp = " gallium etnaviv kmsro freedreno"
 
 # For NXP BSP, enable OSMesa for parts with DRM
+# Also enable swrast for its dri driver
 PACKAGECONFIG_remove_use-nxp-bsp_imxdrm = "gallium"
 PACKAGECONFIG_append_use-nxp-bsp_imxdrm = " osmesa"
+DRIDRIVERS_use-nxp-bsp_imxdrm = "swrast"
 
 BACKEND = \
     "${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'wayland', \


### PR DESCRIPTION
This is trying to fix https://github.com/Freescale/meta-freescale/issues/509.

This is still in progress, with failure for `MACHINE=imx6qdlsabresd DISTRO=fsl-wayland`:

```
| meson.build:455:4: ERROR: Problem encountered: building dri drivers require at least one windowing system or classic osmesa
```

`DISTRO=fsl-xwayland` is building fine. `master` is building fine.
