### PR TITLE
Boot Container support for mainline BSP and mx8m machines

### DIFF
--- a/classes/imx-boot-container.bbclass
+++ b/classes/imx-boot-container.bbclass
@@ -1,0 +1,107 @@
+#
+# This class provides a support to build the boot container for
+# i.MX8M derivatives
+#
+# imx8m machines require a separate build target to be executed
+# due to the fact that final boot image is constructed using flash.bin
+# taget. It produces a boot binary image, which is constructed from
+# various binary components (u-boot with separate dtb, atf, DDR
+# firmware and optional op-tee) into a single image using FIT format.
+# This flash.bin file is then parsed and loaded either via
+# SPL directly (imx8mm), or using bootrom code (imx8mn and imx8mp).
+#
+# In order to use flash.bin binary boot image, it is required that
+# the U-Boot build is to be invoked for an additional build target.
+# This class extendes the U-Boot build targets with the "flash.bin",
+# which effectively serves as a boot container. It replaces the boot
+# container `imx-boot` provided by NXP.
+#
+# Class inheritance is performed in u-boot-fslc recipe, and is controlled
+# by variable UBOOT_PROVIDES_BOOT_CONTAINER, which is defined in the
+# base machine include file (imx-base.inc), and is set to "1" when the
+# 'imx-boot-container' is present in MACHINEOVERRIDES.
+
+# Extend the UBOOT_MAKE_TARGET with additional target for U-Boot build
+# system to produce the boot container
+UBOOT_MAKE_TARGET += "flash.bin"
+
+# Define ATF binary file to be deployed to the U-Boot build folder
+ATF_MACHINE_NAME = "bl31-${ATF_PLATFORM}.bin"
+ATF_MACHINE_NAME_append = "${@bb.utils.contains('MACHINE_FEATURES', 'optee', '-optee', '', d)}"
+
+# This package aggregates output deployed by other packages, so set the
+# appropriate dependencies for populate binaries task
+do_resolve_and_populate_binaries[depends] += " \
+    ${@' '.join('%s:do_deploy' % r for r in '${IMX_EXTRA_FIRMWARE}'.split() )} \
+    imx-atf:do_deploy \
+    ${@bb.utils.contains('MACHINE_FEATURES', 'optee', 'optee-os:do_deploy', '', d)} \
+"
+
+# Append make flags to include ATF load address
+EXTRA_OEMAKE += "ATF_LOAD_ADDR=${ATF_LOAD_ADDR}"
+
+# Define an additional task that collects binary output from dependent packages
+# and deploys them into the U-Boot build folder
+do_resolve_and_populate_binaries() {
+    if [ ! -n "${ATF_LOAD_ADDR}" ]; then
+        bberror "ATF_LOAD_ADDR is undefined, result binary would be unusable!"
+    fi
+
+    if [ -n "${UBOOT_CONFIG}" ]; then
+        for config in ${UBOOT_MACHINE}; do
+            i=$(expr $i + 1);
+            for type in ${UBOOT_CONFIG}; do
+                j=$(expr $j + 1);
+                if [ $j -eq $i ]; then
+                    for ddr_firmware in ${DDR_FIRMWARE_NAME}; do
+                        # Sanitize the FW name as U-Boot expects it to be without version
+                        if [ -n "${DDR_FIRMWARE_VERSION}" ]; then
+                            ddr_firmware_name=$(echo $ddr_firmware | sed s/_${DDR_FIRMWARE_VERSION}//)
+                        else
+                            ddr_firmware_name="$ddr_firmware"
+                        fi
+                        bbnote "Copy ddr_firmware: ${ddr_firmware} from ${DEPLOY_DIR_IMAGE} -> ${B}/${config}/${ddr_firmware_name}"
+                        cp ${DEPLOY_DIR_IMAGE}/${ddr_firmware} ${B}/${config}/${ddr_firmware_name}
+                    done
+                    if [ -n "${ATF_MACHINE_NAME}" ]; then
+                        cp ${DEPLOY_DIR_IMAGE}/${BOOT_TOOLS}/${ATF_MACHINE_NAME} ${B}/${config}/bl31.bin
+                    else
+                        bberror "ATF binary is undefined, result binary would be unusable!"
+                    fi
+                fi
+            done
+            unset  j
+        done
+        unset  i
+    fi
+}
+addtask do_resolve_and_populate_binaries before do_compile after do_configure
+
+# Append the u-boot do_deploy task to deploy also the result flash.bin
+# boot container as a replacement for the one provided by NXP BSP.
+#
+# Deploy task renames the target file from flash.bin to imx-boot to match
+# the name WKS file requires.
+#
+# This effectively would allow the usage of the same WKS file for those
+# derivatives that are using the boot container from U-Boot and those
+# that are not yet have support for it enabled.
+do_deploy_append() {
+    # Deploy the resulted flash.bin for WIC to pick it up
+    if [ -n "${UBOOT_CONFIG}" ]; then
+        for config in ${UBOOT_MACHINE}; do
+            i=$(expr $i + 1);
+            for type in ${UBOOT_CONFIG}; do
+                j=$(expr $j + 1);
+                if [ $j -eq $i ]
+                then
+                    install -m 0644 ${B}/${config}/flash.bin  ${DEPLOYDIR}/flash.bin-${MACHINE}-${UBOOT_CONFIG}
+                    ln -sf flash.bin-${MACHINE}-${UBOOT_CONFIG} imx-boot
+                    ln -sf flash.bin-${MACHINE}-${UBOOT_CONFIG} flash.bin
+                fi
+            done
+            unset  j
+        done
+        unset  i
+    fi
+}

--- a/conf/machine/imx8mn-ddr4-evk.conf
+++ b/conf/machine/imx8mn-ddr4-evk.conf
@@ -11,10 +11,12 @@ KERNEL_DEVICETREE_append_use-nxp-bsp = " \
     freescale/${KERNEL_DEVICETREE_BASENAME}-usd-wifi.dtb \
 "
 UBOOT_CONFIG_BASENAME = "imx8mn_ddr4_evk"
+
+DDR_FIRMWARE_VERSION = "201810"
 DDR_FIRMWARE_NAME = " \
-    ddr4_imem_1d_201810.bin \
-    ddr4_dmem_1d_201810.bin \
-    ddr4_imem_2d_201810.bin \
-    ddr4_dmem_2d_201810.bin \
+    ddr4_imem_1d_${DDR_FIRMWARE_VERSION}.bin \
+    ddr4_dmem_1d_${DDR_FIRMWARE_VERSION}.bin \
+    ddr4_imem_2d_${DDR_FIRMWARE_VERSION}.bin \
+    ddr4_dmem_2d_${DDR_FIRMWARE_VERSION}.bin \
 "
 IMXBOOT_TARGETS_BASENAME = "flash_ddr4_evk"

--- a/conf/machine/imx8mp-evk.conf
+++ b/conf/machine/imx8mp-evk.conf
@@ -4,7 +4,7 @@
 #@DESCRIPTION: Machine configuration for NXP i.MX 8M Plus Evaluation Kit
 #@MAINTAINER: Jun Zhu <junzhu@nxp.com>
 
-MACHINEOVERRIDES =. "mx8:mx8m:mx8mp:"
+MACHINEOVERRIDES =. "imx-boot-container:mx8:mx8m:mx8mp:"
 
 require conf/machine/include/imx-base.inc
 require conf/machine/include/tune-cortexa53.inc
@@ -59,8 +59,12 @@ DDR_FIRMWARE_NAME = " \
 # Set u-boot DTB
 UBOOT_DTB_NAME = "imx8mp-evk.dtb"
 
-# Set ATF platform name
+# Set ATF platform name and load address
 ATF_PLATFORM = "imx8mp"
+ATF_LOAD_ADDR = "0x970000"
+
+# Extra firmware package name, that is required to build boot container for fslc bsp
+IMX_EXTRA_FIRMWARE = "firmware-imx-8m"
 
 # Set imx-mkimage boot target
 IMXBOOT_TARGETS = "${@bb.utils.contains('UBOOT_CONFIG', 'fspi', 'flash_evk_flexspi', 'flash_evk', d)}"
@@ -71,10 +75,11 @@ SERIAL_CONSOLES = "115200;ttymxc1"
 
 LOADADDR = ""
 UBOOT_SUFFIX = "bin"
-UBOOT_MAKE_TARGET = ""
+UBOOT_MAKE_TARGET = "all"
 IMX_BOOT_SEEK = "32"
 
 OPTEE_BIN_EXT = "8mp"
+TEE_LOAD_ADDR = "0x56000000"
 
 # Add additional firmware
 MACHINE_FIRMWARE_append = " linux-firmware-ath10k"

--- a/conf/machine/imx8mp-evk.conf
+++ b/conf/machine/imx8mp-evk.conf
@@ -9,8 +9,11 @@ MACHINEOVERRIDES =. "imx-boot-container:mx8:mx8m:mx8mp:"
 require conf/machine/include/imx-base.inc
 require conf/machine/include/tune-cortexa53.inc
 
-MACHINE_FEATURES += "pci wifi bluetooth optee jailhouse"
-MACHINE_FEATURES_append_use-nxp-bsp = " mrvl8997"
+MACHINE_FEATURES += "pci wifi bluetooth jailhouse"
+
+# OP-TEE is also applicable to NXP BSP, mainline BSP seems not to have
+# a full support for it yet.
+MACHINE_FEATURES_append_use-nxp-bsp = " optee mrvl8997"
 
 # Mainline kernel contains only one DTB file for
 # imx8mpevk machine

--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -57,6 +57,12 @@ UBOOT_ENTRYPOINT_mx7ulp = "0x60008000"
 UBOOT_ENTRYPOINT_mx8m   = "0x40480000"
 UBOOT_ENTRYPOINT_vf = "0x80008000"
 
+# Some derivates can utilize the boot container provided by U-Boot,
+# below variable sets that those machines which have a imx-boot-container
+# in their MACHINEOVERRIDES can inherit a imx-boot-container class
+UBOOT_PROVIDES_BOOT_CONTAINER = "0"
+UBOOT_PROVIDES_BOOT_CONTAINER_imx-boot-container = "1"
+
 PREFERRED_PROVIDER_virtual/xserver = "xserver-xorg"
 XSERVER_DRIVER                  = "xf86-video-fbdev"
 XSERVER_DRIVER_imxgpu2d         = "xf86-video-imx-vivante"
@@ -390,13 +396,37 @@ WKS_FILE_DEPENDS_append_mx8 = " imx-boot"
 WKS_FILE_DEPENDS_append_mx8m = " imx-boot"
 
 # We need to restrict the append so we don't add this for other i.MX SoC's.
-WKS_FILE_DEPENDS_append_use-mainline-bsp_aarch64 = " imx-boot"
+# Derivatives that are not yet adopted the usage of boot container provided
+# by U-Boot build are still targeted to use 'imx-boot' package provided by
+# NXP. Moving those derivatives to mainline BSP would require to define an
+# 'imx-boot-container' override, and test if the U-Boot built 'flash.bin'
+# binary is used a replacement.
+# Note, that the results binary name of the boot container is set to 'imx-boot'
+# for both NXP and Mainline BSP.
+# For Mainline BSP: the 'flash.bin' boot container is renamed during the
+# deployment task extesion execution defined in imx-boot-container class.
+# For NXP BSP: rename is done in 'imx-boot' recipe at the execution of compile
+# task.
+WKS_FILE_DEPENDS_append_use-mainline-bsp_aarch64 = " \
+    ${@oe.utils.ifelse(d.getVar('UBOOT_PROVIDES_BOOT_CONTAINER') == '0', 'imx-boot', '')} \
+"
 
 SOC_DEFAULT_WKS_FILE ?= "imx-uboot-bootpart.wks.in"
 SOC_DEFAULT_WKS_FILE_mx8m ?= "imx-imx-boot-bootpart.wks.in"
 
 SOC_DEFAULT_WKS_FILE_mx8 ?= "imx-imx-boot-bootpart.wks.in"
 SOC_DEFAULT_WKS_FILE_mxs ?= "imx-uboot-mxs-bootpart.wks.in"
+
+# Boot container built as a part of mainline U-Boot uses the same WKS
+# file as the entire mx8m series, as it renames flash.bin binary to
+# imx-boot before it is packed into the boot partition.
+# This operation is performed in imx-boot-container class as a part of
+# delopyment task.
+# flash.bin binary is produced by U-Boot build itself, and is serves as a
+# direct replacement of imx-boot from NXP.
+# Creation of the flash.bin is controlled by UBOOT_PROVIDES_BOOT_CONTAINER
+# variable defined above
+SOC_DEFAULT_WKS_FILE_imx-boot-container ?= "imx-imx-boot-bootpart.wks.in"
 
 WKS_FILE ?= "${SOC_DEFAULT_WKS_FILE}"
 

--- a/conf/machine/include/imx8mm-evk.inc
+++ b/conf/machine/include/imx8mm-evk.inc
@@ -1,4 +1,4 @@
-MACHINEOVERRIDES =. "mx8:mx8m:mx8mm:"
+MACHINEOVERRIDES =. "imx-boot-container:mx8:mx8m:mx8mm:"
 
 require conf/machine/include/imx-base.inc
 require conf/machine/include/tune-cortexa53.inc
@@ -27,6 +27,10 @@ UBOOT_CONFIG[mfgtool]  = "${UBOOT_CONFIG_BASENAME}_defconfig"
 SPL_BINARY = "spl/u-boot-spl.bin"
 
 ATF_PLATFORM = "imx8mm"
+ATF_LOAD_ADDR = "0x920000"
+
+# Extra firmware package name, that is required to build boot container for fslc bsp
+IMX_EXTRA_FIRMWARE = "firmware-imx-8m"
 
 IMXBOOT_TARGETS = "${@bb.utils.contains('UBOOT_CONFIG', 'fspi', '${IMXBOOT_TARGETS_BASENAME}_flexspi', '${IMXBOOT_TARGETS_BASENAME}', d)}"
 
@@ -36,10 +40,11 @@ SERIAL_CONSOLES = "115200;ttymxc1"
 
 LOADADDR = ""
 UBOOT_SUFFIX = "bin"
-UBOOT_MAKE_TARGET = ""
+UBOOT_MAKE_TARGET = "all"
 IMX_BOOT_SEEK = "33"
 
 OPTEE_BIN_EXT = "8mm"
+TEE_LOAD_ADDR = "0xbe000000"
 
 # Add additional firmware
 MACHINE_FIRMWARE_append = " linux-firmware-ath10k"

--- a/conf/machine/include/imx8mm-evk.inc
+++ b/conf/machine/include/imx8mm-evk.inc
@@ -3,13 +3,15 @@ MACHINEOVERRIDES =. "imx-boot-container:mx8:mx8m:mx8mm:"
 require conf/machine/include/imx-base.inc
 require conf/machine/include/tune-cortexa53.inc
 
-MACHINE_FEATURES += "pci wifi bluetooth optee bcm43455 bcm4356"
+MACHINE_FEATURES += "pci wifi bluetooth bcm43455 bcm4356"
 
 # NXP BSP can consume BCM4359 and QCA9377 driver and firmware
 # Since the firmware is not available publicly, and rather distributed
 # under "Proprietary" license - we opt-out from using it in all BSPs
 # and pin it to NXP BSP only
-MACHINE_FEATURES_append_use-nxp-bsp = " bcm4359 qca9377"
+# OP-TEE is also applicable to NXP BSP, mainline BSP seems not to have
+# a full support for it yet.
+MACHINE_FEATURES_append_use-nxp-bsp = " optee bcm4359 qca9377"
 
 KERNEL_DEVICETREE = " \
     freescale/${KERNEL_DEVICETREE_BASENAME}.dtb \

--- a/conf/machine/include/imx8mn-evk.inc
+++ b/conf/machine/include/imx8mn-evk.inc
@@ -3,10 +3,12 @@ MACHINEOVERRIDES =. "imx-boot-container:mx8:mx8m:mx8mn:"
 require conf/machine/include/imx-base.inc
 require conf/machine/include/tune-cortexa53.inc
 
-MACHINE_FEATURES += "wifi bluetooth optee bcm43455 bcm4356"
+MACHINE_FEATURES += "wifi bluetooth bcm43455 bcm4356"
 
 # NXP BSP can consume proprietary jailhouse and Broadcom drivers
-MACHINE_FEATURES_append_use-nxp-bsp = " jailhouse bcm4359"
+# OP-TEE is also applicable to NXP BSP, mainline BSP seems not to have
+# a full support for it yet.
+MACHINE_FEATURES_append_use-nxp-bsp = " optee jailhouse bcm4359"
 
 KERNEL_DEVICETREE = " \
 	freescale/${KERNEL_DEVICETREE_BASENAME}.dtb \

--- a/conf/machine/include/imx8mn-evk.inc
+++ b/conf/machine/include/imx8mn-evk.inc
@@ -1,4 +1,4 @@
-MACHINEOVERRIDES =. "mx8:mx8m:mx8mn:"
+MACHINEOVERRIDES =. "imx-boot-container:mx8:mx8m:mx8mn:"
 
 require conf/machine/include/imx-base.inc
 require conf/machine/include/tune-cortexa53.inc
@@ -28,6 +28,10 @@ UBOOT_CONFIG[mfgtool] = "${UBOOT_CONFIG_BASENAME}_defconfig"
 SPL_BINARY = "spl/u-boot-spl.bin"
 
 ATF_PLATFORM = "imx8mn"
+ATF_LOAD_ADDR = "0x960000"
+
+# Extra firmware package name, that is required to build boot container for fslc bsp
+IMX_EXTRA_FIRMWARE = "firmware-imx-8m"
 
 IMXBOOT_TARGETS = "${@bb.utils.contains('UBOOT_CONFIG', 'fspi', '${IMXBOOT_TARGETS_BASENAME}_flexspi', '${IMXBOOT_TARGETS_BASENAME}', d)}"
 
@@ -38,7 +42,7 @@ SERIAL_CONSOLES = "115200;ttymxc1"
 BOOT_SPACE = "65536"
 LOADADDR = ""
 UBOOT_SUFFIX = "bin"
-UBOOT_MAKE_TARGET = ""
+UBOOT_MAKE_TARGET = "all"
 
 # Image boot offset as defined in section 6.1.6.1 "Primary image offset and IVT offset" of
 # i.MX 8M Nano Applications Processor Reference Manual, Rev. 0, 12/2019
@@ -46,6 +50,7 @@ UBOOT_MAKE_TARGET = ""
 IMX_BOOT_SEEK = "32"
 
 OPTEE_BIN_EXT = "8mn"
+TEE_LOAD_ADDR = "0x56000000"
 
 # Add additional firmware
 MACHINE_FIRMWARE_append = " linux-firmware-ath10k"

--- a/recipes-bsp/firmware-imx/firmware-imx-8m_8.10.bb
+++ b/recipes-bsp/firmware-imx/firmware-imx-8m_8.10.bb
@@ -21,4 +21,4 @@ addtask deploy after do_install before do_build
 
 PACKAGE_ARCH = "${MACHINE_SOCARCH}"
 
-COMPATIBLE_MACHINE = "(mx8m)"
+COMPATIBLE_MACHINE = "(mx8m|imx-boot-container)"

--- a/recipes-bsp/imx-atf/imx-atf_2.2.bb
+++ b/recipes-bsp/imx-atf/imx-atf_2.2.bb
@@ -48,4 +48,4 @@ do_deploy() {
 addtask deploy after do_compile
 
 PACKAGE_ARCH = "${MACHINE_SOCARCH}"
-COMPATIBLE_MACHINE = "(mx8|use-mainline-bsp)"
+COMPATIBLE_MACHINE = "(mx8|imx-boot-container)"

--- a/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
+++ b/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
@@ -199,4 +199,4 @@ addtask deploy before do_build after do_compile
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 FILES_${PN} = "/boot"
 
-COMPATIBLE_MACHINE = "(mx8|use-mainline-bsp)"
+COMPATIBLE_MACHINE = "(mx8)"

--- a/recipes-bsp/u-boot/u-boot-fslc_2020.10.bb
+++ b/recipes-bsp/u-boot/u-boot-fslc_2020.10.bb
@@ -6,7 +6,9 @@ order to provide support for some backported features and fixes, or because it \
 was submitted for revision and it takes some time to become part of a stable \
 version, or because it is not applicable for upstreaming."
 
-DEPENDS_append = " bc-native dtc-native lzop-native"
+inherit ${@oe.utils.ifelse(d.getVar('UBOOT_PROVIDES_BOOT_CONTAINER') == '1', 'imx-boot-container', '')}
+
+DEPENDS += "bc-native dtc-native lzop-native"
 
 # Location known to imx-boot component, where U-Boot artifacts
 # should be additionally deployed.
@@ -38,6 +40,14 @@ EXTRA_OEMAKE += 'HOSTCC="${BUILD_CC} ${BUILD_CPPFLAGS}" \
 # it is required that the U-Boot dtb files are to be deployed into
 # a location known by imx-boot so they could be picked up and
 # inserted into the boot container.
+#
+# NOTE: This is only applicable to those derivatives of mx8m family,
+# which did not adopt the boot container mechanism provided by U-Boot
+# build system itself. U-Boot is capable of producing a result binary,
+# which includes all those deployed pieces below, hence once derivative
+# starts to use it - below append would not be necessary.
+# Once all mx8m derivatives are migrated to use the 'flash.bin' boot
+# container - this append can be dropped completely.
 do_deploy_append_mx8m() {
     # Deploy the mkimage, u-boot-nodtb.bin and fsl-imx8m*-XX.dtb for mkimage to generate boot binary
     if [ -n "${UBOOT_CONFIG}" ]; then

--- a/recipes-security/optee-imx/optee-os_3.10.0.imx.bb
+++ b/recipes-security/optee-imx/optee-os_3.10.0.imx.bb
@@ -97,4 +97,4 @@ FILES_${PN}-staticdev = "/usr/include/optee/"
 RDEPENDS_${PN}-dev += "${PN}-staticdev"
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
-COMPATIBLE_MACHINE = "(imx)"
+COMPATIBLE_MACHINE = "(imx|imx-boot-container)"


### PR DESCRIPTION
This PR provides a mechanism to create a full image for `mx8m` derivatives based on Community BSP (when _IMX_DEFAULT_BSP_ is set to `use-mainline-bsp`) and allows creation of runtime images that could be used on those derivatives.

Implementation provides a "boot container", which serves as a replacement of `imx-boot` package used in NXP BSP, and is populated in the final image file via new WIC template file.

Basic mechanism description can be summarized as following:
1. Machines that would like to utilize the boot container defines `boot-container` in their _MACHINEOVERRIDES_, which indicates that components required to produce a container are receiving compatibility option.
2. Machines are also **required** to define _ATF_LOAD_ADDR_ parameter, which is used in compilation process of container.
3. Base machine include file defines a variable _UBOOT_PROVIDES_BOOT_CONTAINER_, which indicates that the U-Boot package build should be extended with additional functionality that creates the boot container. This variable is set to "1" in case if `boot-container` is present in _MACHINEOVERRIDES_.
4. U-Boot package build system is extended via inheritance on the separate class (`imx-boot-container`), which takes care of the steps required before container can be created, and deployment of the result container binary after build completes.
5. U-Boot build system creates a container, which is done via special U-Boot build target: `flash.bin`
6. Boot container is deployed and picked up by a WIC file to the result image. It resides at the same location as a binary produced by `imx-boot` package in NXP BSP.
7. Result image file can be then further used to boot the target using the boot container.

This approach has been built and verified on `imx8mm-lpddr4-evk`, `imx8mn-ddr4-evk` and `imx8mp-evk` machines with _DISTRO=poky_.

Build has also been performed for above machines with `fsl-xwayland` distro to make sure that no impact of this implementation is recorded on NXP BSP flavor.

In addition, build of `DISTRO=poky MACHINE=imx7dsabresd bitbake core-image-base` has been performed to make sure that machines utilizing mainline BSP and not setting `boot-container` in their _MACHINEOVERRIDES_ are also unaffected.

--
Cc: @gibsson @MaxKrummenacher @thochstein @fabioestevam @pberginkonsult @hutchman @RobertBerger

