### PR TITLE
conf: machine: imx8m: correct tune for mainline bsp

### DIFF
--- a/conf/machine/include/imx8mm-evk.inc
+++ b/conf/machine/include/imx8mm-evk.inc
@@ -3,6 +3,11 @@ MACHINEOVERRIDES =. "imx-boot-container:mx8:mx8m:mx8mm:"
 require conf/machine/include/imx-base.inc
 require conf/machine/include/arm/armv8a/tune-cortexa53.inc
 
+# Mainline BSP defaults to "generic" cortexa53 configuration,
+# adjust it here to include crypto extension which enables
+# inline NEON and FPU code generation
+DEFAULTTUNE:use-mainline-bsp = "cortexa53-crypto"
+
 MACHINE_FEATURES += "pci wifi bluetooth bcm43455 bcm4356"
 
 # NXP BSP can consume proprietary jailhouse, BCM4359, and QCA9377 driver and firmware

--- a/conf/machine/include/imx8mn-evk.inc
+++ b/conf/machine/include/imx8mn-evk.inc
@@ -3,6 +3,11 @@ MACHINEOVERRIDES =. "imx-boot-container:mx8:mx8m:mx8mn:"
 require conf/machine/include/imx-base.inc
 require conf/machine/include/arm/armv8a/tune-cortexa53.inc
 
+# Mainline BSP defaults to "generic" cortexa53 configuration,
+# adjust it here to include crypto extension which enables
+# inline NEON and FPU code generation
+DEFAULTTUNE:use-mainline-bsp = "cortexa53-crypto"
+
 MACHINE_FEATURES += "wifi bluetooth bcm43455 bcm4356"
 
 # NXP BSP can consume proprietary jailhouse and Broadcom drivers

--- a/conf/machine/include/imx8mp-evk.inc
+++ b/conf/machine/include/imx8mp-evk.inc
@@ -3,6 +3,11 @@ MACHINEOVERRIDES =. "imx-boot-container:mx8:mx8m:mx8mp:"
 require conf/machine/include/imx-base.inc
 require conf/machine/include/arm/armv8a/tune-cortexa53.inc
 
+# Mainline BSP defaults to "generic" cortexa53 configuration,
+# adjust it here to include crypto extension which enables
+# inline NEON and FPU code generation
+DEFAULTTUNE:use-mainline-bsp = "cortexa53-crypto"
+
 MACHINE_FEATURES += "pci wifi bluetooth"
 
 # NXP BSP can consume proprietary jailhouse and Marvell drivers


### PR DESCRIPTION
Mainline BSP does not contain imx8m in machine overrides, which causes
generic tunes to be set for i.MX8M derivates, rather than a more precise
tune which enables crypto extension. Those extensions are enabled in NXP
BSP due to those settings rely on machine overrides.

Adapt tunes for Mainline BSP in machine include files to include crypto
extensions and align it with NXP BSP.

-- andrey