### PR TITLE
uuu: Limit target recipe to to imx machines

### DIFF
--- a/recipes-devtools/uuu/uuu_git.bb
+++ b/recipes-devtools/uuu/uuu_git.bb
@@ -17,4 +17,6 @@ S = "${WORKDIR}/git"
 
 DEPENDS = "libusb zlib bzip2 openssl"
 
+COMPATIBLE_MACHINE   = "(imx)"
+
 BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
uuu is not used in other SOCs

Signed-off-by: Khem Raj <raj.khem@gmail.com>