### PR TITLE
Fix bootloader advanced use

### DIFF
--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -63,6 +63,10 @@ UBOOT_BINARY ?= "u-boot.${UBOOT_SUFFIX}"
 IMX_DEFAULT_BOOTLOADER ??= "u-boot-fslc"
 UBOOT_SUFFIX ?= "${UBOOT_SUFFIX_pn-${IMX_DEFAULT_BOOTLOADER}}"
 
+# We need to export the original variable to allow it to be used when generating
+# wic based images.
+SPL_BINARY ?= "${SPL_BINARY_pn-${IMX_DEFAULT_BOOTLOADER}}"
+
 IMX_DEFAULT_UBOOTTOOLS = "${@bb.utils.contains('IMX_DEFAULT_BOOTLOADER', 'u-boot-imx','u-boot-imx-tools', 'u-boot-tools', d)}"
 IMX_DEFAULT_MFGTOOL = "${@bb.utils.contains('IMX_DEFAULT_BOOTLOADER', 'u-boot-imx','u-boot-imx-mfgtool', 'u-boot-fslc', d)}"
 

--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -64,9 +64,10 @@ IMX_DEFAULT_BOOTLOADER ??= "u-boot-fslc"
 UBOOT_SUFFIX ?= "${UBOOT_SUFFIX_pn-${IMX_DEFAULT_BOOTLOADER}}"
 
 IMX_DEFAULT_UBOOTTOOLS = "${@bb.utils.contains('IMX_DEFAULT_BOOTLOADER', 'u-boot-imx','u-boot-imx-tools', 'u-boot-tools', d)}"
+IMX_DEFAULT_MFGTOOL = "${@bb.utils.contains('IMX_DEFAULT_BOOTLOADER', 'u-boot-imx','u-boot-imx-mfgtool', 'u-boot-fslc', d)}"
 
 PREFERRED_PROVIDER_u-boot ??= "${IMX_DEFAULT_BOOTLOADER}"
-PREFERRED_PROVIDER_u-boot-mfgtool ??= "${IMX_DEFAULT_BOOTLOADER}-mfgtool"
+PREFERRED_PROVIDER_u-boot-mfgtool ??= "${IMX_DEFAULT_MFGTOOL}"
 PREFERRED_PROVIDER_u-boot-tools-native ??= "${IMX_DEFAULT_UBOOTTOOLS}-native"
 PREFERRED_PROVIDER_nativesdk-u-boot-tools ??= "nativesdk-${IMX_DEFAULT_UBOOTTOOLS}"
 PREFERRED_PROVIDER_u-boot-mkimage-native ??= "${IMX_DEFAULT_UBOOTTOOLS}-native"

--- a/recipes-bsp/u-boot/libubootenv_%.bbappend
+++ b/recipes-bsp/u-boot/libubootenv_%.bbappend
@@ -1,0 +1,43 @@
+# Fixup for the libubootenv which rely on uboot-config class for no good reason.
+#
+# This is not intended to be permanent but we need to get the integration
+# working and there is no good solution for now so we are adding this in a
+# non-intrusive way and using the `IMX_DEFAULT_BOOTLOADER` as a guard to do any
+# code execution.
+
+def fixup_uboot_config_dependency(d):
+    ubootmachine = d.getVar("UBOOT_MACHINE")
+    ubootconfig = (d.getVar('UBOOT_CONFIG') or "").split()
+    imx_default_bootloader = d.get('IMX_DEFAULT_BOOTLOADER')
+
+    if not ubootmachine and not ubootconfig and imx_default_bootloader:
+       # FIXME: We need to provide the UBOOT_MACHINE or UBOOT_CONFIG to allow libubootenv to
+       # build. This is caused by the commit below:
+       #
+       # ,----[ libubootenv change ]
+       # | commit 10aa1291979fb90bed1beb49be4d406ed0e1e4d5 ┃
+       # | ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━━━━━━━━━━━
+       # | Author: Ming Liu <liu.ming50@gmail.com>
+       # | Date:   Tue Aug 25 20:08:01 2020 +0200
+       # |
+       # |     libubootenv: inherit uboot-config
+       # |
+       # |     This mainly aims to involve in the sanity check of UBOOT_CONFIG and
+       # |     UBOOT_MACHINE, it will throw a error message at recipe parsing time if
+       # |     neither of them is set, and libubootenv would be skipped.
+       # |
+       # |     Signed-off-by: Ming Liu <liu.ming50@gmail.com>
+       # |     Signed-off-by: Richard Purdie <richard.purdie@linuxfoundation.org>
+       # `----
+       ubootmachine = d.getVar("UBOOT_MACHINE_pn-%s" % imx_default_bootloader)
+       ubootconfig = (d.getVar("UBOOT_CONFIG_pn-%s" % imx_default_bootloader) or "").split()
+
+       d.setVar("UBOOT_CONFIG", ubootconfig)
+       d.setVar("UBOOT_MACHINE", ubootmachine)
+
+python fixup_uboot_config_dependency_handler() {
+    fixup_uboot_config_dependency(d)
+}
+
+fixup_uboot_config_dependency_handler[eventmask] = "bb.event.RecipePreFinalise"
+addhandler fixup_uboot_config_dependency_handler


### PR DESCRIPTION
We found some corner cases which are raised when external layers do make some fancy use of the bootloader settings. This is sometimes required and this is very hard to debug. We ended working on the required fixes which covered the known cases.