### PR TITLE
Draft: Master isp imx

### DIFF
--- a/recipes-bsp/isp-imx/isp-imx/0001-isp-imx-drop-use-of-__TIME__-__DATE__.patch
+++ b/recipes-bsp/isp-imx/isp-imx/0001-isp-imx-drop-use-of-__TIME__-__DATE__.patch
@@ -1,6 +1,6 @@
-From accaeb1ae77eb40b89e70df3efcb00d0dc2af758 Mon Sep 17 00:00:00 2001
+From ea5ce303fa5bc7b6a17c522b4caf49d349adb12b Mon Sep 17 00:00:00 2001
 From: Max Krummenacher <max.krummenacher@toradex.com>
-Date: Mon, 14 Jun 2021 08:20:48 +0000
+Date: Sat, 30 Oct 2021 17:26:42 +0200
 Subject: [PATCH] isp-imx: drop use of __TIME__, __DATE__
 
 With reproducible build enabled the compiler is configured to throw
@@ -21,7 +21,7 @@ Signed-off-by: Max Krummenacher <max.krummenacher@toradex.com>
  2 files changed, 7 insertions(+), 4 deletions(-)
 
 diff --git a/mediacontrol/CMakeLists.txt b/mediacontrol/CMakeLists.txt
-index 48cd7633e..f587758e0 100755
+index 5849c163e..8a8e1a4a0 100755
 --- a/mediacontrol/CMakeLists.txt
 +++ b/mediacontrol/CMakeLists.txt
 @@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.1.0)
@@ -35,38 +35,38 @@ index 48cd7633e..f587758e0 100755
      if(DEFINED PLATFORM)
          if(${PLATFORM} STREQUAL ARM64)
 diff --git a/mediacontrol/daemon/main_v4l2.cpp b/mediacontrol/daemon/main_v4l2.cpp
-index a3033cf83..d08dee127 100644
+index d3d1c2423..dd0514358 100644
 --- a/mediacontrol/daemon/main_v4l2.cpp
 +++ b/mediacontrol/daemon/main_v4l2.cpp
