### PR TITLE
Consolidated Kernel update (v5.4.126 + v5.10.44 + 5.12.11)

### DIFF
--- a/recipes-kernel/linux/linux-fslc-imx_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_5.4.bb
@@ -28,7 +28,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v5.4.125
+#    tag: v5.4.126
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
@@ -71,14 +71,14 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
 KBRANCH = "5.4-2.3.x-imx"
-SRCREV = "ef8eb7d4787bee4be718a83b6c73fb8cc7e8f158"
+SRCREV = "a402819056e695056c43981ca9acf520b6b00c84"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.125"
+LINUX_VERSION = "5.4.126"
 
 # Local version indicates the branch name in the NXP kernel tree where patches are collected from.
 LOCALVERSION = "-imx-5.4.70-2.3.0"

--- a/recipes-kernel/linux/linux-fslc-lts_5.10.bb
+++ b/recipes-kernel/linux/linux-fslc-lts_5.10.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.10.43"
+LINUX_VERSION = "5.10.44"
 
 KBRANCH = "5.10.x+fslc"
-SRCREV = "e670310572827c94fa220a71cd318bede2328fb0"
+SRCREV = "1d2f89fc03e31e2eae35d0babc5d289f2ce91d68"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"

--- a/recipes-kernel/linux/linux-fslc_5.12.bb
+++ b/recipes-kernel/linux/linux-fslc_5.12.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.12.10"
+LINUX_VERSION = "5.12.11"
 
 KBRANCH = "5.12.x+fslc"
-SRCREV = "7844946153845ad1f2e8d738b7d647a5ac7b8f70"
+SRCREV = "55f71ca4e7196e3c667c720b55d4fd1117d0a051"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"


### PR DESCRIPTION
Kernel branches were updated up to and including following versions for recipes from stable korg:
- `linux-fslc-imx`: _v5.4.126_
- `linux-fslc-lts`: _v5.10.44_
- `linux-fslc`: _v5.12.11_

Update recipe `SRCREV` to point to those versions now.

Upstream commits and resolved conflicts are recorded in corresponding recipe commit messages.

-- andrey