### PR TITLE
Rework bootloader choosing logic

### DIFF
--- a/conf/machine/imx23evk.conf
+++ b/conf/machine/imx23evk.conf
@@ -9,6 +9,13 @@ MACHINEOVERRIDES =. "mxs:mx23:"
 include conf/machine/include/imx-base.inc
 include conf/machine/include/tune-arm926ejs.inc
 
+# This machine is not supported by u-boot-imx as it is not tested by NXP on this
+# board. So we force it to use u-boot-fslc which is based on mainline here.
+IMX_DEFAULT_BOOTLOADER = "u-boot-fslc"
+
+UBOOT_MAKE_TARGET = "u-boot.sb"
+UBOOT_SUFFIX = "sb"
+
 UBOOT_MACHINE = "mx23evk_config"
 
 KERNEL_DEVICETREE = "imx23-evk.dtb"

--- a/conf/machine/imx25pdk.conf
+++ b/conf/machine/imx25pdk.conf
@@ -9,6 +9,13 @@ MACHINEOVERRIDES =. "mx25:"
 include conf/machine/include/imx-base.inc
 include conf/machine/include/tune-arm926ejs.inc
 
+# This machine is not supported by u-boot-imx as it is not tested by NXP on this
+# board. So we force it to use u-boot-fslc which is based on mainline here.
+IMX_DEFAULT_BOOTLOADER = "u-boot-fslc"
+
+UBOOT_MAKE_TARGET = "u-boot.imx"
+UBOOT_SUFFIX = "imx"
+
 UBOOT_MACHINE ?= "mx25pdk_defconfig"
 
 KERNEL_DEVICETREE = "imx25-pdk.dtb"

--- a/conf/machine/imx28evk.conf
+++ b/conf/machine/imx28evk.conf
@@ -9,6 +9,13 @@ MACHINEOVERRIDES =. "mxs:mx28:"
 include conf/machine/include/imx-base.inc
 include conf/machine/include/tune-arm926ejs.inc
 
+# This machine is not supported by u-boot-imx as it is not tested by NXP on this
+# board. So we force it to use u-boot-fslc which is based on mainline here.
+IMX_DEFAULT_BOOTLOADER = "u-boot-fslc"
+
+UBOOT_MAKE_TARGET = "u-boot.sb"
+UBOOT_SUFFIX = "sb"
+
 UBOOT_CONFIG ??= "sd"
 UBOOT_CONFIG[sd] = "mx28evk_config,sdcard"
 UBOOT_CONFIG[nand] = "mx28evk_nand_config,ubifs"

--- a/conf/machine/imx28evk.conf
+++ b/conf/machine/imx28evk.conf
@@ -9,8 +9,6 @@ MACHINEOVERRIDES =. "mxs:mx28:"
 include conf/machine/include/imx-base.inc
 include conf/machine/include/tune-arm926ejs.inc
 
-IMXBOOTLETS_MACHINE = "iMX28_EVK"
-
 UBOOT_CONFIG ??= "sd"
 UBOOT_CONFIG[sd] = "mx28evk_config,sdcard"
 UBOOT_CONFIG[nand] = "mx28evk_nand_config,ubifs"

--- a/conf/machine/imx51evk.conf
+++ b/conf/machine/imx51evk.conf
@@ -11,4 +11,11 @@ include conf/machine/include/tune-cortexa8.inc
 
 KERNEL_DEVICETREE = "imx51-babbage.dtb"
 
+# This machine is not supported by u-boot-imx as it is not tested by NXP on this
+# board. So we force it to use u-boot-fslc which is based on mainline here.
+IMX_DEFAULT_BOOTLOADER = "u-boot-fslc"
+
+UBOOT_MAKE_TARGET = "u-boot.imx"
+UBOOT_SUFFIX = "imx"
+
 UBOOT_MACHINE = "mx51evk_config"

--- a/conf/machine/imx51evk.conf
+++ b/conf/machine/imx51evk.conf
@@ -9,9 +9,6 @@ MACHINEOVERRIDES =. "mx5:mx51:"
 include conf/machine/include/imx-base.inc
 include conf/machine/include/tune-cortexa8.inc
 
