### PR TITLE
mesa: Use osmesa and swrast for all imxgpu override

### DIFF
--- a/recipes-graphics/mesa/mesa_%.bbappend
+++ b/recipes-graphics/mesa/mesa_%.bbappend
@@ -30,9 +30,9 @@ PACKAGECONFIG_REMOVE_NXPBSP_imxgpu        = "dri"
 DRIDRIVERS_NXPBSP_imxgpu                  = ""
 #
 # For parts with GPU and DRM, use osmesa, dri, and swrast
-PACKAGECONFIG_REMOVE_NXPBSP_imxgpu_imxdrm = "gallium"
-PACKAGECONFIG_APPEND_NXPBSP_imxgpu_imxdrm = "osmesa"
-DRIDRIVERS_NXPBSP_imxgpu_imxdrm           = "swrast"
+PACKAGECONFIG_REMOVE_NXPBSP_imxgpu = "gallium"
+PACKAGECONFIG_APPEND_NXPBSP_imxgpu = "osmesa"
+DRIDRIVERS_NXPBSP_imxgpu           = "swrast"
 #
 PACKAGECONFIG_remove_use-nxp-bsp = "${PACKAGECONFIG_REMOVE_NXPBSP}"
 PACKAGECONFIG_append_use-nxp-bsp = " ${PACKAGECONFIG_APPEND_NXPBSP}"


### PR DESCRIPTION
The following error appears when building mesa with NXP BSP:

ERROR: Problem encountered: building dri drivers require at least one
windowing system or classic osmesa

Using the same imxdrm configuration to all imxgpu machines to build mesa
with IMX_DEFAULT_BSP nxp.

Signed-off-by: Fabio Berton <fabio.berton@ossystems.com.br>