### PR TITLE
imx-base.inc: Define a default value for OPTEE_BIN_EXT

### DIFF
--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -406,6 +406,7 @@ SOC_DEFAULT_IMAGE_FSTYPES:mxs = "uboot-mxsboot-sdcard wic.bmap wic.gz"
 # Do not update fstab file when using wic images
 WIC_CREATE_EXTRA_ARGS ?= "--no-fstab-update"
 
+OPTEE_BIN_EXT ??= ""
 OPTEE_BOOT_IMAGE         = "tee.bin uTee-${OPTEE_BIN_EXT}"
 OPTEE_BOOT_IMAGE:aarch64 = "tee.bin"
 


### PR DESCRIPTION
Without a default the IMAGE_BOOT_FILES is not parsed properly, leading
to the following error for machines without such a variable definition:

```
| ERROR: _exec_cmd: install -m 0644 -D /z/build-master/imx233-olinuxino-maxi/build/tmp-glibc/deploy/images/imx233-olinuxino-maxi/make_dtb_boot_files /z/build-master/imx233-olinuxino-maxi/build/tmp-glibc/work/imx233_olinuxino_maxi-oe-linux-gnueabi/core-image-base/1.0-r0/tmp-wic/boot.2/make_dtb_boot_files returned '1' instead of 0
| output: install: cannot stat '/z/build-master/imx233-olinuxino-maxi/build/tmp-glibc/deploy/images/imx233-olinuxino-maxi/make_dtb_boot_files': No such file or directory

ERROR: Task (/opt/oe/configs/z/build-master/imx233-olinuxino-maxi/layers/openembedded-core/meta/recipes-core/images/core-image-base.bb:do_image_wic) failed with exit code '1'
```

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>