-# Disable perf features as 2.6.35.3 fails to build otherwise
-PERF_FEATURES_ENABLE = ""
-
 KERNEL_DEVICETREE = "imx51-babbage.dtb"
 
 UBOOT_MACHINE = "mx51evk_config"

--- a/conf/machine/imx53ard.conf
+++ b/conf/machine/imx53ard.conf
@@ -13,9 +13,16 @@ include conf/machine/include/tune-cortexa8.inc
 PERF_FEATURES_ENABLE = ""
 
 KERNEL_DEVICETREE = "imx53-ard.dtb"
+KERNEL_IMAGETYPE = "uImage"
+
+# This machine is not supported by u-boot-imx as it is not tested by NXP on this
+# board. So we force it to use u-boot-fslc which is based on mainline here.
+IMX_DEFAULT_BOOTLOADER = "u-boot-fslc"
+
+UBOOT_MAKE_TARGET = "u-boot.imx"
+UBOOT_SUFFIX = "imx"
 
 UBOOT_MACHINE = "mx53ard_config"
-KERNEL_IMAGETYPE = "uImage"
 
 MACHINE_FIRMWARE += "linux-firmware-ar3k \
                      linux-firmware-ath6k"

--- a/conf/machine/imx53qsb.conf
+++ b/conf/machine/imx53qsb.conf
@@ -11,6 +11,13 @@ include conf/machine/include/tune-cortexa8.inc
 
 KERNEL_DEVICETREE = "imx53-qsb.dtb imx53-qsrb.dtb"
 
+# This machine is not supported by u-boot-imx as it is not tested by NXP on this
+# board. So we force it to use u-boot-fslc which is based on mainline here.
+IMX_DEFAULT_BOOTLOADER = "u-boot-fslc"
+
+UBOOT_MAKE_TARGET = "u-boot.imx"
+UBOOT_SUFFIX = "imx"
+
 UBOOT_MACHINE = "mx53loco_config"
 
 MACHINE_FIRMWARE = "linux-firmware-ar3k \

--- a/conf/machine/imx6qdlsabreauto.conf
+++ b/conf/machine/imx6qdlsabreauto.conf
@@ -40,9 +40,9 @@ UBOOT_SUFFIX = "img"
 SPL_BINARY = "SPL"
 WKS_FILE = "imx-uboot-spl-bootpart.wks.in"
 
-# The fsl distro uses u-boot-imx which does not provide unified functionality
-# for dl/q/qp SoC variants. Change the defconfig to the targeted SoC variant.
-UBOOT_MACHINE_fsl = "mx6qsabreauto_defconfig"
+# The u-boot-imx does not provide unified functionality for DL/Q/QP SoC
+# variants. Change the defconfig to the targeted SoC variant.
+UBOOT_MACHINE_pn-u-boot-imx = "mx6qsabreauto_defconfig"
 
 SERIAL_CONSOLES = "115200;ttymxc3"
 

--- a/conf/machine/imx6qdlsabreauto.conf
+++ b/conf/machine/imx6qdlsabreauto.conf
@@ -34,12 +34,11 @@ KERNEL_DEVICETREE_use-mainline-bsp = " \
 
 UBOOT_MACHINE ?= "mx6sabreauto_defconfig"
 
-# These u-boot variables default to the correct settings for u-boot-imx.
-# Set overrides for u-boot-fslc.
-UBOOT_MAKE_TARGET_pn-u-boot-fslc = "all"
-UBOOT_SUFFIX_pn-u-boot-fslc = "img"
-SPL_BINARY_pn-u-boot-fslc = "SPL"
-WKS_FILE_pn-u-boot-fslc = "imx-uboot-spl-bootpart.wks.in"
+# Use fslc u-boot by default. See also imx-base.inc.
+UBOOT_MAKE_TARGET = "all"
+UBOOT_SUFFIX = "img"
+SPL_BINARY = "SPL"
+WKS_FILE = "imx-uboot-spl-bootpart.wks.in"
 
 # The fsl distro uses u-boot-imx which does not provide unified functionality
 # for dl/q/qp SoC variants. Change the defconfig to the targeted SoC variant.

