### PR TITLE
Consolidated Kernel update (v5.4.105 + [v5.10.23 + KPROBES option])

### DIFF
--- a/recipes-kernel/linux/linux-fslc-imx_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_5.4.bb
@@ -28,7 +28,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v5.4.102
+#    tag: v5.4.103
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
@@ -71,14 +71,14 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
 KBRANCH = "5.4-2.3.x-imx"
-SRCREV = "c6036e92d242ca4457bef28f3e70751f50df1eeb"
+SRCREV = "fa0b19f1fb666dd7afa9858bdf9c76c8d98039d9"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.102"
+LINUX_VERSION = "5.4.103"
 
 # Local version indicates the branch name in the NXP kernel tree where patches are collected from.
 LOCALVERSION = "-imx-5.4.70-2.3.0"

--- a/recipes-kernel/linux/linux-fslc-imx_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_5.4.bb
@@ -28,7 +28,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v5.4.104
+#    tag: v5.4.105
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
@@ -71,14 +71,14 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
 KBRANCH = "5.4-2.3.x-imx"
-SRCREV = "c7225ae91c73214f1c94d6e73865096b07a8c348"
+SRCREV = "1c320bdc60474c21bc5a3050fde3fa849ee31f45"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.104"
+LINUX_VERSION = "5.4.105"
 
 # Local version indicates the branch name in the NXP kernel tree where patches are collected from.
 LOCALVERSION = "-imx-5.4.70-2.3.0"

--- a/recipes-kernel/linux/linux-fslc-imx_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_5.4.bb
@@ -28,7 +28,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v5.4.103
+#    tag: v5.4.104
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
@@ -71,14 +71,14 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
 KBRANCH = "5.4-2.3.x-imx"
-SRCREV = "fa0b19f1fb666dd7afa9858bdf9c76c8d98039d9"
+SRCREV = "c7225ae91c73214f1c94d6e73865096b07a8c348"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.103"
+LINUX_VERSION = "5.4.104"
 
 # Local version indicates the branch name in the NXP kernel tree where patches are collected from.
 LOCALVERSION = "-imx-5.4.70-2.3.0"

--- a/recipes-kernel/linux/linux-fslc_5.10.bb
+++ b/recipes-kernel/linux/linux-fslc_5.10.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.10.22"
+LINUX_VERSION = "5.10.23"
 
 KBRANCH = "5.10.x+fslc"
-SRCREV = "ad7cbaf354ee8e1f5cf9cec63c5fe41acaf91983"
+SRCREV = "cd0198bf7317180a49626114678bea1c5dfa629d"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"

--- a/recipes-kernel/linux/linux-fslc_5.10.bb
+++ b/recipes-kernel/linux/linux-fslc_5.10.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.10.21"
+LINUX_VERSION = "5.10.22"
 
 KBRANCH = "5.10.x+fslc"
-SRCREV = "d7a9ad53cf6996da64d08de861ba822aa57609c2"
+SRCREV = "d8293dcef6e771d75f0ed2f5b4b3bbd4e978b489"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"

--- a/recipes-kernel/linux/linux-fslc_5.10.bb
+++ b/recipes-kernel/linux/linux-fslc_5.10.bb
@@ -22,6 +22,6 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 LINUX_VERSION = "5.10.22"
 
 KBRANCH = "5.10.x+fslc"
-SRCREV = "d8293dcef6e771d75f0ed2f5b4b3bbd4e978b489"
+SRCREV = "ad7cbaf354ee8e1f5cf9cec63c5fe41acaf91983"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"

--- a/recipes-kernel/linux/linux-fslc_5.10.bb
+++ b/recipes-kernel/linux/linux-fslc_5.10.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.10.20"
+LINUX_VERSION = "5.10.21"
 
 KBRANCH = "5.10.x+fslc"
-SRCREV = "86a5f1327bea3fbf246df078ad2009987e7770d3"
+SRCREV = "d7a9ad53cf6996da64d08de861ba822aa57609c2"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"


### PR DESCRIPTION
Kernel branches were updated up to and including following versions for recipes from stable korg:
- `linux-fslc-imx`: _v5.4.105_
- `linux-fslc`: _v5.10.23_

Update recipe `SRCREV` to point to those versions now.

`linux-fslc` tree is also updated with `defconfig` modifications enabling `KPROBES` config options to resolve the _LTT-ng_ modules build issue.

Upstream commits are recorded in corresponding recipe commit messages.

Boot-tested on `imx8mm-lpddr4-evk` machine, result - **PASS**.

-- andrey