### PR TITLE
opencv: Backport updates from OE-Core

### DIFF
--- a/recipes-support/opencv/opencv/0001-Use-the-one-argument-version-of-SetTotalBytesLimit.patch
+++ b/recipes-support/opencv/opencv/0001-Use-the-one-argument-version-of-SetTotalBytesLimit.patch
@@ -1,0 +1,41 @@
+From 9cfa84313c5833d7295fcf57be93d5d2aaadfd88 Mon Sep 17 00:00:00 2001
+From: Vincent Rabaud <vrabaud@google.com>
+Date: Sat, 10 Jul 2021 00:21:52 +0200
+Subject: [PATCH] Use the one argument version of SetTotalBytesLimit.
+
+The two argument versions has been deprecated, cf
+https://developers.google.com/protocol-buffers/docs/reference/cpp/google.protobuf.io.coded_stream
+
+Upstream-Status: Backport [9cfa84313c5833d7295fcf57be93d5d2aaadfd88 - from master after 4.5.3 tag]
+Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>
+---
+ modules/dnn/src/caffe/caffe_io.cpp | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/modules/dnn/src/caffe/caffe_io.cpp b/modules/dnn/src/caffe/caffe_io.cpp
+index 2fc4d84f46..ebecf95eea 100644
+--- a/modules/dnn/src/caffe/caffe_io.cpp
++++ b/modules/dnn/src/caffe/caffe_io.cpp
+@@ -92,6 +92,7 @@
+ #ifdef HAVE_PROTOBUF
+ #include <google/protobuf/io/coded_stream.h>
+ #include <google/protobuf/io/zero_copy_stream_impl.h>
++#include <google/protobuf/stubs/common.h>
+ #include <google/protobuf/text_format.h>
+ 
+ #include <opencv2/core.hpp>
+@@ -1111,7 +1112,11 @@ static const int kProtoReadBytesLimit = INT_MAX;  // Max size of 2 GB minus 1 by
+ 
+ bool ReadProtoFromBinary(ZeroCopyInputStream* input, Message *proto) {
+     CodedInputStream coded_input(input);
++#if GOOGLE_PROTOBUF_VERSION >= 3006000
++    coded_input.SetTotalBytesLimit(kProtoReadBytesLimit);
++#else
+     coded_input.SetTotalBytesLimit(kProtoReadBytesLimit, 536870912);
++#endif
+ 
+     return proto->ParseFromCodedStream(&coded_input);
+ }
+-- 
+2.32.0
+

--- a/recipes-support/opencv/opencv_4.5.2.imx.bb
+++ b/recipes-support/opencv/opencv_4.5.2.imx.bb
@@ -58,6 +58,7 @@ SRC_URI = "git://github.com/opencv/opencv.git;name=opencv;branch=master;protocol
            file://download.patch \
            file://0001-Make-ts-module-external.patch \
            file://0001-sfm-link-with-Glog_LIBS.patch;patchdir=../contrib \
+           file://0001-Use-the-one-argument-version-of-SetTotalBytesLimit.patch \
            "
 SRC_URI:append:riscv64 = " file://0001-Use-Os-to-compile-tinyxml2.cpp.patch;patchdir=../contrib"
 
@@ -111,6 +112,12 @@ EXTRA_OECMAKE:append:x86 = " -DX86=ON"
 PACKAGECONFIG ??= "gapi python3 eigen jpeg png tiff v4l libv4l gstreamer samples tbb gphoto2 \
     ${@bb.utils.contains("DISTRO_FEATURES", "x11", "gtk", "", d)} \
     ${@bb.utils.contains("LICENSE_FLAGS_WHITELIST", "commercial", "libav", "", d)}"
+
+# TBB does not build for powerpc so disable that package config
+PACKAGECONFIG:remove:powerpc = "tbb"
+# tbb now needs getcontect/setcontext which is not there for all arches on musl
+PACKAGECONFIG:remove:libc-musl:riscv64 = "tbb"
+PACKAGECONFIG:remove:libc-musl:riscv32 = "tbb"
 
 PACKAGECONFIG[gapi] = "-DWITH_ADE=ON -Dade_DIR=${STAGING_LIBDIR},-DWITH_ADE=OFF,ade"
 PACKAGECONFIG[amdblas] = "-DWITH_OPENCLAMDBLAS=ON,-DWITH_OPENCLAMDBLAS=OFF,libclamdblas,"
@@ -229,9 +236,11 @@ do_install:append() {
         sed -e 's@${STAGING_DIR_HOST}@@g' \
             -i ${D}${libdir}/cmake/opencv4/OpenCVModules.cmake
     fi
+    # remove setup_vars_opencv4.sh as its content is confusing and useless
+    if [ -f ${D}${bindir}/setup_vars_opencv4.sh ]; then
+        rm -rf ${D}${bindir}/setup_vars_opencv4.sh
+    fi
 }
-
-TOOLCHAIN = "gcc"
 
 ########## End of meta-openembedded copy ##########
 


### PR DESCRIPTION
2178fd7386 opencv: remove setup_vars_opencv4.sh
cafcc65e74 opencv: fix build with protobuf-3.18 when dnn PACKAGECONFIG is enabled
3c022cd50d opencv: Do not lock to gcc only compiler

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>