--- a/conf/machine/imx6qdlsabreauto.conf
+++ b/conf/machine/imx6qdlsabreauto.conf
@@ -32,17 +32,25 @@ KERNEL_DEVICETREE_use-mainline-bsp = " \
     imx6dl-sabreauto.dtb \
 "
 
-UBOOT_MACHINE ?= "mx6sabreauto_defconfig"
+### u-boot-fslc settings ###
 
-# Use fslc u-boot by default. See also imx-base.inc.
-UBOOT_MAKE_TARGET = "all"
-UBOOT_SUFFIX = "img"
-SPL_BINARY = "SPL"
-WKS_FILE = "imx-uboot-spl-bootpart.wks.in"
+SPL_BINARY_pn-u-boot-fslc = "SPL"
+UBOOT_MACHINE_pn-u-boot-fslc ?= "mx6sabreauto_defconfig"
+UBOOT_SUFFIX_pn-u-boot-fslc = "img"
+
+### u-boot-imx settings ###
 
 # The u-boot-imx does not provide unified functionality for DL/Q/QP SoC
 # variants. Change the defconfig to the targeted SoC variant.
+SPL_BINARY_pn-u-boot-imx = ""
 UBOOT_MACHINE_pn-u-boot-imx = "mx6qsabreauto_defconfig"
+UBOOT_MAKE_TARGET_pn-u-boot-imx = "u-boot.imx"
+UBOOT_SUFFIX_pn-u-boot-imx = "imx"
+
+WKS_FILE = " \
+    ${@bb.utils.contains('IMX_DEFAULT_BOOTLOADER', \
+                         'u-boot-fslc', 'imx-uboot-spl-bootpart.wks.in', \
+                                        'imx-uboot-bootpart.wks.in', d)}"
 
 SERIAL_CONSOLES = "115200;ttymxc3"
 

--- a/conf/machine/imx6qdlsabresd.conf
+++ b/conf/machine/imx6qdlsabresd.conf
@@ -49,9 +49,9 @@ UBOOT_SUFFIX = "img"
 SPL_BINARY = "SPL"
 WKS_FILE = "imx-uboot-spl-bootpart.wks.in"
 
-# The fsl distro uses u-boot-imx which does not provide unified functionality
-# for dl/q/qp SoC variants. Change the defconfig to the targeted SoC variant.
-UBOOT_MACHINE_fsl = "mx6qsabresd_defconfig"
+# The u-boot-imx does not provide unified functionality for DL/Q/QP SoC
+# variants. Change the defconfig to the targeted SoC variant.
+UBOOT_MACHINE_pn-u-boot-imx = "mx6qsabresd_defconfig"
 
 SERIAL_CONSOLES = "115200;ttymxc0"
 

--- a/conf/machine/imx6qdlsabresd.conf
+++ b/conf/machine/imx6qdlsabresd.conf
@@ -43,12 +43,11 @@ KERNEL_DEVICETREE_use-mainline-bsp = " \
 
 UBOOT_MACHINE ?= "mx6sabresd_defconfig"
 
-# These u-boot variables default to the correct settings for u-boot-imx.
-# Set overrides for u-boot-fslc.
-UBOOT_MAKE_TARGET_pn-u-boot-fslc = "all"
-UBOOT_SUFFIX_pn-u-boot-fslc = "img"
-SPL_BINARY_pn-u-boot-fslc = "SPL"
-WKS_FILE_pn-u-boot-fslc = "imx-uboot-spl-bootpart.wks.in"
+# Use fslc u-boot by default. See also imx-base.inc.
+UBOOT_MAKE_TARGET = "all"
+UBOOT_SUFFIX = "img"
+SPL_BINARY = "SPL"
+WKS_FILE = "imx-uboot-spl-bootpart.wks.in"
 
 # The fsl distro uses u-boot-imx which does not provide unified functionality
 # for dl/q/qp SoC variants. Change the defconfig to the targeted SoC variant.

--- a/conf/machine/imx6qdlsabresd.conf
+++ b/conf/machine/imx6qdlsabresd.conf
@@ -41,17 +41,25 @@ KERNEL_DEVICETREE_use-mainline-bsp = " \
     imx6dl-sabresd.dtb \
 "
 
