### PR TITLE
recipes: use https protocol and add explicit branch parameter

### DIFF
--- a/dynamic-layers/chromium-browser-layer/recipes-browser/chromium/chromium-imx.inc
+++ b/dynamic-layers/chromium-browser-layer/recipes-browser/chromium/chromium-imx.inc
@@ -14,7 +14,7 @@ CHROMIUM_IMX_COMMON_PATCHES ?= " "
 CHROMIUM_IMX_VPU_PATCHES ?= " "
 CHROMIUM_IMX_WAYLAND_PATCHES ?= " "
 
-SRC_URI += "git://github.com/Freescale/chromium-imx.git;destsuffix=${CHROMIUM_IMX_DESTSUFFIX};branch=${CHROMIUM_IMX_BRANCH};rev=${CHROMIUM_IMX_SRCREV}"
+SRC_URI += "git://github.com/Freescale/chromium-imx.git;destsuffix=${CHROMIUM_IMX_DESTSUFFIX};branch=${CHROMIUM_IMX_BRANCH};rev=${CHROMIUM_IMX_SRCREV};protocol=https"
 
 do_unpack[postfuncs] += "copy_chromium_imx_files"
 # using =+ instead of += to make sure add_chromium_imx_patches is

--- a/recipes-bsp/atf/qoriq-atf_2.4.bb
+++ b/recipes-bsp/atf/qoriq-atf_2.4.bb
@@ -7,7 +7,7 @@ DEPENDS:append:lx2160a += "ddr-phy"
 DEPENDS:append:lx2162a += "ddr-phy"
 do_compile[depends] += "u-boot:do_deploy rcw:do_deploy uefi:do_deploy"
 
-SRC_URI += "git://github.com/ARMmbed/mbedtls;nobranch=1;destsuffix=git/mbedtls;name=mbedtls"
+SRC_URI += "git://github.com/ARMmbed/mbedtls;nobranch=1;destsuffix=git/mbedtls;name=mbedtls;protocol=https"
 SRCREV_mbedtls = "0795874acdf887290b2571b193cafd3c4041a708"
 SRCREV_FORMAT = "atf"
 

--- a/recipes-bsp/ddr-phy/ddr-phy_git.bb
+++ b/recipes-bsp/ddr-phy/ddr-phy_git.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://NXP-Binary-EULA.txt;md5=89cc852481956e861228286ac7430
 
 inherit deploy
 
-SRC_URI = "git://github.com/nxp/ddr-phy-binary.git;nobranch=1"
+SRC_URI = "git://github.com/nxp/ddr-phy-binary.git;nobranch=1;protocol=https"
 SRCREV = "fbc036b88acb6c06ffed02c898cbae9856ec75ba"
 
 S = "${WORKDIR}/git"

--- a/recipes-bsp/firmware-imx/firmware-nxp-wifi_1.0.bb
+++ b/recipes-bsp/firmware-imx/firmware-nxp-wifi_1.0.bb
@@ -10,7 +10,7 @@ SECTION = "kernel"
 LICENSE = "Proprietary"
 LIC_FILES_CHKSUM = "file://cyw-wifi-bt/EULA.txt;md5=80c0478f4339af024519b3723023fe28"
 
-SRC_URI = "git://github.com/NXP/imx-firmware.git;protocol=https"
+SRC_URI = "git://github.com/NXP/imx-firmware.git;protocol=https;branch=master"
 SRCREV = "484d38224fa2c26b8859a7bf20b7c4d49100f5bc"
 
 S = "${WORKDIR}/git"

--- a/recipes-bsp/imx-kobs/imx-kobs_git.bb
+++ b/recipes-bsp/imx-kobs/imx-kobs_git.bb
@@ -8,7 +8,7 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=393a5ca445f6965873eca0259a17f833"
 
 PV = "5.5+git${SRCPV}"
-SRC_URI = "git://github.com/NXPmicro/imx-kobs.git;protocol=https \
+SRC_URI = "git://github.com/NXPmicro/imx-kobs.git;protocol=https;branch=master \
 "
 SRCREV = "269fdffcf97238684de9f28977a73677282e061f"
 S = "${WORKDIR}/git"

