### PR TITLE
Consolidated Kernel update (v5.4.119 + v5.10.37 + 5.12.4)

### DIFF
--- a/recipes-kernel/linux/linux-fslc-imx_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_5.4.bb
@@ -28,7 +28,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v5.4.118
+#    tag: v5.4.119
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
@@ -71,14 +71,14 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
 KBRANCH = "5.4-2.3.x-imx"
-SRCREV = "d1bb99cd3c58a5569908d8302d2dc2352c9e51dd"
+SRCREV = "af18e9f3baa80b9fd53b7d06c375687941338a29"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.118"
+LINUX_VERSION = "5.4.119"
 
 # Local version indicates the branch name in the NXP kernel tree where patches are collected from.
 LOCALVERSION = "-imx-5.4.70-2.3.0"

--- a/recipes-kernel/linux/linux-fslc-lts_5.10.bb
+++ b/recipes-kernel/linux/linux-fslc-lts_5.10.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.10.36"
+LINUX_VERSION = "5.10.37"
 
 KBRANCH = "5.10.x+fslc"
-SRCREV = "0c4c7d656f51c4ebfa0d124cd18b7ee2f70d6fd2"
+SRCREV = "7df1df8d02126ab1f44b57aaecf1b5f02f95a812"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"

--- a/recipes-kernel/linux/linux-fslc_5.12.bb
+++ b/recipes-kernel/linux/linux-fslc_5.12.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.12.3"
+LINUX_VERSION = "5.12.4"
 
 KBRANCH = "5.12.x+fslc"
-SRCREV = "4cfbdcd5ab63a0aa5ba1ddb7014bda9443fbf387"
+SRCREV = "92555a9f427986a52c4388ec013aa395e8f7a95e"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"


### PR DESCRIPTION
Kernel branches were updated up to and including following versions for recipes from stable korg:
- `linux-fslc-imx`: _v5.4.119_
- `linux-fslc-lts`: _v5.10.37_
- `linux-fslc`: _v5.12.4_

Update recipe `SRCREV` to point to those versions now.

Upstream commits are recorded in corresponding recipe commit messages.

-- andrey