### PR TITLE
weston-init: modify weston.service file in do_install_append

### DIFF
--- a/recipes-graphics/wayland/weston-init.bbappend
+++ b/recipes-graphics/wayland/weston-init.bbappend
@@ -46,6 +46,13 @@ uncomment() {
     sed -i -e 's,^#'"$1"','"$1"',g' $2
 }
 
+update_file() {
+    if ! grep -q "$1" $3; then
+        bbfatal $1 not found in $3
+    fi
+    sed -i -e "s,$1,$2," $3
+}
+
 do_install_append() {
     if [ -f "${WORKDIR}/weston.config" ]; then
         install -Dm0755 ${WORKDIR}/weston.config ${D}${sysconfdir}/default/weston
@@ -53,4 +60,8 @@ do_install_append() {
     for assignment in ${INI_UNCOMMENT_ASSIGNMENTS}; do
         uncomment "$assignment" ${D}${sysconfdir}/xdg/weston/weston.ini
     done
+
+    # FIXME: weston should be run as weston, not as root
+    update_file "User=weston" "User=root" ${D}${systemd_system_unitdir}/weston.service
+    update_file "Group=weston" "Group=root" ${D}${systemd_system_unitdir}/weston.service
 }


### PR DESCRIPTION
As per:

https://source.codeaurora.org/external/imx/meta-imx/tree/meta-bsp/recipes-graphics/wayland/weston-init.bbappend?h=hardknott-5.10.35-2.0.0

Replace weston user/group with root. weston should be run as weston,
not as root, but needed for now to run things like GPU demos or
gstreamer pipelines as the default root user in the BSP.

Signed-off-by: Chris Dimich <Chris.Dimich@boundarydevices.com>