### PR TITLE
imx6ullevk: remove obsolete device tree entry

### DIFF
--- a/conf/machine/imx6ullevk.conf
+++ b/conf/machine/imx6ullevk.conf
@@ -17,7 +17,6 @@ KERNEL_DEVICETREE = " \
 
 KERNEL_DEVICETREE_append_use-nxp-bsp = " \
 	imx6ull-14x14-evk-btwifi.dtb \
-	imx6ull-14x14-evk-btwifi-oob.dtb \
 	imx6ull-14x14-evk-emmc.dtb \
 	imx6ull-14x14-evk-gpmi-weim.dtb \
 "


### PR DESCRIPTION
The imx6ul-14x14-evk-btwifi-oob.dtb has been removed from the Linux
kernel lf-5.10.y since the
commit a1488e98156e ("MLK-25618-1: arm: dts: imx6/7: clean up the old supported wifi/bt nodes to better support nxp wifi/bt")

Bumping linux-imx_5.10.bb recipe to 5.10.52 broke building a kernel
for imx6ullevk.

Remove an entry for a non-existent dtb file. This fixes building a
Linux kernel recipe for imx6ullevk.

Fixes: c0659168 ("linux-imx*: Upgrade to 5.10.52")
Signed-off-by: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>