### PR TITLE
Consolidated Kernel update (v5.4.102 + v5.10.20)

### DIFF
--- a/recipes-kernel/linux/linux-fslc-imx_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_5.4.bb
@@ -28,7 +28,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v5.4.100
+#    tag: v5.4.101
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
@@ -71,14 +71,14 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
 KBRANCH = "5.4-2.3.x-imx"
-SRCREV = "f4e16a6a8681a09229b45fa8fe74d95f0df3b4a4"
+SRCREV = "13155f4c5e198e91b853f830447e7786241a4540"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.100"
+LINUX_VERSION = "5.4.101"
 
 # Local version indicates the branch name in the NXP kernel tree where patches are collected from.
 LOCALVERSION = "-imx-5.4.70-2.3.0"

--- a/recipes-kernel/linux/linux-fslc-imx_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_5.4.bb
@@ -28,7 +28,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v5.4.101
+#    tag: v5.4.102
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
@@ -71,14 +71,14 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
 KBRANCH = "5.4-2.3.x-imx"
-SRCREV = "13155f4c5e198e91b853f830447e7786241a4540"
+SRCREV = "c6036e92d242ca4457bef28f3e70751f50df1eeb"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.101"
+LINUX_VERSION = "5.4.102"
 
 # Local version indicates the branch name in the NXP kernel tree where patches are collected from.
 LOCALVERSION = "-imx-5.4.70-2.3.0"

--- a/recipes-kernel/linux/linux-fslc_5.10.bb
+++ b/recipes-kernel/linux/linux-fslc_5.10.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.10.19"
+LINUX_VERSION = "5.10.20"
 
 KBRANCH = "5.10.x+fslc"
-SRCREV = "804eb1ad8bcceefe16c0b9fb793d5733e8bc03e6"
+SRCREV = "86a5f1327bea3fbf246df078ad2009987e7770d3"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"

--- a/recipes-kernel/linux/linux-fslc_5.10.bb
+++ b/recipes-kernel/linux/linux-fslc_5.10.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.10.18"
+LINUX_VERSION = "5.10.19"
 
 KBRANCH = "5.10.x+fslc"
-SRCREV = "e96f454f9d4b52526ab436c148418fb773a312cf"
+SRCREV = "804eb1ad8bcceefe16c0b9fb793d5733e8bc03e6"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"


### PR DESCRIPTION
Kernel branches were updated up to and including following versions for recipes from stable korg:
- `linux-fslc-imx`: _v5.4.102_
- `linux-fslc`: _v5.10.20_

Update recipe `SRCREV` to point to those versions now.

Upstream commits are recorded in corresponding recipe commit messages.

-- andrey