### PR TITLE
qemu-qoriq: copy qemu.inc to not break build for 4.1.0

### DIFF
--- a/recipes-devtools/qemu/qemu-qoriq_4.1.0.bb
+++ b/recipes-devtools/qemu/qemu-qoriq_4.1.0.bb
@@ -1,6 +1,6 @@
 BBCLASSEXTEND = ""
 
-require recipes-devtools/qemu/qemu.inc
+require qemu.inc
 
 COMPATIBLE_MACHINE = "(qoriq)"
 

--- a/recipes-devtools/qemu/qemu-targets.inc
+++ b/recipes-devtools/qemu/qemu-targets.inc
@@ -1,0 +1,28 @@
+# possible arch values are:
+#    aarch64 arm armeb alpha cris i386 x86_64 m68k microblaze
+#    mips mipsel mips64 mips64el ppc ppc64 ppc64abi32 ppcemb
+#    riscv32 riscv64 sparc sparc32 sparc32plus
+
+def get_qemu_target_list(d):
+    import bb
+    archs = d.getVar('QEMU_TARGETS').split()
+    tos = d.getVar('HOST_OS')
+    softmmuonly = ""
+    for arch in ['ppcemb', 'lm32']:
+        if arch in archs:
+            softmmuonly += arch + "-softmmu,"
+            archs.remove(arch)
+    linuxuseronly = ""
+    for arch in ['armeb', 'alpha', 'ppc64abi32', 'ppc64le', 'sparc32plus', 'aarch64_be']:
+        if arch in archs:
+            linuxuseronly += arch + "-linux-user,"
+            archs.remove(arch)
+    if 'linux' not in tos:
+        return softmmuonly + ''.join([arch + "-softmmu" + "," for arch in archs]).rstrip(',')
+    return softmmuonly + linuxuseronly + ''.join([arch + "-linux-user" + "," + arch + "-softmmu" + "," for arch in archs]).rstrip(',')
+
+def get_qemu_usermode_target_list(d):
+    return ",".join(filter(lambda i: "-linux-user" in i, get_qemu_target_list(d).split(',')))
+
+def get_qemu_system_target_list(d):
+    return ",".join(filter(lambda i: "-linux-user" not in i, get_qemu_target_list(d).split(',')))

