### PR TITLE
imx8x-mek.inc: Remove obsolete dtb for DSP

### DIFF
--- a/conf/machine/include/imx8x-mek.inc
+++ b/conf/machine/include/imx8x-mek.inc
@@ -26,7 +26,6 @@ KERNEL_DEVICETREE = " \
 KERNEL_DEVICETREE:append:use-nxp-bsp = " \
     freescale/${KERNEL_DEVICETREE_BASENAME}-dsi-rm67191.dtb \
     freescale/${KERNEL_DEVICETREE_BASENAME}-dsi-rm67191-rpmsg.dtb \
-    freescale/${KERNEL_DEVICETREE_BASENAME}-dsp.dtb \
     freescale/${KERNEL_DEVICETREE_BASENAME}-enet2-tja1100.dtb \
     freescale/${KERNEL_DEVICETREE_BASENAME}-it6263-lvds0-dual-channel.dtb \
     freescale/${KERNEL_DEVICETREE_BASENAME}-it6263-lvds0-dual-channel-rpmsg.dtb \


### PR DESCRIPTION
Some dtb for DSP were removed from the kernel.

Signed-off-by: Vinicius Aquino <vinicius.aquino@ossystems.com.br>