-@@ -96,7 +96,7 @@ int main(int argc, char* argv[]) {
-     if (argc ==  2){
+@@ -105,7 +105,7 @@ int main(int argc, char* argv[]) {
           if(!(string2Version.find(argv[1])==string2Version.end())){
               std::cout << "Version : "<<MEDIA_SERVER_VERSION<<std::endl;
+ #ifndef ANDROID
 -             std::cout << "Build Time : "<<__DATE__<<", "<<__TIME__<<std::endl;
 +             std::cout << "Build Time : "<<BUILD_DATE<<std::endl;
+ #endif
               return 0;
           }
-     }
-@@ -105,8 +105,8 @@ int main(int argc, char* argv[]) {
-     if(fd_running >= 0)
+@@ -116,8 +116,8 @@ int main(int argc, char* argv[]) {
      {
          ALOGI("******************************************************************");
+ #ifndef ANDROID
 -        ALOGI("VIV ISP Media Control Framework V%s (%s, %s)",
 -              MEDIA_SERVER_VERSION, __DATE__, __TIME__);
 +        ALOGI("VIV ISP Media Control Framework V%s (%s)",
 +              MEDIA_SERVER_VERSION, BUILD_DATE);
-         ALOGI("******************************************************************\n");
- 
-         if (argc < 2) {
-@@ -123,7 +123,7 @@ int main(int argc, char* argv[]) {
-         while( i < argc ){
+ #else
+         ALOGI("VIV ISP Media Control Framework V%s", MEDIA_SERVER_VERSION);
+ #endif
+@@ -138,7 +138,7 @@ int main(int argc, char* argv[]) {
                  if(!(string2Version.find(argv[i])==string2Version.end())){
                      std::cout << "Version : "<<MEDIA_SERVER_VERSION<<std::endl;
+ #ifndef ANDROID
 -                    std::cout << "Build Time : "<<__DATE__<<", "<<__TIME__<<std::endl;
 +                    std::cout << "Build Time : "<<BUILD_DATE<<std::endl;
+ #endif
                      i++;
                      continue;
-                  }
 -- 
 2.20.1
 

--- a/recipes-bsp/isp-imx/isp-imx_4.2.2.15.0.bb
+++ b/recipes-bsp/isp-imx/isp-imx_4.2.2.15.0.bb
@@ -2,7 +2,7 @@
 
 DESCRIPTION = "i.MX Verisilicon Software ISP"
 LICENSE = "Proprietary"
-LIC_FILES_CHKSUM = "file://COPYING;md5=e565271ec9a80ce47abbddc4bffe56fa" 
+LIC_FILES_CHKSUM = "file://COPYING;md5=e565271ec9a80ce47abbddc4bffe56fa"
 DEPENDS = "python3 libdrm virtual/libg2d libtinyxml2"
 
 SRC_URI = " \
@@ -25,6 +25,7 @@ OECMAKE_GENERATOR = "Unix Makefiles"
 SYSTEMD_SERVICE:${PN} = "imx8-isp.service"
 
 EXTRA_OECMAKE += " \
+    -DSDKTARGETSYSROOT=${STAGING_DIR_HOST} \
     -DCMAKE_BUILD_TYPE=release \
     -DISP_VERSION=ISP8000NANO_V1802 \
     -DPLATFORM=ARM64 \

--- a/recipes-bsp/isp-imx/isp-imx_4.2.2.15.0.bb
+++ b/recipes-bsp/isp-imx/isp-imx_4.2.2.15.0.bb
@@ -3,7 +3,7 @@
 DESCRIPTION = "i.MX Verisilicon Software ISP"
 LICENSE = "Proprietary"
 LIC_FILES_CHKSUM = "file://COPYING;md5=e565271ec9a80ce47abbddc4bffe56fa"
-DEPENDS = "python3 libdrm virtual/libg2d libtinyxml2"
+DEPENDS = "python3 libdrm virtual/libg2d libtinyxml2-8"
 
 SRC_URI = " \
     ${FSL_MIRROR}/${BP}.bin;fsl-eula=true \
@@ -45,6 +45,10 @@ EXTRA_OECMAKE += " \
 
 do_configure:prepend() {
     export SDKTARGETSYSROOT=${STAGING_DIR_HOST}
+}
+
+do_compile:prepend() {
+    ln -sf ${RECIPE_SYSROOT}/${libdir}/libtinyxml2.so.?.?.? ${RECIPE_SYSROOT}/${libdir}/libtinyxml2.so
 }
 
 do_install() {

--- a/recipes-bsp/isp-imx/isp-imx_4.2.2.15.0.bb
+++ b/recipes-bsp/isp-imx/isp-imx_4.2.2.15.0.bb
@@ -60,7 +60,6 @@ do_install() {
     cp -r ${WORKDIR}/build/generated/release/bin/*2775* ${D}/opt/imx8-isp/bin
     cp -r ${WORKDIR}/build/generated/release/bin/isp_media_server ${D}/opt/imx8-isp/bin
     cp -r ${WORKDIR}/build/generated/release/bin/vvext ${D}/opt/imx8-isp/bin
-    cp -r ${WORKDIR}/${BP}/dewarp/dewarp_config/ ${D}/opt/imx8-isp/bin
     cp -r ${WORKDIR}/build/generated/release/lib/*.so* ${D}/${libdir}
     cp -r ${WORKDIR}/build/generated/release/include/* ${D}/${includedir}
 

--- a/recipes-bsp/isp-imx/libtinyxml2-8_8.0.0.bb
+++ b/recipes-bsp/isp-imx/libtinyxml2-8_8.0.0.bb
@@ -1,0 +1,22 @@
+SUMMARY = "TinyXML-2 is a simple, small, efficient, C++ XML parser that can be easily integrating into other programs"
+HOMEPAGE = "http://www.grinninglizard.com/tinyxml2/"
+SECTION = "libs"
+LICENSE = "Zlib"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=135624eef03e1f1101b9ba9ac9b5fffd"
+
+SRC_URI = "git://github.com/leethomason/tinyxml2.git"
+
+SRCREV = "bf15233ad88390461f6ab0dbcf046cce643c5fcb"
+
+S = "${WORKDIR}/git"
+
+inherit cmake
+
+# make sure we don't provide files which are also present in the
+# current libtinyxml2 version's -dev package.
+do_install:append() {
+    rm -rf ${D}/${includedir}
+    rm -rf ${D}/${libdir}/cmake
+    rm -rf ${D}/${libdir}/libtinyxml2.so
+    rm -rf ${D}/${libdir}/pkgconfig
+}


### PR DESCRIPTION
isp-imx currently does not build, These two patches do address the do_patch and do_configure failures.

However there seems to be a binary only file deployed linked against an older version of libtinyxml2 and thus a QA error is generated. (libtinyxml2.so.9 is now provided from meta-openembedded) resulting in:

```
ERROR: isp-imx-4.2.2.15.0-r0 do_package_qa: QA Issue: /usr/lib/libcam_device.so contained in package isp-imx requires libtinyxml2.so.8()(64bit), but no providers found in RDEPENDS:isp-imx? [file-rdeps]
ERROR: isp-imx-4.2.2.15.0-r0 do_package_qa: QA run found fatal errors. Please consider fixing them.
ERROR: Logfile of failure stored in: /build/krm/oe-core_master/build/tmp/work/aarch64-mx8mp-tdx-linux/isp-imx/4.2.2.15.0-r0/temp/log.do_package_qa.6780
ERROR: Task (/build/krm/oe-core_master/build/../layers/meta-freescale/recipes-bsp/isp-imx/isp-imx_4.2.2.15.0.bb:do_package_qa) failed with exit code '1'
```

For this I have no solution yet, so I don't think we should merge this. I just wanted to make the first part of the fix public.