### PR TITLE
imx53qsb: U-Boot fixup

### DIFF
--- a/conf/machine/imx53qsb.conf
+++ b/conf/machine/imx53qsb.conf
@@ -12,8 +12,8 @@ include conf/machine/include/tune-cortexa8.inc
 KERNEL_DEVICETREE = "imx53-qsb.dtb imx53-qsrb.dtb"
 
 # This machine is not supported by u-boot-imx as it is not tested by NXP on this
-# board. So we force it to use u-boot-fslc which is based on mainline here.
-IMX_DEFAULT_BOOTLOADER = "u-boot-fslc"
+# board. Use mainline instead.
+IMX_DEFAULT_BOOTLOADER = "u-boot"
 
 UBOOT_MAKE_TARGET = "u-boot.imx"
 UBOOT_SUFFIX = "imx"


### PR DESCRIPTION
A change was made in oe-core, that forced a change in the BSP layer, that
highlighted an issue with the U-Boot variable for this machine.

Build tested for imx53qsb.

Signed-off-by: Trevor Woerner <twoerner@gmail.com>