### PR TITLE
imx8mp-ddr4-evk: Set mainline BSP to use u-boot-imx for now

### DIFF
--- a/conf/machine/imx8mp-ddr4-evk.conf
+++ b/conf/machine/imx8mp-ddr4-evk.conf
@@ -6,6 +6,10 @@
 
 require include/imx8mp-evk.inc
 
+# FIXME: This machine is not yet supported by u-boot-fslc, so for now
+# use u-boot-imx for mainline.
+IMX_DEFAULT_BOOTLOADER_use-mainline-bsp = "u-boot-imx"
+
 KERNEL_DEVICETREE_BASENAME = "${MACHINE}"
 
 UBOOT_CONFIG_BASENAME = "imx8mp_ddr4_evk"

--- a/recipes-bsp/u-boot/u-boot-imx_2020.04.bb
+++ b/recipes-bsp/u-boot/u-boot-imx_2020.04.bb
@@ -29,4 +29,4 @@ do_deploy_append_mx8m() {
 }
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
-COMPATIBLE_MACHINE = "(mx6|mx7|mx8)"
+COMPATIBLE_MACHINE = "(mx6|mx7|mx8|use-mainline-bsp)"


### PR DESCRIPTION
Fixes #710.