### PR TITLE
u-boot-fslc: update to v2021.07-rc3

### DIFF
--- a/recipes-bsp/u-boot/u-boot-fslc-common_2021.07.inc
+++ b/recipes-bsp/u-boot/u-boot-fslc-common_2021.07.inc
@@ -10,7 +10,7 @@ DEPENDS += "flex-native bison-native"
 
 SRC_URI = "git://github.com/Freescale/u-boot-fslc.git;branch=${SRCBRANCH}"
 
-SRCREV = "f0f7f23c85185e1237693eeb8f1f73634fd8a10d"
+SRCREV = "dcb27e421ca6a7478026a54ae64606539ba6a4fb"
 SRCBRANCH = "2021.07+fslc"
 
 PV = "v2021.07+git${SRCPV}"


### PR DESCRIPTION
U-Boot repository has been upgraded to `v2021.07-rc3` from _DENX_ repository.

Upstream commits are recorded in corresponding recipe commit message.

Link: https://lists.denx.de/pipermail/u-boot/2021-May/450703.html

-- andrey
