### PR TITLE
[dunfell]: Consolidated Kernel update (v5.4.113)

### DIFF
--- a/recipes-kernel/linux/linux-fslc-imx_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_5.4.bb
@@ -28,7 +28,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v5.4.112
+#    tag: v5.4.113
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
@@ -73,14 +73,14 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
 SRCBRANCH = "5.4-2.1.x-imx"
-SRCREV = "ae2b69f7c60838f7a7a5483c6a805ae9a2a606fd"
+SRCREV = "ac73e0de1af4c060630870dbf3a47d80fc4b181d"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.112"
+LINUX_VERSION = "5.4.113"
 
 # Local version indicates the branch name in the NXP kernel tree where patches are collected from.
 LOCALVERSION = "-imx-5.4.24-2.1.0"

--- a/recipes-kernel/linux/linux-fslc_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc_5.4.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.112"
+LINUX_VERSION = "5.4.113"
 
 SRCBRANCH = "5.4.x+fslc"
-SRCREV = "b4429278fef5c4cbb703c97cdc1da8dff5cf1a58"
+SRCREV = "5a4f4fa2dc102040ead3f98a770847cee2788d86"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"


### PR DESCRIPTION
Both kernel branches were updated to _v5.4.113_ from stable korg, recipe `SRCREV` are updated to point to that version now.

Upstream commits and resolved conflicts are recorded in corresponding recipe commit messages.

-- andrey
