### PR TITLE
Backport CL patches from master to gatesgarth

### DIFF
--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -302,6 +302,8 @@ PREFERRED_PROVIDER_virtual/libgles1_imxgpu3d ?= "imx-gpu-viv"
 PREFERRED_PROVIDER_virtual/libgles2_imxgpu3d ?= "imx-gpu-viv"
 PREFERRED_PROVIDER_virtual/libg2d            ?= "imx-gpu-g2d"
 PREFERRED_PROVIDER_virtual/libg2d_imxdpu     ?= "imx-dpu-g2d"
+PREFERRED_PROVIDER_opencl-headers_imxgpu     ?= "imx-gpu-viv"
+PREFERRED_PROVIDER_opencl-icd-loader_imxgpu  ?= "imx-gpu-viv"
 
 PREFERRED_VERSION_weston_imx ?= "8.0.0.imx"
 PREFERRED_VERSION_weston_use-mainline-bsp = ""

--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -198,11 +198,11 @@ MACHINE_SOCARCH_FILTER_append_use-mainline-bsp = " \
     qtbase \
 "
 MACHINE_SOCARCH_FILTER_append_mx6q = " \
-    virtual/opencl-icd \
+    opencl-icd-loader \
     opencl-headers \
 "
 MACHINE_SOCARCH_FILTER_append_mx8 = " \
-    virtual/opencl-icd \
+    opencl-icd-loader \
     opencl-headers \
 "
 MACHINE_SOCARCH_FILTER_append_mx8qm = " \

--- a/recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc
+++ b/recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc
@@ -44,10 +44,9 @@ PROVIDES += " \
     libgal-imx \
     opencl-headers \
     opencl-clhpp \
+    opencl-icd-loader \
     virtual/egl \
     virtual/libopenvg \
-    virtual/opencl-headers \
-    virtual/opencl-icd \
     ${PROVIDES_OPENVX} \
     ${EXTRA_PROVIDES} \
 "

--- a/recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc
+++ b/recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc
@@ -47,6 +47,7 @@ PROVIDES += " \
     opencl-icd-loader \
     virtual/egl \
     virtual/libopenvg \
+    virtual/opencl-icd \
     ${PROVIDES_OPENVX} \
     ${EXTRA_PROVIDES} \
 "


### PR DESCRIPTION
Those 3 patches from @thochstein are missing in Gatesgarth branch and prevent to build properly some packages that currently throw:
```
arm-compute-library-20.02+gitAUTOINC+86520b575f-r0 do_prepare_recipe_sysroot: The file /usr/include/CL/cl_icd.h is installed by both opencl-headers and imx-gpu-viv, aborting
```
With those 3 patches backported this error is gone as expected.