### PR TITLE
Consolidated Kernel update (v5.4.134 + v5.10.52 + 5.12.19 [EOL])

### DIFF
--- a/recipes-kernel/linux/linux-fslc-imx_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_5.4.bb
@@ -28,7 +28,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v5.4.129
+#    tag: v5.4.134
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
@@ -38,6 +38,21 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 3. Critical patches (SHA(s))
 # ------------------------------------------------------------------------------
+#    48afde5dc8ee LF-2692: clk: imx: scu: Do not enable runtime PM for CPU clks
+#    dc760ca6a531 MLK-25468: seco_mu: hook v2x reset event
+#    fee1ade052eb MPSDK-172 remoteproc: imx_rproc: Re-building communication channels when a remote crashes
+#    b93083071e9f MLK-23277: 8qm: Fix SW workaround for i.MX8QM TKT340553
+#    edfc37d93d8d MLK-25444: arch: arm64: dts: imx8dxl: Fix lcdif nodes
+#    319f1755edf3 MLK-25105-2: dts: arm64: imx8mp-ab2: use AK5552 compatible for sound card
+#    1e306d7fbb17 MLK-25105-1: dts: arm64: imx8mp-ab2: ensure SAI3 RX not in sync with TX
+#    67355ffc4af7 MLK-25103: ASoC: wm8524: avoid EPROBE_DEFER log
+#    090f71d23f8f clk: imx: add mux ops for i.MX8M composite clk
+#    a7466010c566 LF-3623: media: imx8: isi: fix Can't match soc version
+#    398435ef11d7 MLK-25427 arm64: dts: imx8mp: add power-domains to irqsteer hdmi
+#    3125360c70f2 LF-3132: dmaengine: imx-sdma: raise up channel0 priority after resume
+#    eddc2ac1d148 MLK-25116-2: dmaengine: imx-sdma: correct iram_pool check point
+#    c53ff3924c06 MLK-25116-1: dmaengine: imx-sdma: save iram pool for bd allocated
+#    09370995212a MLK-25426 remoteproc: imx_rproc: fix firmware reload
 #    b598b85172f7 irq-imx-irqsteer: fix compile error if CONFIG_PM_SLEEP is not set
 #    845099bfd0b8 fbdev: fix fbinfo flag dropped upstream
 #    847bfb09bb3b arm64: dts: imx8m: change ocotp node name on i.MX8M SoCs
@@ -71,14 +86,14 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
 KBRANCH = "5.4-2.3.x-imx"
-SRCREV = "05c302bdd5fe7eb75c22eeb4ab2b669d4849a9df"
+SRCREV = "e3b082933caab27829e775606708381fe1b7c3ba"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.129"
+LINUX_VERSION = "5.4.134"
 
 # Local version indicates the branch name in the NXP kernel tree where patches are collected from.
 LOCALVERSION = "-5.4.70-2.3.0"

--- a/recipes-kernel/linux/linux-fslc-lts_5.10.bb
+++ b/recipes-kernel/linux/linux-fslc-lts_5.10.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.10.47"
+LINUX_VERSION = "5.10.52"
 
 KBRANCH = "5.10.x+fslc"
-SRCREV = "03eb3893e83beaee3a83b119cd9f2a3001573012"
+SRCREV = "cb67a3e29a88e06e2891f8e2aac289305d8f08ff"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"

--- a/recipes-kernel/linux/linux-fslc_5.12.bb
+++ b/recipes-kernel/linux/linux-fslc_5.12.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.12.14"
+LINUX_VERSION = "5.12.19"
 
 KBRANCH = "5.12.x+fslc"
-SRCREV = "2f4aa90810432316f74d4ebfc4c92b959622184c"
+SRCREV = "a7601274fa6ecb02a9335c8aac5575e8aa8d65fd"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"


### PR DESCRIPTION
Kernel branches were updated up to and including following versions for recipes from stable korg:
- `linux-fslc-imx`: _v5.4.134_
- `linux-fslc-lts`: _v5.10.52_
- `linux-fslc`: _v5.12.19 [EOL]_ 

Update recipe `SRCREV` to point to those versions now.

Upstream commits, resolved conflicts and NXP-specific commits to `linux-fslc-imx` are recorded in corresponding recipe commit messages.

**NOTE**: According to [Greg's announcement on LKML](https://lore.kernel.org/lkml/1626791065147152@kroah.com/), `linux-5.12.y` goes into EOL with `v5.12.19` being the last release.

-- andrey