-UBOOT_MACHINE ?= "mx6sabresd_defconfig"
+### u-boot-fslc settings ###
 
-# Use fslc u-boot by default. See also imx-base.inc.
-UBOOT_MAKE_TARGET = "all"
-UBOOT_SUFFIX = "img"
-SPL_BINARY = "SPL"
-WKS_FILE = "imx-uboot-spl-bootpart.wks.in"
+SPL_BINARY_pn-u-boot-fslc = "SPL"
+UBOOT_MACHINE_pn-u-boot-fslc ?= "mx6sabresd_defconfig"
+UBOOT_SUFFIX_pn-u-boot-fslc = "img"
+
+### u-boot-imx settings ###
 
 # The u-boot-imx does not provide unified functionality for DL/Q/QP SoC
 # variants. Change the defconfig to the targeted SoC variant.
-UBOOT_MACHINE_pn-u-boot-imx = "mx6qsabresd_defconfig"
+SPL_BINARY_pn-u-boot-imx = ""
+UBOOT_MACHINE_pn-u-boot-imx ?= "mx6qsabresd_defconfig"
+UBOOT_MAKE_TARGET_pn-u-boot-imx = "u-boot.imx"
+UBOOT_SUFFIX_pn-u-boot-imx = "imx"
+
+WKS_FILE = " \
+    ${@bb.utils.contains('IMX_DEFAULT_BOOTLOADER', \
+                         'u-boot-fslc', 'imx-uboot-spl-bootpart.wks.in', \
+                                        'imx-uboot-bootpart.wks.in', d)}"
 
 SERIAL_CONSOLES = "115200;ttymxc0"
 

--- a/conf/machine/imx6slevk.conf
+++ b/conf/machine/imx6slevk.conf
@@ -17,6 +17,9 @@ KERNEL_DEVICETREE_append_use-nxp-bsp = " \
     imx6sl-evk-uart.dtb \
 "
 
+UBOOT_MAKE_TARGET = "u-boot.imx"
+UBOOT_SUFFIX = "imx"
+
 UBOOT_CONFIG ??= " \
     sd \
     ${@bb.utils.contains('MACHINE_FEATURES', 'optee', 'sd-optee', '', d)} \

--- a/conf/machine/imx6sllevk.conf
+++ b/conf/machine/imx6sllevk.conf
@@ -11,6 +11,9 @@ include conf/machine/include/tune-cortexa9.inc
 
 KERNEL_DEVICETREE = "imx6sll-evk.dtb"
 
+UBOOT_MAKE_TARGET = "u-boot.imx"
+UBOOT_SUFFIX = "imx"
+
 UBOOT_CONFIG ??= " \
     sd \
     ${@bb.utils.contains('MACHINE_FEATURES', 'optee', 'sd-optee', '', d)} \

--- a/conf/machine/imx6sxsabreauto.conf
+++ b/conf/machine/imx6sxsabreauto.conf
@@ -12,8 +12,8 @@ require conf/machine/include/tune-cortexa9.inc
 KERNEL_DEVICETREE = "imx6sx-sabreauto.dtb"
 KERNEL_DEVICETREE_use-mainline-bsp = "imx6sx-sabreauto.dtb"
 
-PREFERRED_PROVIDER_u-boot = "u-boot-fslc"
-PREFERRED_PROVIDER_virtual/bootloader = "u-boot-fslc"
+UBOOT_MAKE_TARGET = "u-boot.imx"
+UBOOT_SUFFIX = "imx"
 
 UBOOT_CONFIG ??= " \
     sd \

--- a/conf/machine/imx6sxsabresd.conf
+++ b/conf/machine/imx6sxsabresd.conf
@@ -25,6 +25,9 @@ KERNEL_DEVICETREE_append_use-nxp-bsp = " \
     imx6sx-sdb-reva-ldo.dtb \
 "
 
+UBOOT_MAKE_TARGET = "u-boot.imx"
+UBOOT_SUFFIX = "imx"
+
 UBOOT_CONFIG ??= " \
     sd \
     ${@bb.utils.contains('MACHINE_FEATURES', 'optee', 'sd-optee', '', d)} \

