### PR TITLE
packagegroup-fsl-isp: Make is machine specific

### DIFF
--- a/recipes-fsl/packagegroups/packagegroup-fsl-isp.bb
+++ b/recipes-fsl/packagegroups/packagegroup-fsl-isp.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "Add packages for ISP build"
 
 # basler-camera* gets dynamically renamed
-PACKAGE_ARCH = "${MACHINE_SOCARCH}"
+PACKAGE_ARCH = "${MACHINE_ARCH}"
 inherit packagegroup
 
 ISP_PKGS      ?= ""


### PR DESCRIPTION
MACHINE_SOCARCH is not universally defined and results in errors on
non-fsl machines.

Signed-off-by: Khem Raj <raj.khem@gmail.com>