### PR TITLE
imx-base.inc: Provide a default value for SPL_BINARY

### DIFF
--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -65,7 +65,7 @@ UBOOT_SUFFIX ?= "${UBOOT_SUFFIX_pn-${IMX_DEFAULT_BOOTLOADER}}"
 
 # We need to export the original variable to allow it to be used when generating
 # wic based images.
-SPL_BINARY ?= "${SPL_BINARY_pn-${IMX_DEFAULT_BOOTLOADER}}"
+SPL_BINARY ??= "${@get_spl_binary(d)}"
 
 IMX_DEFAULT_UBOOTTOOLS = "${@bb.utils.contains('IMX_DEFAULT_BOOTLOADER', 'u-boot-imx','u-boot-imx-tools', 'u-boot-tools', d)}"
 IMX_DEFAULT_MFGTOOL = "${@bb.utils.contains('IMX_DEFAULT_BOOTLOADER', 'u-boot-imx','u-boot-imx-mfgtool', 'u-boot-fslc', d)}"

--- a/conf/machine/include/utilities.inc
+++ b/conf/machine/include/utilities.inc
@@ -20,3 +20,9 @@ def make_dtb_boot_files(d):
         return os.path.basename(dtb)
 
     return ' '.join([transform(dtb) for dtb in alldtbs.split() if dtb])
+
+def get_spl_binary(d):
+    imx_default_bootloader = d.get('IMX_DEFAULT_BOOTLOADER')
+    spl_binary = d.getVar("SPL_BINARY_pn-%s" % imx_default_bootloader)
+
+    return spl_binary or ""


### PR DESCRIPTION
This fixes the build case when machine does not use SPL and does not set
it. We couldn't use dynamic expansion or we trigger a recursive
expansion so we opted to use an utility function to do the proper logic.

Fixes: f98059fe ("imx-base.inc: Allow use of SPL_BINARY variable inside wic images")
Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>