--- a/recipes-bsp/imx-uuc/imx-uuc_git.bb
+++ b/recipes-bsp/imx-uuc/imx-uuc_git.bb
@@ -11,7 +11,7 @@ inherit autotools-brokensep
 PR = "r1"
 PV = "0.5.1+git${SRCPV}"
 
-SRC_URI = "git://github.com/NXPmicro/imx-uuc.git;protocol=https"
+SRC_URI = "git://github.com/NXPmicro/imx-uuc.git;protocol=https;branch=master"
 SRCREV = "d6afb27e55d73d7ad08cd2dd51c784d8ec9694dc"
 
 S = "${WORKDIR}/git"

--- a/recipes-bsp/inphi/inphi_git.bb
+++ b/recipes-bsp/inphi/inphi_git.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://EULA.txt;md5=86d76166990962fa552f840ff08e5798"
 
 inherit deploy
 
-SRC_URI = "git://github.com/nxp/qoriq-firmware-inphi.git;nobranch=1"
+SRC_URI = "git://github.com/nxp/qoriq-firmware-inphi.git;nobranch=1;protocol=https"
 SRCREV = "f22e9ff3bfed8342da6efb699e473b11fbad5695"
 
 S = "${WORKDIR}/git"

--- a/recipes-bsp/isp-imx/libtinyxml2-8_8.0.0.bb
+++ b/recipes-bsp/isp-imx/libtinyxml2-8_8.0.0.bb
@@ -4,7 +4,7 @@ SECTION = "libs"
 LICENSE = "Zlib"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=135624eef03e1f1101b9ba9ac9b5fffd"
 
-SRC_URI = "git://github.com/leethomason/tinyxml2.git"
+SRC_URI = "git://github.com/leethomason/tinyxml2.git;branch=master;protocol=https"
 
 SRCREV = "bf15233ad88390461f6ab0dbcf046cce643c5fcb"
 

--- a/recipes-bsp/libimxdmabuffer/libimxdmabuffer_1.0.1.bb
+++ b/recipes-bsp/libimxdmabuffer/libimxdmabuffer_1.0.1.bb
@@ -9,7 +9,7 @@ PV .= "+git${SRCPV}"
 
 SRCBRANCH ?= "master"
 SRCREV = "d2058aa404ee1e8e8abd552c6a637787bcdcf514"
-SRC_URI = "git://github.com/Freescale/libimxdmabuffer.git;branch=${SRCBRANCH} \
+SRC_URI = "git://github.com/Freescale/libimxdmabuffer.git;branch=${SRCBRANCH};protocol=https \
            file://run-ptest \
           "
 

--- a/recipes-bsp/ls2-phy/ls2-phy_git.bb
+++ b/recipes-bsp/ls2-phy/ls2-phy_git.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://EULA.txt;md5=86d76166990962fa552f840ff08e5798"
 
 inherit deploy
 
-SRC_URI = "git://github.com/nxp/qoriq-firmware-cortina.git;nobranch=1"
+SRC_URI = "git://github.com/nxp/qoriq-firmware-cortina.git;nobranch=1;protocol=https"
 SRCREV = "9143c2a3adede595966583c00ca4edc99ec698cf"
 
 S = "${WORKDIR}/git"

--- a/recipes-bsp/mxsldr/mxsldr_git.bb
+++ b/recipes-bsp/mxsldr/mxsldr_git.bb
@@ -7,7 +7,7 @@ LICENSE = "GPLv2+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 SRCREV = "c40d80472525e1d57dae5317c028b745968c0399"
-SRC_URI = "git://git.denx.de/mxsldr.git \
+SRC_URI = "git://git.denx.de/mxsldr.git;branch=master \
            file://0001-Do-not-ignore-OE-cflags-and-ldflags.patch \
            "
 

--- a/recipes-bsp/ppfe-firmware/ppfe-firmware_git.bb
+++ b/recipes-bsp/ppfe-firmware/ppfe-firmware_git.bb
@@ -7,7 +7,7 @@ INHIBIT_DEFAULT_DEPS = "1"
 
 inherit deploy
 
