### PR TITLE
[backport dunfell] recipes: use https protocol and add explicit branch parameter

### DIFF
--- a/dynamic-layers/browser-layer/recipes-browser/chromium/chromium-imx.inc
+++ b/dynamic-layers/browser-layer/recipes-browser/chromium/chromium-imx.inc
@@ -14,7 +14,7 @@ CHROMIUM_IMX_COMMON_PATCHES ?= " "
 CHROMIUM_IMX_VPU_PATCHES ?= " "
 CHROMIUM_IMX_WAYLAND_PATCHES ?= " "
 
-SRC_URI += "git://github.com/Freescale/chromium-imx.git;destsuffix=${CHROMIUM_IMX_DESTSUFFIX};branch=${CHROMIUM_IMX_BRANCH};rev=${CHROMIUM_IMX_SRCREV}"
+SRC_URI += "git://github.com/Freescale/chromium-imx.git;destsuffix=${CHROMIUM_IMX_DESTSUFFIX};branch=${CHROMIUM_IMX_BRANCH};rev=${CHROMIUM_IMX_SRCREV};protocol=https"
 
 do_unpack[postfuncs] += "copy_chromium_imx_files"
 # using =+ instead of += to make sure add_chromium_imx_patches is

--- a/recipes-bsp/ddr-phy/ddr-phy_git.bb
+++ b/recipes-bsp/ddr-phy/ddr-phy_git.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://NXP-Binary-EULA.txt;md5=89cc852481956e861228286ac7430
 
 inherit deploy
 
-SRC_URI = "git://github.com/nxp/ddr-phy-binary.git;nobranch=1"
+SRC_URI = "git://github.com/nxp/ddr-phy-binary.git;nobranch=1;protocol=https"
 SRCREV = "fbc036b88acb6c06ffed02c898cbae9856ec75ba"
 
 S = "${WORKDIR}/git"

--- a/recipes-bsp/imx-kobs/imx-kobs_git.bb
+++ b/recipes-bsp/imx-kobs/imx-kobs_git.bb
@@ -8,7 +8,7 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=393a5ca445f6965873eca0259a17f833"
 
 PV = "5.5+git${SRCPV}"
-SRC_URI = "git://github.com/NXPmicro/imx-kobs.git;protocol=https \
+SRC_URI = "git://github.com/NXPmicro/imx-kobs.git;protocol=https;branch=master \
 "
 SRCREV = "cee66d0e956a64d03cc866fa8819da5b798c7f1b"
 S = "${WORKDIR}/git"

--- a/recipes-bsp/imx-uuc/imx-uuc_git.bb
+++ b/recipes-bsp/imx-uuc/imx-uuc_git.bb
@@ -11,7 +11,7 @@ inherit autotools-brokensep
 PR = "r1"
 PV = "0.5.1+git${SRCPV}"
 
-SRC_URI = "git://github.com/NXPmicro/imx-uuc.git;protocol=https"
+SRC_URI = "git://github.com/NXPmicro/imx-uuc.git;protocol=https;branch=master"
 SRCREV = "d6afb27e55d73d7ad08cd2dd51c784d8ec9694dc"
 
 S = "${WORKDIR}/git"

--- a/recipes-bsp/inphi/inphi_git.bb
+++ b/recipes-bsp/inphi/inphi_git.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://EULA.txt;md5=86d76166990962fa552f840ff08e5798"
 
 inherit deploy
 
-SRC_URI = "git://github.com/nxp/qoriq-firmware-inphi.git;nobranch=1"
+SRC_URI = "git://github.com/nxp/qoriq-firmware-inphi.git;nobranch=1;protocol=https"
 SRCREV = "f22e9ff3bfed8342da6efb699e473b11fbad5695"
 
 S = "${WORKDIR}/git"

--- a/recipes-bsp/libimxdmabuffer/libimxdmabuffer_1.0.1.bb
+++ b/recipes-bsp/libimxdmabuffer/libimxdmabuffer_1.0.1.bb
@@ -9,7 +9,7 @@ PV .= "+git${SRCPV}"
 
 SRCBRANCH ?= "master"
 SRCREV = "d2058aa404ee1e8e8abd552c6a637787bcdcf514"
