### PR TITLE
uefi: update to 06e9608

### DIFF
--- a/recipes-bsp/uefi/uefi_git.bb
+++ b/recipes-bsp/uefi/uefi_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://NXP-Binary-EULA;md5=343ec8f06efc37467a6de53686fa6315"
 inherit deploy
 
 SRC_URI = "git://github.com/NXP/qoriq-uefi-binary.git;nobranch=1"
-SRCREV= "83a97bf09bb8880933416bc358112503c64ddae4"
+SRCREV= "06e960829ba204f35979440364b9ac7e51ed996b"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Fix USB xHC transfer polling timeout.
Set DWC3 controller as a non-coherent device, otherwise xHC will not
generate any Event TRB, causing xHC driver polling URB status timeout
during USB device enumeration.

Signed-off-by: Ting Liu <ting.liu@nxp.com>