-SRC_URI = "git://github.com/NXP/qoriq-engine-pfe-bin.git;nobranch=1"
+SRC_URI = "git://github.com/NXP/qoriq-engine-pfe-bin.git;nobranch=1;protocol=https"
 SRCREV = "f55ee9f72090309bbb7ab71f48a498fc02909234"
 
 S = "${WORKDIR}/git"

--- a/recipes-bsp/qe-ucode/qe-ucode_git.bb
+++ b/recipes-bsp/qe-ucode/qe-ucode_git.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://NXP-Binary-EULA;md5=c62f8109b4df15ca37ceeb5e4943626c"
 
 inherit deploy
 
-SRC_URI = "git://github.com/NXP/qoriq-qe-ucode.git;nobranch=1"
+SRC_URI = "git://github.com/NXP/qoriq-qe-ucode.git;nobranch=1;protocol=https"
 SRCREV= "57401f6dff6507055558eaa6838116baa8a2fd46"
 
 S = "${WORKDIR}/git"

--- a/recipes-bsp/u-boot/u-boot-fslc-common_2021.07.inc
+++ b/recipes-bsp/u-boot/u-boot-fslc-common_2021.07.inc
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://Licenses/README;md5=5a7450c57ffe5ae63fd732446b988025"
 
 DEPENDS += "flex-native bison-native"
 
-SRC_URI = "git://github.com/Freescale/u-boot-fslc.git;branch=${SRCBRANCH}"
+SRC_URI = "git://github.com/Freescale/u-boot-fslc.git;branch=${SRCBRANCH};protocol=https"
 
 SRCREV = "691e634bfd317ede487d2b864a126847ffeb4aa7"
 SRCBRANCH = "2021.07+fslc"

--- a/recipes-bsp/uefi/uefi_git.bb
+++ b/recipes-bsp/uefi/uefi_git.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://NXP-Binary-EULA;md5=343ec8f06efc37467a6de53686fa6315"
 
 inherit deploy
 
-SRC_URI = "git://github.com/NXP/qoriq-uefi-binary.git;nobranch=1"
+SRC_URI = "git://github.com/NXP/qoriq-uefi-binary.git;nobranch=1;protocol=https"
 SRCREV= "1b28cad962a3f7b61baae2229cb3b84926941cfa"
 
 S = "${WORKDIR}/git"

--- a/recipes-devtools/devregs/devregs_git.bb
+++ b/recipes-devtools/devregs/devregs_git.bb
@@ -4,7 +4,7 @@ LICENSE = "GPL-1"
 LIC_FILES_CHKSUM = "file://COPYING;md5=5003fa041d799dd5dd5f646b74e36924"
 
 SRCREV = "d5f6223027f4d6ae71bd5d432f5611486e0e6074"
-SRC_URI = "git://github.com/boundarydevices/devregs.git;protocol=http"
+SRC_URI = "git://github.com/boundarydevices/devregs.git;protocol=https;branch=master"
 
 PV = "1.0+${SRCPV}"
 

--- a/recipes-devtools/imx-usb-loader/imx-usb-loader_git.bb
+++ b/recipes-devtools/imx-usb-loader/imx-usb-loader_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 DEPENDS = "libusb1"
 
 SRCREV = "f009770d841468204ab104bf7d3b0c5bc8425dbb"
-SRC_URI = "git://github.com/boundarydevices/imx_usb_loader.git;protocol=http"
+SRC_URI = "git://github.com/boundarydevices/imx_usb_loader.git;protocol=https;branch=master"
 
 PV = "1.0+${SRCPV}"
 

--- a/recipes-devtools/utp-com/utp-com_git.bb
+++ b/recipes-devtools/utp-com/utp-com_git.bb
@@ -6,7 +6,7 @@ DEPENDS = "sg3-utils"
 
 SRCREV = "dee512ced1e9367d223d22f10797fbf9aeacfab6"
 SRC_URI = " \
-    git://github.com/Freescale/utp_com;protocol=https \
+    git://github.com/Freescale/utp_com;protocol=https;branch=master \
 "
 
 PV = "1.0+git${SRCPV}"

