### PR TITLE
Consolidated Kernel update (v5.4.97 + v5.10.15)

### DIFF
--- a/recipes-kernel/linux/linux-fslc-imx_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_5.4.bb
@@ -28,7 +28,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v5.4.95
+#    tag: v5.4.96
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
@@ -71,14 +71,14 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
 SRCBRANCH = "5.4-2.3.x-imx"
-SRCREV = "3e30474a9fe2cbf3c78a1c173ab6ce2db22f943f"
+SRCREV = "31272db029d013be75160f3fe4aa31d77c911c95"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.95"
+LINUX_VERSION = "5.4.96"
 
 # Local version indicates the branch name in the NXP kernel tree where patches are collected from.
 LOCALVERSION = "-imx-5.4.70-2.3.0"

--- a/recipes-kernel/linux/linux-fslc-imx_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_5.4.bb
@@ -28,7 +28,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v5.4.96
+#    tag: v5.4.97
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
@@ -71,14 +71,14 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
 SRCBRANCH = "5.4-2.3.x-imx"
-SRCREV = "31272db029d013be75160f3fe4aa31d77c911c95"
+SRCREV = "9a4b5ae7ee915f0009f1b5cd75a8fe9f98849093"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.96"
+LINUX_VERSION = "5.4.97"
 
 # Local version indicates the branch name in the NXP kernel tree where patches are collected from.
 LOCALVERSION = "-imx-5.4.70-2.3.0"

--- a/recipes-kernel/linux/linux-fslc-imx_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_5.4.bb
@@ -28,7 +28,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v5.4.94
+#    tag: v5.4.95
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
@@ -71,14 +71,14 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
 SRCBRANCH = "5.4-2.3.x-imx"
-SRCREV = "9c8316d4da6e70ecbf18ce03c9105ed7124660d9"
+SRCREV = "3e30474a9fe2cbf3c78a1c173ab6ce2db22f943f"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.94"
+LINUX_VERSION = "5.4.95"
 
 # Local version indicates the branch name in the NXP kernel tree where patches are collected from.
 LOCALVERSION = "-imx-5.4.70-2.3.0"

--- a/recipes-kernel/linux/linux-fslc_5.10.bb
+++ b/recipes-kernel/linux/linux-fslc_5.10.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.10.12"
+LINUX_VERSION = "5.10.13"
 
 SRCBRANCH = "5.10.x+fslc"
-SRCREV = "ed3accb10c8f8fce55e92fdaad7b36b1f083d15c"
+SRCREV = "b3d3cc6c571692afb8227550252d3369c7f0c1ef"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"

--- a/recipes-kernel/linux/linux-fslc_5.10.bb
+++ b/recipes-kernel/linux/linux-fslc_5.10.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.10.14"
+LINUX_VERSION = "5.10.15"
 
 SRCBRANCH = "5.10.x+fslc"
-SRCREV = "3f8e2dc0c73d764bf80baaa3f09c0004bc05b73e"
+SRCREV = "45593367aeedba4e2d636539c5b91f1f33178d67"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"

--- a/recipes-kernel/linux/linux-fslc_5.10.bb
+++ b/recipes-kernel/linux/linux-fslc_5.10.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.10.13"
+LINUX_VERSION = "5.10.14"
 
 SRCBRANCH = "5.10.x+fslc"
-SRCREV = "b3d3cc6c571692afb8227550252d3369c7f0c1ef"
+SRCREV = "3f8e2dc0c73d764bf80baaa3f09c0004bc05b73e"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"


### PR DESCRIPTION
Kernel branches were updated up to and including following versions for recipes from stable korg:
- `linux-fslc-imx`: _v5.4.97_
- `linux-fslc`: _v5.10.15_

Update recipe `SRCREV` to point to those versions now.

Upstream commits are recorded in corresponding recipe commit messages.

Boot-tested on _imx8mm-lpddr4-evk_ machine, result: **PASS**.

-- andrey