--- a/conf/machine/imx6ulevk.conf
+++ b/conf/machine/imx6ulevk.conf
@@ -23,12 +23,11 @@ KERNEL_DEVICETREE = " \
 "
 KERNEL_DEVICETREE_use-mainline-bsp = "imx6ul-14x14-evk.dtb"
 
-# These u-boot variables default to the correct settings for u-boot-imx.
-# Set overrides for u-boot-fslc.
-UBOOT_MAKE_TARGET_pn-u-boot-fslc = ""
-UBOOT_SUFFIX_pn-u-boot-fslc = "img"
-SPL_BINARY_pn-u-boot-fslc = "SPL"
-WKS_FILE_pn-u-boot-fslc = "imx-uboot-spl-bootpart.wks.in"
+# Use fslc u-boot by default. See also imx-base.inc.
+UBOOT_MAKE_TARGET = ""
+UBOOT_SUFFIX = "img"
+SPL_BINARY = "SPL"
+WKS_FILE = "imx-uboot-spl-bootpart.wks.in"
 
 UBOOT_CONFIG ??= " \
     sd \

--- a/conf/machine/imx6ulevk.conf
+++ b/conf/machine/imx6ulevk.conf
@@ -23,11 +23,23 @@ KERNEL_DEVICETREE = " \
 "
 KERNEL_DEVICETREE_use-mainline-bsp = "imx6ul-14x14-evk.dtb"
 
-# Use fslc u-boot by default. See also imx-base.inc.
-UBOOT_MAKE_TARGET = ""
-UBOOT_SUFFIX = "img"
-SPL_BINARY = "SPL"
-WKS_FILE = "imx-uboot-spl-bootpart.wks.in"
+### u-boot-fslc settings ###
+
+SPL_BINARY_pn-u-boot-fslc = "SPL"
+UBOOT_SUFFIX_pn-u-boot-fslc = "img"
+
+### u-boot-imx settings ###
+
+# The u-boot-imx does not provide unified functionality for DL/Q/QP SoC
+# variants. Change the defconfig to the targeted SoC variant.
+SPL_BINARY_pn-u-boot-imx = ""
+UBOOT_MAKE_TARGET_pn-u-boot-imx = "u-boot.imx"
+UBOOT_SUFFIX_pn-u-boot-imx = "imx"
+
+WKS_FILE = " \
+    ${@bb.utils.contains('IMX_DEFAULT_BOOTLOADER', \
+                         'u-boot-fslc', 'imx-uboot-spl-bootpart.wks.in', \
+                                        'imx-uboot-bootpart.wks.in', d)}"
 
 UBOOT_CONFIG ??= " \
     sd \

--- a/conf/machine/imx6ullevk.conf
+++ b/conf/machine/imx6ullevk.conf
@@ -22,6 +22,9 @@ KERNEL_DEVICETREE_append_use-nxp-bsp = " \
 	imx6ull-14x14-evk-gpmi-weim.dtb \
 "
 
+UBOOT_MAKE_TARGET = "u-boot.imx"
+UBOOT_SUFFIX = "imx"
+
 UBOOT_CONFIG ??= " \
     sd \
     ${@bb.utils.contains('MACHINE_FEATURES', 'optee', 'sd-optee', '', d)} \

--- a/conf/machine/imx6ulz-14x14-evk.conf
+++ b/conf/machine/imx6ulz-14x14-evk.conf
@@ -20,6 +20,9 @@ KERNEL_DEVICETREE_append_use-nxp-bsp = " \
     imx6ulz-14x14-evk-gpmi-weim.dtb \
 "
 
+UBOOT_MAKE_TARGET = "u-boot.imx"
+UBOOT_SUFFIX = "imx"
+
 UBOOT_CONFIG ??= " \
     sd \
     ${@bb.utils.contains('MACHINE_FEATURES', 'optee', 'sd-optee', '', d)} \

--- a/conf/machine/imx7dsabresd.conf
+++ b/conf/machine/imx7dsabresd.conf
@@ -24,6 +24,8 @@ KERNEL_DEVICETREE_append_use-nxp-bsp = " \
 	imx7d-sdb-usd-wifi.dtb \
 "
 
