### PR TITLE
Consolidated Kernel update (v5.4.121 + v5.10.39 + 5.12.6)

### DIFF
--- a/recipes-kernel/linux/linux-fslc-imx_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_5.4.bb
@@ -28,7 +28,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v5.4.120
+#    tag: v5.4.121
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
@@ -71,14 +71,14 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
 KBRANCH = "5.4-2.3.x-imx"
-SRCREV = "14900e57bb56e375c00864da1f4ada7095c2778b"
+SRCREV = "52ae115cca1fa0c3a96ea9563dd962bec3d23fa2"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.120"
+LINUX_VERSION = "5.4.121"
 
 # Local version indicates the branch name in the NXP kernel tree where patches are collected from.
 LOCALVERSION = "-imx-5.4.70-2.3.0"

--- a/recipes-kernel/linux/linux-fslc-imx_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_5.4.bb
@@ -28,7 +28,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v5.4.119
+#    tag: v5.4.120
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
@@ -71,14 +71,14 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
 KBRANCH = "5.4-2.3.x-imx"
-SRCREV = "af18e9f3baa80b9fd53b7d06c375687941338a29"
+SRCREV = "14900e57bb56e375c00864da1f4ada7095c2778b"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.119"
+LINUX_VERSION = "5.4.120"
 
 # Local version indicates the branch name in the NXP kernel tree where patches are collected from.
 LOCALVERSION = "-imx-5.4.70-2.3.0"

--- a/recipes-kernel/linux/linux-fslc-lts_5.10.bb
+++ b/recipes-kernel/linux/linux-fslc-lts_5.10.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.10.37"
+LINUX_VERSION = "5.10.38"
 
 KBRANCH = "5.10.x+fslc"
-SRCREV = "7df1df8d02126ab1f44b57aaecf1b5f02f95a812"
+SRCREV = "892817b19fc59c0bb20b125628bf24f7946d1ea1"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"

--- a/recipes-kernel/linux/linux-fslc-lts_5.10.bb
+++ b/recipes-kernel/linux/linux-fslc-lts_5.10.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.10.38"
+LINUX_VERSION = "5.10.39"
 
 KBRANCH = "5.10.x+fslc"
-SRCREV = "892817b19fc59c0bb20b125628bf24f7946d1ea1"
+SRCREV = "9dac86d4c733c4f11605d626ca00fb4220c60709"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"

--- a/recipes-kernel/linux/linux-fslc_5.12.bb
+++ b/recipes-kernel/linux/linux-fslc_5.12.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.12.4"
+LINUX_VERSION = "5.12.5"
 
 KBRANCH = "5.12.x+fslc"
-SRCREV = "92555a9f427986a52c4388ec013aa395e8f7a95e"
+SRCREV = "73cfd05e78e40a5de4859bac44be96a6ce8c08d5"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"

--- a/recipes-kernel/linux/linux-fslc_5.12.bb
+++ b/recipes-kernel/linux/linux-fslc_5.12.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.12.5"
+LINUX_VERSION = "5.12.6"
 
 KBRANCH = "5.12.x+fslc"
-SRCREV = "73cfd05e78e40a5de4859bac44be96a6ce8c08d5"
+SRCREV = "efa1b95da59c14ed5e6965e52b5092a659cdacd6"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"


### PR DESCRIPTION
Kernel branches were updated up to and including following versions for recipes from stable korg:
- `linux-fslc-imx`: _v5.4.121_
- `linux-fslc-lts`: _v5.10.39_
- `linux-fslc`: _v5.12.6_

Update recipe `SRCREV` to point to those versions now.

Upstream commits are recorded in corresponding recipe commit messages.

-- andrey