### PR TITLE
imx-gpu-apitrace: exclude from builds with glibc 2.34+

### DIFF
--- a/recipes-graphics/imx-gpu-apitrace/imx-gpu-apitrace_9.0.0.bb
+++ b/recipes-graphics/imx-gpu-apitrace/imx-gpu-apitrace_9.0.0.bb
@@ -44,3 +44,6 @@ FILES:${PN} += " \
 
 PACKAGE_ARCH = "${MACHINE_SOCARCH}"
 COMPATIBLE_MACHINE = "(imxgpu)"
+
+# see https://github.com/apitrace/apitrace/issues/756
+PNBLACKLIST[imx-gpu-apitrace] ?= "Upstream needs porting to glibc 2.34+"


### PR DESCRIPTION
Upstream project has issues with new glibc dropping `__libc_dlopen_mode` and `__libc_dlsym` functions, which were initially marked as **GLIBC_PRIVATE**.

Since according to https://github.com/apitrace/apitrace/issues/756 there is no solution for upstream at the moment, exclude the NXP fork of _apitrace_ from builds.

meta-oe has similar exclusion commit ba94b0fef ("apitrace: Exclude from builds with glibc 2.34+") for upstream component.

Cc: @thochstein 
Cc: @kraj 