### PR TITLE
tsntool: update to 3111f7f

### DIFF
--- a/recipes-extended/tsntool/tsntool_git.bb
+++ b/recipes-extended/tsntool/tsntool_git.bb
@@ -8,7 +8,7 @@ DEPENDS = "cjson libnl readline"
 inherit pkgconfig
 
 SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/tsntool;protocol=https;nobranch=1"
-SRCREV = "1d1686e83c8f83472055189c278b837434990dcc"
+SRCREV = "3111f7f79e7d1b1a5e60f37fe76785559b2d0360"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
New commits:
3111f7f Pull request #22: cnc: add cbgen and cbrec functions
54a6554 cnc: add cbgen and cbrec functions
b30a3fb demo:cnc: support parameter for devices GROUP_NAME
4444d30 cnc: demo: json format unifiy
107ec39 Update cnc demo README
3b69fb2 libtsn: fix the libtsn for third party
44f8c29 cnc: fix subprocess not response- not sure
61ab161 cnc: remove the devices list and set by the device neighbor table
be944a4 cnc: remove some informations
5301380 cnc: fix ip6 resolve address
e506476 cnc: fix the pmc not feedbach make hang
1a4099a cnc: remove more message
93885f6 cnc: fix global neighbors interfaces dynamic changes
bca7435 cnc:add path show with color obviously
b744065 cnc: fix switch can't do path check as end station
d3770dd cnc: add path found
6775903 cnc: get path found frontend and restapi added
1bf2a2a cnc: frontend add path delay input
3f0b50e cnc: add frontend port delay code and showing the link tooltip
dd9993e cnc: revert the graph1 for topology demo
dd86c81 cnc: add support the backend code for link delay
5cdfd8f cnc: add support port delay for devices
c3a26d2 cnc: add REST APIs for devices and topology
a9ec1a9 cnc: add support topology support

Signed-off-by: Ting Liu <ting.liu@nxp.com>