### PR TITLE
optee-os.imx: replace pycrypto with pycryptodome - a drop-in replacement

### DIFF
--- a/recipes-security/optee-imx/optee-os_3.7.0.imx.bb
+++ b/recipes-security/optee-imx/optee-os_3.7.0.imx.bb
@@ -7,7 +7,7 @@ LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=c1f21c4f72f372ef38a5a4aee55ec173"
 
 inherit deploy python3native autotools
-DEPENDS = "python3-pycrypto-native python3-pyelftools-native u-boot-mkimage-native"
+DEPENDS = "python3-pycryptodome-native python3-pyelftools-native u-boot-mkimage-native"
 
 SRCBRANCH = "imx_5.4.24_2.1.0"
 


### PR DESCRIPTION
New pycryptodome is a drop-in replacement for the old pycrypto module. As
pycryptodome is in oe-core/dunfell, while old pycrypto requires meta-python
from meta-openembedded collection, it's better to limit unnecessary BSP
dependencies by replacing pycrypto with pycryptodome.

For more details about corresponding upstream changes, see:
https://git.openembedded.org/openembedded-core/commit/?id=a96f815c53364b119b5743b8b7100eb5588d5cf5
https://git.openembedded.org/meta-openembedded/commit/?id=a8f3c00d8d113b46a49584682e10435157d516ca
https://git.yoctoproject.org/cgit/cgit.cgi/meta-arm/commit/?id=06b648821aa3fbbdf7c00724cf3c3cedbb4f0546

Signed-off-by: Denys Dmytriyenko <denis@denix.org>