### PR TITLE
imx-vpu-hantro-vc: add do_install function

### DIFF
--- a/recipes-bsp/imx-vpu-hantro-vc/imx-vpu-hantro-vc_1.3.0.bb
+++ b/recipes-bsp/imx-vpu-hantro-vc/imx-vpu-hantro-vc_1.3.0.bb
@@ -13,4 +13,23 @@ S = "${WORKDIR}/${BPN}-${PV}"
 SRC_URI[md5sum] = "37c61718602ff08041b81319cfd6a8d9"
 SRC_URI[sha256sum] = "8425796fc63d7107f2f57c51497281c4d54c883b2670817347fbe55f39dc2b8c"
 
+# SCR is the location and name of the Software Content Register file
+# relative to ${D}${D_SUBDIR}.
+SCR = "SCR.txt"
+
+do_install () {
+    install -d ${D}${D_SUBDIR}
+    cp -r ${S}/* ${D}${D_SUBDIR}
+    if [ -d "${D}/usr/lib" ] && [ "${D}/usr/lib" != "${D}${libdir}" ]; then
+        mv ${D}/usr/lib ${D}${libdir}
+    fi
+    rm ${D}${D_SUBDIR}/COPYING
+    if [ ! -f ${D}${D_SUBDIR}/${SCR} ]; then
+        bbfatal "Missing Software Content Register \"${D}${D_SUBDIR}/${SCR}\""
+    fi
+    rm ${D}${D_SUBDIR}/${SCR}
+}
+
+FILES_${PN} = "/"
+
 COMPATIBLE_MACHINE = "(mx8mp)"


### PR DESCRIPTION
The encoding library was not previously being installed.