### PR TITLE
Consolidated Kernel update (v5.4.122 + v5.10.40 + 5.12.7)

### DIFF
--- a/recipes-kernel/linux/linux-fslc-imx_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_5.4.bb
@@ -28,7 +28,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v5.4.121
+#    tag: v5.4.122
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
@@ -71,14 +71,14 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
 KBRANCH = "5.4-2.3.x-imx"
-SRCREV = "52ae115cca1fa0c3a96ea9563dd962bec3d23fa2"
+SRCREV = "f1aad6febd86b718e6b34d87eb245026d704ae94"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.121"
+LINUX_VERSION = "5.4.122"
 
 # Local version indicates the branch name in the NXP kernel tree where patches are collected from.
 LOCALVERSION = "-imx-5.4.70-2.3.0"

--- a/recipes-kernel/linux/linux-fslc-lts_5.10.bb
+++ b/recipes-kernel/linux/linux-fslc-lts_5.10.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.10.39"
+LINUX_VERSION = "5.10.40"
 
 KBRANCH = "5.10.x+fslc"
-SRCREV = "9dac86d4c733c4f11605d626ca00fb4220c60709"
+SRCREV = "68d8068e24fa954bedbdee02a142e4dea80ca105"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"

--- a/recipes-kernel/linux/linux-fslc_5.12.bb
+++ b/recipes-kernel/linux/linux-fslc_5.12.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.12.6"
+LINUX_VERSION = "5.12.7"
 
 KBRANCH = "5.12.x+fslc"
-SRCREV = "efa1b95da59c14ed5e6965e52b5092a659cdacd6"
+SRCREV = "b512d115bab71da68285638d75c274dbbfb1652a"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"


### PR DESCRIPTION
Kernel branches were updated up to and including following versions for recipes from stable korg:
- `linux-fslc-imx`: _v5.4.122_
- `linux-fslc-lts`: _v5.10.40_
- `linux-fslc`: _v5.12.7_

Update recipe `SRCREV` to point to those versions now.

Upstream commits are recorded in corresponding recipe commit messages.

`linux-fslc-imx` received a commit `ff9d9347c331 ("mmc: core: fix missing reserved indexes")`, which fixes the `v5.4.119` merge issue where the reserved indexes of mmc devices has been accidentally dropped.

This should address the problem reported in #788, where it was indicated that indexes were changing.

Cc: @onurcalili
Cc: @sapiippo

-- andrey