### PR TITLE
imx-gpu-apitrace: Upgrade to restore eglretrace

### DIFF
--- a/recipes-graphics/imx-gpu-apitrace/imx-gpu-apitrace_9.0.0.bb
+++ b/recipes-graphics/imx-gpu-apitrace/imx-gpu-apitrace_9.0.0.bb
@@ -5,19 +5,28 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=aeb969185a143c3c25130bc2c3ef9a50"
 DEPENDS = "imx-gpu-viv zlib libpng procps"
 
 SRC_URI = "git://source.codeaurora.org/external/imx/apitrace-imx.git;protocol=https;branch=imx_9.0"
-SRCREV = "fed74f6f84cb4f48ddace4306c9bf90bf7a9a967"
+SRCREV = "c50e6a954e44998f2e3793a8de863e961f8008c6"
 
 S = "${WORKDIR}/git"
 
 inherit cmake pkgconfig perlnative python3native
 
-PACKAGECONFIG ??= "egl"
-PACKAGECONFIG_append = \
-    "${@bb.utils.contains('DISTRO_FEATURES', 'wayland', '', \
-        bb.utils.contains('DISTRO_FEATURES',     'x11', ' x11', \
-                                                        '', d), d)}"
-PACKAGECONFIG_append_mx8 = " waffle"
-PACKAGECONFIG_append_imxgpu2d = " vivante"
+PACKAGECONFIG_BACKEND_mx6 = " \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'waffle', \
+       bb.utils.contains('DISTRO_FEATURES',     'x11',    'x11', \
+                                                             '', d), d)} \
+"
+PACKAGECONFIG_BACKEND_mx7 = "${PACKAGECONFIG_BACKEND_mx6}"
+PACKAGECONFIG_BACKEND_mx8 = "waffle"
+
+PACKAGECONFIG_GPU2D          = ""
+PACKAGECONFIG_GPU2D_imxgpu2d = "vivante"
+
+PACKAGECONFIG ??= " \
+    egl \
+    ${PACKAGECONFIG_BACKEND} \
+    ${PACKAGECONFIG_GPU2D} \
+"
 
 PACKAGECONFIG[egl] = "-DENABLE_EGL=ON,-DENABLE_EGL=OFF,virtual/egl"
 PACKAGECONFIG[gui] = "-DENABLE_GUI=ON,-DENABLE_GUI=OFF"


### PR DESCRIPTION
eglretrace was not available for i.MX 6 and 7 on framebuffer or wayland.
For wayland, waffle is enabled for 6 and 7, matching i.MX 8.

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>