### PR TITLE
xserver-xorg: Cleanup

### DIFF
--- a/recipes-graphics/xorg-xserver/xserver-xorg_%.bbappend
+++ b/recipes-graphics/xorg-xserver/xserver-xorg_%.bbappend
@@ -1,4 +1,6 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
+
+SRC_URI_append_use-mainline-bsp = " file://0001-Allow-to-enable-atomic-in-modesetting-DDX.patch"
 SRC_URI_append_imxgpu = " \
     file://0003-Remove-check-for-useSIGIO-option.patch \
     file://0001-MGS-5186-Per-Specification-EGL_NATIVE_PIXMAP_KHR-req.patch \
@@ -13,7 +15,3 @@ OPENGL_PKGCONFIGS_remove_mx6        = "${IMX_OPENGL_PKGCONFIGS_REMOVE}"
 OPENGL_PKGCONFIGS_remove_mx7        = "${IMX_OPENGL_PKGCONFIGS_REMOVE}"
 OPENGL_PKGCONFIGS_remove_mx8        = "${IMX_OPENGL_PKGCONFIGS_REMOVE}"
 OPENGL_PKGCONFIGS_remove_imxdrm     = "dri glx"
-
-FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
-SRC_URI_append_use-mainline-bsp = " file://0001-Allow-to-enable-atomic-in-modesetting-DDX.patch"
-


### PR DESCRIPTION
- drop redundant FILESEXTRAPATHS_prepend line
- co-locate SRC_URI mods

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>