### PR TITLE
jailhouse: Fix firmware location as non-arch specific

### DIFF
--- a/recipes-extended/jailhouse/jailhouse_0.12.bb
+++ b/recipes-extended/jailhouse/jailhouse_0.12.bb
@@ -101,7 +101,7 @@ do_install() {
 
 PACKAGE_BEFORE_PN = "kernel-module-jailhouse pyjailhouse"
 
-FILES_${PN} += "${base_libdir}/firmware ${libexecdir} ${sbindir} ${JH_DATADIR}"
+FILES_${PN} += "${nonarch_base_libdir}/firmware ${libexecdir} ${sbindir} ${JH_DATADIR}"
 FILES_pyjailhouse = "${PYTHON_SITEPACKAGES_DIR}/pyjailhouse"
 
 RDEPENDS_${PN} += " \


### PR DESCRIPTION
The firmware is installed in /lib regardless of multilib usage.

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>