-SRC_URI = "git://github.com/Freescale/libimxdmabuffer.git;branch=${SRCBRANCH} \
+SRC_URI = "git://github.com/Freescale/libimxdmabuffer.git;branch=${SRCBRANCH};protocol=https \
            file://run-ptest \
           "
 

--- a/recipes-bsp/ls2-phy/ls2-phy_git.bb
+++ b/recipes-bsp/ls2-phy/ls2-phy_git.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://EULA.txt;md5=86d76166990962fa552f840ff08e5798"
 
 inherit deploy
 
-SRC_URI = "git://github.com/nxp/qoriq-firmware-cortina.git;nobranch=1"
+SRC_URI = "git://github.com/nxp/qoriq-firmware-cortina.git;nobranch=1;protocol=https"
 SRCREV = "9143c2a3adede595966583c00ca4edc99ec698cf"
 
 S = "${WORKDIR}/git"

--- a/recipes-bsp/mxsldr/mxsldr_git.bb
+++ b/recipes-bsp/mxsldr/mxsldr_git.bb
@@ -7,7 +7,7 @@ LICENSE = "GPLv2+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 SRCREV = "c40d80472525e1d57dae5317c028b745968c0399"
-SRC_URI = "git://git.denx.de/mxsldr.git \
+SRC_URI = "git://git.denx.de/mxsldr.git;branch=master \
            file://0001-Do-not-ignore-OE-cflags-and-ldflags.patch \
            "
 

--- a/recipes-bsp/ppfe-firmware/ppfe-firmware_git.bb
+++ b/recipes-bsp/ppfe-firmware/ppfe-firmware_git.bb
@@ -7,7 +7,7 @@ INHIBIT_DEFAULT_DEPS = "1"
 
 inherit deploy
 
-SRC_URI = "git://github.com/NXP/qoriq-engine-pfe-bin.git;nobranch=1"
+SRC_URI = "git://github.com/NXP/qoriq-engine-pfe-bin.git;nobranch=1;protocol=https"
 SRCREV = "d3a8ef0760c54ddc243039c86389497e37be90ab"
 
 S = "${WORKDIR}/git"

--- a/recipes-bsp/qe-ucode/qe-ucode_git.bb
+++ b/recipes-bsp/qe-ucode/qe-ucode_git.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://NXP-Binary-EULA;md5=c62f8109b4df15ca37ceeb5e4943626c"
 
 inherit deploy
 
-SRC_URI = "git://github.com/NXP/qoriq-qe-ucode.git;nobranch=1"
+SRC_URI = "git://github.com/NXP/qoriq-qe-ucode.git;nobranch=1;protocol=https"
 SRCREV= "57401f6dff6507055558eaa6838116baa8a2fd46"
 
 S = "${WORKDIR}/git"

--- a/recipes-bsp/u-boot/u-boot-fslc-common_2020.04.inc
+++ b/recipes-bsp/u-boot/u-boot-fslc-common_2020.04.inc
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://Licenses/README;md5=30503fd321432fc713238f582193b78e"
 
 DEPENDS += "bison-native"
 
-SRC_URI = "git://github.com/Freescale/u-boot-fslc.git;branch=${SRCBRANCH}"
+SRC_URI = "git://github.com/Freescale/u-boot-fslc.git;branch=${SRCBRANCH};protocol=https"
 
 SRCREV = "88c58453be8cd87eb55f8e283ac4dcce5b59006d"
 SRCBRANCH = "2020.04+fslc"

--- a/recipes-bsp/uefi/uefi_git.bb
+++ b/recipes-bsp/uefi/uefi_git.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://NXP-Binary-EULA;md5=343ec8f06efc37467a6de53686fa6315"
 
 inherit deploy
 
-SRC_URI = "git://github.com/NXP/qoriq-uefi-binary.git;nobranch=1"
+SRC_URI = "git://github.com/NXP/qoriq-uefi-binary.git;nobranch=1;protocol=https"
 SRCREV= "e95ed52322f15437f98dee2b27de45a7495d648c"
 
 S = "${WORKDIR}/git"

