### PR TITLE
weston-init: Update weston.ini for IVI

### DIFF
--- a/dynamic-layers/ivi/recipes-graphics/wayland/weston-init/weston.ini
+++ b/dynamic-layers/ivi/recipes-graphics/wayland/weston-init/weston.ini
@@ -2,11 +2,17 @@
 shell=ivi-shell.so
 modules=hmi-controller.so
 #gbm-format=argb8888
+idle-time=0
 #use-g2d=1
 #xwayland=true
+#repaint-window=16
+#enable-overlay-view=1
 
 #[shell]
 #size=1920x1080
+
+[libinput]
+touchscreen_calibrator=true
 
 [ivi-shell]
 ivi-shell-user-interface=weston-ivi-shell-user-interface


### PR DESCRIPTION
- Set core idle-time to 0 to align with non-IVI setting
- Add repaint-window for all i.MX 8 to support 4K display
- Add enable-overlay-view option as comment
- Enable touchscreen_calibrator

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>
(cherry picked from commit e2abe0525384a31f54e1b1fe3ba1aac887ea3573)