### PR TITLE
qoriq-atf: Do not use append with += operator

### DIFF
--- a/recipes-bsp/atf/qoriq-atf_2.4.bb
+++ b/recipes-bsp/atf/qoriq-atf_2.4.bb
@@ -3,8 +3,8 @@ require recipes-bsp/atf/qoriq-atf-2.4.inc
 inherit deploy
 
 DEPENDS += "u-boot-mkimage-native u-boot openssl openssl-native mbedtls rcw cst-native bc-native"
-DEPENDS:append:lx2160a += "ddr-phy"
-DEPENDS:append:lx2162a += "ddr-phy"
+DEPENDS:append:lx2160a = " ddr-phy"
+DEPENDS:append:lx2162a = " ddr-phy"
 do_compile[depends] += "u-boot:do_deploy rcw:do_deploy uefi:do_deploy"
 
 SRC_URI += "git://github.com/ARMmbed/mbedtls;nobranch=1;destsuffix=git/mbedtls;name=mbedtls;protocol=https"


### PR DESCRIPTION
this is undefined behaviour, mant times devs used them together to get
the missing space at the beginning of string which append/prepend needs
but thats not intended behaviour

Signed-off-by: Khem Raj <raj.khem@gmail.com>