### PR TITLE
libimxvpuapi2: Update to version 2.2.0

### DIFF
--- a/recipes-multimedia/libimxvpuapi/libimxvpuapi2_2.2.0.bb
+++ b/recipes-multimedia/libimxvpuapi/libimxvpuapi2_2.2.0.bb
@@ -8,7 +8,7 @@ DEPENDS = "virtual/imxvpu libimxdmabuffer"
 PV .= "+git${SRCPV}"
 
 SRCBRANCH ?= "master"
-SRCREV = "29c90975dcbb52ca09512693af417d73ab2800a9"
+SRCREV = "a650f13fb5de94e0c7c9e77f4d07ea275ea80dac"
 SRC_URI = "git://github.com/Freescale/libimxvpuapi.git;branch=${SRCBRANCH}"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
* Add IMX_VPU_API_DEC_OUTPUT_CODE_VIDEO_PARAMETERS_CHANGED output code
* Deprecate encoder drain mode, better document decoder drain mode
* Various documentation fixes and new overviews about en- and
  decoding to help with the basic concepts
* Add note about the current state of i.MX8m plus support
* New functions:
  imx_vpu_api_is_color_format_rgb()
  imx_vpu_api_vp8_profile_number()
  imx_vpu_api_vp8_partition_count_number()
  imx_vpu_api_vp9_profile_number()
  imx_vpu_api_enc_set_frame_rate()
* imx6-coda: Fix decoded frame fb_context
  This was causing crashes when callers relied on said fb_context

Signed-off-by: Carlos Rafael Giani <crg7475@mailbox.org>