### PR TITLE
basler-camera,isp-imx,kernel-module-isp-vvcam: Mark imx specific

### DIFF
--- a/recipes-bsp/isp-imx/basler-camera_4.2.2.6.0.bb
+++ b/recipes-bsp/isp-imx/basler-camera_4.2.2.6.0.bb
@@ -23,3 +23,5 @@ SYSTEMD_AUTO_ENABLE = "enable"
 
 FILES_${PN} = "${libdir} /opt"
 INSANE_SKIP_${PN} = "file-rdeps already-stripped"
+
+COMPATIBLE_MACHINE = "(imx|use-nxp-bsp)"

--- a/recipes-bsp/isp-imx/isp-imx_4.2.2.6.0.bb
+++ b/recipes-bsp/isp-imx/isp-imx_4.2.2.6.0.bb
@@ -80,3 +80,5 @@ FILES_${PN}-dbg += "${libdir}/.debug"
 
 INSANE_SKIP_${PN} += "rpaths dev-deps dev-so"
 INSANE_SKIP_${PN}-dev += "rpaths dev-elf"
+
+COMPATIBLE_MACHINE = "(imx|use-nxp-bsp)"

--- a/recipes-kernel/kernel-modules/kernel-module-isp-vvcam_4.2.2.6.0.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-isp-vvcam_4.2.2.6.0.bb
@@ -15,3 +15,5 @@ SRCREV = "9824e601d336bcef2dc6284ff3605e0b1d32d63d"
 S = "${WORKDIR}/git/vvcam/v4l2"
 
 inherit module
+
+COMPATIBLE_MACHINE = "(imx|use-nxp-bsp)"


### PR DESCRIPTION
These recipes are really not meant for non imx architectures, therefore
pin them as such

Signed-off-by: Khem Raj <raj.khem@gmail.com>