### PR TITLE
gtk+3: Fix incorrect PACKAGECONFIG_remove

### DIFF
--- a/recipes-graphics/gtk+/gtk+3_%.bbappend
+++ b/recipes-graphics/gtk+/gtk+3_%.bbappend
@@ -1,5 +1,5 @@
 DEPENDS_append_imxgpu2d = " virtual/egl"
 
-PACKAGECONFIG_remove_imxgpu2d = " \
+PACKAGECONFIG_remove_pn-imxgpu2d = " \
     ${@bb.utils.contains("DISTRO_FEATURES", "wayland", "x11", "", d)} \
 "


### PR DESCRIPTION
Overridding PACKAGECONFIGs with PACKAGECONFIG_remove for a
different package than the current context requires the spelling
PACKAGECONFIG_pn-packagename (where packagename is replaced with
the packagename, but pn is a literal pn). The gtk+3 bbappend
uses PACKAGECONFIG_remove_imxgpu2d when it should be
PACKAGECONFIG_remove_pn-imxgpu2d, which makes the remove apply
to the recipe this is appended to (gtk+3 from openembedded-core),
which breaks gtk+3 when both wayland and x11 are in your distro
features as they are when requesting x11 backcompat for wayland.
It also makes the remove not actually apply to imxgpu2d.

Fixing the spelling here fixes both issues.

Signed-off-by: Seth Foster <seth@opentrons.com>