### PR TITLE
imx8dx-mek: Fix ATF_PLATFORM and IMX_BOOT_SOC_TARGET

### DIFF
--- a/conf/machine/imx8dx-mek.conf
+++ b/conf/machine/imx8dx-mek.conf
@@ -10,3 +10,7 @@ require include/imx8x-mek.inc
 KERNEL_DEVICETREE_BASENAME = "${MACHINE}"
 
 UBOOT_CONFIG_BASENAME = "imx8dx_mek"
+
+ATF_PLATFORM = "imx8dx"
+
+IMX_BOOT_SOC_TARGET = "iMX8DX"

--- a/conf/machine/imx8qxp-mek.conf
+++ b/conf/machine/imx8qxp-mek.conf
@@ -24,3 +24,7 @@ KERNEL_DEVICETREE_append_use-nxp-bsp = " \
 "
 
 UBOOT_CONFIG_BASENAME = "imx8qxp_mek"
+
+ATF_PLATFORM = "imx8qx"
+
+IMX_BOOT_SOC_TARGET = "iMX8QX"

--- a/conf/machine/include/imx8x-mek.inc
+++ b/conf/machine/include/imx8x-mek.inc
@@ -59,9 +59,6 @@ IMX_BOOT_SEEK = "32"
 IMX_DEFAULT_BOOTLOADER = "u-boot-imx"
 UBOOT_SUFFIX = "bin"
 
-# Set ATF platform name
-ATF_PLATFORM = "imx8qx"
-
 IMXBOOT_TARGETS_SD = \
     "${@bb.utils.contains('MACHINE_FEATURES', 'optee', 'flash_spl', \
                                                        'flash', d)}"
@@ -71,8 +68,6 @@ IMXBOOT_TARGETS_FSPI = \
 IMXBOOT_TARGETS = \
     "${@bb.utils.contains('UBOOT_CONFIG',        'sd', '${IMXBOOT_TARGETS_SD}', \
                                                        '${IMXBOOT_TARGETS_FSPI}', d)}"
-IMX_BOOT_SOC_TARGET = "iMX8QX"
-
 BOARD_TYPE = "mek"
 
 # Add additional firmware


### PR DESCRIPTION
The values for ATF_PLATFORM and IMX_BOOT_SOC_TARGET need to be set
in the machine config file directly, as they are not shared with
imx8qxp-mek and are now removed from the include file.
