### PR TITLE
u-boot-fslc: update revision to include mx8mn sd card fixes

### DIFF
--- a/recipes-bsp/u-boot/u-boot-fslc-common_2020.10.inc
+++ b/recipes-bsp/u-boot/u-boot-fslc-common_2020.10.inc
@@ -10,7 +10,7 @@ DEPENDS += "bison-native"
 
 SRC_URI = "git://github.com/Freescale/u-boot-fslc.git;branch=${SRCBRANCH}"
 
-SRCREV = "5003fc093c40895e541fe481016bd3220078a81c"
+SRCREV = "80c23498b425447a4a04d2a85ca4c2aec6ec349a"
 SRCBRANCH = "2020.10+fslc"
 
 PV = "v2020.10+git${SRCPV}"


### PR DESCRIPTION
Upstream repository has been updated with following commit:
```
80c23498b4 imx8mn_ddr4_evk: Allow booting the kernel by default
```

Bump up revision in recipe to pick up patch applied.

-- andrey