### PR TITLE
imx-boot-container.bbclass: support having more than one UBOOT_CONFIG

### DIFF
--- a/classes/imx-boot-container.bbclass
+++ b/classes/imx-boot-container.bbclass
@@ -85,10 +85,17 @@ do_deploy_append() {
                 j=$(expr $j + 1);
                 if [ $j -eq $i ]
                 then
-                    install -m 0644 ${B}/${config}/u-boot.itb  ${DEPLOYDIR}/u-boot.itb-${MACHINE}-${UBOOT_CONFIG}
-                    install -m 0644 ${B}/${config}/flash.bin  ${DEPLOYDIR}/flash.bin-${MACHINE}-${UBOOT_CONFIG}
-                    ln -sf u-boot.itb-${MACHINE}-${UBOOT_CONFIG} u-boot.itb
-                    ln -sf flash.bin-${MACHINE}-${UBOOT_CONFIG} flash.bin
+                    install -m 0644 ${B}/${config}/u-boot.itb  ${DEPLOYDIR}/u-boot.itb-${MACHINE}-${type}
+                    install -m 0644 ${B}/${config}/flash.bin  ${DEPLOYDIR}/flash.bin-${MACHINE}-${type}
+                    # When there's more than one word in UBOOT_CONFIG,
+                    # this will overwrite the links created in
+                    # previous loop iterations, effectively making
+                    # u-boot.itb and flash.bin correspond to the _last_
+                    # word in UBOOT_CONFIG. This is also how all other
+                    # artifacts handled by oe-core's u-boot.inc are
+                    # treated.
+                    ln -sf u-boot.itb-${MACHINE}-${type} u-boot.itb
+                    ln -sf flash.bin-${MACHINE}-${type} flash.bin
                 fi
             done
             unset  j


### PR DESCRIPTION
The whole purpose of the UBOOT_CONFIG machinery is to allow one to
build multiple versions of U-Boot within the same recipe, e.g. one for
writing to an eMMC boot partition, and one for use with an SD card for
bootstrapping/recovery. But the current code here assumes UBOOT_CONFIG
consists of just a single word (and normally leading whitespace in that
variable would be harmless).

So use the variable ${type} which gets set in turn to each individual
word in UBOOT_CONFIG. For compatibility, keep creating the u-boot.itb
and flash.bin symlinks, but only for the first type in
UBOOT_CONFIG.

It might be better (a little less arbitrary) to make the test
something like

  if [ ${type} = "sd" ]

but that's not entirely equivalent to the current code if UBOOT_CONFIG
does consist of a single word, but not the word "sd". Long-term, it's
likely better to just update the wic definition to point at the proper
file instead of adding compatibility symlinks.