### PR TITLE
imx-mkimage: fix node name generations

### DIFF
--- a/recipes-bsp/imx-mkimage/files/0001-mkimage_fit_atf-fix-fit-generator-node-naming.patch
+++ b/recipes-bsp/imx-mkimage/files/0001-mkimage_fit_atf-fix-fit-generator-node-naming.patch
@@ -1,0 +1,166 @@
+From 9cf936493388897379f33b511ec869c6fa5409ce Mon Sep 17 00:00:00 2001
+From: Andrey Zhizhikin <andrey.z@gmail.com>
+Date: Thu, 22 Apr 2021 12:20:28 +0000
+Subject: [PATCH] mkimage_fit_atf: fix fit generator node naming
+
+Since upstream commit 79af75f777 ("fit: Don't allow verification of images
+with @ nodes") [1], unit addresses on the nodes are prohibited and nodes
+that do contain those addresses are ignored during the ITS parsing. This
+is done in an effort to cover the CVE-2021-27138, where nodes with unit
+addresses can be mis-interpreted by libfdt.
+
+Correct FIT generator script and replace nodes with unit addresses to
+plain node names with "-" instead of "@" to create a unique naming.
+
+In addition, extend sections which contains "firmware" in their types
+with "os" parameter to conform to the latest FIT specification.
+
+Indicate that load and entry addresses are covered by one 32-bit value
+by adding "address-cells" in the root node of the generated ITS.
+
+Upstream-Status: Inappropriate [script is imx-boot specific]
+Link: [1] https://github.com/u-boot/u-boot/commit/79af75f7776fc20b0d7eb6afe1e27c00fdb4b9b4
+Signed-off-by: Andrey Zhizhikin <andrey.z@gmail.com>
+Cc: Tom Hochstein <tom.hochstein@nxp.com>
+---
+ iMX8M/mkimage_fit_atf.sh | 40 ++++++++++++++++++++++------------------
+ 1 file changed, 22 insertions(+), 18 deletions(-)
+
+diff --git a/iMX8M/mkimage_fit_atf.sh b/iMX8M/mkimage_fit_atf.sh
+index 95749b1..10903ea 100755
+--- a/iMX8M/mkimage_fit_atf.sh
++++ b/iMX8M/mkimage_fit_atf.sh
+@@ -23,7 +23,7 @@ else
+ fi
+ 
+ BL32="tee.bin"
+-LOADABLES="\"atf@1\""
++LOADABLES="\"atf-1\""
+ 
+ if [ ! -f $BL32 ]; then
+ 	BL32=/dev/null
+@@ -31,7 +31,7 @@ else
+ 	echo "Building with TEE support, make sure your bl31 is compiled with spd. If you do not want tee, please delete tee.bin" >&2
+ 	echo "tee.bin size: " >&2
+ 	ls -lct tee.bin | awk '{print $5}' >&2
+-	LOADABLES="$LOADABLES, \"tee@1\""
++	LOADABLES="$LOADABLES, \"tee-1\""
+ fi
+ 
+ BL33="u-boot-nodtb.bin"
+@@ -41,7 +41,7 @@ if [ ! -f $DEK_BLOB ]; then
+ 	DEK_BLOB=/dev/null
+ else
+ 	echo "Building with encrypted boot support, make sure to replace DEK Blob in final image." >&2
+-	LOADABLES="\"dek_blob@1\", $LOADABLES"
++	LOADABLES="\"dek_blob-1\", $LOADABLES"
+ fi
+ 
+ if [ ! -f $BL33 ]; then
+@@ -64,10 +64,12 @@ cat << __HEADER_EOF
+ 
+ / {
+ 	description = "Configuration to load ATF before U-Boot";
++	#address-cells = <1>;
+ 
+ 	images {
+-		uboot@1 {
++		uboot-1 {
+ 			description = "U-Boot (64-bit)";
++			os = "u-boot";
+ 			data = /incbin/("$BL33");
+ 			type = "standalone";
+ 			arch = "arm64";
+@@ -80,7 +82,7 @@ cnt=1
+ for dtname in $*
+ do
+ 	cat << __FDT_IMAGE_EOF
+-		fdt@$cnt {
++		fdt-$cnt {
+ 			description = "$(basename $dtname .dtb)";
+ 			data = /incbin/("$dtname");
+ 			type = "flat_dt";
+@@ -91,8 +93,9 @@ cnt=$((cnt+1))
+ done
+ 
+ cat << __HEADER_EOF
+-		atf@1 {
++		atf-1 {
+ 			description = "ARM Trusted Firmware";
++			os = "arm-trusted-firmware";
+ 			data = /incbin/("$BL31");
+ 			type = "firmware";
+ 			arch = "arm64";
+@@ -104,8 +107,9 @@ __HEADER_EOF
+ 
+ if [ -f $BL32 ]; then
+ cat << __HEADER_EOF
+-		tee@1 {
++		tee-1 {
+ 			description = "TEE firmware";
++			os = "op-tee-firmware";
+ 			data = /incbin/("$BL32");
+ 			type = "firmware";
+ 			arch = "arm64";
+@@ -118,7 +122,7 @@ fi
+ 
+ if [ -f $DEK_BLOB ]; then
+ cat << __HEADER_EOF
+-		dek_blob@1 {
++		dek_blob-1 {
+ 			description = "dek_blob";
+ 			data = /incbin/("$DEK_BLOB");
+ 			type = "script";
+@@ -131,7 +135,7 @@ fi
+ cat << __CONF_HEADER_EOF
+ 	};
+ 	configurations {
+-		default = "config@1";
++		default = "config-1";
+ 
+ __CONF_HEADER_EOF
+ 
+@@ -141,31 +145,31 @@ do
+ if [ -f $BL32 ]; then
+ if [ $ROLLBACK_INDEX_IN_FIT ]; then
+ cat << __CONF_SECTION_EOF
+-		config@$cnt {
++		config-$cnt {
+ 			description = "$(basename $dtname .dtb)";
+-			firmware = "uboot@1";
++			firmware = "uboot-1";
+ 			loadables = $LOADABLES;
+-			fdt = "fdt@$cnt";
++			fdt = "fdt-$cnt";
+ 			rbindex = "$ROLLBACK_INDEX_IN_FIT";
+ 		};
+ __CONF_SECTION_EOF
+ else
+ cat << __CONF_SECTION_EOF
+-		config@$cnt {
++		config-$cnt {
+ 			description = "$(basename $dtname .dtb)";
+-			firmware = "uboot@1";
++			firmware = "uboot-1";
+ 			loadables = $LOADABLES;
+-			fdt = "fdt@$cnt";
++			fdt = "fdt-$cnt";
+ 		};
+ __CONF_SECTION_EOF
+ fi
+ else
+ cat << __CONF_SECTION1_EOF
+-		config@$cnt {
++		config-$cnt {
+ 			description = "$(basename $dtname .dtb)";
+-			firmware = "uboot@1";
++			firmware = "uboot-1";
+ 			loadables = $LOADABLES;
+-			fdt = "fdt@$cnt";
++			fdt = "fdt-$cnt";
+ 		};
+ __CONF_SECTION1_EOF
+ fi
+-- 
+2.17.1
+

--- a/recipes-bsp/imx-mkimage/imx-mkimage_git.inc
+++ b/recipes-bsp/imx-mkimage/imx-mkimage_git.inc
@@ -3,7 +3,10 @@
 DEPENDS = "zlib-native openssl-native"
 
 SRCBRANCH = "imx_5.4.70_2.3.0"
-SRC_URI = "git://source.codeaurora.org/external/imx/imx-mkimage.git;protocol=https;branch=${SRCBRANCH}"
+SRC_URI = "git://source.codeaurora.org/external/imx/imx-mkimage.git;protocol=https;branch=${SRCBRANCH} \
+           file://0001-mkimage_fit_atf-fix-fit-generator-node-naming.patch \
+"
+
 SRCREV = "8947fea369ab3932259630232cfb9f87b8f9dda1"
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
FIT node names generated by imx-mkimage script are not conformant to the latest version of mkimage tool and are caused to be skipped at parsing stage, leading to build errors.

Introduce the patch to correct generated node names (drop unit address fields and replace with names-only).

Fixes: #741 

@thochstein, can you please consider applying the patch internally?

Until the `u-boot-imx` is not switched to use _binman_, the `mkimage_fit_atf.sh` script need to be used to generate a boot container and would fail during later _its_ parsing step (like it is now reported in #741).

-- andrey