### PR TITLE
mesa: Disable dri for parts without DRM

### DIFF
--- a/recipes-graphics/mesa/mesa_%.bbappend
+++ b/recipes-graphics/mesa/mesa_%.bbappend
@@ -17,10 +17,15 @@ python () {
 # Enable Etnaviv and Freedreno support
 PACKAGECONFIG_append_use-mainline-bsp = " gallium etnaviv kmsro freedreno"
 
-# For NXP BSP, enable OSMesa for parts with DRM
-# Also enable swrast for its dri driver
-PACKAGECONFIG_remove_use-nxp-bsp_imxdrm = "gallium"
-PACKAGECONFIG_append_use-nxp-bsp_imxdrm = " osmesa"
+# For NXP BSP, disable dri for parts without DRM.
+# Disable gallium and enable OSMesa for parts with DRM.
+# Also enable swrast for its dri driver for parts with DRM.
+PACKAGECONFIG_REMOVE_NXPBSP        = "dri"
+PACKAGECONFIG_APPEND_NXPBSP        = ""
+PACKAGECONFIG_REMOVE_NXPBSP_imxdrm = "gallium"
+PACKAGECONFIG_APPEND_NXPBSP_imxdrm = "osmesa"
+PACKAGECONFIG_remove_use-nxp-bsp   = "${PACKAGECONFIG_REMOVE_NXPBSP}"
+PACKAGECONFIG_append_use-nxp-bsp   = " ${PACKAGECONFIG_APPEND_NXPBSP}"
 DRIDRIVERS_use-nxp-bsp_imxdrm = "swrast"
 
 BACKEND = \


### PR DESCRIPTION
On dunfell parts without DRM (i.MX 6 and 7) break because dri is enabled:

```
| meson.build:455:4: ERROR: Problem encountered: building dri drivers require at least one windowing system or classic osmesa
```

The break does not occur on master since dri is effectively disabled if no dri
drivers are configured. Disabling dri outright is still a better implementation
on master, and of course is required on dunfell.

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>