### PR TITLE
Consolidated Kernel update (v5.4.147 + v5.10.67 + 5.14.6)

### DIFF
--- a/recipes-kernel/linux/linux-fslc-imx_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_5.4.bb
@@ -28,7 +28,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v5.4.143
+#    tag: v5.4.144
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
@@ -86,14 +86,14 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
 KBRANCH = "5.4-2.3.x-imx"
-SRCREV = "992eac2c403de62a640246018204afc58180ab5e"
+SRCREV = "bead25ae325e60cd00710df183254bd698f8a3d0"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.143"
+LINUX_VERSION = "5.4.144"
 
 # Local version indicates the branch name in the NXP kernel tree where patches are collected from.
 LOCALVERSION = "-5.4.70-2.3.0"

--- a/recipes-kernel/linux/linux-fslc-imx_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_5.4.bb
@@ -28,7 +28,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v5.4.141
+#    tag: v5.4.142
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
@@ -86,14 +86,14 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
 KBRANCH = "5.4-2.3.x-imx"
-SRCREV = "a5b253b55d22f8845a6450001c408d93c8baeeeb"
+SRCREV = "4d7089e573e63cefc3a71bc91bb8eb932d3a9348"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.141"
+LINUX_VERSION = "5.4.142"
 
 # Local version indicates the branch name in the NXP kernel tree where patches are collected from.
 LOCALVERSION = "-5.4.70-2.3.0"

--- a/recipes-kernel/linux/linux-fslc-imx_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_5.4.bb
@@ -28,7 +28,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v5.4.134
+#    tag: v5.4.141
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
@@ -86,14 +86,14 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
 KBRANCH = "5.4-2.3.x-imx"
-SRCREV = "e3b082933caab27829e775606708381fe1b7c3ba"
+SRCREV = "a5b253b55d22f8845a6450001c408d93c8baeeeb"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.134"
+LINUX_VERSION = "5.4.141"
 
 # Local version indicates the branch name in the NXP kernel tree where patches are collected from.
 LOCALVERSION = "-5.4.70-2.3.0"

--- a/recipes-kernel/linux/linux-fslc-imx_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_5.4.bb
@@ -28,7 +28,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v5.4.145
+#    tag: v5.4.147
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
@@ -86,14 +86,14 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
 KBRANCH = "5.4-2.3.x-imx"
-SRCREV = "e54bee29a4192399bac0a07b7267869733b26457"
+SRCREV = "aad410850445424f566e57a419527b6e2d3ab42d"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.145"
+LINUX_VERSION = "5.4.147"
 
 # Local version indicates the branch name in the NXP kernel tree where patches are collected from.
 LOCALVERSION = "-5.4.70-2.3.0"

--- a/recipes-kernel/linux/linux-fslc-imx_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_5.4.bb
@@ -28,7 +28,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v5.4.142
+#    tag: v5.4.143
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
@@ -86,14 +86,14 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
 KBRANCH = "5.4-2.3.x-imx"
-SRCREV = "4d7089e573e63cefc3a71bc91bb8eb932d3a9348"
+SRCREV = "992eac2c403de62a640246018204afc58180ab5e"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.142"
+LINUX_VERSION = "5.4.143"
 
 # Local version indicates the branch name in the NXP kernel tree where patches are collected from.
 LOCALVERSION = "-5.4.70-2.3.0"

--- a/recipes-kernel/linux/linux-fslc-imx_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_5.4.bb
@@ -28,7 +28,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v5.4.144
+#    tag: v5.4.145
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
@@ -86,14 +86,14 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
 KBRANCH = "5.4-2.3.x-imx"
-SRCREV = "bead25ae325e60cd00710df183254bd698f8a3d0"
+SRCREV = "e54bee29a4192399bac0a07b7267869733b26457"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.144"
+LINUX_VERSION = "5.4.145"
 
 # Local version indicates the branch name in the NXP kernel tree where patches are collected from.
 LOCALVERSION = "-5.4.70-2.3.0"

--- a/recipes-kernel/linux/linux-fslc-lts_5.10.bb
+++ b/recipes-kernel/linux/linux-fslc-lts_5.10.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.10.62"
+LINUX_VERSION = "5.10.64"
 
 KBRANCH = "5.10.x+fslc"
-SRCREV = "e4e0f7ffbed445d4559db8d19a5247636dd7fc23"
+SRCREV = "d2ffd8a38756da23967dd0e724f3fc6edebeb10a"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"

--- a/recipes-kernel/linux/linux-fslc-lts_5.10.bb
+++ b/recipes-kernel/linux/linux-fslc-lts_5.10.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.10.55"
+LINUX_VERSION = "5.10.56"
 
 KBRANCH = "5.10.x+fslc"
-SRCREV = "c2d04702d915f0621c4046dca990b2890c29f54c"
+SRCREV = "6d231414e892bd6ac80dedeba21ce6753bdcaa34"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"

--- a/recipes-kernel/linux/linux-fslc-lts_5.10.bb
+++ b/recipes-kernel/linux/linux-fslc-lts_5.10.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.10.56"
+LINUX_VERSION = "5.10.57"
 
 KBRANCH = "5.10.x+fslc"
-SRCREV = "6d231414e892bd6ac80dedeba21ce6753bdcaa34"
+SRCREV = "b29243d6ab6b9b45ed68000bd97fe36c64fddd73"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"

