### PR TITLE
layer: license: fix GPL-2.0 license identifiers changed upstream

### DIFF
--- a/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
+++ b/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
@@ -4,7 +4,7 @@ require imx-mkimage_git.inc
 
 DESCRIPTION = "Generate Boot Loader for i.MX 8 device"
 LICENSE = "GPLv2"
-LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6"
 SECTION = "BSP"
 
 inherit use-imx-security-controller-firmware

--- a/recipes-bsp/imx-mkimage/imx-mkimage_git.bb
+++ b/recipes-bsp/imx-mkimage/imx-mkimage_git.bb
@@ -5,7 +5,7 @@ require imx-mkimage_git.inc
 
 DESCRIPTION = "i.MX make image"
 LICENSE = "GPLv2"
-LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6"
 SECTION = "BSP"
 
 inherit deploy native

--- a/recipes-bsp/imx-test/imx-test_git.bb
+++ b/recipes-bsp/imx-test/imx-test_git.bb
@@ -5,8 +5,8 @@
 SUMMARY = "Test programs for i.MX BSP"
 DESCRIPTION = "Unit tests for the i.MX BSP"
 SECTION = "base"
-LICENSE = "GPLv2"
-LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6"
+LICENSE = "GPLv2+"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-2.0-or-later;md5=fed54355545ffd980b814dab4a3b312c"
 
 DEPENDS = "alsa-lib libdrm"
 DEPENDS_append_mx6 = " imx-lib"

--- a/recipes-kernel/kernel-modules/kernel-module-imx-gpu-viv_6.4.3.p1.0.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-imx-gpu-viv_6.4.3.p1.0.bb
@@ -5,7 +5,7 @@ SUMMARY = "Kernel loadable module for Vivante GPU"
 DESCRIPTION = "Builds the Vivante GPU kernel driver as a loadable kernel module, \
 allowing flexibility to use a newer graphics release with an older kernel."
 LICENSE = "GPLv2"
-LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6"
 
 SRCBRANCH = "imx_5.4.70_2.3.0"
 LOCALVERSION = "-${SRCBRANCH}"


### PR DESCRIPTION
Upstream commit 2456f523cf ("licenses: Update license file to match current SPDX names") deprecated the usage of GPL-2.0 SPDX identifier, removed GPL-2.0 license file and replaced it with GPL-2.0-only SPDX identifier and text file.

Adjust layer recipes to use new SDPX identifier and text file.

imx-test recipe has license has been re-captured to use GPL-2.0-or-later identifier, since it is required by the license text accompanying the source code repository through "GPLv2 or later" statement in COPYING file.

-- andrey