### PR TITLE
Consolidated Kernel update (v5.4.98 + v5.10.16)

### DIFF
--- a/recipes-kernel/linux/linux-fslc-imx_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_5.4.bb
@@ -28,7 +28,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v5.4.97
+#    tag: v5.4.98
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
@@ -71,14 +71,14 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
 SRCBRANCH = "5.4-2.3.x-imx"
-SRCREV = "9a4b5ae7ee915f0009f1b5cd75a8fe9f98849093"
+SRCREV = "c789925f9aa01b54630ef32fcd0b5f1804f85ff9"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.97"
+LINUX_VERSION = "5.4.98"
 
 # Local version indicates the branch name in the NXP kernel tree where patches are collected from.
 LOCALVERSION = "-imx-5.4.70-2.3.0"

--- a/recipes-kernel/linux/linux-fslc_5.10.bb
+++ b/recipes-kernel/linux/linux-fslc_5.10.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.10.15"
+LINUX_VERSION = "5.10.16"
 
 SRCBRANCH = "5.10.x+fslc"
-SRCREV = "45593367aeedba4e2d636539c5b91f1f33178d67"
+SRCREV = "42271aef2fea42e32d3129b4a3abe31ea52b5f61"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"


### PR DESCRIPTION
Kernel branches were updated up to and including following versions for recipes from stable korg:
- `linux-fslc-imx`: _v5.4.98_
- `linux-fslc`: _v5.10.16_

Update recipe `SRCREV` to point to those versions now.

Upstream commits are recorded in corresponding recipe commit messages.

Boot-tested on _imx8mp-evk_ machine, result: **PASS**.

-- andrey