### PR TITLE
u-boot-imx: Update for NXP release 5.4.70-2.3.2

### DIFF
--- a/recipes-bsp/u-boot/u-boot-imx-common.inc
+++ b/recipes-bsp/u-boot/u-boot-imx-common.inc
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://Licenses/gpl-2.0.txt;md5=b234ee4d69f5fce4486a80fdaf4a
 
 SRCBRANCH = "imx_v2020.04_5.4.70_2.3.0"
 SRC_URI = "git://source.codeaurora.org/external/imx/uboot-imx.git;protocol=https;branch=${SRCBRANCH}"
-SRCREV = "e42dee801ec55bc40347cbb98f13bfb5899f0368"
+SRCREV = "185bdaaaf5644319284566e5c340927d28954a1a"
 
 DEPENDS += "flex-native bison-native bc-native dtc-native"
 
@@ -14,7 +14,7 @@ B = "${WORKDIR}/build"
 
 inherit fsl-u-boot-localversion
 
-LOCALVERSION ?= "-${SRCBRANCH}"
+LOCALVERSION ?= "-imx_v2020.04_5.4.70_2.3.2"
 
 BOOT_TOOLS = "imx-boot-tools"
 

--- a/recipes-bsp/u-boot/u-boot-imx_2020.04.bb
+++ b/recipes-bsp/u-boot/u-boot-imx_2020.04.bb
@@ -1,6 +1,6 @@
 # Copyright (C) 2013-2016 Freescale Semiconductor
 # Copyright 2018 (C) O.S. Systems Software LTDA.
-# Copyright (C) 2017-2020 NXP
+# Copyright (C) 2017-2021 NXP
 
 require recipes-bsp/u-boot/u-boot.inc
 require u-boot-imx-common.inc


### PR DESCRIPTION
Includes following commits:

185bdaaaf5 MA-18534 imx8mp: Enable trusty for powersave config
30549fb526 MA-18346-11 Android refine power on imx8mp board
42ed8fa287 MA-18422 Locate the misc partition by name
35ab562a3b LFU-15 Fix using uninitialized value
5b339f5614 MA-18352-6 Enable device IDs provision
c3acd3ca3a MA-18352-5 Support device IDs provision
970305d9f1 MA-18458 Sync configs for Android 11 release
933b8ef869 MA-18406 Fix panic when provision keys on boards without rpmb key
0fffe00758 MA-16954 set partition type to efi after flash gpt partition

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>