### PR TITLE
alsa-lib: Fix imx-cs42888 model name, fix fuzz

### DIFF
--- a/recipes-multimedia/alsa/alsa-lib/0001-add-conf-for-multichannel-support-in-imx.patch
+++ b/recipes-multimedia/alsa/alsa-lib/0001-add-conf-for-multichannel-support-in-imx.patch
@@ -1,4 +1,4 @@
-From cc06048dcd722049f92ab17958760bd798fb4781 Mon Sep 17 00:00:00 2001
+From 49a7eac8e02c33cae8a168e6d22d9ff8aaf86d44 Mon Sep 17 00:00:00 2001
 From: Shengjiu Wang <b02247@freescale.com>
 Date: Thu, 5 Jun 2014 17:37:47 +0800
 Subject: [PATCH] add conf for multichannel support in imx
@@ -6,9 +6,10 @@ Subject: [PATCH] add conf for multichannel support in imx
 Upstream Status: Inappropriate [platform specific]
 
 Signed-off-by: Shengjiu Wang <b02247@freescale.com>
+
 ---
- src/conf/cards/CS42888.conf  | 94 ++++++++++++++++++++++++++++++++++++++++++++
- src/conf/cards/IMX-HDMI.conf | 67 +++++++++++++++++++++++++++++++
+ src/conf/cards/CS42888.conf  | 94 ++++++++++++++++++++++++++++++++++++
+ src/conf/cards/IMX-HDMI.conf | 67 +++++++++++++++++++++++++
  src/conf/cards/Makefile.am   |  4 +-
  src/conf/cards/aliases.conf  |  2 +
  4 files changed, 166 insertions(+), 1 deletion(-)
@@ -204,18 +205,15 @@ index 00999f0..fbf0697 100644
  if BUILD_ALISP
  cfg_files += aliases.alisp
 diff --git a/src/conf/cards/aliases.conf b/src/conf/cards/aliases.conf
-index 18a920f..2c422ee 100644
+index 7e352f7..a9e6d76 100644
 --- a/src/conf/cards/aliases.conf
 +++ b/src/conf/cards/aliases.conf
 @@ -57,6 +57,8 @@ CMI8786 cards.CMI8788
  CMI8787 cards.CMI8788
  pistachio cards.pistachio-card
  VC4-HDMI cards.vc4-hdmi
-+cs42888-audio cards.CS42888
++imx-cs42888 cards.CS42888
 +imx-hdmi-soc cards.IMX-HDMI
  
+ <confdir:ctl/default.conf>
  <confdir:pcm/default.conf>
- <confdir:pcm/dmix.conf>
--- 
-2.7.4
-

--- a/recipes-multimedia/alsa/alsa-lib/0004-pcm-Don-t-store-the-state-for-SND_PCM_STATE_SUSPENDE.patch
+++ b/recipes-multimedia/alsa/alsa-lib/0004-pcm-Don-t-store-the-state-for-SND_PCM_STATE_SUSPENDE.patch
@@ -1,7 +1,7 @@
-From 93607819d90ddf9bbdad8bbbe4af5d917ca572dc Mon Sep 17 00:00:00 2001
+From 09c1a959e7d007e00741606f69444c1f865a4beb Mon Sep 17 00:00:00 2001
 From: Shengjiu Wang <shengjiu.wang@freescale.com>
 Date: Tue, 10 May 2016 15:09:26 +0800
-Subject: [PATCH 2/2] pcm: Don't store the state for SND_PCM_STATE_SUSPENDED
+Subject: [PATCH] pcm: Don't store the state for SND_PCM_STATE_SUSPENDED
 
 The resume function don't update the dmix->state, if store SUSPENDED
 state in snd_pcm_dmix_state, the write function after resume will
@@ -13,6 +13,7 @@ for dmix,dshare,dsnoop.
 Upstream-Status: Pending
 
 Signed-off-by: Shengjiu Wang <shengjiu.wang@freescale.com>
+
 ---
  src/pcm/pcm_dmix.c   | 2 +-
  src/pcm/pcm_dshare.c | 2 +-
@@ -20,10 +21,10 @@ Signed-off-by: Shengjiu Wang <shengjiu.wang@freescale.com>
  3 files changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/src/pcm/pcm_dmix.c b/src/pcm/pcm_dmix.c
-index a6a8f3a..89c07d1 100644
+index 608593f..3d068c7 100644
 --- a/src/pcm/pcm_dmix.c
 +++ b/src/pcm/pcm_dmix.c
