### PR TITLE
imx-vpu-hantro-vc: backport do_install fix

### DIFF
--- a/recipes-bsp/imx-vpu-hantro-vc/imx-vpu-hantro-vc_1.2.0.bb
+++ b/recipes-bsp/imx-vpu-hantro-vc/imx-vpu-hantro-vc_1.2.0.bb
@@ -13,4 +13,23 @@ S = "${WORKDIR}/${BPN}-${PV}"
 SRC_URI[md5sum] = "d2b7c0cfdb380e5a65a94251c2437a34"
 SRC_URI[sha256sum] = "10a7f60964feb9641291815876fb8110dfec603c6451ed9b9c7fe57c23afd10e"
 
+# SCR is the location and name of the Software Content Register file
+# relative to ${D}${D_SUBDIR}.
+SCR = "SCR.txt"
+
+do_install () {
+    install -d ${D}${D_SUBDIR}
+    cp -r ${S}/* ${D}${D_SUBDIR}
+    if [ -d "${D}/usr/lib" ] && [ "${D}/usr/lib" != "${D}${libdir}" ]; then
+        mv ${D}/usr/lib ${D}${libdir}
+    fi
+    rm ${D}${D_SUBDIR}/COPYING
+    if [ ! -f ${D}${D_SUBDIR}/${SCR} ]; then
+        bbfatal "Missing Software Content Register \"${D}${D_SUBDIR}/${SCR}\""
+    fi
+    rm ${D}${D_SUBDIR}/${SCR}
+}
+
+FILES_${PN} = "/"
+
 COMPATIBLE_MACHINE = "(mx8mp)"


### PR DESCRIPTION
The encoding library was not previously being installed.