### PR TITLE
[RFC]: Use upstream U-Boot for imx8m Mini, Nano and Plus machines (Mainline BSP)

### DIFF
--- a/conf/machine/include/imx8mm-evk.inc
+++ b/conf/machine/include/imx8mm-evk.inc
@@ -28,7 +28,7 @@ KERNEL_DEVICETREE:append:use-nxp-bsp = " \
 UBOOT_DTB_NAME = "${KERNEL_DEVICETREE_BASENAME}.dtb"
 
 IMX_DEFAULT_BOOTLOADER:use-nxp-bsp = "u-boot-imx"
-IMX_DEFAULT_BOOTLOADER:use-mainline-bsp = "u-boot-fslc"
+IMX_DEFAULT_BOOTLOADER:use-mainline-bsp = "u-boot"
 
 UBOOT_SUFFIX = "bin"
 

--- a/conf/machine/include/imx8mn-evk.inc
+++ b/conf/machine/include/imx8mn-evk.inc
@@ -28,7 +28,7 @@ KERNEL_DEVICETREE:append:use-nxp-bsp = " \
 UBOOT_DTB_NAME = "${KERNEL_DEVICETREE_BASENAME}.dtb"
 
 IMX_DEFAULT_BOOTLOADER:use-nxp-bsp = "u-boot-imx"
-IMX_DEFAULT_BOOTLOADER:use-mainline-bsp = "u-boot-fslc"
+IMX_DEFAULT_BOOTLOADER:use-mainline-bsp = "u-boot"
 
 UBOOT_SUFFIX = "bin"
 

--- a/conf/machine/include/imx8mp-evk.inc
+++ b/conf/machine/include/imx8mp-evk.inc
@@ -24,7 +24,7 @@ KERNEL_DEVICETREE = " \
 UBOOT_DTB_NAME = "${KERNEL_DEVICETREE_BASENAME}.dtb"
 
 IMX_DEFAULT_BOOTLOADER:use-nxp-bsp = "u-boot-imx"
-IMX_DEFAULT_BOOTLOADER:use-mainline-bsp = "u-boot-fslc"
+IMX_DEFAULT_BOOTLOADER:use-mainline-bsp = "u-boot"
 
 UBOOT_SUFFIX = "bin"
 

--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -1,0 +1,8 @@
+# So far, we just need a container to be inherited
+inherit ${@oe.utils.ifelse(d.getVar('UBOOT_PROVIDES_BOOT_CONTAINER') == '1', 'imx-boot-container', '')}
+
+# Location known to imx-boot component, where U-Boot artifacts
+# should be additionally deployed.
+# See below note above do_deploy:append:mx8m for the purpose of
+# this delopyment location
+BOOT_TOOLS = "imx-boot-tools"


### PR DESCRIPTION
Since recent _U-Boot_ releases, Mini, Nano and Plus are supported in the upstream. The delta that is kept in `u-boot-fslc` repository is negligible, and to my knowledge does not contain any specific commit that are relevant to those derivatives.

Therefore, I wanted to post this RFC here with the attempt to switch _u-boot_ provider from `u-boot-fslc` to `u-boot` provided in the OE-Core.

Current version in upstream recipe is already newer that the one inside `u-boot-fslc` repository, so this would also effectively provide an upgrade of _U-Boot_ package to _2021.10_.

This would also allow to pickup upgrades from upstream rather than maintaining it in a separate repository (at least for those derivatives).

i.MX8M Quad does lack essential _binman_ support, therefore it cannot be used now with upstream U-Boot. Patch to address it is submitted, so once accepted - that machine can be switched over as well at the release this fix would be merged in.

Cc: @fabioestevam 

-- andrey