### PR TITLE
imx8qm-mek: remove obsolete dtb

### DIFF
--- a/conf/machine/imx8qm-mek.conf
+++ b/conf/machine/imx8qm-mek.conf
@@ -32,7 +32,6 @@ KERNEL_DEVICETREE = " \
 	freescale/imx8qm-mek-dom0.dtb \
 	freescale/imx8qm-mek-domu.dtb \
 	freescale/imx8qm-mek-dsi-rm67191.dtb \
-	freescale/imx8qm-mek-dsp.dtb \
 	freescale/imx8qm-mek-enet2-tja1100.dtb \
 	freescale/imx8qm-mek-esai.dtb \
 	freescale/imx8qm-mek-hdmi.dtb \


### PR DESCRIPTION
imx8qm-mek-dsp.dtb is no longer available in the kernel,
it was removed in de78ae45bfffed2c9490ab733d11ebab2672984d

Signed-off-by: Samuli Piippo <samuli.piippo@qt.io>