### PR TITLE
classes: fsl-kernel-localversion: Fix config fragments apply

### DIFF
--- a/classes/fsl-kernel-localversion.bbclass
+++ b/classes/fsl-kernel-localversion.bbclass
@@ -42,4 +42,4 @@ do_kernel_localversion() {
 	fi
 }
 
-addtask kernel_localversion before do_configure after do_patch do_kernel_configme
+addtask kernel_localversion before do_configure after do_patch do_kernel_metadata


### PR DESCRIPTION
We have to ensure the task run do_kernel_metadata so the config
fragments can be applied properly.

Refs: #707.
Fixes: #733.
Fixes: 49299998 ("classes: fsl-kernel-localversion: Fix task dependency")
Fixes: c7e23876 ("linux-imx.inc: inherit kernel-yocto class")
Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>