--- a/recipes-kernel/linux/linux-fslc-lts_5.10.bb
+++ b/recipes-kernel/linux/linux-fslc-lts_5.10.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.10.59"
+LINUX_VERSION = "5.10.60"
 
 KBRANCH = "5.10.x+fslc"
-SRCREV = "04d3f58281f3ae0b8dcb1b86c6ee44703137e7e5"
+SRCREV = "db9476087eabff8007bce096a1b87b7b254d244d"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"

--- a/recipes-kernel/linux/linux-fslc-lts_5.10.bb
+++ b/recipes-kernel/linux/linux-fslc-lts_5.10.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.10.54"
+LINUX_VERSION = "5.10.55"
 
 KBRANCH = "5.10.x+fslc"
-SRCREV = "6fe3cad42247e89bc62d2d9864a618a0ba7de99b"
+SRCREV = "c2d04702d915f0621c4046dca990b2890c29f54c"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"

--- a/recipes-kernel/linux/linux-fslc-lts_5.10.bb
+++ b/recipes-kernel/linux/linux-fslc-lts_5.10.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.10.66"
+LINUX_VERSION = "5.10.67"
 
 KBRANCH = "5.10.x+fslc"
-SRCREV = "540e779464c1c701449a565b4185a702204e9cb8"
+SRCREV = "5d6224bd7e38de87fa7dcef0046e6f7377d68660"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"

--- a/recipes-kernel/linux/linux-fslc-lts_5.10.bb
+++ b/recipes-kernel/linux/linux-fslc-lts_5.10.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.10.52"
+LINUX_VERSION = "5.10.54"
 
 KBRANCH = "5.10.x+fslc"
-SRCREV = "cb67a3e29a88e06e2891f8e2aac289305d8f08ff"
+SRCREV = "6fe3cad42247e89bc62d2d9864a618a0ba7de99b"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"

--- a/recipes-kernel/linux/linux-fslc-lts_5.10.bb
+++ b/recipes-kernel/linux/linux-fslc-lts_5.10.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.10.58"
+LINUX_VERSION = "5.10.59"
 
 KBRANCH = "5.10.x+fslc"
-SRCREV = "cf1bebbb69c45619088db7f740626209a12f6cd4"
+SRCREV = "04d3f58281f3ae0b8dcb1b86c6ee44703137e7e5"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"

--- a/recipes-kernel/linux/linux-fslc-lts_5.10.bb
+++ b/recipes-kernel/linux/linux-fslc-lts_5.10.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.10.57"
+LINUX_VERSION = "5.10.58"
 
 KBRANCH = "5.10.x+fslc"
-SRCREV = "b29243d6ab6b9b45ed68000bd97fe36c64fddd73"
+SRCREV = "cf1bebbb69c45619088db7f740626209a12f6cd4"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"

--- a/recipes-kernel/linux/linux-fslc-lts_5.10.bb
+++ b/recipes-kernel/linux/linux-fslc-lts_5.10.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.10.61"
+LINUX_VERSION = "5.10.62"
 
 KBRANCH = "5.10.x+fslc"
-SRCREV = "bfcccf5fa99f1f1389e7bad0817061d952db1cbc"
+SRCREV = "e4e0f7ffbed445d4559db8d19a5247636dd7fc23"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"

--- a/recipes-kernel/linux/linux-fslc-lts_5.10.bb
+++ b/recipes-kernel/linux/linux-fslc-lts_5.10.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.10.60"
+LINUX_VERSION = "5.10.61"
 
 KBRANCH = "5.10.x+fslc"
-SRCREV = "db9476087eabff8007bce096a1b87b7b254d244d"
+SRCREV = "bfcccf5fa99f1f1389e7bad0817061d952db1cbc"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"

--- a/recipes-kernel/linux/linux-fslc-lts_5.10.bb
+++ b/recipes-kernel/linux/linux-fslc-lts_5.10.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.10.64"
+LINUX_VERSION = "5.10.66"
 
 KBRANCH = "5.10.x+fslc"
-SRCREV = "d2ffd8a38756da23967dd0e724f3fc6edebeb10a"
+SRCREV = "540e779464c1c701449a565b4185a702204e9cb8"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"

--- a/recipes-kernel/linux/linux-fslc_5.14.bb
+++ b/recipes-kernel/linux/linux-fslc_5.14.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.14.5"
+LINUX_VERSION = "5.14.6"
 
 KBRANCH = "5.14.x+fslc"
-SRCREV = "065fd8439f339d85e378ae0d32257a824e860e48"
+SRCREV = "79bcc3a5a2e73ad1024c63fd0e7c368652e48145"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"

--- a/recipes-kernel/linux/linux-fslc_5.14.bb
+++ b/recipes-kernel/linux/linux-fslc_5.14.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.14.3"
+LINUX_VERSION = "5.14.5"
 
 KBRANCH = "5.14.x+fslc"
-SRCREV = "4b88a1ee28e7be1fce90e389d786575408924d65"
+SRCREV = "065fd8439f339d85e378ae0d32257a824e860e48"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"


### PR DESCRIPTION
Kernel branches were updated up to and including following versions for recipes from stable korg:
- `linux-fslc-imx`: _v5.4.147_
- `linux-fslc-lts`: _v5.10.67_
- `linux-fslc`: _v5.14.6_

Update recipe `SRCREV` to point to those versions now.

Upstream commits and resolved conflicts are recorded in corresponding recipe commit messages.

Recipe commits are separated based on PR in _linux-fslc_ repository in order to provide a possibility to bisect kernel versions in case of faults (both build and runtime).

-- andrey