--- a/recipes-devtools/uuu/uuu_git.bb
+++ b/recipes-devtools/uuu/uuu_git.bb
@@ -2,7 +2,7 @@ SUMMARY = "Universal Update Utility"
 DESCRIPTION = "Image deploy tool for i.MX chips"
 HOMEPAGE = "https://github.com/NXPmicro/mfgtools"
 
-SRC_URI = "git://github.com/NXPmicro/mfgtools.git;protocol=https"
+SRC_URI = "git://github.com/NXPmicro/mfgtools.git;protocol=https;branch=master"
 SRCREV = "e10b0260076e0119c259f7f44447904f14109ba2"
 PV = "1.4.165"
 

--- a/recipes-dpaa/fm-ucode/fm-ucode_git.bb
+++ b/recipes-dpaa/fm-ucode/fm-ucode_git.bb
@@ -7,7 +7,7 @@ PR = "r1"
 
 inherit deploy
 
-SRC_URI = "git://github.com/NXP/qoriq-fm-ucode.git;nobranch=1"
+SRC_URI = "git://github.com/NXP/qoriq-fm-ucode.git;nobranch=1;protocol=https"
 SRCREV = "c275e91392e2adab1ed22f3867b8269ca3c54014"
 
 S = "${WORKDIR}/git"

--- a/recipes-dpaa2/management-complex/management-complex_10.14.1.bb
+++ b/recipes-dpaa2/management-complex/management-complex_10.14.1.bb
@@ -6,7 +6,7 @@ inherit deploy
 
 INHIBIT_DEFAULT_DEPS = "1"
 
-SRC_URI = "git://github.com/nxp/qoriq-mc-binary;nobranch=1"
+SRC_URI = "git://github.com/nxp/qoriq-mc-binary;nobranch=1;protocol=https"
 SRCREV = "408110ee632f6291545b0b156cd74e7e3b4612cc"
 
 S = "${WORKDIR}/git"

--- a/recipes-dpaa2/management-complex/management-complex_10.20.4.bb
+++ b/recipes-dpaa2/management-complex/management-complex_10.20.4.bb
@@ -6,7 +6,7 @@ inherit deploy
 
 INHIBIT_DEFAULT_DEPS = "1"
 
-SRC_URI = "git://github.com/nxp/qoriq-mc-binary;nobranch=1"
+SRC_URI = "git://github.com/nxp/qoriq-mc-binary;nobranch=1;protocol=https"
 SRCREV = "f73683596a7b72124d67b62e64f3dc2bb36b9321"
 
 S = "${WORKDIR}/git"

--- a/recipes-dpaa2/management-complex/management-complex_10.24.0.bb
+++ b/recipes-dpaa2/management-complex/management-complex_10.24.0.bb
@@ -6,7 +6,7 @@ inherit deploy
 
 INHIBIT_DEFAULT_DEPS = "1"
 
-SRC_URI = "git://github.com/nxp/qoriq-mc-binary;nobranch=1"
+SRC_URI = "git://github.com/nxp/qoriq-mc-binary;nobranch=1;protocol=https"
 SRCREV = "324817697a4c89a9a940fb7dba1b18909913ee20"
 
 S = "${WORKDIR}/git"

--- a/recipes-dpaa2/management-complex/management-complex_10.29.0.bb
+++ b/recipes-dpaa2/management-complex/management-complex_10.29.0.bb
@@ -6,7 +6,7 @@ inherit deploy
 
 INHIBIT_DEFAULT_DEPS = "1"
 
-SRC_URI = "git://github.com/nxp/qoriq-mc-binary;nobranch=1"
+SRC_URI = "git://github.com/nxp/qoriq-mc-binary;nobranch=1;protocol=https"
 SRCREV = "d21bc22000a14b0b6eeafc017fb93bc70499f74a"
 
 S = "${WORKDIR}/git"

--- a/recipes-kernel/kernel-modules/kernel-module-imx-gpu-viv_6.4.0.p2.4+fslc.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-imx-gpu-viv_6.4.0.p2.4+fslc.bb
@@ -10,7 +10,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e"
 PV .= "+git${SRCPV}"
 
 SRCREV = "f2e8483fbda59bf2482f77efb0804c014848f749"
