### PR TITLE
u-boot-fslc: update to v2021.07-rc5

### DIFF
--- a/recipes-bsp/u-boot/u-boot-fslc-common_2021.07.inc
+++ b/recipes-bsp/u-boot/u-boot-fslc-common_2021.07.inc
@@ -10,7 +10,7 @@ DEPENDS += "flex-native bison-native"
 
 SRC_URI = "git://github.com/Freescale/u-boot-fslc.git;branch=${SRCBRANCH}"
 
-SRCREV = "08aa31bfbd6d530cb1ba22ddb1c1ce838dc624c2"
+SRCREV = "587e796995604fb669a3552daae682b4d6d346d9"
 SRCBRANCH = "2021.07+fslc"
 
 PV = "v2021.07+git${SRCPV}"


### PR DESCRIPTION
U-Boot repository has been upgraded to `v2021.07-rc5` from _DENX_ repository.

Upstream commits and resolved conflicts are recorded in corresponding recipe commit message.

Link: https://lore.kernel.org/u-boot/20210628194137.GU9516@bill-the-cat/
Link: https://github.com/Freescale/u-boot-fslc/pull/41
