### PR TITLE
imx-atf improvements (Clang ready)

### DIFF
--- a/recipes-bsp/imx-atf/imx-atf_2.4.bb
+++ b/recipes-bsp/imx-atf/imx-atf_2.4.bb
@@ -25,13 +25,16 @@ EXTRA_OEMAKE += " \
     PLAT=${ATF_PLATFORM} \
 "
 
-BUILD_OPTEE = "${@bb.utils.contains('MACHINE_FEATURES', 'optee', 'true', 'false', d)}"
+# Let the Makefile handle setting up the CFLAGS and LDFLAGS as it is a standalone application
+CFLAGS[unexport] = "1"
+LDFLAGS[unexport] = "1"
+AS[unexport] = "1"
+LD[unexport] = "1"
 
-CFLAGS:remove:mx8mq = "-O2"
+BUILD_OPTEE = "${@bb.utils.contains('MACHINE_FEATURES', 'optee', 'true', 'false', d)}"
 
 do_compile() {
     # Clear LDFLAGS to avoid the option -Wl recognize issue
-    unset LDFLAGS
     oe_runmake bl31
     if ${BUILD_OPTEE}; then
        oe_runmake clean BUILD_BASE=build-optee

--- a/recipes-bsp/imx-atf/imx-atf_2.4.bb
+++ b/recipes-bsp/imx-atf/imx-atf_2.4.bb
@@ -36,6 +36,17 @@ DEPENDS:remove = "virtual/${TARGET_PREFIX}compilerlibs virtual/libc"
 
 BUILD_OPTEE = "${@bb.utils.contains('MACHINE_FEATURES', 'optee', 'true', 'false', d)}"
 
+# CC and LD introduce arguments which conflict with those otherwise provided by
+# this recipe. The heads of these variables excluding those arguments
+# are therefore used instead.
+def remove_options_tail (in_string):
+    from itertools import takewhile
+    return ' '.join(takewhile(lambda x: not x.startswith('-'), in_string.split(' ')))
+
+EXTRA_OEMAKE += "LD=${@remove_options_tail(d.getVar('LD'))}"
+
+EXTRA_OEMAKE += "CC=${@remove_options_tail(d.getVar('CC'))}"
+
 do_compile() {
     # Clear LDFLAGS to avoid the option -Wl recognize issue
     oe_runmake bl31

--- a/recipes-bsp/imx-atf/imx-atf_2.4.bb
+++ b/recipes-bsp/imx-atf/imx-atf_2.4.bb
@@ -31,6 +31,9 @@ LDFLAGS[unexport] = "1"
 AS[unexport] = "1"
 LD[unexport] = "1"
 
+# Baremetal, just need a compiler
+DEPENDS:remove = "virtual/${TARGET_PREFIX}compilerlibs virtual/libc"
+
 BUILD_OPTEE = "${@bb.utils.contains('MACHINE_FEATURES', 'optee', 'true', 'false', d)}"
 
 do_compile() {


### PR DESCRIPTION
This PR is generally a set of patches ported from _meta-arm_, which provides recipe for upstream TF-A.

It addresses the match of toolchain which is provided in the sysroot to what TF-A expects in it's Makefile, specifically:
- Unsets `CFLAGS`, `LDFLAGS`, `AS` and `LD` variables which are defined by TF-A itself
- Drops dependency on C-runtime as it is not required for TF-A (baremetal)
- Enables support to use _Clang_ for TF-A build by sanitizing `CC` and `LD` variables.

Original commits used for this port are linked in commits to this layer.

@thochstein This PR also drops the 79ba26618a075332ac9106f55c1aad573e42c9e0 as `CFLAGS` will be set by TF-A itself. I've tested this on `imx8mq_evk` machine and observed no build issues.

-- andrey