-SRC_URI = "git://github.com/Freescale/kernel-module-imx-gpu-viv.git;protocol=https"
+SRC_URI = "git://github.com/Freescale/kernel-module-imx-gpu-viv.git;protocol=https;branch=master"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-kernel/kernel-modules/kernel-module-imx-gpu-viv_6.4.3.p2.2.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-imx-gpu-viv_6.4.3.p2.2.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0-only;md5=801f80980d171d
 
 SRCBRANCH = "lf-5.10.y"
 LOCALVERSION = "-5.10.52-2.1.0"
-KERNEL_SRC ?= "git://source.codeaurora.org/external/imx/linux-imx.git;protocol=https"
+KERNEL_SRC ?= "git://source.codeaurora.org/external/imx/linux-imx.git;protocol=https;branch=master"
 SRC_URI = " \
     ${KERNEL_SRC};branch=${SRCBRANCH};subpath=drivers/mxc/gpu-viv;destsuffix=git/src \
     file://Add-makefile.patch \

--- a/recipes-kernel/kernel-modules/kernel-module-isp-vvcam_4.2.2.15.0.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-isp-vvcam_4.2.2.15.0.bb
@@ -5,7 +5,7 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://${WORKDIR}/git/vvcam/LICENSE;md5=64381a6ea83b48c39fe524c85f65fb44"
 
 SRCBRANCH = "lf-5.10.52_2.1.0"
-ISP_KERNEL_SRC ?= "git://source.codeaurora.org/external/imx/isp-vvcam.git;protocol=https"
+ISP_KERNEL_SRC ?= "git://source.codeaurora.org/external/imx/isp-vvcam.git;protocol=https;branch=master"
 
 SRC_URI = " \
     ${ISP_KERNEL_SRC};branch=${SRCBRANCH} \

--- a/recipes-kernel/linux/linux-fslc-qoriq_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc-qoriq_5.4.bb
@@ -14,4 +14,4 @@ LINUX_VERSION = "5.4.92"
 
 SRCBRANCH = "5.4.y+qoriq+fslc"
 SRCREV = "11d4722c637a77c6e1c9a8eeec091f1588f6b3f3"
-SRC_URI := "git://github.com/Freescale/linux-fslc.git;branch=${SRCBRANCH}"
+SRC_URI := "git://github.com/Freescale/linux-fslc.git;branch=${SRCBRANCH};protocol=https"

--- a/recipes-kernel/linux/linux-fslc.inc
+++ b/recipes-kernel/linux/linux-fslc.inc
@@ -5,6 +5,6 @@ require recipes-kernel/linux/linux-imx.inc
 
 DEPENDS += "lzop-native bc-native"
 
-SRC_URI = "git://github.com/Freescale/linux-fslc.git;branch=${KBRANCH} \
+SRC_URI = "git://github.com/Freescale/linux-fslc.git;branch=${KBRANCH};protocol=https \
            file://defconfig"
 LOCALVERSION = "-fslc"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.18.0.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.18.0.imx.bb
@@ -10,7 +10,7 @@ DEFAULT_PREFERENCE = "-1"
 PACKAGE_ARCH:imxpxp = "${MACHINE_SOCARCH}"
 PACKAGE_ARCH:mx8 = "${MACHINE_SOCARCH}"
 
-GST1.0-PLUGINS-BAD_SRC ?= "gitsm://source.codeaurora.org/external/imx/gst-plugins-bad.git;protocol=https"
+GST1.0-PLUGINS-BAD_SRC ?= "gitsm://source.codeaurora.org/external/imx/gst-plugins-bad.git;protocol=https;branch=master"
 SRCBRANCH = "MM_04.06.01_2105_L5.10.y"
 
 SRC_URI = " \

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.18.0.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.18.0.imx.bb
@@ -6,7 +6,7 @@ BUGTRACKER = "https://gitlab.freedesktop.org/gstreamer/gst-plugins-base/-/issues
 LICENSE = "GPLv2+ & LGPLv2+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6762ed442b3822387a51c92d928ead0d"
 
