### PR TITLE
devregs: bump revision to dcc3e3f2

### DIFF
--- a/recipes-devtools/devregs/devregs_git.bb
+++ b/recipes-devtools/devregs/devregs_git.bb
@@ -1,9 +1,9 @@
 DESCRIPTION = "i.MX Register tool"
 SECTION = "devel"
-LICENSE = "GPL-1"
+LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=5003fa041d799dd5dd5f646b74e36924"
 
-SRCREV = "d5f6223027f4d6ae71bd5d432f5611486e0e6074"
+SRCREV = "dcc3e3f26d3d867d5297a104dc32bd99f5e6fa71"
 SRC_URI = "git://github.com/boundarydevices/devregs.git;protocol=https;branch=master"
 
 PV = "1.0+${SRCPV}"


### PR DESCRIPTION
Changelog:
dcc3e3f clarify project license to be GPLv2
ed28469 devregs_imx8mm.dat: add mipi csi regs
2c92a1d scripts: add rough idea of a technical reference parser
05a0313 devregs: add fancy color mode
d713004 devregs: add imx8mm to fixit manual list

Update the license in the recipe now that it has been clarified.

Signed-off-by: Gary Bisson <gary.bisson@boundarydevices.com>