### PR TITLE
Fixes for weston and gpu drivers

### DIFF
--- a/recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc
+++ b/recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc
@@ -286,6 +286,7 @@ FILES_libgal-imx = "${libdir}/libGAL${SOLIBS} ${libdir}/libGAL_egl${SOLIBS}"
 FILES_libgal-imx-dev = "${libdir}/libGAL${SOLIBSDEV} ${includedir}/HAL"
 RDEPENDS_libgal-imx += "${@bb.utils.contains('PACKAGECONFIG', 'valgrind', 'valgrind', '', d)}"
 RPROVIDES_libgal-imx += "libgal-imx"
+RRECOMMENDS_libgal-imx += "kernel-module-imx-gpu-viv"
 INSANE_SKIP_libgal-imx += "build-deps"
 
 FILES_libvsc-imx = "${libdir}/libVSC${SOLIBS}"

--- a/recipes-graphics/wayland/weston_9.0.0.imx.bb
+++ b/recipes-graphics/wayland/weston_9.0.0.imx.bb
@@ -131,7 +131,7 @@ SUMMARY_libweston-${WESTON_MAJOR_VERSION} = "Helper library for implementing 'wa
 FILES_${PN}-examples = "${bindir}/*"
 
 FILES_${PN}-xwayland = "${libdir}/libweston-${WESTON_MAJOR_VERSION}/xwayland.so"
-RDEPENDS_${PN}-xwayland += "xserver-xorg-xwayland"
+RDEPENDS_${PN}-xwayland += "xwayland"
 
 RDEPENDS_${PN} += "xkeyboard-config"
 RRECOMMENDS_${PN} = "weston-init liberation-fonts"


### PR DESCRIPTION
This fixes two issues that caused weston to not work. The second one is particularly noteworthy since it partially reverts a previous commit. @thochstein , can you take a look as well, since that previous commit was yours? When I used strace on weston to find out what's wrong, I noticed attempts at accessing `/dev/galcore`, which just wasn't present. Adding the GPU kernel module adds that device node, fixing the second issue.