### PR TITLE
u-boot-fslc: update to v2021.07

### DIFF
--- a/recipes-bsp/u-boot/u-boot-fslc-common_2021.07.inc
+++ b/recipes-bsp/u-boot/u-boot-fslc-common_2021.07.inc
@@ -10,7 +10,7 @@ DEPENDS += "flex-native bison-native"
 
 SRC_URI = "git://github.com/Freescale/u-boot-fslc.git;branch=${SRCBRANCH}"
 
-SRCREV = "587e796995604fb669a3552daae682b4d6d346d9"
+SRCREV = "691e634bfd317ede487d2b864a126847ffeb4aa7"
 SRCBRANCH = "2021.07+fslc"
 
 PV = "v2021.07+git${SRCPV}"


### PR DESCRIPTION
U-Boot repository has been upgraded to `v2021.07` from _DENX_ repository.

Upstream commits are recorded in corresponding recipe commit message.

Link: https://lore.kernel.org/u-boot/20210705151317.GW9516@bill-the-cat/
Link: https://github.com/Freescale/u-boot-fslc/pull/42
