### PR TITLE
imx-gpu-apitrace: enable back for glibc >= 2.34

### DIFF
--- a/recipes-graphics/imx-gpu-apitrace/imx-gpu-apitrace/0001-dlsym-workaround-glibc-2.34-build-failure.patch
+++ b/recipes-graphics/imx-gpu-apitrace/imx-gpu-apitrace/0001-dlsym-workaround-glibc-2.34-build-failure.patch
@@ -1,0 +1,33 @@
+From d11884c88eac803c174f759414d0162154450b6a Mon Sep 17 00:00:00 2001
+From: Andrey Zhizhikin <andrey.z@gmail.com>
+Date: Thu, 2 Sep 2021 09:43:33 +0000
+Subject: [PATCH] dlsym: workaround glibc 2.34 build failure
+
+As suggested in [1], upstream component does not have a solution for the
+issue, and therefore for glibc version >= 2.34 dlsym wrappers should be
+skipped.
+
+Link: [1]: https://github.com/apitrace/apitrace/issues/756
+
+Upstream-Status: Pending
+Signed-off-by: Andrey Zhizhikin <andrey.z@gmail.com>
+---
+ wrappers/dlsym.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/wrappers/dlsym.cpp b/wrappers/dlsym.cpp
+index cdf5cfdb..4061afc4 100644
+--- a/wrappers/dlsym.cpp
++++ b/wrappers/dlsym.cpp
+@@ -34,7 +34,7 @@
+ #include "os.hpp"
+ 
+ 
+-#ifdef __GLIBC__
++#if defined(__GLIBC__) && !(__GLIBC__ == 2 && __GLIBC_MINOR__ >= 34)
+ 
+ 
+ #include <dlfcn.h>
+-- 
+2.17.1
+

--- a/recipes-graphics/imx-gpu-apitrace/imx-gpu-apitrace_9.0.0.bb
+++ b/recipes-graphics/imx-gpu-apitrace/imx-gpu-apitrace_9.0.0.bb
@@ -4,7 +4,9 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=aeb969185a143c3c25130bc2c3ef9a50"
 DEPENDS = "imx-gpu-viv zlib libpng procps"
 
-SRC_URI = "git://source.codeaurora.org/external/imx/apitrace-imx.git;protocol=https;branch=imx_9.0"
+SRC_URI = "git://source.codeaurora.org/external/imx/apitrace-imx.git;protocol=https;branch=imx_9.0 \
+           file://0001-dlsym-workaround-glibc-2.34-build-failure.patch \
+"
 SRCREV = "c50e6a954e44998f2e3793a8de863e961f8008c6"
 
 S = "${WORKDIR}/git"
@@ -44,6 +46,3 @@ FILES:${PN} += " \
 
 PACKAGE_ARCH = "${MACHINE_SOCARCH}"
 COMPATIBLE_MACHINE = "(imxgpu)"
-
-# see https://github.com/apitrace/apitrace/issues/756
-PNBLACKLIST[imx-gpu-apitrace] ?= "Upstream needs porting to glibc 2.34+"


### PR DESCRIPTION
[Upsteam suggested](https://github.com/apitrace/apitrace/issues/756) that for glibc >= 2.34, dlsym wrappers can be disabled.

Similar commit is introduced in meta-oe:
`9fdc7960b ("apitrace: Enable on glibc >= 2.34")`

Cc: @thochstein