### PR TITLE
openssl-qoriq: enable cryptodev-linux PACKAGECONFIG

### DIFF
--- a/recipes-connectivity/openssl/openssl_%.bbappend
+++ b/recipes-connectivity/openssl/openssl_%.bbappend
@@ -4,3 +4,5 @@ SRC_URI_append_qoriq = " \
 	file://0001-eng_devcrypto-add-support-for-TLS-algorithms-offload.patch \
 	file://0002-eng_devcrypto-add-support-for-TLS1.2-algorithms-offl.patch \
 "
+
+PACKAGECONFIG_append_qoriq = " cryptodev-linux"


### PR DESCRIPTION
Enable it to offload crypto operation on Qoriq platforms.

Signed-off-by: Ting Liu <ting.liu@nxp.com>