+UBOOT_MAKE_TARGET = "u-boot.imx"
+UBOOT_SUFFIX = "imx"
 
 UBOOT_CONFIG ??= " \
     sd \

--- a/conf/machine/imx7ulpevk.conf
+++ b/conf/machine/imx7ulpevk.conf
@@ -31,6 +31,9 @@ KERNEL_DEVICETREE_append_use-nxp-bsp = " \
 	imx7ulp-evkb-spi-slave.dtb \
 "
 
+UBOOT_MAKE_TARGET = "u-boot.imx"
+UBOOT_SUFFIX = "imx"
+
 UBOOT_CONFIG ??= " \
     sd \
     ${@bb.utils.contains('MACHINE_FEATURES', 'optee', 'sd-optee', '', d)} \

--- a/conf/machine/imx8dxl-evk.conf
+++ b/conf/machine/imx8dxl-evk.conf
@@ -34,6 +34,9 @@ KERNEL_DEVICETREE_append_use-nxp-bsp = " \
     freescale/imx8dxl-evk-rpmsg.dtb \
 "
 
+ATF_PLATFORM = "imx8dxl"
+IMX_BOOT_SOC_TARGET = "iMX8DXL"
+
 UBOOT_MAKE_TARGET = "all"
 SPL_BINARY = "spl/u-boot-spl.bin"
 

--- a/conf/machine/imx8dxl-evk.conf
+++ b/conf/machine/imx8dxl-evk.conf
@@ -37,8 +37,13 @@ KERNEL_DEVICETREE_append_use-nxp-bsp = " \
 ATF_PLATFORM = "imx8dxl"
 IMX_BOOT_SOC_TARGET = "iMX8DXL"
 
+# This machine is not supported by u-boot-fslc, so we force it to use
+# u-boot-imx here.
+IMX_DEFAULT_BOOTLOADER = "u-boot-imx"
+
 UBOOT_MAKE_TARGET = "all"
 SPL_BINARY = "spl/u-boot-spl.bin"
+UBOOT_SUFFIX = "bin"
 
 UBOOT_CONFIG ??= "sd"
 UBOOT_CONFIG[sd]   = "imx8dxl_evk_defconfig,sdcard"

--- a/conf/machine/imx8mp-evk.conf
+++ b/conf/machine/imx8mp-evk.conf
@@ -42,6 +42,11 @@ KERNEL_DEVICETREE_append_use-nxp-bsp = " \
 	freescale/imx8mp-evk-spdif-lb.dtb \
 "
 
+IMX_DEFAULT_BOOTLOADER_use-nxp-bsp = "u-boot-imx"
+IMX_DEFAULT_BOOTLOADER_use-mainline-bsp = "u-boot-fslc"
+
+UBOOT_SUFFIX = "bin"
+
 UBOOT_CONFIG ??= "sd"
 UBOOT_CONFIG[sd]      = "imx8mp_evk_defconfig,sdcard"
 UBOOT_CONFIG[fspi]    = "imx8mp_evk_defconfig"

--- a/conf/machine/imx8mq-evk.conf
+++ b/conf/machine/imx8mq-evk.conf
@@ -40,6 +40,11 @@ KERNEL_DEVICETREE_append_use-nxp-bsp = " \
 	freescale/imx8mq-evk-usdhc2-m2.dtb \
 "
 
+IMX_DEFAULT_BOOTLOADER_use-nxp-bsp = "u-boot-imx"
+IMX_DEFAULT_BOOTLOADER_use-mainline-bsp = "u-boot-fslc"
+
+UBOOT_SUFFIX = "bin"
+
 UBOOT_CONFIG ??= "sd"
 UBOOT_CONFIG[sd]       = "imx8mq_evk_config,sdcard"
 UBOOT_CONFIG[mfgtool]  = "imx8mq_evk_config"

--- a/conf/machine/imx8qm-mek.conf
+++ b/conf/machine/imx8qm-mek.conf
@@ -55,6 +55,9 @@ UBOOT_MAKE_TARGET = \
 SPL_BINARY = \
     "${@bb.utils.contains('MACHINE_FEATURES', 'optee', 'spl/u-boot-spl.bin', \
                                                        '', d)}"