--- a/recipes-devtools/qemu/qemu.inc
+++ b/recipes-devtools/qemu/qemu.inc
@@ -1,0 +1,198 @@
+SUMMARY = "Fast open source processor emulator"
+DESCRIPTION = "QEMU is a hosted virtual machine monitor: it emulates the \
+machine's processor through dynamic binary translation and provides a set \
+of different hardware and device models for the machine, enabling it to run \
+a variety of guest operating systems"
+HOMEPAGE = "http://qemu.org"
+LICENSE = "GPLv2 & LGPLv2.1"
+
+RDEPENDS_${PN}-ptest = "bash make"
+
+require qemu-targets.inc
+inherit pkgconfig ptest
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=441c28d2cf86e15a37fa47e15a72fbac \
+                    file://COPYING.LIB;endline=24;md5=8c5efda6cf1e1b03dcfd0e6c0d271c7f"
+
+SRC_URI = "https://download.qemu.org/${BPN}-${PV}.tar.xz \
+           file://powerpc_rom.bin \
+           file://run-ptest \
+           file://0001-qemu-Add-missing-wacom-HID-descriptor.patch \
+           file://0002-Add-subpackage-ptest-which-runs-all-unit-test-cases-.patch \
+           file://0003-qemu-Add-addition-environment-space-to-boot-loader-q.patch \
+           file://0004-qemu-disable-Valgrind.patch \
+           file://0005-qemu-native-set-ld.bfd-fix-cflags-and-set-some-envir.patch \
+           file://0006-chardev-connect-socket-to-a-spawned-command.patch \
+           file://0007-apic-fixup-fallthrough-to-PIC.patch \
+           file://0008-linux-user-Fix-webkitgtk-hangs-on-32-bit-x86-target.patch \
+           file://0009-Fix-webkitgtk-builds.patch \
+           file://0010-configure-Add-pkg-config-handling-for-libgcrypt.patch \
+           file://0001-Add-enable-disable-udev.patch \
+           file://0001-qemu-Do-not-include-file-if-not-exists.patch \
+           file://find_datadir.patch \
+           file://usb-fix-setup_len-init.patch \
+           file://0001-target-mips-Increase-number-of-TLB-entries-on-the-34.patch \
+           file://CVE-2020-24352.patch \
+           file://CVE-2020-29129-CVE-2020-29130.patch \
+           file://CVE-2020-25624.patch \
+           file://CVE-2020-25723.patch \
+           file://CVE-2020-28916.patch \
+	   file://CVE-2020-35517.patch \
+	   file://CVE-2020-29443.patch \
+	   file://CVE-2021-20203.patch \
+           "
+UPSTREAM_CHECK_REGEX = "qemu-(?P<pver>\d+(\.\d+)+)\.tar"
+
+SRC_URI[sha256sum] = "c9174eb5933d9eb5e61f541cd6d1184cd3118dfe4c5c4955bc1bdc4d390fa4e5"
+
+COMPATIBLE_HOST_mipsarchn32 = "null"
+COMPATIBLE_HOST_mipsarchn64 = "null"
+
+# Per https://lists.nongnu.org/archive/html/qemu-devel/2020-09/msg03873.html
+# upstream states qemu doesn't work without optimization
+DEBUG_BUILD = "0"
+
+do_install_append() {
+    # Prevent QA warnings about installed ${localstatedir}/run
+    if [ -d ${D}${localstatedir}/run ]; then rmdir ${D}${localstatedir}/run; fi
+}
+
+do_compile_ptest() {
+	make buildtest-TESTS
+}
+
+do_install_ptest() {
+	cp -rL ${B}/tests ${D}${PTEST_PATH}
+	find ${D}${PTEST_PATH}/tests -type f -name "*.[Sshcod]" | xargs -i rm -rf {}
+
+	cp ${S}/tests/Makefile.include ${D}${PTEST_PATH}/tests
+	# Don't check the file genreated by configure
+	sed -i -e '/wildcard config-host.mak/d' \
+	       -e '$ {/endif/d}' ${D}${PTEST_PATH}/tests/Makefile.include
+        sed -i -e 's,${HOSTTOOLS_DIR}/python3,${bindir}/python3,' \
+            ${D}/${PTEST_PATH}/tests/qemu-iotests/common.env 
+}
+
+# QEMU_TARGETS is overridable variable
+QEMU_TARGETS ?= "arm aarch64 i386 mips mipsel mips64 mips64el ppc ppc64 ppc64le riscv32 riscv64 sh4 x86_64"
+
+EXTRA_OECONF = " \
+    --prefix=${prefix} \
+    --bindir=${bindir} \
+    --includedir=${includedir} \
+    --libdir=${libdir} \
+    --mandir=${mandir} \
+    --datadir=${datadir} \
+    --docdir=${docdir}/${BPN} \
+    --sysconfdir=${sysconfdir} \
+    --libexecdir=${libexecdir} \
+    --localstatedir=${localstatedir} \
+    --with-confsuffix=/${BPN} \
+    --disable-strip \
+    --disable-werror \
+    --extra-cflags='${CFLAGS}' \
+    --extra-ldflags='${LDFLAGS}' \
+    --with-git=/bin/false \
+    --disable-git-update \
+    ${PACKAGECONFIG_CONFARGS} \
+    "
+
+export LIBTOOL="${HOST_SYS}-libtool"
+
+B = "${WORKDIR}/build"
+
+EXTRA_OECONF_append = " --python=${HOSTTOOLS_DIR}/python3"
+
+do_configure_prepend_class-native() {
+	# Append build host pkg-config paths for native target since the host may provide sdl
+	BHOST_PKGCONFIG_PATH=$(PATH=/usr/bin:/bin pkg-config --variable pc_path pkg-config || echo "")
+	if [ ! -z "$BHOST_PKGCONFIG_PATH" ]; then
+		export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$BHOST_PKGCONFIG_PATH
+	fi
+}
+
+do_configure() {
+    ${S}/configure ${EXTRA_OECONF}
+}
+do_configure[cleandirs] += "${B}"
+
+do_install () {
+	export STRIP=""
+	oe_runmake 'DESTDIR=${D}' install
+}
+
+# The following fragment will create a wrapper for qemu-mips user emulation
+# binary in order to work around a segmentation fault issue. Basically, by
+# default, the reserved virtual address space for 32-on-64 bit is set to 4GB.
+# This will trigger a MMU access fault in the virtual CPU. With this change,
+# the qemu-mips works fine.
+# IMPORTANT: This piece needs to be removed once the root cause is fixed!
+do_install_append() {
+	if [ -e "${D}/${bindir}/qemu-mips" ]; then
+		create_wrapper ${D}/${bindir}/qemu-mips \
+			QEMU_RESERVED_VA=0x0
+	fi
+}
+# END of qemu-mips workaround
+
+make_qemu_wrapper() {
+        gdk_pixbuf_module_file=`pkg-config --variable=gdk_pixbuf_cache_file gdk-pixbuf-2.0`
+
+        for tool in `ls ${D}${bindir}/qemu-system-*`; do
+                create_wrapper $tool \
+                        GDK_PIXBUF_MODULE_FILE=$gdk_pixbuf_module_file \
+                        FONTCONFIG_PATH=/etc/fonts \
+                        GTK_THEME=Adwaita
+        done
+}
+
+# Disable kvm/virgl/mesa on targets that do not support it
+PACKAGECONFIG_remove_darwin = "kvm virglrenderer glx gtk+"
+PACKAGECONFIG_remove_mingw32 = "kvm virglrenderer glx gtk+"
+
+PACKAGECONFIG[sdl] = "--enable-sdl,--disable-sdl,libsdl2"
+PACKAGECONFIG[virtfs] = "--enable-virtfs --enable-attr --enable-cap-ng,--disable-virtfs,libcap-ng attr,"
+PACKAGECONFIG[aio] = "--enable-linux-aio,--disable-linux-aio,libaio,"
+PACKAGECONFIG[xfs] = "--enable-xfsctl,--disable-xfsctl,xfsprogs,"
+PACKAGECONFIG[xen] = "--enable-xen,--disable-xen,xen-tools,xen-tools-libxenstore xen-tools-libxenctrl xen-tools-libxenguest"
+PACKAGECONFIG[vnc-sasl] = "--enable-vnc --enable-vnc-sasl,--disable-vnc-sasl,cyrus-sasl,"
+PACKAGECONFIG[vnc-jpeg] = "--enable-vnc --enable-vnc-jpeg,--disable-vnc-jpeg,jpeg,"
+PACKAGECONFIG[vnc-png] = "--enable-vnc --enable-vnc-png,--disable-vnc-png,libpng,"
+PACKAGECONFIG[libcurl] = "--enable-curl,--disable-curl,curl,"
+PACKAGECONFIG[nss] = "--enable-smartcard,--disable-smartcard,nss,"
+PACKAGECONFIG[curses] = "--enable-curses,--disable-curses,ncurses,"
+PACKAGECONFIG[gtk+] = "--enable-gtk,--disable-gtk,gtk+3 gettext-native"
+PACKAGECONFIG[vte] = "--enable-vte,--disable-vte,vte gettext-native"
+PACKAGECONFIG[libcap-ng] = "--enable-cap-ng,--disable-cap-ng,libcap-ng,"
+PACKAGECONFIG[ssh] = "--enable-libssh,--disable-libssh,libssh,"
+PACKAGECONFIG[gcrypt] = "--enable-gcrypt,--disable-gcrypt,libgcrypt,"
+PACKAGECONFIG[nettle] = "--enable-nettle,--disable-nettle,nettle"
+PACKAGECONFIG[libusb] = "--enable-libusb,--disable-libusb,libusb1"
+PACKAGECONFIG[fdt] = "--enable-fdt,--disable-fdt,dtc"
+PACKAGECONFIG[alsa] = "--audio-drv-list='oss alsa',,alsa-lib"
+PACKAGECONFIG[glx] = "--enable-opengl,--disable-opengl,virtual/libgl"
+PACKAGECONFIG[lzo] = "--enable-lzo,--disable-lzo,lzo"
+PACKAGECONFIG[numa] = "--enable-numa,--disable-numa,numactl"
+PACKAGECONFIG[gnutls] = "--enable-gnutls,--disable-gnutls,gnutls"
+PACKAGECONFIG[bzip2] = "--enable-bzip2,--disable-bzip2,bzip2"
+PACKAGECONFIG[libiscsi] = "--enable-libiscsi,--disable-libiscsi"
+PACKAGECONFIG[kvm] = "--enable-kvm,--disable-kvm"
+PACKAGECONFIG[virglrenderer] = "--enable-virglrenderer,--disable-virglrenderer,virglrenderer"
+# spice will be in meta-networking layer
+PACKAGECONFIG[spice] = "--enable-spice,--disable-spice,spice"
+# usbredir will be in meta-networking layer
+PACKAGECONFIG[usb-redir] = "--enable-usb-redir,--disable-usb-redir,usbredir"
+PACKAGECONFIG[snappy] = "--enable-snappy,--disable-snappy,snappy"
+PACKAGECONFIG[glusterfs] = "--enable-glusterfs,--disable-glusterfs,glusterfs"
+PACKAGECONFIG[xkbcommon] = "--enable-xkbcommon,--disable-xkbcommon,libxkbcommon"
+PACKAGECONFIG[libudev] = "--enable-libudev,--disable-libudev,eudev"
+PACKAGECONFIG[libxml2] = "--enable-libxml2,--disable-libxml2,libxml2"
+PACKAGECONFIG[attr] = "--enable-attr,--disable-attr,attr,"
+PACKAGECONFIG[rbd] = "--enable-rbd,--disable-rbd,ceph,ceph"
+PACKAGECONFIG[vhost] = "--enable-vhost-net,--disable-vhost-net,,"
+PACKAGECONFIG[ust] = "--enable-trace-backend=ust,--enable-trace-backend=nop,lttng-ust,"
+PACKAGECONFIG[pie] = "--enable-pie,--disable-pie,,"
+
+INSANE_SKIP_${PN} = "arch"
+
+FILES_${PN} += "${datadir}/icons"


### PR DESCRIPTION
qemu-qoriq resues qemu.inc from oe-core. As oe-core had upgraded to 5.2.0 which
switched to meson+ninja, build error appear as qemu-qoriq version is 4.1.0.

Copy a working qemu.inc from gatesgarth branch to not break the build.

Some errors:
| stdout: Applying patch cross.patch
| patching file configure
| Hunk #1 FAILED at 6973.
| Hunk #2 FAILED at 6999.
| 2 out of 2 hunks FAILED -- rejects in file configure
| Patch cross.patch does not apply (enforce with -f)
...
| DEBUG: Executing shell function do_configure
| ERROR: unknown option --with-suffix=qemu-qoriq

Signed-off-by: Ting Liu <ting.liu@nxp.com>