### PR TITLE
ls1043/ls1046: use _prepend to adjust dtb order

### DIFF
--- a/conf/machine/ls1043ardb.conf
+++ b/conf/machine/ls1043ardb.conf
@@ -27,7 +27,7 @@ KERNEL_DEVICETREE ?= "\
     freescale/fsl-ls1043a-qds.dtb \
 "
 # usdpaa dtb is used for dpdk. TODO: rename in kernel
-KERNEL_DEVICETREE_append_use-nxp-bsp = "\
+KERNEL_DEVICETREE_prepend_use-nxp-bsp = "\
     freescale/fsl-ls1043a-rdb-sdk.dtb \
     freescale/fsl-ls1043a-rdb-usdpaa.dtb \
     freescale/fsl-ls1043a-qds-sdk.dtb \

--- a/conf/machine/ls1046afrwy.conf
+++ b/conf/machine/ls1046afrwy.conf
@@ -25,7 +25,7 @@ KERNEL_DEVICETREE ?= "\
     freescale/fsl-ls1046a-frwy.dtb \
 "
 # usdpaa dtb is used for dpdk. TODO: rename in kernel
-KERNEL_DEVICETREE_append_use-nxp-bsp = "\
+KERNEL_DEVICETREE_prepend_use-nxp-bsp = "\
     freescale/fsl-ls1046a-frwy-sdk.dtb \
     freescale/fsl-ls1046a-frwy-usdpaa.dtb \
 "

--- a/conf/machine/ls1046ardb.conf
+++ b/conf/machine/ls1046ardb.conf
@@ -26,7 +26,7 @@ KERNEL_DEVICETREE ?= "\
     freescale/fsl-ls1046a-qds.dtb \
 "
 # usdpaa dtb is used for dpdk. TODO: rename in kernel
-KERNEL_DEVICETREE_append_use-nxp-bsp = "\
+KERNEL_DEVICETREE_prepend_use-nxp-bsp = "\
     freescale/fsl-ls1046a-rdb-sdk.dtb \
     freescale/fsl-ls1046a-rdb-usdpaa.dtb \
     freescale/fsl-ls1046a-qds-sdk.dtb \


### PR DESCRIPTION
When generating fitImage, the default configuration uses the first dtb
file in KERNEL_DEVICETREE. Change to _prepend to adjust the dtb order,
thus changing the default configuration in fitImage if using nxp BSP.

Signed-off-by: Ting Liu <ting.liu@nxp.com>