+IMX_DEFAULT_BOOTLOADER_use-nxp-bsp = "u-boot-imx"
+IMX_DEFAULT_BOOTLOADER_use-mainline-bsp = "u-boot-fslc"
+
 UBOOT_SUFFIX = "bin"
 
 UBOOT_CONFIG ??= "sd"

--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -18,7 +18,50 @@ IMX_DEFAULT_BSP_mx5 ?= "mainline"
 
 MACHINEOVERRIDES =. "use-${IMX_DEFAULT_BSP}-bsp:"
 
+# UBOOT_BINARY is used inside the wks files to dynamically find the required
+# U-Boot file.
+UBOOT_BINARY ?= "u-boot.${UBOOT_SUFFIX}"
+
+# Using the 'IMX_DEFAULT_BOOTLOADER' the machine can support multiple bootloader
+# versions. This is done for NXP reference board where we support 'u-boot-fslc'
+# and 'u-boot-imx'.
+#
+# So, for example in imx6qdlsabresd, we support both flavor and for this we
+# define:
+#
+# ,----[ imx6qdlsabresd.conf ]
+# | ### u-boot-fslc settings ###
+# |
+# | SPL_BINARY_pn-u-boot-fslc = "SPL"
+# | UBOOT_MACHINE_pn-u-boot-fslc ?= "mx6sabresd_defconfig"
+# | UBOOT_SUFFIX_pn-u-boot-fslc = "img"
+# |
+# | ### u-boot-imx settings ###
+# |
+# | # The u-boot-imx does not provide unified functionality for DL/Q/QP SoC
+# | # variants. Change the defconfig to the targeted SoC variant.
+# | UBOOT_MACHINE_pn-u-boot-imx ?= "mx6qsabresd_defconfig"
+# | UBOOT_SUFFIX_pn-u-boot-imx = "imx"
+# `----
+#
+# As result, the 'UBOOT_SUFFIX' is dynamically set based on the preferred U-Boot
+# flavor to use.
+#
+# For machines where one of the flavors is required, we can force it. An example
+# is the imx53qsb, which we define:
+#
+# ,----[ imx53qsb.conf ]
+# | # This machine is not supported by u-boot-imx as it is not tested by NXP on this
+# | # board. So we force it to use u-boot-fslc which is based on mainline here.
+# | IMX_DEFAULT_BOOTLOADER = "u-boot-fslc"
+# |
+# | UBOOT_MAKE_TARGET = "u-boot.imx"
+# | UBOOT_SUFFIX = "imx"
+# |
+# | UBOOT_MACHINE = "mx53loco_config"
+# `----
 IMX_DEFAULT_BOOTLOADER ??= "u-boot-fslc"
+UBOOT_SUFFIX ?= "${UBOOT_SUFFIX_pn-${IMX_DEFAULT_BOOTLOADER}}"
 
 IMX_DEFAULT_UBOOTTOOLS = "${@bb.utils.contains('IMX_DEFAULT_BOOTLOADER', 'u-boot-imx','u-boot-imx-tools', 'u-boot-tools', d)}"
 
@@ -31,16 +74,6 @@ PREFERRED_PROVIDER_nativesdk-u-boot-mkimage ??= "nativesdk-${IMX_DEFAULT_UBOOTTO
 PREFERRED_PROVIDER_virtual/bootloader ??= "${IMX_DEFAULT_BOOTLOADER}"
 
 PREFERRED_PROVIDER_u-boot-mxsboot-native ??= "u-boot-fslc-mxsboot-native"
-
-# Set specific make target and binary suffix
-UBOOT_BINARY ?= "u-boot.${UBOOT_SUFFIX}"
-UBOOT_MAKE_TARGET ?= "u-boot.${UBOOT_SUFFIX}"
-UBOOT_MAKE_TARGET_mxs ?= "u-boot.sb"
-UBOOT_MAKE_TARGET_mx8 ?= ""
-
-UBOOT_SUFFIX ?= "imx"
-UBOOT_SUFFIX_mxs ?= "sb"
-UBOOT_SUFFIX_mx8 ?= "bin"
 
 UBOOT_ENTRYPOINT_mxs    = "0x40008000"
 UBOOT_ENTRYPOINT_mx51   = "0x90008000"

