### PR TITLE
imx8mm-evk.inc: Drop qca9377

### DIFF
--- a/conf/machine/include/imx8mm-evk.inc
+++ b/conf/machine/include/imx8mm-evk.inc
@@ -10,13 +10,13 @@ DEFAULTTUNE:use-mainline-bsp = "cortexa53-crypto"
 
 MACHINE_FEATURES += "pci wifi bluetooth bcm43455 bcm4356"
 
-# NXP BSP can consume proprietary jailhouse, BCM4359, and QCA9377 driver and firmware
+# NXP BSP can consume proprietary jailhouse and BCM4359 firmware
 # Since the firmware is not available publicly, and rather distributed
 # under "Proprietary" license - we opt-out from using it in all BSPs
 # and pin it to NXP BSP only
 # OP-TEE is also applicable to NXP BSP, mainline BSP seems not to have
 # a full support for it yet.
-MACHINE_FEATURES:append:use-nxp-bsp = " optee jailhouse bcm4359 qca9377"
+MACHINE_FEATURES:append:use-nxp-bsp = " optee jailhouse bcm4359"
 
 KERNEL_DEVICETREE = " \
     freescale/${KERNEL_DEVICETREE_BASENAME}.dtb \


### PR DESCRIPTION
The build for kernel-module-qca9377 is broken:

```
| /.../yocto/master/build/tmp/work/imx8mm_lpddr4_evk-fsl-linux/kernel-module-qca9377/3.1-r0/git/CORE/SERVICES/COMMON/adf/linux/adf_os_dma_pvt.h:104:25: error: 'DMA_ATTR_NON_CONSISTENT' undeclared (first use in this function)
|   104 |                         DMA_ATTR_NON_CONSISTENT);
|       |                         ^~~~~~~~~~~~~~~~~~~~~~~
```

The Linux API here is changed for 5.10, so the i.MX fork is now
incompatible. Nothing suitable is found in Qualcomm's source either,
so drop qca9377.

Fixes: #851
Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>