### PR TITLE
weston-init: Rework uncomment function logic

### DIFF
--- a/recipes-graphics/wayland/weston-init.bbappend
+++ b/recipes-graphics/wayland/weston-init.bbappend
@@ -40,7 +40,7 @@ INI_UNCOMMENT_ASSIGNMENTS_append_mx8mq = " \
 "
 
 uncomment() {
-    if ! (grep "^#$1" $2); then
+    if ! grep -q "^#$1" $2 && ! grep -q "^$1" $2; then
         bbfatal "Commented setting '#$1' not found in file $2"
     fi
     sed -i -e 's,^#'"$1"','"$1"',g' $2


### PR DESCRIPTION
Fix error "Commented setting '#use-g2d=1' not found"
when building for some imx machines.

Signed-off-by: Vinicius Aquino <voa.aquino@gmail.com>