### PR TITLE
ceetm: use new api tc_print_rate from iproute2

### DIFF
--- a/recipes-kernel/ceetm/ceetm/0001-use-new-api-tc_print_rate.patch
+++ b/recipes-kernel/ceetm/ceetm/0001-use-new-api-tc_print_rate.patch
@@ -1,0 +1,71 @@
+From 1eeee62be6f4f4c0564a1ebbf47b5d1ebd7ab282 Mon Sep 17 00:00:00 2001
+From: Ting Liu <ting.liu@nxp.com>
+Date: Thu, 15 Apr 2021 14:43:31 +0530
+Subject: [PATCH] use new api tc_print_rate
+
+Fix the build issue due to api change in iproute2:
+| dpaa1_ceetm.c:637:4: error: too few arguments to function 'print_rate'
+| print_rate(buf, sizeof(buf), qopt->rate);
+| ^~~~~~~~~~
+
+Upstream-Status: Pending
+
+Signed-off-by: Ting Liu <ting.liu@nxp.com>
+---
+ dpaa1_ceetm.c | 12 ++++--------
+ dpaa2_ceetm.c |  6 ++----
+ 2 files changed, 6 insertions(+), 12 deletions(-)
+
+diff --git a/dpaa1_ceetm.c b/dpaa1_ceetm.c
+index 15a2cd8..347e79a 100644
+--- a/dpaa1_ceetm.c
++++ b/dpaa1_ceetm.c
+@@ -634,11 +634,9 @@ int dpaa1_ceetm_print_qopt(struct qdisc_util *qu, FILE *f,
+ 		fprintf(f, "type root");
+ 
+ 		if (qopt->shaped) {
+-			print_rate(buf, sizeof(buf), qopt->rate);
+-			fprintf(f, " shaped rate %s ", buf);
++			tc_print_rate(PRINT_FP, NULL, " shaped rate %s ", qopt->rate);
+ 
+-			print_rate(buf, sizeof(buf), qopt->ceil);
+-			fprintf(f, "ceil %s ", buf);
++			tc_print_rate(PRINT_FP, NULL, "ceil %s ", qopt->ceil);
+ 
+ 			fprintf(f, "overhead %u ", qopt->overhead);
+ 
+@@ -692,11 +690,9 @@ int dpaa1_ceetm_print_copt(struct qdisc_util *qu, FILE *f,
+ 		fprintf(f, "type root ");
+ 
+ 		if (copt->shaped) {
+-			print_rate(buf, sizeof(buf), copt->rate);
+-			fprintf(f, "shaped rate %s ", buf);
++			tc_print_rate(PRINT_FP, NULL, "shaped rate %s ", copt->rate);
+ 
+-			print_rate(buf, sizeof(buf), copt->ceil);
+-			fprintf(f, "ceil %s ", buf);
++			tc_print_rate(PRINT_FP, NULL, "ceil %s ", copt->ceil);
+ 
+ 		} else {
+ 			fprintf(f, "unshaped tbl %d", copt->tbl);
+diff --git a/dpaa2_ceetm.c b/dpaa2_ceetm.c
+index 6b1b033..0505046 100644
+--- a/dpaa2_ceetm.c
++++ b/dpaa2_ceetm.c
+@@ -516,11 +516,9 @@ int dpaa2_ceetm_print_copt(struct qdisc_util *qu, FILE *f, struct rtattr *opt)
+ 		fprintf(f, "type root ");
+ 
+ 		if (copt->shaped) {
+-			print_rate(buf, sizeof(buf), copt->shaping_cfg.cir);
+-			fprintf(f, "CIR %s ", buf);
++			tc_print_rate(PRINT_FP, NULL, "CIR %s ", copt->shaping_cfg.cir);
+ 
+-			print_rate(buf, sizeof(buf), copt->shaping_cfg.eir);
+-			fprintf(f, "EIR %s ", buf);
++			tc_print_rate(PRINT_FP, NULL, "EIR %s ", copt->shaping_cfg.eir);
+ 
+ 			fprintf(f, "CBS %d EBS %d ", copt->shaping_cfg.cbs, copt->shaping_cfg.ebs);
+ 
+-- 
+2.25.1
+

--- a/recipes-kernel/ceetm/ceetm_git.bb
+++ b/recipes-kernel/ceetm/ceetm_git.bb
@@ -5,6 +5,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=bac620b9883d38a84dfb73ca7122d915"
 SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/ceetm;nobranch=1"
 SRCREV = "6a7f2ec2091df2f4380cb8d25a36c399aed5af1b"
 SRC_URI_append = " file://0001-Makefile-update-CFLAGS.patch \
+    file://0001-use-new-api-tc_print_rate.patch \
 "
 DEPENDS = "iproute2"
 


### PR DESCRIPTION
Fix the build issue due to api change in iproute2:
| dpaa1_ceetm.c:637:4: error: too few arguments to function 'print_rate'
| print_rate(buf, sizeof(buf), qopt->rate);
| ^~~~~~~~~~

Signed-off-by: Ting Liu <ting.liu@nxp.com>