-@@ -466,9 +466,9 @@ static snd_pcm_state_t snd_pcm_dmix_state(snd_pcm_t *pcm)
+@@ -460,9 +460,9 @@ static snd_pcm_state_t snd_pcm_dmix_state(snd_pcm_t *pcm)
  	snd_pcm_state_t state;
  	state = snd_pcm_state(dmix->spcm);
  	switch (state) {
@@ -35,10 +36,10 @@ index a6a8f3a..89c07d1 100644
  	case SND_PCM_STATE_XRUN:
  		if ((err = snd_pcm_direct_slave_recover(dmix)) < 0)
 diff --git a/src/pcm/pcm_dshare.c b/src/pcm/pcm_dshare.c
-index 7cdfea2..e0b4ea7 100644
+index a918512..18071fb 100644
 --- a/src/pcm/pcm_dshare.c
 +++ b/src/pcm/pcm_dshare.c
-@@ -261,9 +261,9 @@ static snd_pcm_state_t snd_pcm_dshare_state(snd_pcm_t *pcm)
+@@ -258,9 +258,9 @@ static snd_pcm_state_t snd_pcm_dshare_state(snd_pcm_t *pcm)
  	snd_pcm_state_t state;
  	state = snd_pcm_state(dshare->spcm);
  	switch (state) {
@@ -50,10 +51,10 @@ index 7cdfea2..e0b4ea7 100644
  	case SND_PCM_STATE_XRUN:
  		if ((err = snd_pcm_direct_slave_recover(dshare)) < 0)
 diff --git a/src/pcm/pcm_dsnoop.c b/src/pcm/pcm_dsnoop.c
-index 539b671..03df6ff 100644
+index 2c3b9f4..3b711ab 100644
 --- a/src/pcm/pcm_dsnoop.c
 +++ b/src/pcm/pcm_dsnoop.c
-@@ -212,9 +212,9 @@ static snd_pcm_state_t snd_pcm_dsnoop_state(snd_pcm_t *pcm)
+@@ -209,9 +209,9 @@ static snd_pcm_state_t snd_pcm_dsnoop_state(snd_pcm_t *pcm)
  	snd_pcm_state_t state;
  	state = snd_pcm_state(dsnoop->spcm);
  	switch (state) {
@@ -64,6 +65,3 @@ index 539b671..03df6ff 100644
  		return state;
  	case SND_PCM_STATE_XRUN:
  		if ((err = snd_pcm_direct_slave_recover(dsnoop)) < 0)
--- 
-2.7.4
-

--- a/recipes-multimedia/alsa/alsa-lib/0005-add-ak4458-conf-for-multichannel-support.patch
+++ b/recipes-multimedia/alsa/alsa-lib/0005-add-ak4458-conf-for-multichannel-support.patch
@@ -1,7 +1,10 @@
-From 1641ce8c724018365d7fa598f9a70c6492e7c271 Mon Sep 17 00:00:00 2001
+From d78b7e2b964c9713c2e9889f4ec85922528ba971 Mon Sep 17 00:00:00 2001
 From: Shengjiu Wang <shengjiu.wang@nxp.com>
 Date: Wed, 31 Jan 2018 15:06:53 +0800
 Subject: [PATCH] add ak4458 conf for multichannel support
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
 
 one limitation is that ALSA and pulseaudio only support
 maximum 8 channels, but ak4458 may support 16 channels
@@ -9,17 +12,19 @@ maximum 8 channels, but ak4458 may support 16 channels
 Upstream-Status: Inappropriate [i.MX specific]
 
 Signed-off-by: Shengjiu Wang <shengjiu.wang@nxp.com>
+
 ---
- src/conf/cards/AK4458.conf  | 74 +++++++++++++++++++++++++++++++++++++++++++++
+ src/conf/cards/AK4458.conf  | 74 +++++++++++++++++++++++++++++++++++++
  src/conf/cards/Makefile.am  |  3 +-
  src/conf/cards/aliases.conf |  1 +
  3 files changed, 77 insertions(+), 1 deletion(-)
  create mode 100644 src/conf/cards/AK4458.conf
 
-Index: alsa-lib-1.1.6/src/conf/cards/AK4458.conf
-===================================================================
+diff --git a/src/conf/cards/AK4458.conf b/src/conf/cards/AK4458.conf
+new file mode 100644
+index 0000000..3b5b195
 --- /dev/null
-+++ alsa-lib-1.1.6/src/conf/cards/AK4458.conf
++++ b/src/conf/cards/AK4458.conf
 @@ -0,0 +1,74 @@
 +#
 +# Configuration for the AK4458 chip
@@ -95,10 +100,10 @@ Index: alsa-lib-1.1.6/src/conf/cards/AK4458.conf
 +	}
 +	slave.channels 8
 +}
-Index: alsa-lib-1.1.6/src/conf/cards/Makefile.am
-===================================================================
---- alsa-lib-1.1.6.orig/src/conf/cards/Makefile.am
-+++ alsa-lib-1.1.6/src/conf/cards/Makefile.am
+diff --git a/src/conf/cards/Makefile.am b/src/conf/cards/Makefile.am
+index fbf0697..34fa5a3 100644
+--- a/src/conf/cards/Makefile.am
++++ b/src/conf/cards/Makefile.am
 @@ -60,7 +60,8 @@ cfg_files = aliases.conf \
  	VXPocket.conf \
  	VXPocket440.conf \
@@ -109,15 +114,15 @@ Index: alsa-lib-1.1.6/src/conf/cards/Makefile.am
  
  if BUILD_ALISP
  cfg_files += aliases.alisp
-Index: alsa-lib-1.1.6/src/conf/cards/aliases.conf
-===================================================================
---- alsa-lib-1.1.6.orig/src/conf/cards/aliases.conf
-+++ alsa-lib-1.1.6/src/conf/cards/aliases.conf
+diff --git a/src/conf/cards/aliases.conf b/src/conf/cards/aliases.conf
+index a9e6d76..2f0a22a 100644
+--- a/src/conf/cards/aliases.conf
++++ b/src/conf/cards/aliases.conf
 @@ -59,6 +59,7 @@ pistachio cards.pistachio-card
  VC4-HDMI cards.vc4-hdmi
- cs42888-audio cards.CS42888
+ imx-cs42888 cards.CS42888
  imx-hdmi-soc cards.IMX-HDMI
 +ak4458-audio cards.AK4458
  
+ <confdir:ctl/default.conf>
  <confdir:pcm/default.conf>
- <confdir:pcm/dmix.conf>

--- a/recipes-multimedia/alsa/alsa-lib/0006-add-conf-for-iMX-XCVR-sound-card.patch
+++ b/recipes-multimedia/alsa/alsa-lib/0006-add-conf-for-iMX-XCVR-sound-card.patch
@@ -1,4 +1,4 @@
-From 2fd2737a1a0553e164d1b4f78687edf573f8e621 Mon Sep 17 00:00:00 2001
+From cfbe756d55a303803805d3e8e3d3cf3b97866964 Mon Sep 17 00:00:00 2001
 From: Viorel Suman <viorel.suman@nxp.com>
 Date: Mon, 9 Mar 2020 14:25:46 +0200
 Subject: [PATCH] add conf for iMX XCVR sound card
@@ -6,8 +6,9 @@ Subject: [PATCH] add conf for iMX XCVR sound card
 Upstream Status: Pending
 
 Signed-off-by: Viorel Suman <viorel.suman@nxp.com>
+
 ---
- src/conf/cards/IMX-XCVR.conf | 69 ++++++++++++++++++++++++++++++++++++++++++++
+ src/conf/cards/IMX-XCVR.conf | 69 ++++++++++++++++++++++++++++++++++++
  src/conf/cards/Makefile.am   |  3 +-
  src/conf/cards/aliases.conf  |  1 +
  3 files changed, 72 insertions(+), 1 deletion(-)
@@ -103,17 +104,14 @@ index 34fa5a3..70b9bab 100644
  if BUILD_ALISP
  cfg_files += aliases.alisp
 diff --git a/src/conf/cards/aliases.conf b/src/conf/cards/aliases.conf
-index 5d92ac7..c195848 100644
+index 2f0a22a..e824145 100644
 --- a/src/conf/cards/aliases.conf
 +++ b/src/conf/cards/aliases.conf
 @@ -60,6 +60,7 @@ VC4-HDMI cards.vc4-hdmi
- cs42888-audio cards.CS42888
+ imx-cs42888 cards.CS42888
  imx-hdmi-soc cards.IMX-HDMI
  ak4458-audio cards.AK4458
 +imx-audio-xcvr cards.IMX-XCVR
  
+ <confdir:ctl/default.conf>
  <confdir:pcm/default.conf>
- <confdir:pcm/dmix.conf>
--- 
-2.7.4
-


### PR DESCRIPTION
The model name for the i.MX CS42888 sound card is imx-cs42888.

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>