### PR TITLE
weston-init: Do not exit with error if uncomment function fail

### DIFF
--- a/recipes-graphics/wayland/weston-init.bbappend
+++ b/recipes-graphics/wayland/weston-init.bbappend
@@ -41,7 +41,7 @@ INI_UNCOMMENT_ASSIGNMENTS_append_mx8mq = " \
 
 uncomment() {
     if ! grep -q "^#$1" $2 && ! grep -q "^$1" $2; then
-        bbfatal "Commented setting '#$1' not found in file $2"
+        bbwarn "Commented setting '#$1' not found in file $2"
     fi
     sed -i -e 's,^#'"$1"','"$1"',g' $2
 }


### PR DESCRIPTION
Show a warning instead of raising an error when uncomment function can't
found the text. This allows using a custom weston.ini file in bbappend.

Signed-off-by: Fabio Berton <fabio.berton@ossystems.com.br>