-GST1.0-PLUGINS-BASE_SRC ?= "gitsm://source.codeaurora.org/external/imx/gst-plugins-base.git;protocol=https"
+GST1.0-PLUGINS-BASE_SRC ?= "gitsm://source.codeaurora.org/external/imx/gst-plugins-base.git;protocol=https;branch=master"
 SRCBRANCH = "MM_04.06.01_2105_L5.10.y"
 SRC_URI = "${GST1.0-PLUGINS-BASE_SRC};branch=${SRCBRANCH} \
            file://0003-viv-fb-Make-sure-config.h-is-included.patch \

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.18.0.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.18.0.imx.bb
@@ -1,6 +1,6 @@
 require recipes-multimedia/gstreamer/gstreamer1.0-plugins-common.inc
 
-GST1.0-PLUGINS-GOOD_SRC ?= "gitsm://source.codeaurora.org/external/imx/gst-plugins-good.git;protocol=https"
+GST1.0-PLUGINS-GOOD_SRC ?= "gitsm://source.codeaurora.org/external/imx/gst-plugins-good.git;protocol=https;branch=master"
 SRCBRANCH = "MM_04.06.01_2105_L5.10.y"
 
 SRC_URI = " \

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-imx_2.0.0.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-imx_2.0.0.bb
@@ -16,7 +16,7 @@ PV .= "+git${SRCPV}"
 
 SRCBRANCH ?= "master"
 SRCREV = "11e3a555a280f97d55d5243e8259a255b3ed14d0"
-SRC_URI = "git://github.com/Freescale/gstreamer-imx.git;branch=${SRCBRANCH}"
+SRC_URI = "git://github.com/Freescale/gstreamer-imx.git;branch=${SRCBRANCH};protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-multimedia/gstreamer/gstreamer1.0_1.18.0.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0_1.18.0.imx.bb
@@ -16,7 +16,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6762ed442b3822387a51c92d928ead0d \
 S = "${WORKDIR}/git"
 
 # Use i.MX fork of GST for customizations
-GST1.0_SRC ?= "gitsm://source.codeaurora.org/external/imx/gstreamer.git;protocol=https"
+GST1.0_SRC ?= "gitsm://source.codeaurora.org/external/imx/gstreamer.git;protocol=https;branch=master"
 SRCBRANCH = "MM_04.06.01_2105_L5.10.y"
 SRC_URI = "${GST1.0_SRC};branch=${SRCBRANCH} \
            file://run-ptest \

--- a/recipes-multimedia/libimxvpuapi/libimxvpuapi2_2.2.0.bb
+++ b/recipes-multimedia/libimxvpuapi/libimxvpuapi2_2.2.0.bb
@@ -9,7 +9,7 @@ PV .= "+git${SRCPV}"
 
 SRCBRANCH ?= "master"
 SRCREV = "a650f13fb5de94e0c7c9e77f4d07ea275ea80dac"
-SRC_URI = "git://github.com/Freescale/libimxvpuapi.git;branch=${SRCBRANCH}"
+SRC_URI = "git://github.com/Freescale/libimxvpuapi.git;branch=${SRCBRANCH};protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-multimedia/libimxvpuapi/libimxvpuapi_git.bb
+++ b/recipes-multimedia/libimxvpuapi/libimxvpuapi_git.bb
@@ -10,7 +10,7 @@ PV = "0.10.3+${SRCPV}"
 
 SRCBRANCH ?= "v1"
 SRCREV = "3a1ee3a54fe93813868d38c3d32ea065b59e227e"
-SRC_URI = "git://github.com/Freescale/libimxvpuapi.git;branch=${SRCBRANCH}"
+SRC_URI = "git://github.com/Freescale/libimxvpuapi.git;branch=${SRCBRANCH};protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-support/opencv/opencv_4.5.2.imx.bb
+++ b/recipes-support/opencv/opencv_4.5.2.imx.bb
@@ -44,13 +44,13 @@ IPP_FILENAME = "${@ipp_filename(d)}"
 IPP_MD5 = "${@ipp_md5sum(d)}"
 
 SRCREV_FORMAT = "opencv_contrib_ipp_boostdesc_vgg"
