### PR TITLE
linux-imx*: upgrade to 5.10.52

### DIFF
--- a/recipes-kernel/kernel-modules/kernel-module-imx-gpu-viv_6.4.3.p2.0.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-imx-gpu-viv_6.4.3.p2.0.bb
@@ -8,7 +8,7 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6"
 
 SRCBRANCH = "lf-5.10.y"
-LOCALVERSION = "-5.10.35-2.0.0"
+LOCALVERSION = "-5.10.52-2.1.0"
 KERNEL_SRC ?= "git://source.codeaurora.org/external/imx/linux-imx.git;protocol=https"
 SRC_URI = " \
     ${KERNEL_SRC};branch=${SRCBRANCH};subpath=drivers/mxc/gpu-viv;destsuffix=git/src \

--- a/recipes-kernel/linux/linux-imx-headers_5.10.bb
+++ b/recipes-kernel/linux/linux-imx-headers_5.10.bb
@@ -8,7 +8,7 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
 SRCBRANCH = "lf-5.10.y"
-LOCALVERSION = "-5.10.35-2.0.0"
+LOCALVERSION = "-5.10.52-2.1.0"
 SRC_URI = "git://source.codeaurora.org/external/imx/linux-imx.git;protocol=https;branch=${SRCBRANCH}"
 SRCREV = "ef3f2cfc6010c13feb40cfb7fd7490832cf86f45"
 

--- a/recipes-kernel/linux/linux-imx_5.10.bb
+++ b/recipes-kernel/linux/linux-imx_5.10.bb
@@ -18,15 +18,15 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 DEPENDS += "lzop-native bc-native"
 
 SRCBRANCH = "lf-5.10.y"
-LOCALVERSION = "-5.10.35-2.0.0"
-SRCREV = "ef3f2cfc6010c13feb40cfb7fd7490832cf86f45"
+LOCALVERSION = "-5.10.52-2.1.0"
+SRCREV = "a11753a89ec610768301d4070e10b8bd60fde8cd"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.10.35"
+LINUX_VERSION = "5.10.52"
 
 DEFAULT_PREFERENCE = "1"
 


### PR DESCRIPTION
I found out that linux.imx is broken for target imx8mp-evk-lpddr4 after commit 93cf9cd9492e4c932591806f6bafc43270a934d8. Fixed this by upgrading kernel to 5.10.52-2.1.0. Also bumped linux-imx-hraders and kernel-module-imx-gpu-viv that also had references to 5.10.35.