### PR TITLE
[dunfell]: Consolidated Kernel update (up to v5.4.106)

### DIFF
--- a/recipes-kernel/linux/linux-fslc-imx_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_5.4.bb
@@ -28,7 +28,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v5.4.105
+#    tag: v5.4.106
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
@@ -73,14 +73,14 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
 SRCBRANCH = "5.4-2.1.x-imx"
-SRCREV = "3eb8b1936db2bd27203ebbbaa3a0a31d9aec3b9a"
+SRCREV = "eb6f11341a5495dbfc1f7824ee4ee165c3066b7e"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.105"
+LINUX_VERSION = "5.4.106"
 
 # Local version indicates the branch name in the NXP kernel tree where patches are collected from.
 LOCALVERSION = "-imx-5.4.24-2.1.0"

--- a/recipes-kernel/linux/linux-fslc_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc_5.4.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.105"
+LINUX_VERSION = "5.4.106"
 
 SRCBRANCH = "5.4.x+fslc"
-SRCREV = "67eae6828ecd40474369dcd5f3242a3d0e8c30f1"
+SRCREV = "eebecd1ae47089d0d06ca6bf207ab8e6f59386bd"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"


### PR DESCRIPTION
Both kernel branches were updated up to and including _v5.4.106_ from stable korg, recipe `SRCREV` are updated to point to that version now.

Upstream commits and resolved merge conflicts are recorded in corresponding recipe commit messages.

Boot-tested on `imx8mmevk` machine, result - **PASS**.

-- andrey