-SRC_URI = "git://github.com/opencv/opencv.git;name=opencv \
-           git://github.com/opencv/opencv_contrib.git;destsuffix=contrib;name=contrib \
-           git://github.com/opencv/opencv_3rdparty.git;branch=ippicv/master_20191018;destsuffix=ipp;name=ipp \
-           git://github.com/opencv/opencv_3rdparty.git;branch=contrib_xfeatures2d_boostdesc_20161012;destsuffix=boostdesc;name=boostdesc \
-           git://github.com/opencv/opencv_3rdparty.git;branch=contrib_xfeatures2d_vgg_20160317;destsuffix=vgg;name=vgg \
-           git://github.com/opencv/opencv_3rdparty.git;branch=contrib_face_alignment_20170818;destsuffix=face;name=face \
-           git://github.com/WeChatCV/opencv_3rdparty.git;branch=wechat_qrcode;destsuffix=wechat_qrcode;name=wechat-qrcode \
+SRC_URI = "git://github.com/opencv/opencv.git;name=opencv;branch=master;protocol=https \
+           git://github.com/opencv/opencv_contrib.git;destsuffix=contrib;name=contrib;branch=master;protocol=https \
+           git://github.com/opencv/opencv_3rdparty.git;branch=ippicv/master_20191018;destsuffix=ipp;name=ipp;protocol=https \
+           git://github.com/opencv/opencv_3rdparty.git;branch=contrib_xfeatures2d_boostdesc_20161012;destsuffix=boostdesc;name=boostdesc;protocol=https \
+           git://github.com/opencv/opencv_3rdparty.git;branch=contrib_xfeatures2d_vgg_20160317;destsuffix=vgg;name=vgg;protocol=https \
+           git://github.com/opencv/opencv_3rdparty.git;branch=contrib_face_alignment_20170818;destsuffix=face;name=face;protocol=https \
+           git://github.com/WeChatCV/opencv_3rdparty.git;branch=wechat_qrcode;destsuffix=wechat_qrcode;name=wechat-qrcode;protocol=https \
            file://0001-3rdparty-ippicv-Use-pre-downloaded-ipp.patch \
            file://0003-To-fix-errors-as-following.patch \
            file://0001-Temporarliy-work-around-deprecated-ffmpeg-RAW-functi.patch \
@@ -243,15 +243,15 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 # Replace the opencv URL with the fork
 SRCREV_opencv = "5423d53ae0d116ee5bbe52f8b5503f0cd8586998"
-OPENCV_SRC ?= "git://source.codeaurora.org/external/imx/opencv-imx.git;protocol=https"
+OPENCV_SRC ?= "git://source.codeaurora.org/external/imx/opencv-imx.git;protocol=https;branch=master"
 SRCBRANCH = "4.5.2_imx"
-SRC_URI:remove = "git://github.com/opencv/opencv.git;name=opencv"
+SRC_URI:remove = "git://github.com/opencv/opencv.git;name=opencv;branch=master;protocol=https"
 SRC_URI =+ "${OPENCV_SRC};branch=${SRCBRANCH};name=opencv"
 
 # Add opencv_extra
 SRCREV_extra = "855c4528402e563283f86f28c6393f57eb5dcf62"
 SRC_URI += " \
-    git://github.com/opencv/opencv_extra.git;destsuffix=extra;name=extra \
+    git://github.com/opencv/opencv_extra.git;destsuffix=extra;name=extra;branch=master;protocol=https \
     file://0001-Add-smaller-version-of-download_models.py.patch;patchdir=../extra \
 "
 SRCREV_FORMAT:append = "_extra"


### PR DESCRIPTION
Due to https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git
it is required to use https protocol for github repo accessing.

Update created with oe-core/scripts/contrib/convert-srcuri.py (see [0])

Fixes:

WARNING: /work/meta-freescale/recipes-bsp/u-boot/u-boot-fslc-mxsboot_2021.07.bb: URL: git://github.com/Freescale/u-boot-fslc.git;branch=2021.07+fslc uses git protocol which is no longer supported by github. Please change to ;protocol=https in the url.

[0] - https://git.openembedded.org/openembedded-core/tree/scripts/contrib/convert-srcuri.py

Signed-off-by: Pierre-Jean Texier <texier.pj2@gmail.com>