--- a/recipes-devtools/devregs/devregs_git.bb
+++ b/recipes-devtools/devregs/devregs_git.bb
@@ -4,7 +4,7 @@ LICENSE = "GPL-1"
 LIC_FILES_CHKSUM = "file://COPYING;md5=5003fa041d799dd5dd5f646b74e36924"
 
 SRCREV = "d5f6223027f4d6ae71bd5d432f5611486e0e6074"
-SRC_URI = "git://github.com/boundarydevices/devregs.git;protocol=http"
+SRC_URI = "git://github.com/boundarydevices/devregs.git;protocol=https;branch=master"
 
 PV = "1.0+${SRCPV}"
 

--- a/recipes-devtools/imx-usb-loader/imx-usb-loader_git.bb
+++ b/recipes-devtools/imx-usb-loader/imx-usb-loader_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 DEPENDS = "libusb1"
 
 SRCREV = "f009770d841468204ab104bf7d3b0c5bc8425dbb"
-SRC_URI = "git://github.com/boundarydevices/imx_usb_loader.git;protocol=http"
+SRC_URI = "git://github.com/boundarydevices/imx_usb_loader.git;protocol=https;branch=master"
 
 PV = "1.0+${SRCPV}"
 

--- a/recipes-devtools/utp-com/utp-com_git.bb
+++ b/recipes-devtools/utp-com/utp-com_git.bb
@@ -6,7 +6,7 @@ DEPENDS = "sg3-utils"
 
 SRCREV = "dee512ced1e9367d223d22f10797fbf9aeacfab6"
 SRC_URI = " \
-    git://github.com/Freescale/utp_com;protocol=https \
+    git://github.com/Freescale/utp_com;protocol=https;branch=master \
 "
 
 PV = "1.0+git${SRCPV}"

--- a/recipes-dpaa/fm-ucode/fm-ucode_git.bb
+++ b/recipes-dpaa/fm-ucode/fm-ucode_git.bb
@@ -7,7 +7,7 @@ PR = "r1"
 
 inherit deploy
 
-SRC_URI = "git://github.com/NXP/qoriq-fm-ucode.git;nobranch=1"
+SRC_URI = "git://github.com/NXP/qoriq-fm-ucode.git;nobranch=1;protocol=https"
 SRCREV = "c275e91392e2adab1ed22f3867b8269ca3c54014"
 
 S = "${WORKDIR}/git"

--- a/recipes-dpaa2/management-complex/management-complex_10.14.1.bb
+++ b/recipes-dpaa2/management-complex/management-complex_10.14.1.bb
@@ -6,7 +6,7 @@ inherit deploy
 
 INHIBIT_DEFAULT_DEPS = "1"
 
-SRC_URI = "git://github.com/nxp/qoriq-mc-binary;nobranch=1"
+SRC_URI = "git://github.com/nxp/qoriq-mc-binary;nobranch=1;protocol=https"
 SRCREV = "408110ee632f6291545b0b156cd74e7e3b4612cc"
 
 S = "${WORKDIR}/git"

--- a/recipes-dpaa2/management-complex/management-complex_10.20.4.bb
+++ b/recipes-dpaa2/management-complex/management-complex_10.20.4.bb
@@ -6,7 +6,7 @@ inherit deploy
 
 INHIBIT_DEFAULT_DEPS = "1"
 
-SRC_URI = "git://github.com/nxp/qoriq-mc-binary;nobranch=1"
+SRC_URI = "git://github.com/nxp/qoriq-mc-binary;nobranch=1;protocol=https"
 SRCREV = "f73683596a7b72124d67b62e64f3dc2bb36b9321"
 
 S = "${WORKDIR}/git"

--- a/recipes-kernel/kernel-modules/kernel-module-imx-gpu-viv_6.4.0.p2.4+fslc.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-imx-gpu-viv_6.4.0.p2.4+fslc.bb
@@ -10,7 +10,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e"
 PV .= "+git${SRCPV}"
 
 SRCREV = "f2e8483fbda59bf2482f77efb0804c014848f749"
