### PR TITLE
Consolidated Kernel update (v5.4.114 + v5.10.32)

### DIFF
--- a/recipes-kernel/linux/linux-fslc-imx_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_5.4.bb
@@ -28,7 +28,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v5.4.113
+#    tag: v5.4.114
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
@@ -71,14 +71,14 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
 KBRANCH = "5.4-2.3.x-imx"
-SRCREV = "2d9839ccc31cc8964fb7e2424ad112501906ccd5"
+SRCREV = "e67919750cd7d48b9321b79dbbc6d0709e5b53df"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.113"
+LINUX_VERSION = "5.4.114"
 
 # Local version indicates the branch name in the NXP kernel tree where patches are collected from.
 LOCALVERSION = "-imx-5.4.70-2.3.0"

--- a/recipes-kernel/linux/linux-fslc_5.10.bb
+++ b/recipes-kernel/linux/linux-fslc_5.10.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.10.31"
+LINUX_VERSION = "5.10.32"
 
 KBRANCH = "5.10.x+fslc"
-SRCREV = "7ae1de1d2bd389bf3a735457de14b793c79b5ec9"
+SRCREV = "692b5e03f4be94f8e6ce381336cd290858841f49"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"


### PR DESCRIPTION
Kernel branches were updated to following versions for recipes from stable korg:
- `linux-fslc-imx`: _v5.4.114_
- `linux-fslc`: _v5.10.32_

Update recipe `SRCREV` to point to those versions now.

Upstream commits and resolved conflicts are recorded in corresponding recipe commit messages.

-- andrey