### PR TITLE
xserver-xorg: Don't apply same patch twice

### DIFF
--- a/recipes-graphics/xorg-xserver/xserver-xorg_%.bbappend
+++ b/recipes-graphics/xorg-xserver/xserver-xorg_%.bbappend
@@ -15,6 +15,5 @@ OPENGL_PKGCONFIGS_remove_mx8        = "${IMX_OPENGL_PKGCONFIGS_REMOVE}"
 OPENGL_PKGCONFIGS_remove_imxdrm     = "dri glx"
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
-SRC_URI_append_imxgpu2d = " file://0003-Remove-check-for-useSIGIO-option.patch"
 SRC_URI_append_use-mainline-bsp = " file://0001-Allow-to-enable-atomic-in-modesetting-DDX.patch"
 


### PR DESCRIPTION
The patch 0003-Remove-check-for-useSIGIO-option.patch is applied for
both imxgpu and imxgpu2d overrides. imxgpu is enough.

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>