-SRC_URI = "git://github.com/Freescale/kernel-module-imx-gpu-viv.git;protocol=https"
+SRC_URI = "git://github.com/Freescale/kernel-module-imx-gpu-viv.git;protocol=https;branch=master"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-kernel/linux/linux-fslc-qoriq_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc-qoriq_5.4.bb
@@ -14,4 +14,4 @@ LINUX_VERSION = "5.4.64"
 
 SRCBRANCH = "5.4.y+qoriq+fslc"
 SRCREV = "4c04c442c0e91e7cf01f830aca524f09b5613f29"
-SRC_URI := "git://github.com/Freescale/linux-fslc.git;branch=${SRCBRANCH}"
+SRC_URI := "git://github.com/Freescale/linux-fslc.git;branch=${SRCBRANCH};protocol=https"

--- a/recipes-kernel/linux/linux-fslc.inc
+++ b/recipes-kernel/linux/linux-fslc.inc
@@ -5,6 +5,6 @@ require recipes-kernel/linux/linux-imx.inc
 
 DEPENDS += "lzop-native bc-native"
 
-SRC_URI = "git://github.com/Freescale/linux-fslc.git;branch=${SRCBRANCH} \
+SRC_URI = "git://github.com/Freescale/linux-fslc.git;branch=${SRCBRANCH};protocol=https \
            file://defconfig"
 LOCALVERSION = "-fslc"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-imx_0.13.1.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-imx_0.13.1.bb
@@ -18,7 +18,7 @@ PV .= "+git${SRCPV}"
 
 SRCBRANCH ?= "master"
 SRCREV = "805987bff74af13fcb14ff111955206f1c92554d"
-SRC_URI = "git://github.com/Freescale/gstreamer-imx.git;branch=${SRCBRANCH}"
+SRC_URI = "git://github.com/Freescale/gstreamer-imx.git;branch=${SRCBRANCH};protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-multimedia/libimxvpuapi/libimxvpuapi2_2.2.0.bb
+++ b/recipes-multimedia/libimxvpuapi/libimxvpuapi2_2.2.0.bb
@@ -9,7 +9,7 @@ PV .= "+git${SRCPV}"
 
 SRCBRANCH ?= "master"
 SRCREV = "a650f13fb5de94e0c7c9e77f4d07ea275ea80dac"
-SRC_URI = "git://github.com/Freescale/libimxvpuapi.git;branch=${SRCBRANCH}"
+SRC_URI = "git://github.com/Freescale/libimxvpuapi.git;branch=${SRCBRANCH};protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-multimedia/libimxvpuapi/libimxvpuapi_git.bb
+++ b/recipes-multimedia/libimxvpuapi/libimxvpuapi_git.bb
@@ -10,7 +10,7 @@ PV = "0.10.3+${SRCPV}"
 
 SRCBRANCH ?= "v1"
 SRCREV = "3a1ee3a54fe93813868d38c3d32ea065b59e227e"
-SRC_URI = "git://github.com/Freescale/libimxvpuapi.git;branch=${SRCBRANCH}"
+SRC_URI = "git://github.com/Freescale/libimxvpuapi.git;branch=${SRCBRANCH};protocol=https"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
This is a backport of commit bef00d6e4f25b4a9d3272e0d69db7545590ed204 to the dunfell LTS branch:

```
Due to https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git
it is required to use https protocol for github repo accessing.

Update created with oe-core/scripts/contrib/convert-srcuri.py (see [0])

Fixes:

WARNING: /work/meta-freescale/recipes-bsp/u-boot/u-boot-fslc-mxsboot_2021.07.bb: URL: git://github.com/Freescale/u-boot-fslc.git;branch=2021.07+fslc uses git protocol which is no longer supported by github. Please change to ;protocol=https in the url.

[0] - https://git.openembedded.org/openembedded-core/tree/scripts/contrib/convert-srcuri.py

Signed-off-by: Pierre-Jean Texier <texier.pj2@gmail.com>
```