### PR TITLE
Consolidated Kernel update (v5.4.118 + v5.10.36 + 5.12.3)

### DIFF
--- a/recipes-bsp/u-boot/u-boot-fslc-common_2021.07.inc
+++ b/recipes-bsp/u-boot/u-boot-fslc-common_2021.07.inc
@@ -10,7 +10,7 @@ DEPENDS += "flex-native bison-native"
 
 SRC_URI = "git://github.com/Freescale/u-boot-fslc.git;branch=${SRCBRANCH}"
 
-SRCREV = "b047e1dcd20a2a767aa72aba8a040b16903f261f"
+SRCREV = "f0f7f23c85185e1237693eeb8f1f73634fd8a10d"
 SRCBRANCH = "2021.07+fslc"
 
 PV = "v2021.07+git${SRCPV}"

--- a/recipes-kernel/linux/linux-fslc-imx_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_5.4.bb
@@ -28,7 +28,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v5.4.117
+#    tag: v5.4.118
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
@@ -71,14 +71,14 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
 KBRANCH = "5.4-2.3.x-imx"
-SRCREV = "3ec285efe932699470c60430ea53d8753d705891"
+SRCREV = "d1bb99cd3c58a5569908d8302d2dc2352c9e51dd"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.117"
+LINUX_VERSION = "5.4.118"
 
 # Local version indicates the branch name in the NXP kernel tree where patches are collected from.
 LOCALVERSION = "-imx-5.4.70-2.3.0"

--- a/recipes-kernel/linux/linux-fslc-imx_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_5.4.bb
@@ -28,7 +28,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v5.4.116
+#    tag: v5.4.117
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
@@ -71,14 +71,14 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
 KBRANCH = "5.4-2.3.x-imx"
-SRCREV = "3431b95888fa203fe81af87046713d3b538b8af3"
+SRCREV = "3ec285efe932699470c60430ea53d8753d705891"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.116"
+LINUX_VERSION = "5.4.117"
 
 # Local version indicates the branch name in the NXP kernel tree where patches are collected from.
 LOCALVERSION = "-imx-5.4.70-2.3.0"

--- a/recipes-kernel/linux/linux-fslc-lts_5.10.bb
+++ b/recipes-kernel/linux/linux-fslc-lts_5.10.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.10.34"
+LINUX_VERSION = "5.10.35"
 
 KBRANCH = "5.10.x+fslc"
-SRCREV = "4ba5340367382e542c0cd88088169b9337340f95"
+SRCREV = "a590b0e5d1bf37140349d8f97d882f03b4a477ee"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"

--- a/recipes-kernel/linux/linux-fslc-lts_5.10.bb
+++ b/recipes-kernel/linux/linux-fslc-lts_5.10.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.10.35"
+LINUX_VERSION = "5.10.36"
 
 KBRANCH = "5.10.x+fslc"
-SRCREV = "a590b0e5d1bf37140349d8f97d882f03b4a477ee"
+SRCREV = "0c4c7d656f51c4ebfa0d124cd18b7ee2f70d6fd2"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"

--- a/recipes-kernel/linux/linux-fslc_5.12.bb
+++ b/recipes-kernel/linux/linux-fslc_5.12.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.12.1"
+LINUX_VERSION = "5.12.3"
 
 KBRANCH = "5.12.x+fslc"
-SRCREV = "1a5fea11bc2fbc64287260fb00e4f40bf7531c05"
+SRCREV = "4cfbdcd5ab63a0aa5ba1ddb7014bda9443fbf387"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"


### PR DESCRIPTION
Kernel branches were updated up to and including following versions for recipes from stable korg:
- `linux-fslc-imx`: _v5.4.118_
- `linux-fslc-lts`: _v5.10.36_
- `linux-fslc`: _v5.12.3_

Update recipe `SRCREV` to point to those versions now.

Upstream commits and resolved conflicts are recorded in corresponding recipe commit messages.

-- andrey