### PR TITLE
imx-lib: fix packaging

### DIFF
--- a/recipes-bsp/imx-lib/imx-lib_git.bb
+++ b/recipes-bsp/imx-lib/imx-lib_git.bb
@@ -42,6 +42,9 @@ do_compile () {
 
 do_install () {
     oe_runmake PLATFORM="${PLATFORM}" DEST_DIR="${D}" install
+
+    # Remove .go file for Android
+    find ${D}/ -name *.go -exec rm {} \;
 }
 
 COMPATIBLE_MACHINE = "(mx6|mx7|mx8ulp)"


### PR DESCRIPTION
Fixes commit 87cb0d99 ("imx-lib: upgrade to 5.10.52_2.1.0")

| ERROR: imx-lib-1_5.9+AUTOINC+87ddd80953-r0 do_package: QA Issue: imx-lib: Files/directories were installed but not shipped in any package:
|   /usr/lib/libcec.go
|   /usr/lib/libipu.go

Signed-off-by: Max Krummenacher <max.krummenacher@toradex.com>