### PR TITLE
basler-camera, isp: Fix compatibility for 8M Plus only

### DIFF
--- a/recipes-bsp/isp-imx/basler-camera_4.2.2.11.0.bb
+++ b/recipes-bsp/isp-imx/basler-camera_4.2.2.11.0.bb
@@ -24,4 +24,4 @@ SYSTEMD_AUTO_ENABLE = "enable"
 FILES_${PN} = "${libdir} /opt"
 INSANE_SKIP_${PN} = "file-rdeps already-stripped"
 
-COMPATIBLE_MACHINE = "(imx|use-nxp-bsp)"
+COMPATIBLE_MACHINE = "(mx8mp)"

--- a/recipes-bsp/isp-imx/isp-imx_4.2.2.11.0.bb
+++ b/recipes-bsp/isp-imx/isp-imx_4.2.2.11.0.bb
@@ -83,4 +83,4 @@ INSANE_SKIP_${PN} = "rpaths"
 
 RDEPENDS_${PN} = "libdrm libpython3"
 
-COMPATIBLE_MACHINE = "(imx|use-nxp-bsp)"
+COMPATIBLE_MACHINE = "(mx8mp)"

--- a/recipes-kernel/kernel-modules/kernel-module-isp-vvcam_4.2.2.11.0.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-isp-vvcam_4.2.2.11.0.bb
@@ -16,4 +16,4 @@ S = "${WORKDIR}/git/vvcam/v4l2"
 
 inherit module
 
-COMPATIBLE_MACHINE = "(imx|use-nxp-bsp)"
+COMPATIBLE_MACHINE = "(mx8mp)"


### PR DESCRIPTION
The basler camera support is for 8M Plus SOC only.

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>
(cherry picked from commit 7bfd1773f586a79be8abedf36e04c46b77c7c73c)