### PR TITLE
firmware-imx: Prevent sdma-imx6q and imx7d installation

### DIFF
--- a/recipes-bsp/firmware-imx/firmware-imx_8.9.bb
+++ b/recipes-bsp/firmware-imx/firmware-imx_8.9.bb
@@ -16,6 +16,8 @@ do_install() {
     # SDMA Firmware section
     install -d ${D}${nonarch_base_libdir}/firmware/imx/sdma
     install -m 0644 ${S}/firmware/sdma/* ${D}${nonarch_base_libdir}/firmware/imx/sdma
+    rm -f ${D}${nonarch_base_libdir}/firmware/imx/sdma/sdma-imx6q.bin
+    rm -f ${D}${nonarch_base_libdir}/firmware/imx/sdma/sdma-imx7d.bin
 
     # EASRC Firmware section
     install -d ${D}${nonarch_base_libdir}/firmware/imx/easrc


### PR DESCRIPTION
When building a eSDK, sdma-imx6q/7d files are installed by
both firmware-imx and linux-firmware causing a abort.
Prevent firmware-imx to install sdma-imx6q/7d allows
linux-firmware to install them exclusively.

Signed-off-by: Vinicius Aquino <voa.aquino@gmail.com>
(cherry picked from commit 9f5ecc8396a9b247109236cb5d94ab560ff62be9)