### PR TITLE
linux-fslc: update version to v5.15.12

### DIFF
--- a/recipes-kernel/linux/linux-fslc_5.15.bb
+++ b/recipes-kernel/linux/linux-fslc_5.15.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.15.2"
+LINUX_VERSION = "5.15.12"
 
 KBRANCH = "5.15.x+fslc"
-SRCREV = "3b7c3ba50480a1ee9043c3d07293c175c2e9d47b"
+SRCREV = "503f83efaba7cf3821bb48ddad156c770330f75f"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"


### PR DESCRIPTION
Kernel repository has been upgraded up to v5.15.12 from stable korg.

Following upstream commits are included in this version:
----
25960cafa06e Linux 5.15.12
53ccdc73eeda phonet/pep: refuse to enable an unbound pipe
3cb5ae77799e tun: avoid double free in tun_free_netdev
03d00f7f1815 hamradio: improve the incomplete fix to avoid NPD
cb6c99aedd2c hamradio: defer ax25 kfree after unregister_netdev
a8e4a64cdc97 ax25: NPD bug when detaching AX25 device
f547b0f8f3ce r8152: sync ocp base
5cc8813c4966 hwmon: (lm90) Do not report 'busy' status bit as alarm
722fc45be049 hwmom: (lm90) Fix citical alarm status for MAX6680/MAX6681
fb563baa3eb8 pinctrl: mediatek: fix global-out-of-bounds issue
aa50406f36a1 ASoC: rt5682: fix the wrong jack type detected
46b3fe1eb2b7 ASoC: SOF: Intel: pci-tgl: add ADL-N support
d0fa8c252956 ASoC: SOF: Intel: pci-tgl: add new ADL-P variant
d9ad0ae8bfa0 ASoC: tas2770: Fix setting of high sample rates
cc71a723f3d8 Input: goodix - add id->model mapping for the "9111" model
efaa327b4146 Input: elants_i2c - do not check Remark ID on eKTH3900/eKTH5312
70750056620b Input: iqs626a - prohibit inlining of channel parsing functions
2f06c8293d27 kfence: fix memory leak when cat kfence objects
ca38833c915e arm64: dts: lx2160a: fix scl-gpios property name
0ae519ecbbdb KVM: VMX: Fix stale docs for kvm-intel.emulate_invalid_guest_state
35f9ff45ee5c netfs: fix parameter of cleanup()
a8a9d753edd7 f2fs: fix to do sanity check on last xattr entry in __f2fs_setxattr()
91e94e42f6fc tee: optee: Fix incorrect page free bug
330c6117a82c mm/damon/dbgfs: protect targets destructions with kdamond_lock
c691e7575eff mm/hwpoison: clear MF_COUNT_INCREASED before retrying get_any_page()
7a77e22fde63 mm, hwpoison: fix condition in free hugetlb page path
6b2cdcc8f555 mm: mempolicy: fix THP allocations escaping mempolicy restrictions
c1d1ec4db5f7 mac80211: fix locking in ieee80211_start_ap error path
a2c144d17623 ksmbd: disable SMB2_GLOBAL_CAP_ENCRYPTION for SMB 3.1.1
f43ba86a8211 ksmbd: fix uninitialized symbol 'pntsd_size'
89d0ffb4bb96 ksmbd: fix error code in ndr_read_int32()
c99513dffd36 ARM: 9169/1: entry: fix Thumb2 bug in iWMMXt exception handling
c7814569b387 mmc: mmci: stm32: clear DLYB_CR after sending tuning command
c0db06fd0993 mmc: core: Disable card detect during shutdown
9d93c863d04f mmc: meson-mx-sdhc: Set MANUAL_STOP for multi-block SDIO commands
46e2fc260543 mmc: sdhci-tegra: Fix switch to HS400ES mode
e5dd3e61baed gpio: dln2: Fix interrupts when replugging the device
c1ce3c410038 pinctrl: stm32: consider the GPIO offset to expose all the GPIO lines
b9d7c7a5bf6e KVM: VMX: Wake vCPU when delivering posted IRQ even if vCPU == this vCPU
e4e4e7cb2298 KVM: VMX: Always clear vmx->fail on emulation_required
543bfbcb5cf5 KVM: nVMX: Synthesize TRIPLE_FAULT for L2 if emulation is required
d884eefd75cc KVM: x86/mmu: Don't advance iterator after restart due to yielding
5dea76f5da65 KVM: x86: Always set kvm_run->if_flag
9ca1324755f1 platform/x86: intel_pmc_core: fix memleak on registration failure
a42c41be8324 platform/x86: amd-pmc: only use callbacks for suspend
9ede07c4af14 x86/pkey: Fix undefined behaviour with PKRU_WD_BIT
492eb7afe858 tee: handle lookup of shm with reference count 0
c576d7a197b7 parisc: Fix mask used to select futex spinlock
7c6567979c82 parisc: Correct completer in lws start
5aae769a0ef7 ipmi: fix initialization when workqueue allocation fails
77a7311ca167 ipmi: ssif: initialize ssif_info->client early
7232a5941d3f ipmi: bail out if init_srcu_struct fails
7f7f61042f70 Input: atmel_mxt_ts - fix double free in mxt_read_info_block
6084a6c1ca7f ASoC: tegra: Restore headphones jack name on Nyan Big
f7fe9d303445 ASoC: tegra: Add DAPM switches for headphones and mic jack
8e9b8b8a8ff2 ASoC: meson: aiu: Move AIU_I2S_MISC hold setting to aiu-fifo-i2s
88b4fbd6348a ALSA: hda/realtek: Fix quirk for Clevo NJ51CU
417e6ee4df64 ALSA: hda/realtek: fix mute/micmute LEDs for a HP ProBook
0896c97e6657 ALSA: hda/realtek: Add new alc285-hp-amp-init model
3934aa1259d9 ALSA: hda/realtek: Amp init fixup for HP ZBook 15 G6
2e9cd9ff997f ALSA: hda/hdmi: Disable silent stream on GLK
b398fcbe4de1 ALSA: rawmidi - fix the uninitalized user_pversion
3fd58303b05e ALSA: drivers: opl3: Fix incorrect use of vp->state
fdaa60d900a7 ALSA: jack: Check the return value of kstrdup()
28b03ec2c0c5 x86/boot: Move EFI range reservation after cmdline parsing
f95fcac5d66a Revert "x86/boot: Pull up cmdline preparation and early param parsing"
70e7705b0230 kernel/crash_core: suppress unknown crashkernel parameter warning
4a34b51ea99b platform/x86/intel: Remove X86_PLATFORM_DRIVERS_INTEL
50f27a29d758 compiler.h: Fix annotation macro misplacement with Clang
0cd3ef801004 uapi: Fix undefined __always_inline on non-glibc systems
8a351388b295 ARM: 9160/1: NOMMU: Reload __secondary_data after PROCINFO_INITFUNC
afda22fea766 hwmon: (lm90) Drop critical attribute support for MAX6654
9d21029e7199 hwmon: (lm90) Add basic support for TI TMP461
983084e19aeb hwmon: (lm90) Introduce flag indicating extended temperature support
d105f30bea91 hwmon: (lm90) Prevent integer overflow/underflow in hysteresis calculations
4b8f0e940972 hwmon: (lm90) Fix usage of CONFIG2 register in detect function
79c6d4fa1be1 pinctrl: bcm2835: Change init order for gpio hogs
dfd5b60b5342 Input: elantech - fix stack out of bound access in elantech_change_report_id()
b480d5f42d45 net: stmmac: dwmac-visconti: Fix value of ETHER_CLK_SEL_FREQ_SEL_2P5M
f80527200d01 r8152: fix the force speed doesn't work for RTL8156
b8871c6734d8 net: bridge: fix ioctl old_deviceless bridge argument
1c66ea39c6c4 net: bridge: Use array_size() helper in copy_to_user()
be2473e5f377 net: stmmac: ptp: fix potentially overflowing expression
d2269ae48598 veth: ensure skb entering GRO are not cloned.
20fb0dc35bf9 io_uring: zero iocb->ki_pos for stream file types
5cf03976e1f0 asix: fix wrong return value in asix_check_host_enable()
d259f621c859 asix: fix uninit-value in asix_mdio_read()
d00726b7061c sfc: falcon: Check null pointer of rx_queue->page_ring
20c3efcca612 sfc: Check null pointer of rx_queue->page_ring
8307c1ecd366 net: ks8851: Check for error irq
98a5242e82f2 drivers: net: smc911x: Check for error irq
643c89669e31 fjes: Check for error irq
a038c504f6f5 bonding: fix ad_actor_system option setting to default
1f0d95fb3755 gpio: virtio: remove timeout
6b3f7e4b10f3 ipmi: Fix UAF when uninstall ipmi_si and ipmi_msghandler module
33385aded71e igb: fix deadlock caused by taking RTNL in RPM resume path
b99c71f90978 net: skip virtio_net_hdr_set_proto if protocol already set
8ba353f553da net: accept UFOv6 packages in virtio_net_hdr_to_skb
0249a4b8a554 inet: fully convert sk->sk_rx_dst to RCU rules
98a8e5c20027 ipv6: move inet6_sk(sk)->rx_dst_cookie to sk->sk_rx_dst_cookie
8e096cffc6d3 tcp: move inet->rx_dst_ifindex to sk->sk_rx_dst_ifindex
e69eacf74e15 qlcnic: potential dereference null pointer of rx_queue->page_ring
5c553a0cd126 net: marvell: prestera: fix incorrect structure access
da3feb8a9baf net: marvell: prestera: fix incorrect return of port_find
ad6d20da2cfb ice: xsk: return xsk buffers back to pool when cleaning the ring
c1c36df0b0a5 ice: Use xdp_buf instead of rx_buf for xsk zero-copy
ef73e3b650b7 ARM: dts: imx6qdl-wandboard: Fix Ethernet support
406b7337d6bc netfilter: fix regression in looped (broad|multi)cast's MAC handling
9d558e5f0d6f netfilter: nf_tables: fix use-after-free in nft_set_catchall_destroy()
2eb1cac16bc7 RDMA/hns: Replace kfree() with kvfree()
aefcc25f3a0c IB/qib: Fix memory leak in qib_user_sdma_queue_pkts()
c41b98070392 RDMA/hns: Fix RNR retransmission issue for HIP08
9b0ed41b25e2 ASoC: meson: aiu: fifo: Add missing dma_coerce_mask_and_coherent()
71d07ebc5000 drm/mediatek: hdmi: Perform NULL pointer check for mtk_hdmi_conf
11bf802877bf ucounts: Fix rlimit max values check
3121b5bff903 spi: change clk_disable_unprepare to clk_unprepare
512dbc1a09ac bus: sunxi-rsb: Fix shutdown
115a291395df arm64: dts: allwinner: orangepi-zero-plus: fix PHY mode
f4321ac030b5 PM: sleep: Fix error handling in dpm_prepare()
eabc0aab98e5 NFSD: Fix READDIR buffer overflow
b1712a691bbb HID: potential dereference of null pointer
3c431e19ad70 HID: holtek: fix mouse probing
a65ac9d23276 selftests: KVM: Fix non-x86 compiling
49c29e13fcd6 ext4: check for inconsistent extents between index and leaf block
f71ab21b1a28 ext4: check for out-of-order index extents in ext4_valid_extent_entries()
02f825cf0255 ext4: prevent partial update of the extent blocks
fedeb1b2c8e6 net: usb: lan78xx: add Allied Telesis AT29M2-AF
1d1c25233a29 arm64: vdso32: require CROSS_COMPILE_COMPAT for gcc+bfd
fb6ad5cb3b67 Linux 5.15.11
bd926d189210 xen/netback: don't queue unlimited number of packages
88449dbe6203 xen/netback: fix rx queue stall detection
153d1ea32722 xen/console: harden hvc_xen against event channel storms
a29c8b5226ed xen/netfront: harden netfront against event channel storms
caf9b51829a5 xen/blkfront: harden blkfront against event channel storms
ffbd663ebac9 Revert "xsk: Do not sleep in poll() when need_wakeup set"
581b09795199 selftests/damon: test debugfs file reads/writes with huge count
a272f990cb26 bus: ti-sysc: Fix variable set but not used warning for reinit_modules
11053a021937 io-wq: drop wqe lock before creating new worker
a96ac0688acb rcu: Mark accesses to rcu_state.n_force_qs
4b4e5bbf9386 io-wq: check for wq exit after adding new worker task_work
024f9c7cd3d8 io-wq: remove spurious bit clear on task_work addition
dfc3fff63793 scsi: scsi_debug: Sanity check block descriptor length in resp_mode_select()
308514764593 scsi: scsi_debug: Fix type in min_t to avoid stack OOB
47d11d35203b scsi: scsi_debug: Don't call kcalloc() if size arg is zero
d2ccdd4e4efa ovl: fix warning in ovl_create_real()
4658f2a9b336 fuse: annotate lock in fuse_reverse_inval_entry()
8c6fdf62bfe1 media: mxl111sf: change mutex_init() location
403716741c6c USB: core: Make do_proc_control() and do_proc_bulk() killable
303644fe7e0c bpf: Fix extable address check.
eea5a58d86a4 bpf, x64: Factor out emission of REX byte in more cases
7e83a6577d5c mptcp: add missing documented NL params
e8d38fcd0a1c xsk: Do not sleep in poll() when need_wakeup set
6b2ee1002c6b ARM: dts: imx6ull-pinfunc: Fix CSI_DATA07__ESAI_TX0 pad name
0e8ffdf3b86d can: m_can: pci: use custom bit timings for Elkhart Lake
274f4b342ba9 can: m_can: make custom bittiming fields const
5b4641e9c06c Revert "can: m_can: remove support for custom bit timing"
e3a01c14e806 drm/amd/pm: fix reading SMU FW version from amdgpu_firmware_info on YC
a386ae526866 drm/amdgpu: don't override default ECO_BITs setting
f2e600f6572b drm/amdgpu: correct register access for RLC_JUMP_TABLE_RESTORE
9b9f2567145b powerpc/module_64: Fix livepatching for RO modules
78f27c43eb16 libata: if T_LENGTH is zero, dma direction should be DMA_NONE
f67c85a557c8 perf inject: Fix segfault due to perf_data__fd() without open
a7c0e6aa63c8 perf inject: Fix segfault due to close without open
4a74df7707b5 riscv: dts: unmatched: Add gpio card detect to mmc-spi-slot
7fe286afbd90 riscv: dts: unleashed: Add gpio card detect to mmc-spi-slot
5e14b8b2680a locking/rtmutex: Fix incorrect condition in rtmutex_spin_on_owner()
c63433a09d6a cifs: sanitize multiple delimiters in prepath
c5664d508674 timekeeping: Really make sure wall_to_monotonic isn't positive
89362ec97ac0 serial: 8250_fintek: Fix garbled text for console
3a1a4eb57417 iocost: Fix divide-by-zero on donation from low hweight cgroup
d153ff65a977 zonefs: add MODULE_ALIAS_FS
210ab4e3c032 btrfs: fix missing blkdev_put() call in btrfs_scan_one_device()
8848395975bd btrfs: check WRITE_ERR when trying to read an extent buffer
bbdaa7a48f46 btrfs: fix double free of anon_dev after failure to create subvolume
493ff661d434 btrfs: fix memory leak in __add_inode_ref()
d1bac0d97bc9 selinux: fix sleeping function called from invalid context
252f245ff4a1 USB: serial: option: add Telit FN990 compositions
db83bbfe1bec USB: serial: cp210x: fix CP2105 GPIO registration
5154bc1c16c9 usb: gadget: u_ether: fix race in setting MAC address in setup phase
428ad19f98bb usb: typec: tcpm: fix tcpm unregister port but leave a pending timer
ffe642edb4e2 usb: cdnsp: Fix lack of spin_lock_irqsave/spin_lock_restore
368bfabceb11 usb: cdnsp: Fix issue in cdnsp_log_ep trace event
ec83d6e57a62 usb: cdnsp: Fix incorrect calling of cdnsp_died function
ed89521e2dcb usb: cdnsp: Fix incorrect status for control request
5cb5c3e1b184 usb: xhci: Extend support for runtime power management for AMD's Yellow carp.
67cbcd3fb8e6 usb: xhci-mtk: fix list_del warning when enable list debug
d8888cdabedf PCI/MSI: Mask MSI-X vectors only on success
4df1af29930b PCI/MSI: Clear PCI_MSIX_FLAGS_MASKALL on error
3901c7784ad7 usb: dwc2: fix STM ID/VBUS detection startup delay in dwc2_driver_probe
af00fb784286 USB: NO_LPM quirk Lenovo USB-C to Ethernet Adapher(RTL8153-04)
e7a8a261bab0 tty: n_hdlc: make n_hdlc_tty_wakeup() asynchronous
5fc3cfa62b85 KVM: x86: Drop guest CPUID check for host initiated writes to MSR_IA32_PERF_CAPABILITIES
9f8b3f238530 Revert "usb: early: convert to readl_poll_timeout_atomic()"
abd3a33b3f2b USB: gadget: bRequestType is a bitfield, not a enum
d0ac17b9bac5 powerpc/85xx: Fix oops when CONFIG_FSL_PMC=n
c8e8e6f4108e bpf, selftests: Fix racing issue in btf_skc_cls_ingress test
9f55f2913ebd bpf: Fix extable fixup offset.
ecd8ad3af6d5 arm64: kexec: Fix missing error code 'ret' warning in load_other_segments()
5473fe0c484a afs: Fix mmap
44a6c846bc3a sit: do not call ipip6_dev_free() from sit_init_net()
eb4687c74429 net: systemport: Add global locking for descriptor lifecycle
e99fe4137b6d net/smc: Prevent smc_release() from long blocking
ff3d58592be4 net: Fix double 0x prefix print in SKB dump
987e1a4682e5 dsa: mv88e6xxx: fix debug print for SPEED_UNFORCED
9a77c02d1d21 sfc_ef100: potential dereference of null pointer
0b4a5d1e15ce net: stmmac: dwmac-rk: fix oob read in rk_gmac_setup
feb116a0ecc5 net/packet: rx_owner_map depends on pg_vec
27358aa81a7d netdevsim: Zero-initialize memory for new map's value in function nsim_bpf_map_alloc
288b0c511c11 ixgbe: set X550 MDIO speed before talking to PHY
2f2ebb7d4324 ixgbe: Document how to enable NBASE-T support
33c1707a8ea4 igc: Fix typo in i225 LTR functions
944b8be08131 igbvf: fix double free in `igbvf_probe`
81ffe207ae1b igb: Fix removal of unicast MAC filters of VFs
12dc89ccaf20 soc/tegra: fuse: Fix bitwise vs. logical OR warning
23311b92755f mptcp: fix deadlock in __mptcp_push_pending()
c26ac0ea3a91 mptcp: clear 'kern' flag from fallback sockets
3de0c86d42f8 mptcp: remove tcp ulp setsockopt support
257b3bb16634 drm/amd/pm: fix a potential gpu_metrics_table memory leak
cc98ef784152 drm/amd/display: Set exit_optimized_pwr_state for DCN31
a0dacf4bc3c5 ice: Don't put stale timestamps in the skb
89f9c880141e ice: Use div64_u64 instead of div_u64 in adjfine
68014890e438 rds: memory leak in __rds_conn_create()
d92781bf78db flow_offload: return EOPNOTSUPP for the unsupported mpls action type
97cb5c82aa1d net: stmmac: fix tc flower deletion for VLAN priority Rx steering
1571ff2d199e mac80211: fix lookup when adding AddBA extension element
0783716ba2bd cfg80211: Acquire wiphy mutex on regulatory work
e0984a4d414b mac80211: agg-tx: don't schedule_and_wake_txq() under sta->lock
95053f4477c9 drm/i915/display: Fix an unsigned subtraction which can never be negative.
fb5099ad02dc drm/ast: potential dereference of null pointer
1456a0004cc5 mptcp: never allow the PM to close a listener subflow
1752132eba08 selftest/net/forwarding: declare NETIFS p9 p10
7c23a5d90733 net: dsa: mv88e6xxx: Unforce speed & duplex in mac_link_down()
4985d3b53c4d selftests/net: toeplitz: fix udp option
491c1253441e net/sched: sch_ets: don't remove idle classes from the round-robin list
215b5046b11e drm: simpledrm: fix wrong unit with pixel clock
00b072a55ffc dmaengine: st_fdma: fix MODULE_ALIAS
ee3701c4d975 dmaengine: idxd: fix missed completion on abort path
088e4d7dba27 selftests: Fix IPv6 address bind tests
28c73d856b71 selftests: Fix raw socket bind tests with VRF
013ed7533966 selftests: Add duplicate config only for MD5 VRF tests
769f38809709 net: hns3: fix race condition in debugfs
4f4a353f6fe0 net: hns3: fix use-after-free bug in hclgevf_send_mbx_msg
a4377575d2e9 selftests: icmp_redirect: pass xfail=0 to log_test()
4cd2d21bbe58 netdevsim: don't overwrite read only ethtool parms
e5d28205bf1d inet_diag: fix kernel-infoleak for UDP sockets
f6deae2e2d83 sch_cake: do not call cake_destroy() from cake_init()
cc851898751d s390/kexec_file: fix error handling when applying relocations
b0eb9ac9ddc3 selftests: net: Correct ping6 expected rc from 2 to 1
9ff66e9ceefc Revert "drm/fb-helper: improve DRM fbdev emulation device names"
03b5d9d618a6 vdpa: Consider device id larger than 31
091b84437a82 virtio/vsock: fix the transport to work with VMADDR_CID_ANY
149a4d12c44b virtio: always enter drivers/virtio/
fac85fe13547 iwlwifi: mvm: don't crash on invalid rate w/o STA
f295986e5b6d soc: imx: Register SoC device only on i.MX boards
ad4adbbf666e clk: Don't parent clks until the parent is fully registered
d058c136fe3d arm64: dts: imx8mq: remove interconnect property from lcdif
f580a4315062 ARM: socfpga: dts: fix qspi node compatible
e7506c76b7ef ceph: initialize pathlen variable in reconnect_caps_cb
24a19e6d6518 ceph: fix duplicate increment of opened_inodes metric
832f3655c613 tee: amdtee: fix an IS_ERR() vs NULL bug
42d08e97b196 mac80211: track only QoS data frames for admission control
b08767936841 dmaengine: idxd: fix calling wq quiesce inside spinlock
05d2cc973cf5 dmaengine: idxd: add halt interrupt support
f2aebdaa3d3c arm64: dts: rockchip: fix poweroff on helios64
d4218b2803de arm64: dts: rockchip: fix audio-supply for Rock Pi 4
77eb455febc5 arm64: dts: rockchip: fix rk3399-leez-p710 vcc3v3-lan supply
e2daa0c9e898 arm64: dts: rockchip: fix rk3308-roc-cc vcc-sd supply
c2ff001288dd arm64: dts: rockchip: remove mmc-hs400-enhanced-strobe from rk3399-khadas-edge
8e72fcf9aa9a pinctrl: amd: Fix wakeups when IRQ is shared with SCI
78ae328fb170 drm/i915/hdmi: Turn DP++ TMDS output buffers back on in encoder->shutdown()
8f50c26fdf65 drm/i915/hdmi: convert intel_hdmi_to_dev to intel_hdmi_to_i915
4999509a9184 scsi: ufs: core: Retry START_STOP on UNIT_ATTENTION
af9b9c8bfeee btrfs: remove stale comment about the btrfs_show_devname
a6e7e218a4d6 btrfs: update latest_dev when we create a sprout device
e342c2558016 btrfs: use latest_dev in btrfs_show_devname
5c460192c2fa btrfs: convert latest_bdev type to btrfs_device and rename
a5f4d17daf2e audit: improve robustness of the audit queue handling
607beb420b3f dm btree remove: fix use after free in rebalance_children()
09cdb8aa5904 ceph: fix up non-directory creation in SGID directories
2c7a616145aa arm64: dts: ten64: remove redundant interrupt declaration for gpio-keys
ab2ba2dd711f recordmcount.pl: look for jgnop instruction as well as bcrl on s390
2eeff00926e5 s390/entry: fix duplicate tracking of irq nesting level
b08b3bfcc720 vdpa: check that offsets are within bounds
0c51663c77d2 virtio_ring: Fix querying of maximum DMA mapping size for virtio device
ebbbc5fea3f6 vduse: check that offset is within bounds in get_config()
e6c67560b434 vduse: fix memory corruption in vduse_dev_ioctl()
2746d3face65 bpf, selftests: Update test case for atomic cmpxchg on r0 with pointer
f87a6c160ecc bpf: Fix kernel address leakage in atomic cmpxchg's r0 aux reg
d0d68083f273 bpf, selftests: Add test case trying to taint map value pointer
dbda060d50ab bpf: Make 32->64 bounds propagation slightly more robust
f77d7a35d491 bpf: Fix signed bounds propagation after mov32
efcad725feb4 bpf, selftests: Add test case for atomic fetch on spilled pointer
423628125a48 bpf: Fix kernel address leakage in atomic fetch
976389cbb16c firmware: arm_scpi: Fix string overflow in SCPI genpd driver
c62b16f98688 mac80211: validate extended element ID is present
e606db721de5 mac80211: send ADDBA requests using the tid/queue of the aggregation session
815ee27cfbf8 mac80211: mark TX-during-stop for TX in in_reconfig
a7aed5c87d74 mac80211: fix regression in SSN handling of addba tx
237ee0f24bc4 mac80211: fix rate control for retransmitted frames
6bd55427e266 KVM: X86: Fix tlb flush for tdp in kvm_invalidate_pcid()
bf4367c02c8c x86/kvm: remove unused ack_notifier callbacks
54bf0b0d3536 KVM: downgrade two BUG_ONs to WARN_ON_ONCE
4b65555a501e KVM: selftests: Make sure kvm_create_max_vcpus test won't hit RLIMIT_NOFILE
6890c75c14b3 KVM: VMX: clear vmx_x86_ops.sync_pir_to_irr if APICv is disabled
efccff32defc reset: tegra-bpmp: Revert Handle errors in BPMP response
d00985c5b5e9 Merge tag 'v5.15.10' into 5.15.x+fslc
57dcae4a8b93 Linux 5.15.10
dbcda209899a perf inject: Fix itrace space allowed for new attributes
5b4a8fbe4b0b fuse: make sure reclaim doesn't write the inode
18fc0ba9b10e staging: most: dim2: use device release method
9985d29c4755 tracing: Fix a kmemleak false positive in tracing_map
43b145f3a20a drm/amdkfd: process_info lock not needed for svm
c21cff0ea6b2 drm/amd/display: add connector type check for CRC source set
d9e63f180fc8 drm/amdkfd: fix double free mem structure
00a3f7fb7ae3 drm/amd/display: Fix for the no Audio bug with Tiled Displays
62477b3a86d6 drm/amdgpu: check atomic flag to differeniate with legacy path
796ddc81437b drm/amdgpu: cancel the correct hrtimer on exit
4c986072a8c9 net: netlink: af_netlink: Prevent empty skb by adding a check on len.
2d5ba2f40e73 i2c: rk3x: Handle a spurious start completion interrupt flag
a5a0cc7c7b84 parisc/agp: Annotate parisc agp init functions with __init
f66f84309623 ALSA: hda/hdmi: fix HDA codec entry table order for ADL-P
5eceb6a60a53 ALSA: hda: Add Intel DG2 PCI ID and HDMI codec vid
ced9b762f2d6 loop: Use pr_warn_once() for loop_control_remove() warning
095a04e0b320 net/mlx4_en: Update reported link modes for 1/10G
8605743472c5 Revert "tty: serial: fsl_lpuart: drop earlycon entry for i.MX8QXP"
0700eab4df5b s390/test_unwind: use raw opcode instead of invalid instruction
2b12c89527ae KVM: arm64: Save PSTATE early on exit
906f7797a38f drm/msm/dp: Avoid unpowered AUX xfers that caused crashes
dc6c1eddfc74 drm/msm/dsi: set default num_data_lanes
d2db21103d84 drm/msm/a6xx: Fix uinitialized use of gpu_scid
f6db3d98f876 drm/msm: Fix null ptr access msm_ioctl_gem_submit()
9cbb957441ed i2c: virtio: fix completion handling
304aa6a73189 vmxnet3: fix minimum vectors alloc issue
569670a02e21 ice: fix FDIR init missing when reset VF
76db15314582 RDMA/irdma: Don't arm the CQ more than two times if no CE for this CQ
918e62519834 RDMA/irdma: Report correct WC errors
b260dfed222b RDMA/irdma: Fix a potential memory allocation issue in 'irdma_prm_add_pble_mem()'
11eebcf63e98 RDMA/irdma: Fix a user-after-free in add_pble_prm
1ac287b7b615 netfs: Fix lockdep warning from taking sb_writers whilst holding mmap_lock
cff728217a2b perf bpf_skel: Do not use typedef to avoid error on old clang
134151c3b11d clk: qcom: sm6125-gcc: Swap ops of ice and apps on sdcc1
439250c09785 dt-bindings: media: nxp,imx7-mipi-csi2: Drop bad if/then schema
d17a8d12a6da inet: use #ifdef CONFIG_SOCK_RX_QUEUE_MAPPING consistently
c6aa8873468c mtd: rawnand: Fix nand_choose_best_timings() on unsupported interface
0c7b48887c34 mtd: rawnand: Fix nand_erase_op delay
e3bc4d4b50ca RDMA/mlx5: Fix releasing unallocated memory in dereg MR flow
acb53e47db1f RDMA: Fix use-after-free in rxe_queue_cleanup
c0d44c58afdd hwmon: (corsair-psu) fix plain integer used as NULL pointer
d89e4211b517 nfc: fix segfault in nfc_genl_dump_devices_done
bcb0bd1422da Merge tag 'v5.15.9' into 5.15.x+fslc
14655b6d4204 Linux 5.15.9
3be0c72f5153 netfilter: selftest: conntrack_vrf.sh: fix file permission
64813c62b812 Merge tag 'v5.15.8' into 5.15.x+fslc
43e577d7a2cb Linux 5.15.8
c2bd1add2c3e bpf: Add selftests to cover packet access corner cases
5475fcf0a1c4 clocksource/drivers/dw_apb_timer_of: Fix probe failure
ee6104661b46 misc: fastrpc: fix improper packet size calculation
62a8ee0502d8 irqchip: nvic: Fix offset for Interrupt Priority Offsets
2d34992ebe9c irqchip/irq-gic-v3-its.c: Force synchronisation when issuing INVALL
4a7c65506473 aio: Fix incorrect usage of eventfd_signal_allowed()
d99d861ce3ef irqchip/armada-370-xp: Fix support for Multi-MSI interrupts
97912b97fd83 irqchip/armada-370-xp: Fix return value of armada_370_xp_msi_alloc()
f2675399eb2a irqchip/aspeed-scu: Replace update_bits with write_bits.
e18f3e046ccd csky: fix typo of fpu config macro
47b355f25b55 bus: mhi: core: Add support for forced PM resume
7f4b37c7a692 bus: mhi: pci_generic: Fix device recovery failed issue
5bff8dff8e21 nvmem: eeprom: at25: fix FRAM byte_len
990bbe357841 misc: rtsx: Avoid mangling IRQ during runtime PM
14508fe13b1c iio: accel: kxcjk-1013: Fix possible memory leak in probe and remove
2906867da4ca iio: ad7768-1: Call iio_trigger_notify_done() on error
b3a4c57a9613 iio: adc: axp20x_adc: fix charging current reporting on AXP22x
41d241ad3e55 iio: adc: stm32: fix a current leak by resetting pcsel before disabling vdda
4071943a533c iio: at91-sama5d2: Fix incorrect sign extension
a862c731f7bc iio: dln2: Check return value of devm_iio_trigger_register()
9b4e3b804c41 iio: dln2-adc: Fix lockdep complaint
363e1286cf81 iio: itg3200: Call iio_trigger_notify_done() on error
e4b600ac98ca iio: kxsd9: Don't return error code in trigger handler
5df9c2c0e4b4 iio: ltr501: Don't return error code in trigger handler
c43517071dfc iio: mma8452: Fix trigger reference couting
00d3c14338b5 iio: stk3310: Don't return error code in interrupt handler
111d5b61fbd7 iio: trigger: stm32-timer: fix MODULE_ALIAS
2db8ad169cc8 iio: trigger: Fix reference counting
7d2a35d99700 iio: gyro: adxrs290: fix data signedness
02d5a2a48bb4 xhci: avoid race between disable slot command and host runtime suspend
d861bc26fe68 usb: core: config: using bit mask instead of individual bits
47c14aceb290 xhci: Remove CONFIG_USB_DEFAULT_PERSIST to prevent xHCI from runtime suspending
0141f85b78a5 usb: core: config: fix validation of wMaxPacketValue entries
f5230fb9bf8e Revert "usb: dwc3: dwc3-qcom: Enable tx-fifo-resize property by default"
6eea4ace62fa USB: gadget: zero allocate endpoint 0 buffers
36dfdf11af49 USB: gadget: detect too-big endpoint 0 requests
ef472b023b85 selftests/fib_tests: Rework fib_rp_filter_test()
a72723e89f4d net/qla3xxx: fix an error code in ql_adapter_up()
0c9f1ab29e7f net, neigh: clear whole pneigh_entry at alloc time
48135149c089 net: fec: only clear interrupt of handling queue in fec_enet_rx_queue()
089bd0b0bf1e net: altera: set a couple error code in probe()
37493d4eb2e5 net: cdc_ncm: Allow for dwNtbOutMaxSize to be unset or zero
8ca1ca40977b tools build: Remove needless libpython-version feature check that breaks test-all fast path
9c2407afbcd0 dt-bindings: net: Reintroduce PHY no lane swap binding
2e837d90ec09 Documentation/locking/locktypes: Update migrate_disable() bits.
395022a71b6c perf tools: Fix SMT detection fast read path
f1131d3f1b50 drm/amd/display: Fix DPIA outbox timeout after S3/S4/reset
99bc19898375 Revert "PCI: aardvark: Fix support for PCI_ROM_ADDRESS1 on emulated bridge"
16431e442db2 i40e: Fix NULL pointer dereference in i40e_dbg_dump_desc
f8358589b31b bpf, sockmap: Re-evaluate proto ops when psock is removed from sockmap
a4953e7b6f6a mtd: rawnand: fsmc: Fix timing computation
ebc8909feecd mtd: rawnand: fsmc: Take instruction delay into account
fabfb7c18c8e i40e: Fix pre-set max number of queues for VF
2132643b956f i40e: Fix failed opcode appearing if handling messages from VF
06ece58874c3 clk: qcom: clk-alpha-pll: Don't reconfigure running Trion
d259ae526fd9 clk: imx: use module_platform_driver
1d044701bdbe hwmon: (dell-smm) Fix warning on /proc/i8k creation error
be7c5d58108b RDMA/hns: Do not destroy QP resources in the hw resetting phase
207f5ea62a9f RDMA/hns: Do not halt commands during reset until later
9b6bf6fca018 ASoC: codecs: wcd934x: return correct value from mixer put
339ffb5b5600 ASoC: codecs: wcd934x: handle channel mappping list correctly
71272640d459 ASoC: codecs: wsa881x: fix return values from kcontrol put
e1e22179376f ASoC: qdsp6: q6routing: Fix return value from msm_routing_put_audio_mixer
cdb5a0d0e007 ASoC: rt5682: Fix crash due to out of scope stack vars
e9362a21147a PM: runtime: Fix pm_runtime_active() kerneldoc comment
a3f0e9b1d6cd qede: validate non LSO skb length
069a849819b3 ALSA: usb-audio: Reorder snd_djm_devices[] entries
ebacb44cb204 scsi: scsi_debug: Fix buffer size of REPORT ZONES command
f8dccc1bdea7 scsi: pm80xx: Do not call scsi_remove_host() in pm8001_alloc()
d429b302c184 block: fix ioprio_get(IOPRIO_WHO_PGRP) vs setuid(2)
e3098ce15fec i2c: mpc: Use atomic read and fix break condition
23a5f9797d6c tracefs: Set all files to the same group ownership as the mount option
60d311f9e638 aio: fix use-after-free due to missing POLLFREE handling
924f51534d42 aio: keep poll requests on waitqueue until completed
8d6760fd5d16 signalfd: use wake_up_pollfree()
f12d997683a7 binder: use wake_up_pollfree()
1ebb6cd8c754 wait: add wake_up_pollfree()
8e12976c0c19 io_uring: ensure task_work gets run as part of cancelations
eb313c47b276 libata: add horkage for ASMedia 1092
b0034d4b71f1 drm/syncobj: Deal with signalled fences in drm_syncobj_find_fence.
021ae1e11dfc thermal: int340x: Fix VCoRefLow MMIO bit offset for TGL
0138d396ffce clk: qcom: regmap-mux: fix parent clock lookup
dfb7285a82fa mmc: renesas_sdhi: initialize variable properly when tuning
62c613419543 hwmon: (pwm-fan) Ensure the fan going on in .probe()
a85d27b2eff4 selftests: KVM: avoid failures due to reserved HyperTransport region
041aae47b000 tracefs: Have new files inherit the ownership of their parent
8bf902fee589 nfsd: Fix nsfd startup race (again)
148c816f10fd nfsd: fix use-after-free due to delegation race
50dacb2289e5 md: fix update super 1.0 on rdev size change
00cd8a99885c perf intel-pt: Fix error timestamp setting on the decoder error path
4fbb83c1bf25 perf intel-pt: Fix missing 'instruction' events with 'q' option
22e5fb70f725 perf intel-pt: Fix next 'err' value, walking trace
f747cc563afd perf intel-pt: Fix state setting when receiving overflow (OVF) packet
e39dd2e60039 perf intel-pt: Fix intel_pt_fup_event() assumptions about setting state type
d9c838b927cd perf intel-pt: Fix sync state when a PSB (synchronization) packet is found
c816dcf69ae4 perf intel-pt: Fix some PGE (packet generation enable/control flow packets) usage
ca06c5cb1b6d btrfs: free exchange changeset on failures
32d4054cb3e8 btrfs: replace the BUG_ON in btrfs_del_root_ref with proper error handling
477675049ca8 btrfs: fix re-dirty process of tree-log nodes
0338e448b905 btrfs: clear extent buffer uptodate when we fail to write it
48fc373d9d54 scsi: qla2xxx: Format log strings only if needed
d14bad8c11cc cifs: Fix crash on unload of cifs_arc4.ko
1fd702980994 ALSA: pcm: oss: Handle missing errors in snd_pcm_oss_change_params*()
35a3e5110321 ALSA: pcm: oss: Limit the period size to 16MB
00a860678098 ALSA: pcm: oss: Fix negative period/buffer sizes
c94a0d734c7b ALSA: hda/realtek: Fix quirk for TongFang PHxTxX1
220aaee85f0e ALSA: hda/realtek - Add headset Mic support for Lenovo ALC897 platform
da171216ac2d ALSA: ctl: Fix copy of updated id with element read/write
f987b61daa98 mm: bdi: initialize bdi_min_ratio when bdi is unregistered
dd902bcec34f mm/slub: fix endianness bug for alloc/free_traces attributes
7d7e02563bcd mm/damon/core: fix fake load reports due to uninterruptible sleeps
5a960e533c2a timers: implement usleep_idle_range()
64d320dcf1f1 KVM: x86: Wait for IPIs to be delivered when handling Hyper-V TLB flush hypercall
21cc93f6df63 KVM: x86: Ignore sparse banks size for an "all CPUs", non-sparse IPI req
eea80da3472b KVM: x86: Don't WARN if userspace mucks with RCX during string I/O exit
d6c37e679631 net: mvpp2: fix XDP rx queues registering
d86216dfda7c net/sched: fq_pie: prevent dismantle issue
973a0373e88c net: dsa: felix: Fix memory leak in felix_setup_mmio_filtering
bfc017140aa7 net: dsa: mv88e6xxx: error handling for serdes_power functions
76e414aa2a24 net: bcm4908: Handle dma_set_coherent_mask error codes
fe30b70ca84d devlink: fix netns refcount leak in devlink_nl_cmd_reload()
f9a22d3ed855 IB/hfi1: Correct guard on eager buffer deallocation
20791287eda1 iavf: Fix reporting when setting descriptor count
d0ed80e3ca88 iavf: restore MSI state on reset
be2b5a78a0c1 netfilter: conntrack: annotate data-races around ct->timeout
d2cd7c7f8f83 netfilter: nft_exthdr: break evaluation if setting TCP option fails
e6182c63d827 udp: using datalen to cap max gso segments
98adb2bbfa40 seg6: fix the iif in the IPv6 socket control block
f707820c0923 nfp: Fix memory leak in nfp_cpp_area_cache_add()
6dada2646a0a bonding: make tx_rebalance_counter an atomic
cfd719f04267 ethtool: do not perform operations on net devices being unregistered
9a7e323edb86 ice: ignore dropped packets during init
b4fb67fd1adf bpf: Fix the off-by-two error in range markings
e76da2e8a09a bpf: Make sure bpf_disable_instrumentation() is safe vs preemption.
9c983fd7cf97 bpf, sockmap: Attach map progs to psock early for feature probes
c817dcb2a65b bpf, x86: Fix "no previous prototype" warning
e8193cebf753 vrf: don't run conntrack on vrf with !dflt qdisc
cffab968e94e selftests: netfilter: add a vrf+conntrack testcase
fae9705d2810 nfc: fix potential NULL pointer deref in nfc_genl_dump_ses_done
0159c7b26683 platform/x86: amd-pmc: Fix s2idle failures on certain AMD laptops
b964ecdb71d9 x86/sme: Explicitly map new EFI memmap table as encrypted
bbf22d47bb3e net: dsa: mv88e6xxx: allow use of PHYs on CPU and DSA ports
f4b8f987a748 net: dsa: mv88e6xxx: fix "don't use PHY_DETECT on internal PHY's"
5c960ae2c22a can: m_can: Disable and ignore ELO interrupt
081816acad36 can: m_can: pci: fix iomap_read_fifo() and iomap_write_fifo()
f4848384c17e can: m_can: pci: fix incorrect reference clock rate
75a422165477 can: m_can: m_can_read_fifo: fix memory leak in error branch
6c73fc931658 can: pch_can: pch_can_rx_normal: fix use after free
474f9a8534f5 can: sja1000: fix use after free in ems_pcmcia_add_card()
c9b5472da3a8 can: kvaser_pciefd: kvaser_pciefd_rx_error_frame(): increase correct stats->{rx,tx}_errors counter
a8b513b824e4 can: kvaser_usb: get CAN clock frequency from device
834d0fb97864 IB/hfi1: Fix leak of rcvhdrtail_dummy_kvaddr
27bbf30f928a IB/hfi1: Fix early init panic
b9e1cc3b95e8 IB/hfi1: Insure use of smp_processor_id() is preempt disabled
33bee1ebfc83 nft_set_pipapo: Fix bucket load in AVX2 lookup routine for six 8-bit groups
20d1064ac956 platform/x86/intel: hid: add quirk to support Surface Go 3
6281306bdc99 HID: Ignore battery for Elan touchscreen on Asus UX550VE
719d5fb2789a HID: sony: fix error path in probe
e537e7ef5e8c mmc: spi: Add device-tree SPI IDs
59146a86b4aa mtd: dataflash: Add device-tree SPI IDs
a579510a64ed HID: check for valid USB device for many HID drivers
05ca95256aba HID: wacom: fix problems when device is not a valid USB device
58f15f5ae778 HID: bigbenff: prevent null pointer dereference
30d3150d9094 HID: add USB_HID dependancy on some USB HID drivers
8c765cf5f1bc HID: add USB_HID dependancy to hid-chicony
10b05037d7a8 HID: add USB_HID dependancy to hid-prodikeys
e1e21632a4c4 HID: add hid_is_usb() function to make it simpler for USB detection
6892f8e27d6e HID: intel-ish-hid: ipc: only enable IRQ wakeup when requested
d38f90239254 HID: google: add eel USB id
c7b9eca23ea2 HID: quirks: Add quirk for the Microsoft Surface 3 type-cover
5131cc731c67 usb: gadget: uvc: fix multiple opens
84037dc707d7 Merge tag 'v5.15.7' into 5.15.x+fslc
4e8c680af6d5 Linux 5.15.7
3ded93ae46ce ipmi: msghandler: Make symbol 'remove_work_wq' static
888fc81107ca serial: liteuart: fix minor-number leak on probe errors
602824cf9aa9 serial: liteuart: fix use-after-free and memleak on unbind
189c99c629bb serial: liteuart: Fix NULL pointer dereference in ->remove()
54b4cfe4c999 serial: 8250: Fix RTS modem control while in rs485 mode
b6e196d931d0 serial: 8250_pci: rewrite pericom_do_set_divisor()
1718ff2e3dad serial: 8250_pci: Fix ACCES entries in pci_serial_quirks array
64e491c1634b serial: core: fix transmit-buffer reset and memleak
d2341178187a serial: tegra: Change lower tolerance baud rate limit for tegra20 and tegra30
ea3628ce85ff serial: pl011: Add ACPI SBSA UART match id
87eb31a7d1e7 tty: serial: msm_serial: Deactivate RX DMA for polling support
498ddcffe2ff x86/64/mm: Map all kernel memory into trampoline_pgd
6e0dd9cceac7 x86/tsc: Disable clocksource watchdog for TSC on qualified platorms
53df08733bc4 x86/tsc: Add a timer to make sure TSC_adjust is always checked
7d94bc8e335c usb: cdnsp: Fix a NULL pointer dereference in cdnsp_endpoint_init()
f4f77594cc30 usb: cdns3: gadget: fix new urb never complete if ep cancel previous requests
cfdb7032a488 usb: typec: tcpm: Wait in SNK_DEBOUNCED until disconnect
43cdf7b5645d USB: NO_LPM quirk Lenovo Powered USB-C Travel Hub
fa75f593c867 xhci: Fix commad ring abort, write all 64 bits to CRCR register.
81dbda4c70f3 vgacon: Propagate console boot parameters before calling `vc_resize'
dbeb9153ded9 parisc: Mark cr16 CPU clocksource unstable on all SMP machines
98736f21f673 parisc: Fix "make install" on newer debian releases
34680557cf3a parisc: Fix KBUILD_IMAGE for self-extracting kernel
8e044b80e6ba serial: 8250_bcm7271: UART errors after resuming from S2
cb0fb54ff6ee net/mlx5e: Sync TIR params updates against concurrent create/modify
a950a93be05f net/mlx5e: Rename TIR lro functions to TIR packet merge functions
3cd81837f46f net/mlx5e: Rename lro_timeout to packet_merge_timeout
66e507d96869 KVM: x86/mmu: Remove spurious TLB flushes in TDP MMU zap collapsible path
e0609b252c8c KVM: x86/mmu: Rename slot_handle_leaf to slot_handle_level_4k
7012eb0e5220 KVM: SEV: Return appropriate error codes if SEV-ES scratch setup fails
a246d92dda9f sched/uclamp: Fix rq->uclamp_max not set on first enqueue
fcf714776066 preempt/dynamic: Fix setup_preempt_mode() return value
e19a07833960 x86/xen: Add xenpv_restore_regs_and_return_to_usermode()
308cc9668d7c x86/entry: Use the correct fence macro after swapgs in kernel CR3
efc5d7be3eb0 x86/entry: Add a fence for kernel entry SWAPGS in paranoid_entry()
ce364f143caa x86/sev: Fix SEV-ES INS/OUTS instructions for word, dword, and qword
690637ec0442 io-wq: don't retry task_work creation failure on fatal conditions
894b21da042f Revert "drm/i915: Implement Wa_1508744258"
812ed9b71246 mctp: Don't let RTM_DELROUTE delete local routes
f1bcddbc7b60 KVM: VMX: Set failure code in prepare_vmcs02()
5333bef073f8 KVM: x86/pmu: Fix reserved bits for AMD PerfEvtSeln register
7a22778cc73b net/mlx5: E-Switch, Check group pointer before reading bw_share value
4cc946fae4c5 net/mlx5: E-Switch, fix single FDB creation on BlueField
301c7519106d net/mlx5: E-switch, Respect BW share of the new group
3f8887350191 net/mlx5: Move MODIFY_RQT command to ignore list in internal error state
1adc4914a0da net/mlx5e: Fix missing IPsec statistics on uplink representor
c4db545992ad KVM: SEV: initialize regions_list of a mirror VM
b5a8918d0865 KVM: X86: Fix when shadow_root_level=5 && guest root_level<4
4768935c2540 iwlwifi: Fix memory leaks in error handling path
8b9bed7c63f0 ASoC: rk817: Add module alias for rk817-codec
805c90e0e919 drm/msm: Restore error return on invalid fence
4c3cdbf25403 drm/msm: Fix wait_fence submitqueue leak
8e2b7fe5e8a4 drm/msm: Fix mmap to include VM_IO and VM_DONTDUMP
a4eb55901df1 drm/msm/devfreq: Fix OPP refcnt leak
8e256b45e058 KVM: x86/mmu: Pass parameter flush as false in kvm_tdp_mmu_zap_collapsible_sptes()
d618539224ea KVM: x86/mmu: Skip tlb flush if it has been done in zap_gfn_range()
be9163800ba7 atlantic: Remove warn trace message.
35b75e2b72c5 atlantic: Fix statistics logic for production hardware
469d2288e059 Remove Half duplex mode speed capabilities.
4b72830f1e30 atlantic: Add missing DIDs and fix 115c.
6816e0fa49f3 atlantic: Fix to display FW bundle version instead of FW mac version.
e9df163300ae atlatnic: enable Nbase-t speeds with base-t
da0027b4178d atlantic: Increase delay for fw transactions
e216e02befc3 drm/vc4: kms: Fix previous HVS commit wait
aeadbd778d66 drm/vc4: kms: Don't duplicate pending commit
2931db9a5ed2 drm/vc4: kms: Clear the HVS FIFO commit pointer once done
53f9601e908d drm/vc4: kms: Add missing drm_crtc_commit_put
b044180fcb38 drm/vc4: kms: Fix return code check
fd7bfba0112d drm/vc4: kms: Wait for the commit before increasing our clock rate
3cae481575f5 drm/msm: Do hw_init() before capturing GPU state
83e54fcf0b14 drm/msm/a6xx: Allocate enough space for GMU registers
3a3db121f999 net/smc: Keep smc_close_final rc during active close
b44a55ee25ef net/rds: correct socket tunable error in rds_tcp_tune()
95518fe354d7 net/smc: fix wrong list_del in smc_lgr_cleanup_early
170739c45e37 ipv4: convert fib_num_tclassid_users to atomic_t
94782c8ffd07 net: annotate data-races on txq->xmit_lock_owner
1c0ddef45b7e octeontx2-af: Fix a memleak bug in rvu_mbox_init()
e83fb96f915a dpaa2-eth: destroy workqueue at the end of remove function
686578a1bac1 net: marvell: mvpp2: Fix the computation of shared CPUs
231117a52713 net: usb: lan78xx: lan78xx_phy_init(): use PHY_POLL instead of "0" if no IRQ is available
823ae758c0f3 net: stmmac: Avoid DMA_CHAN_CONTROL write if no Split Header support
a927f9dfd0d9 ALSA: intel-dsp-config: add quirk for CML devices based on ES8336 codec
9469273e616c rxrpc: Fix rxrpc_local leak in rxrpc_lookup_peer()
bc97458620e3 rxrpc: Fix rxrpc_peer leak in rxrpc_look_up_bundle()
f50dcc9d14f5 ASoC: tegra: Fix kcontrol put callback in AHUB
e13772cfb25d ASoC: tegra: Fix kcontrol put callback in DSPK
1686d2e9edb2 ASoC: tegra: Fix kcontrol put callback in DMIC
e6186c773572 ASoC: tegra: Fix kcontrol put callback in I2S
7b77bdff45ff ASoC: tegra: Fix kcontrol put callback in ADMAIF
a0730b605153 ASoC: tegra: Fix wrong value type in DSPK
7e83ca5d78bb ASoC: tegra: Fix wrong value type in DMIC
36358b208cdb ASoC: tegra: Fix wrong value type in I2S
f3f65b768880 ASoC: tegra: Fix wrong value type in ADMAIF
14b03b8cebdf mt76: mt7915: fix NULL pointer dereference in mt7915_get_phy_mode
f8aceb91a5dd net: dsa: b53: Add SPI ID table
ad7f90bb8846 selftests: net: Correct case name
75917372eef0 net/mlx4_en: Fix an use-after-free bug in mlx4_en_try_alloc_resources()
b762b3e28c92 net/mlx5e: IPsec: Fix Software parser inner l3 type setting in case of encapsulation
3f837fefa59d iwlwifi: fix warnings produced by kernel debug options
b9dffaf94908 arm64: ftrace: add missing BTIs
49d17d1a4ba5 siphash: use _unaligned version by default
519ed0ab5f8b net: mpls: Fix notifications when deleting a device
c5ef33c1489b net: qlogic: qlcnic: Fix a NULL pointer dereference in qlcnic_83xx_add_rings()
5a9afcd827ca tcp: fix page frag corruption on page fault
22a18dd48866 natsemi: xtensa: fix section mismatch warnings
f744230dfbf2 i2c: cbus-gpio: set atomic transfer callback
e2d234f96d8b i2c: stm32f7: stop dma transfer in case of NACK
3dd6c5899695 i2c: stm32f7: recover the bus on access timeout
a153d4253530 i2c: stm32f7: flush TX FIFO upon transfer errors
d5f50794a49f wireguard: ratelimiter: use kvcalloc() instead of kvzalloc()
2745192cb798 wireguard: receive: drop handshakes if queue lock is contended
af794a64d6ca wireguard: receive: use ring buffer for incoming handshakes
4db0d88a9048 wireguard: device: reset peer src endpoint when netns exits
7c0d08d85139 wireguard: selftests: rename DEBUG_PI_LIST to DEBUG_PLIST
631a480320f1 wireguard: selftests: actually test for routing loops
d33493e9654a wireguard: allowedips: add missing __rcu annotation to satisfy sparse
b050a8d576b1 wireguard: selftests: increase default dmesg log size
326fb8a1c267 net: dsa: mv88e6xxx: Link in pcs_get_state() if AN is bypassed
19f7ad89bcb7 net: dsa: mv88e6xxx: Fix inband AN for 2500base-x on 88E6393X family
6f273a649608 net: dsa: mv88e6xxx: Add fix for erratum 5.2 of 88E6393X family
f2be2d4c8e8f net: dsa: mv88e6xxx: Save power by disabling SerDes trasmitter and receiver
865185f74509 net: dsa: mv88e6xxx: Drop unnecessary check in mv88e6393x_serdes_erratum_4_6()
0671c8f7332f net: dsa: mv88e6xxx: Fix application of erratum 4.8 for 88E6393X
f7b4f571d580 tracing/histograms: String compares should not care about signed values
4e06bb02ad6a KVM: x86: check PIR even for vCPUs with disabled APICv
2846d550f8f5 KVM: X86: Use vcpu->arch.walk_mmu for kvm_mmu_invlpg()
6aebd2da8d49 KVM: arm64: Avoid setting the upper 32 bits of TCR_EL2 and CPTR_EL2 to 1
87d9c628be26 KVM: MMU: shadow nested paging does not have PKU
9325b1dbdbf9 KVM: x86: Use a stable condition around all VT-d PI paths
70a37e04c08a KVM: VMX: prepare sync_pir_to_irr for running with APICv disabled
8ed61a2a6a28 KVM: nVMX: Abide to KVM_REQ_TLB_FLUSH_GUEST request on nested vmentry/vmexit
361e68805ace KVM: nVMX: Flush current VPID (L1 vs. L2) for KVM_REQ_TLB_FLUSH_GUEST
85f2cf6419dd KVM: nVMX: Emulate guest TLB flush on nested VM-Enter with new vpid12
3a929e1d7e5e KVM: x86: ignore APICv if LAPIC is not enabled
cbe4fcf37150 KVM: Ensure local memslot copies operate on up-to-date arch-specific data
2bdc79ac9a4f KVM: x86/mmu: Fix TLB flush range when handling disconnected pt
0827b8db5c7f KVM: Disallow user memslot with size that exceeds "unsigned long"
f1a1693ea4e2 KVM: fix avic_set_running for preemptable kernels
245241821ecf drm/i915/dp: Perform 30ms delay after source OUI write
7418356362ce drm/amd/display: Allow DSC on supported MST branch devices
8ef8a76a340e ipv6: fix memory leak in fib6_rule_suppress
3ce84ab279ef scsi: ufs: ufs-pci: Add support for Intel ADL
a8392866c522 scsi: lpfc: Fix non-recovery of remote ports following an unsolicited LOGO
dd267e59a181 sata_fsl: fix warning in remove_proc_entry when rmmod sata_fsl
adf098e2a8a1 sata_fsl: fix UAF in sata_fsl_port_stop when rmmod sata_fsl
6fe4eadd54da fget: check that the fd still exists after getting a ref to it
31aa63f69a3c s390/pci: move pseudo-MMIO to prevent MIO overlap
c1079ff6f9a0 dma-buf: system_heap: Use 'for_each_sgtable_sg' in pages free flow
075d9c1497f2 iwlwifi: mvm: retry init flow if failed
c649d47801df cpufreq: Fix get_cpu_device() failure in add_cpu_dev_symlink()
c4618188b15a ipmi: Move remove_work to dedicated workqueue
2a715e15588c rt2x00: do not mark device gone on EPROTO errors during start
edbdf9da8015 ALSA: hda/cs8409: Set PMSG_ON earlier inside cs8409 driver
16ccd481e3d8 kprobes: Limit max data_size of the kretprobe instances
75fc0eba15df vrf: Reset IPCB/IP6CB when processing outbound pkts in vrf dev xmit
275827a7dcaf net/tls: Fix authentication failure in CCM mode
f06c3b728ae7 ACPI: Add stubs for wakeup handler functions
b589021871cf net/smc: Avoid warning of possible recursive locking
859ea5a20ee7 tracing: Don't use out-of-sync va_list in event printing
71e284dcebec perf report: Fix memory leaks around perf_tip()
5b5c6f57a1f8 perf hist: Fix memory leak of a perf_hpp_fmt
27802de133dc perf inject: Fix ARM SPE handling
cf49756c3d68 perf sort: Fix the 'p_stage_cyc' sort key behavior
199e20f4fdfa perf sort: Fix the 'ins_lat' sort key behavior
57482dc5ac7d perf sort: Fix the 'weight' sort key behavior
40e35c77448e net: ethernet: dec: tulip: de4x5: fix possible array overflows in type3_infoblock()
12f907cb1157 net: tulip: de4x5: fix the problem that the array 'lp->phy[8]' may be out of bound
634ef8cf4e51 ipv6: check return value of ipv6_skip_exthdr
fc7ffa7f10b9 ethernet: hisilicon: hns: hns_dsaf_misc: fix a possible array overflow in hns_dsaf_ge_srst_by_port()
b56c75d4d3c3 ata: libahci: Adjust behavior when StorageD3Enable _DSD is set
ab8efdbda76c ata: ahci: Add Green Sardine vendor ID as board_ahci_mobile
75752ada77e0 drm/amd/amdgpu: fix potential memleak
06c6f8f86ec2 drm/amd/amdkfd: Fix kernel panic when reset failed and been triggered again
c786a7d5b88b drm/amd/pm: Remove artificial freq level on Navi1x
9774ec30cf7b net: usb: r8152: Add MAC passthrough support for more Lenovo Docks
592195692021 scsi: iscsi: Unblock session then wake up error handler
80050db986a1 thermal: core: Reset previous low and high trip during thermal zone init
7440613439a3 btrfs: check-integrity: fix a warning on write caching disabled disk
e26605497f4e btrfs: silence lockdep when reading chunk tree during mount
efc562ea9d8a s390/setup: avoid using memblock_enforce_memory_limit
b6d5c4e3fce7 platform/x86: thinkpad_acpi: Fix WWAN device disabled issue after S3 deep
d17d9e935f72 platform/x86: thinkpad_acpi: Add support for dual fan control
8df09ab9d374 platform/x86: dell-wmi-descriptor: disable by default
aca091aadef4 pinctrl: qcom: fix unmet dependencies on GPIOLIB for GPIOLIB_IRQCHIP
00fdcc2b4474 net: return correct error code
cec49b6dfdb0 atlantic: Fix OOB read and write in hw_atl_utils_fw_rpc_wait
fb92e025baa7 net/smc: Transfer remaining wait queue entries during fallback
cc447c1e1482 x86/hyperv: Move required MSRs check to initial platform probing
60af14bf37ec mac80211: fix throughput LED trigger
9d3eb89e6ca3 mac80211: do not access the IV when it was stripped
8e7c364d1c07 drm/sun4i: fix unmet dependency on RESET_CONTROLLER for PHY_SUN6I_MIPI_DPHY
05d27cd9bc70 powerpc/pseries/ddw: Do not try direct mapping with persistent memory and one window
b67ff10e43d3 powerpc/pseries/ddw: Revert "Extend upper limit for huge DMA window for persistent memory"
f8b76df0055c gfs2: Fix length of holes reported at end-of-file
4b11e583193c gfs2: release iopen glock early in evict
1236351c29c7 ALSA: usb-audio: Don't start stream for capture at prepare
321cd173b8cc ALSA: usb-audio: Switch back to non-latency mode at a later point
2cea047b74da ALSA: usb-audio: Less restriction for low-latency playback mode
c7ac29edfb6a ALSA: usb-audio: Fix packet size calculation regression
458871f21e69 ALSA: usb-audio: Avoid killing in-flight URBs during draining
ff39117fac65 ALSA: usb-audio: Improved lowlatency playback support
7303160785e5 ALSA: usb-audio: Add spinlock to stop_urbs()
31056232ad3c ALSA: usb-audio: Check available frames for the next packet size
8d7c6f515b15 ALSA: usb-audio: Disable low-latency mode for implicit feedback sync
5ca1fa52d351 ALSA: usb-audio: Disable low-latency playback for free-wheel mode
2d9ea74b3751 ALSA: usb-audio: Rename early_playback_start flag with lowlatency_playback
8f0a376b2eaa ALSA: usb-audio: Restrict rates for the shared clocks
7288db16eaad Merge pull request #505 from zandrey/5.15.x+fslc
542932e613c1 Merge tag 'v5.15.6' into 5.15.x+fslc
a2547651bc89 Linux 5.15.6
4268e8325d63 drm/amdgpu/gfx9: switch to golden tsc registers for renoir+
8c501d9cf122 drm/amdgpu/gfx10: add wraparound gpu counter check for APUs as well
db8ed1e61b49 block: avoid to quiesce queue in elevator_init_mq
e03513f58919 blk-mq: cancel blk-mq dispatch work in both blk_cleanup_queue and disk_release()
d9262cc886e2 docs: accounting: update delay-accounting.rst reference
ec8848ab5ebc firmware: arm_scmi: Fix type error in sensor protocol
4cbe2531efeb firmware: arm_scmi: Fix type error assignment in voltage protocol
2d447d318b76 io_uring: fix soft lockup when call __io_remove_buffers
d841c6720fb2 cifs: nosharesock should be set on new server
c9c8c054a01c tracing: Check pid filtering when creating events
6e56e87f43e2 ksmbd: Fix an error handling path in 'smb2_sess_setup()'
278f72e8eb57 vhost/vsock: fix incorrect used length reported to the guest
e4d58ac67e63 vdpa_sim: avoid putting an uninitialized iova_domain
e2c8ed0de4ab iommu/amd: Clarify AMD IOMMUv2 initialization messages
68883f17798c ceph: properly handle statfs on multifs setups
a96c6f0bbba6 cifs: nosharesock should not share socket with future sessions
98805da98d93 riscv: dts: microchip: drop duplicated MMC/SDHC node
fda0d131c0a4 riscv: dts: microchip: fix board compatible
8984bba3b4c0 f2fs: set SBI_NEED_FSCK flag when inconsistent node block found
fb89bcbfbf37 f2fs: quota: fix potential deadlock
724ee060d0ab iommu/vt-d: Fix unmap_pages support
88fc40a33ff3 iommu/rockchip: Fix PAGE_DESC_HI_MASKs for RK3568
229c555260cb sched/scs: Reset task stack state in bringup_cpu()
5f8c2755f850 perf: Ignore sigtrap for tracepoints destined for other tasks
76723ed1fb89 locking/rwsem: Make handoff bit handling more consistent
7b9237a8ef19 net: mscc: ocelot: correctly report the timestamping RX filters in ethtool
93945f2c10bc net: mscc: ocelot: don't downgrade timestamping RX filters in SIOCSHWTSTAMP
d1e71d7d2282 net: hns3: fix incorrect components info of ethtool --reset command
41f967a247bf net: hns3: fix VF RSS failed problem after PF enable multi-TCs
724c50cac0d5 net/smc: Don't call clcsock shutdown twice when smc shutdown
f7fc72a508cf net: vlan: fix underflow for the real_dev refcnt
abfdd9e2f0f9 ethtool: ioctl: fix potential NULL deref in ethtool_set_coalesce()
e25bdbc7e951 net/sched: sch_ets: don't peek at classes beyond 'nbands'
a92f0eebb8dc net: stmmac: Disable Tx queues when reconfiguring the interface
b3c37092378b tls: fix replacing proto_ops
6a012337bc70 tls: splice_read: fix accessing pre-processed records
befe4e291594 tls: splice_read: fix record type check
a6a75b537a4f MIPS: use 3-level pgtable for 64KB page size on MIPS_VA_BITS_48
ea3c7588e16f MIPS: loongson64: fix FTLB configuration
1685d6669a84 igb: fix netpoll exit with traffic
5585036815e5 nvmet: use IOCB_NOWAIT only if the filesystem supports it
a93af38c9f47 net/smc: Fix loop in smc_listen
bb851d0fb025 net/smc: Fix NULL pointer dereferencing in smc_vlan_by_tcpsk()
e85d50c4d85e net: phylink: Force retrigger in case of latched link-fail indicator
d6525de28dfe net: phylink: Force link down and retrigger resolve on interface change
cc1645427a0f lan743x: fix deadlock in lan743x_phy_link_status_change()
8165a96f6b71 tcp_cubic: fix spurious Hystart ACK train detections for not-cwnd-limited flows
7b904ba3568d drm/amd/display: Set plane update flags for all planes in reset
4da564004a73 drm/amd/display: Fix DPIA outbox timeout after GPU reset
c83f27576c46 PM: hibernate: use correct mode for swsusp_close()
fd49f1f5945a net/ncsi : Add payload to be 32-bit aligned to fix dropped packets
ff1a30740f7a arm64: uaccess: avoid blocking within critical sections
85851d9ff790 drm/hyperv: Fix device removal on Gen1 VMs
63a68f377182 nvmet-tcp: fix incomplete data digest send
d10ecfd9518e cpufreq: intel_pstate: Add Ice Lake server to out-of-band IDs
57e91396455e net: marvell: mvpp2: increase MTU limit when XDP enabled
d815f7ca8bd7 net: ipa: kill ipa_cmd_pipeline_clear()
740c461a7340 net: ipa: separate disabling setup from modem stop
f38aa5cfadf1 net: ipa: directly disable ipa-setup-ready interrupt
da4d70199e5d mlxsw: spectrum: Protect driver from buggy firmware
12dea26c05cd net/smc: Ensure the active closing peer first closes clcsock
cc432b0727ce i2c: virtio: disable timeout handling
4339cd082594 erofs: fix deadlock when shrink erofs slab
8b3b9aaada48 scsi: scsi_debug: Zero clear zones at reset write pointer
a67c045b5558 scsi: core: sysfs: Fix setting device state to SDEV_RUNNING
1f10b09ccc83 ice: avoid bpf_prog refcount underflow
992ba40a6763 ice: fix vsi->txq_map sizing
6652101175c5 net: nexthop: release IPv6 per-cpu dsts when replacing a nexthop group
e085ae661afe net: ipv6: add fib6_nh_release_dsts stub
8d196fa5a901 net: stmmac: retain PTP clock time during SIOCSHWTSTAMP ioctls
f6cd57685567 nfp: checking parameter process for rx-usecs/tx-usecs is invalid
f1f243c06675 ipv6: fix typos in __ip6_finish_output()
88f6b5f10fd1 firmware: smccc: Fix check for ARCH_SOC_ID not implemented
80d709875d92 af_unix: fix regression in read after shutdown
97e5d85030c5 mptcp: use delegate action to schedule 3rd ack retrans
10ef3a1c9377 mptcp: fix delack timer
26c3603a2a88 ALSA: intel-dsp-config: add quirk for JSL devices based on ES8336 codec
c6db0b15ced0 xen/pvh: add missing prototype to header
7c7cfc9da026 x86/pvh: add prototype for xen_pvh_init()
229e70bf02d5 iavf: Fix VLAN feature flags after VFR
8d4b4e0f0114 iavf: Fix refreshing iavf adapter stats on ethtool request
e4031c048f48 iavf: Prevent changing static ITR values if adaptive moderation is on
25bbaa3ae179 HID: magicmouse: prevent division by 0 on scroll
6341c9ccb29a HID: input: set usage type to key on keycode remap
740dd84229a5 HID: input: Fix parsing of HID_CP_CONSUMER_CONTROL fields
03e5203d2161 net: marvell: prestera: fix double free issue on err path
8599e15e508e net: marvell: prestera: fix brige port operation
94850e2dda99 drm/aspeed: Fix vga_pw sysfs output
555721765bd6 drm/vc4: fix error code in vc4_create_object()
b28df766a3fc scsi: mpt3sas: Fix incorrect system timestamp
8f13c5eddf50 scsi: mpt3sas: Fix system going into read-only mode
8485649a7655 scsi: mpt3sas: Fix kernel panic during drive powercycle test
032cf0ad6873 scsi: qla2xxx: edif: Fix off by one bug in qla_edif_app_getfcinfo()
8f98d6449b09 drm/nouveau/acr: fix a couple NULL vs IS_ERR() checks
20a09c8b25a2 ARM: socfpga: Fix crash with CONFIG_FORTIRY_SOURCE
c76a5e594920 NFSv42: Don't fail clone() unless the OP_CLONE operation failed
63073a015730 ASoC: stm32: i2s: fix 32 bits channel length without mclk
008fb838e226 firmware: arm_scmi: pm: Propagate return value to caller
7382bcaf30cb firmware: arm_scmi: Fix base agent discover response
6335d90df8af net: ieee802154: handle iftypes as u32
4739705254a7 ASoC: codecs: lpass-rx-macro: fix HPHR setting CLSH mask
b1b33a14298a ASoC: codecs: wcd934x: return error code correctly from hw_params
de178246c303 ASoC: codecs: wcd938x: fix volatile register range
49475a2b29b3 ASoC: topology: Add missing rwsem around snd_ctl_remove() calls
f4c465bf918a ASoC: qdsp6: q6asm: fix q6asm_dai_prepare error handling
f61e5332fe24 ASoC: qdsp6: q6routing: Conditionally reset FrontEnd Mixer
322eebada5e3 ARM: dts: bcm2711: Fix PCIe interrupts
6012bea74344 ARM: dts: BCM5301X: Add interrupt properties to GPIO node
b14b8cf0d1c6 ARM: dts: BCM5301X: Fix I2C controller interrupt
03339d10253e firmware: arm_scmi: Fix null de-reference on error path
75fa2dadb7c2 media: v4l2-core: fix VIDIOC_DQEVENT handling on non-x86
ed741b849ade netfilter: flowtable: fix IPv6 tunnel addr match
e76228cbecc2 netfilter: ipvs: Fix reuse connection if RS weight is 0
49f878330758 netfilter: ctnetlink: do not erase error code with EINVAL
59a0088fde86 netfilter: ctnetlink: fix filtering with CTA_TUPLE_REPLY
37c8d485cb72 ASoC: SOF: Intel: hda: fix hotplug when only codec is suspended
7b3a34f08d11 proc/vmcore: fix clearing user buffer by properly using clear_user()
de6231fc7f2b drm/amd/display: Fix OLED brightness control on eDP
edd145cd0902 PCI: aardvark: Fix link training
cc890665eaa1 PCI: aardvark: Simplify initialization of rootcap on virtual bridge
70b131ff35bd PCI: aardvark: Implement re-issuing config requests on CRS response
c37f8369fa03 PCI: aardvark: Deduplicate code in advk_pcie_rd_conf()
a0a7875c0305 NFSv42: Fix pagecache invalidation after COPY/CLONE
55d2254fd9a0 iomap: Fix inline extent handling in iomap_readpage
c4e3ff8b8b1d powerpc/32: Fix hardlockup on vmap stack overflow
671fbc2e8dea cpufreq: intel_pstate: Fix active mode offline/online EPP handling
7dd74096dd28 arm64: mm: Fix VM_BUG_ON(mm != &init_mm) for trans_pgd
9ed3dc3968ad mdio: aspeed: Fix "Link is Down" issue
4332ead29990 mmc: sdhci: Fix ADMA for PAGE_SIZE >= 64KiB
4721b9ee049a mmc: sdhci-esdhc-imx: disable CMDQ support
55bc4437762a tracing: Fix pid filtering when triggers are attached
a3e90db5180f tracing/uprobe: Fix uprobe_perf_open probes iteration
83247fdb9417 KVM: PPC: Book3S HV: Prevent POWER7/8 TLB flush flushing SLB
11e659827c3a ksmbd: fix memleak in get_file_stream_info()
522cd5c6554a ksmbd: contain default data stream even if xattr is empty
b05576526e84 ksmbd: downgrade addition info error msg to debug in smb2_get_info_sec()
a70414d820f7 drm/nouveau: recognise GA106
832c006eec0d drm/amdgpu/pm: fix powerplay OD interface
2def7fdf5c82 drm/amdgpu: IH process reset count when restart
1c939a53b26b io_uring: fix link traversal locking
3d2a1e68fd99 io_uring: fail cancellation for EXITING tasks
09eb40f6776c io_uring: correct link-list traversal locking
c673d72d2f61 xen: detect uninitialized xenbus in xenbus_init
6660b61a4182 xen: don't continue xenstore initialization in case of errors
695438d30896 fuse: release pipe buf after last use
c8d3775745ad staging: r8188eu: fix a memory leak in rtw_wx_read32()
788fa64fa8de staging: r8188eu: use GFP_ATOMIC under spinlock
b0d61266f56a staging: r8188eu: Fix breakage introduced when 5G code was removed
51bdb198872c staging: r8188eu: Use kzalloc() with GFP_ATOMIC in atomic context
e27ee2f607fe staging: rtl8192e: Fix use after free in _rtl92e_pci_disconnect()
f0340bea8302 staging: greybus: Add missing rwsem around snd_ctl_remove() calls
d58ec6e81803 staging/fbtft: Fix backlight
d048d3eb3ca7 HID: wacom: Use "Confidence" flag to prevent reporting invalid contacts
28849ab40bac Revert "parisc: Fix backtrace to always include init funtion names"
02130f5e7ca3 media: cec: copy sequence field for the reply
238c04518ff1 ALSA: hda/realtek: Fix LED on HP ProBook 435 G7
4e6ef0940048 ALSA: hda/realtek: Add quirk for ASRock NUC Box 1100
25aa8e9f1031 ALSA: ctxfi: Fix out-of-range access
849d86e85951 binder: fix test regression due to sender_euid change
816904fd873b usb: hub: Fix locking issues with address0_mutex
55197c24c6f1 usb: hub: Fix usb enumeration issue due to address0 race
631a7e0afebd usb: xhci: tegra: Check padctrl interrupt presence in device tree
907f68f03f4f usb: typec: fusb302: Fix masking of comparator and bc_lvl interrupts
a815c169c8c4 usb: chipidea: ci_hdrc_imx: fix potential error pointer dereference in probe
39509d76a9a3 net: nexthop: fix null pointer dereference when IPv6 is not enabled
54619c356f6c net: usb: Correct PHY handling of smsc95xx
70ba56d4f464 usb: dwc3: gadget: Fix null pointer exception
ecba9bc9946b usb: dwc3: gadget: Check for L1/L2/U3 for Start Transfer
d92d8b589366 usb: dwc3: gadget: Ignore NoStream after End Transfer
949fac2e09dd usb: dwc3: core: Revise GHWPARAMS9 offset
a6cc2445103e usb: dwc3: leave default DMA for PCI devices
a5e1211d4451 usb: dwc2: hcd_queue: Fix use of floating point literal
581f42756d29 usb: dwc2: gadget: Fix ISOC flow for elapsed frames
8228d7b0281c USB: serial: option: add Fibocom FM101-GL variants
616dc7809103 USB: serial: option: add Telit LE910S1 0x9200 composition
ea773394a003 USB: serial: pl2303: fix GC type detection
e0b8e1ae8306 ACPI: CPPC: Add NULL pointer check to cppc_get_perf()
dbd961095ed4 ACPI: Get acpi_device's parent from the parent field
c82cd4eed128 scsi: sd: Fix sd_do_mode_sense() buffer length handling
fe77d614093b Merge tag 'v5.15.5' into 5.15.x+fslc
f00712e27083 Linux 5.15.5
e6818963e0b0 ALSA: hda: hdac_stream: fix potential locking issue in snd_hdac_stream_assign()
01085644673f ALSA: hda: hdac_ext_stream: fix potential locking issues
faed25ba98db x86/Kconfig: Fix an unused variable error in dell-smm-hwmon
fa5f8606353f net: add and use skb_unclone_keeptruesize() helper
f14c85733154 btrfs: update device path inode time instead of bd_inode
22efa065ff01 fs: export an inode_update_time helper
148ed0e75c5e ice: Delete always true check of PF pointer
0190a2f88823 ice: Fix VF true promiscuous mode
d87edd01ce22 usb: max-3421: Use driver data instead of maintaining a list of bound devices
11a8768144ea ASoC: rsnd: fixup DMAEngine API
330651b2c0d7 ASoC: DAPM: Cover regression by kctl change notification fix
83c8ab8503ad selinux: fix NULL-pointer dereference when hashtab allocation fails
439b99314b63 bpf: Forbid bpf_ktime_get_coarse_ns and bpf_timer_* in tracing progs
354313514e97 RDMA/netlink: Add __maybe_unused to static inline in C file
556d59293a2a hugetlbfs: flush TLBs correctly after huge_pmd_unshare
686bf792032a signal: Replace force_fatal_sig with force_exit_sig when in doubt
7614e046ed48 signal: Don't always set SA_IMMUTABLE for forced signals
02d28b5fdb41 signal: Replace force_sigsegv(SIGSEGV) with force_fatal_sig(SIGSEGV)
3e61002d0597 signal/x86: In emulate_vsyscall force a signal instead of calling do_exit
3c4d5a38ca93 signal/vm86_32: Properly send SIGSEGV when the vm86 state cannot be saved.
1998d85c83e3 signal/sparc32: In setup_rt_frame and setup_fram use force_fatal_sig
905e8609419b signal/sparc32: Exit with a fatal signal when try_to_clear_window_buffer fails
58484ab427f1 signal/s390: Use force_sigsegv in default_trap_handler
c7b7868dba81 signal/powerpc: On swapcontext failure force SIGSEGV
fe67da49f784 exit/syscall_user_dispatch: Send ordinary signals on failure
110ae07d2268 signal: Implement force_fatal_sig
21d727a394f0 drm/amd/pm: avoid duplicate powergate/ungate setting
ca28919fe90d drm/amdgpu: fix set scaling mode Full/Full aspect/Center not works on vga and dvi connectors
2e3eb81884de drm/i915: Fix type1 DVI DP dual mode adapter heuristic for modern platforms
a2dda2817a9a drm/i915/dp: Ensure max link params are always valid
72704e07a003 drm/i915/dp: Ensure sink rate values are always valid
c3d06f6067bf drm/nouveau: clean up all clients on device removal
0b1a35d63995 drm/nouveau: use drm_dev_unplug() during device removal
4ee6807a1ad7 drm/nouveau: Add a dedicated mutex for the clients list
4f8e469a2384 drm/prime: Fix use after free in mmap with drm_gem_ttm_mmap
59fb48db328b drm/udl: fix control-message timeout
f5b5ea165440 drm/i915/guc: Unwind context requests in reverse order
413e603c1447 drm/i915/guc: Don't drop ce->guc_active.lock when unwinding context
2a45b1c66ccc drm/i915/guc: Workaround reset G2H is received after schedule done G2H
ad583a961905 drm/i915/guc: Don't enable scheduling on a banned context, guc_id invalid, not registered
519bd9107ef6 drm/i915/guc: Fix outstanding G2H accounting
296188ce0360 drm/amd/display: Limit max DSC target bpp for sp…