### PR TITLE
mesa: For i.MX parts without GPU use default gallium and dri

### DIFF
--- a/recipes-graphics/mesa/mesa_%.bbappend
+++ b/recipes-graphics/mesa/mesa_%.bbappend
@@ -17,16 +17,26 @@ python () {
 # Enable Etnaviv and Freedreno support
 PACKAGECONFIG_append_use-mainline-bsp = " gallium etnaviv kmsro freedreno"
 
-# For NXP BSP, disable dri for parts without DRM.
-# Disable gallium and enable OSMesa for parts with DRM.
-# Also enable swrast for its dri driver for parts with DRM.
-PACKAGECONFIG_REMOVE_NXPBSP        = "dri"
-PACKAGECONFIG_APPEND_NXPBSP        = ""
-PACKAGECONFIG_REMOVE_NXPBSP_imxdrm = "gallium"
-PACKAGECONFIG_APPEND_NXPBSP_imxdrm = "osmesa"
-PACKAGECONFIG_remove_use-nxp-bsp   = "${PACKAGECONFIG_REMOVE_NXPBSP}"
-PACKAGECONFIG_append_use-nxp-bsp   = " ${PACKAGECONFIG_APPEND_NXPBSP}"
-DRIDRIVERS_use-nxp-bsp_imxdrm = "swrast"
+# For NXP BSP, choose between gallium and osmesa, and between enabling
+# dri and swrast or not. gallium and dri are default.
+#
+# For parts with no GPU, use gallium and dri
+PACKAGECONFIG_REMOVE_NXPBSP               = ""
+PACKAGECONFIG_APPEND_NXPBSP               = ""
+DRIDRIVERS_NXPBSP                         = ""
+#
+# For parts with GPU but no DRM, use gallium
+PACKAGECONFIG_REMOVE_NXPBSP_imxgpu        = "dri"
+DRIDRIVERS_NXPBSP_imxgpu                  = ""
+#
+# For parts with GPU and DRM, use osmesa, dri, and swrast
+PACKAGECONFIG_REMOVE_NXPBSP_imxgpu_imxdrm = "gallium"
+PACKAGECONFIG_APPEND_NXPBSP_imxgpu_imxdrm = "osmesa"
+DRIDRIVERS_NXPBSP_imxgpu_imxdrm           = "swrast"
+#
+PACKAGECONFIG_remove_use-nxp-bsp = "${PACKAGECONFIG_REMOVE_NXPBSP}"
+PACKAGECONFIG_append_use-nxp-bsp = " ${PACKAGECONFIG_APPEND_NXPBSP}"
+DRIDRIVERS_use-nxp-bsp           = "${DRIDRIVERS_NXPBSP}"
 
 BACKEND = \
     "${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'wayland', \


### PR DESCRIPTION
For NXP BSP, building graphics software for a part without GPU can fail with a
dependency issue:

```
ERROR: Nothing RPROVIDES 'libgl' (but /home/r60874/gatesgarth/sources/poky/meta/recipes-gnome/gtk+/gtk+3_3.24.22.bb, /home/r60874/gatesgarth/sources/poky/meta/recipes-graphics/cogl/cogl-1.0_1.22.8.bb RDEPENDS on or otherwise requires it)
```

This is fixed by adding a third case configuration using the default gallium and dri.

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>
(cherry picked from commit 148581622b1097123f0fdb905c3167d0d6d6f5b7)