### PR TITLE
imx-gpu-viv: Provides virtual/libgl for framebuffer

### DIFF
--- a/recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc
+++ b/recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc
@@ -27,9 +27,7 @@ DEPENDS += "${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'mesa', '', d)}"
 
 EXTRA_PROVIDES = ""
 EXTRA_PROVIDES:append:imxgpu3d = " \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'virtual/libgl', \
-       bb.utils.contains('DISTRO_FEATURES',     'x11', 'virtual/libgl', \
-                                                       '', d), d)} \
+    virtual/libgl \
     virtual/libgles1 \
     virtual/libgles2 \
 "


### PR DESCRIPTION
Support for GL on framebuffer is available for some time, at least
since 6.4.0.p2.6.

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>