### PR TITLE
linux-fslc[-imx]: use KBRANCH instead of SRCBRANCH in kernel build

### DIFF
--- a/recipes-kernel/linux/linux-fslc-imx_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_5.4.bb
@@ -70,7 +70,7 @@ include linux-fslc.inc
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
-SRCBRANCH = "5.4-2.3.x-imx"
+KBRANCH = "5.4-2.3.x-imx"
 SRCREV = "c789925f9aa01b54630ef32fcd0b5f1804f85ff9"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition

--- a/recipes-kernel/linux/linux-fslc-lts-4.19.bb
+++ b/recipes-kernel/linux/linux-fslc-lts-4.19.bb
@@ -13,7 +13,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
 PV = "4.19.125+git${SRCPV}"
 
-SRCBRANCH = "4.19.x+fslc"
+KBRANCH = "4.19.x+fslc"
 SRCREV = "d839dc0169b3c568813f2ee2abc30720f5244b89"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"

--- a/recipes-kernel/linux/linux-fslc.inc
+++ b/recipes-kernel/linux/linux-fslc.inc
@@ -5,6 +5,6 @@ require recipes-kernel/linux/linux-imx.inc
 
 DEPENDS += "lzop-native bc-native"
 
-SRC_URI = "git://github.com/Freescale/linux-fslc.git;branch=${SRCBRANCH} \
+SRC_URI = "git://github.com/Freescale/linux-fslc.git;branch=${KBRANCH} \
            file://defconfig"
 LOCALVERSION = "-fslc"

--- a/recipes-kernel/linux/linux-fslc_5.10.bb
+++ b/recipes-kernel/linux/linux-fslc_5.10.bb
@@ -21,7 +21,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 # should be updated once patchlevel is merged.
 LINUX_VERSION = "5.10.16"
 
-SRCBRANCH = "5.10.x+fslc"
+KBRANCH = "5.10.x+fslc"
 SRCREV = "42271aef2fea42e32d3129b4a3abe31ea52b5f61"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"


### PR DESCRIPTION
Kernel recipe should define a kernel branch used in recipe via KBRANCH and not a customized variable SRCBRANCH.

KBRANCH variable is used by several OE tools (e.g. devtool) to define the checkout policy when recipe is modified to a separate user workspace.

Replace the occurrence of SRCBRANCH with KBRANCH in kernel recipes, and change fetcher URI to use KBRANCH variable for checkout.

This solves the issue reported on the [meta-freescale ML](https://lists.yoctoproject.org/g/meta-freescale/message/24352) regarding the failure to use `devtool modify linux-fslc` command.