--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -18,8 +18,8 @@ IMX_DEFAULT_BSP_mx5 ?= "mainline"
 
 MACHINEOVERRIDES =. "use-${IMX_DEFAULT_BSP}-bsp:"
 
-IMX_DEFAULT_BOOTLOADER = "u-boot-fslc"
-IMX_DEFAULT_BOOTLOADER_mx8 = "u-boot-imx"
+IMX_DEFAULT_BOOTLOADER ??= "u-boot-fslc"
+
 IMX_DEFAULT_UBOOTTOOLS = "${@bb.utils.contains('IMX_DEFAULT_BOOTLOADER', 'u-boot-imx','u-boot-imx-tools', 'u-boot-tools', d)}"
 
 PREFERRED_PROVIDER_u-boot ??= "${IMX_DEFAULT_BOOTLOADER}"

--- a/conf/machine/include/imx8mm-evk.inc
+++ b/conf/machine/include/imx8mm-evk.inc
@@ -22,6 +22,11 @@ KERNEL_DEVICETREE_append_use-nxp-bsp = " \
 "
 UBOOT_DTB_NAME = "${KERNEL_DEVICETREE_BASENAME}.dtb"
 
+IMX_DEFAULT_BOOTLOADER_use-nxp-bsp = "u-boot-imx"
+IMX_DEFAULT_BOOTLOADER_use-mainline-bsp = "u-boot-fslc"
+
+UBOOT_SUFFIX = "bin"
+
 UBOOT_CONFIG ??= "sd"
 UBOOT_CONFIG[sd]       = "${UBOOT_CONFIG_BASENAME}_defconfig,sdcard"
 UBOOT_CONFIG[mfgtool]  = "${UBOOT_CONFIG_BASENAME}_defconfig"

--- a/conf/machine/include/imx8mn-evk.inc
+++ b/conf/machine/include/imx8mn-evk.inc
@@ -22,6 +22,11 @@ KERNEL_DEVICETREE_append_use-nxp-bsp = " \
 "
 UBOOT_DTB_NAME = "${KERNEL_DEVICETREE_BASENAME}.dtb"
 
+IMX_DEFAULT_BOOTLOADER_use-nxp-bsp = "u-boot-imx"
+IMX_DEFAULT_BOOTLOADER_use-mainline-bsp = "u-boot-fslc"
+
+UBOOT_SUFFIX = "bin"
+
 UBOOT_CONFIG ??= "sd"
 UBOOT_CONFIG[sd]      = "${UBOOT_CONFIG_BASENAME}_defconfig,sdcard"
 UBOOT_CONFIG[fspi]    = "${UBOOT_CONFIG_BASENAME}_defconfig"

--- a/conf/machine/include/imx8x-mek.inc
+++ b/conf/machine/include/imx8x-mek.inc
@@ -54,6 +54,11 @@ UBOOT_CONFIG[fspi] = "${UBOOT_CONFIG_BASENAME}_fspi_defconfig"
 
 IMX_BOOT_SEEK = "32"
 
+# This machine is not supported by u-boot-fslc, so we force it to use
+# u-boot-imx here.
+IMX_DEFAULT_BOOTLOADER = "u-boot-imx"
+UBOOT_SUFFIX = "bin"
+
 # Set ATF platform name
 ATF_PLATFORM = "imx8qx"
 

--- a/recipes-security/optee-imx/optee-os_3.10.0.imx.bb
+++ b/recipes-security/optee-imx/optee-os_3.10.0.imx.bb
@@ -6,7 +6,7 @@ HOMEPAGE = "http://www.optee.org/"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=c1f21c4f72f372ef38a5a4aee55ec173"
 
-DEPENDS = "python3-pycrypto-native python3-pycryptodomex-native python3-pyelftools-native u-boot-mkimage-native"
+DEPENDS = "python3-pycryptodomex-native python3-pyelftools-native u-boot-mkimage-native"
 
 SRCBRANCH = "imx_5.4.70_2.3.0"
 


### PR DESCRIPTION
We need to make it more obvious what is in use, when we support both bootloaders and for it we are now using the _pn suffix for both.

This also fixes the WIC_FILE depending on the choice otherwise image build fails.