### PR TITLE
Add imx-dsp recipes and enable imx-gst1.0-plugin to support i.MX Audio DSP Codec

### DIFF
--- a/recipes-multimedia/gstreamer/imx-gst1.0-plugin_4.6.1.bb
+++ b/recipes-multimedia/gstreamer/imx-gst1.0-plugin_4.6.1.bb
@@ -49,6 +49,10 @@ PACKAGES =+ "${PN}-gplay ${PN}-libgplaycore ${PN}-libgstfsl ${PN}-grecorder ${PN
 # Add codec list that the beep plugin run-time depended
 BEEP_RDEPENDS = "imx-codec-aac imx-codec-mp3 imx-codec-oggvorbis"
 RDEPENDS:${PN} += "imx-parser ${BEEP_RDEPENDS} gstreamer1.0-plugins-good-id3demux "
+RDEPENDS:${PN}:append:mx8qm = " imx-dsp"
+RDEPENDS:${PN}:append:mx8qxp = " imx-dsp"
+RDEPENDS:${PN}:append:mx8mp = " imx-dsp"
+RDEPENDS:${PN}:append:mx8ulp = " imx-dsp"
 
 # overlaysink rely on G2D,
 # cannot be supported on i.MX6SLL & i.MX6UL & i.MX6ULL & i.MX7D

--- a/recipes-multimedia/imx-dsp/imx-dsp-codec-ext_1.2.0.bb
+++ b/recipes-multimedia/imx-dsp/imx-dsp-codec-ext_1.2.0.bb
@@ -1,0 +1,21 @@
+# Copyright 2018-2021 NXP
+
+DESCRIPTION = "i.MX DSP Codec Wrapper and Lib owned by NXP"
+LICENSE = "Proprietary"
+LIC_FILES_CHKSUM = "file://COPYING;md5=03bcadc8dc0a788f66ca9e2b89f56c6f"
+
+inherit fsl-eula-unpack autotools pkgconfig
+
+SRC_URI = "${FSL_MIRROR}/${BP}.bin;fsl-eula=true"
+
+SRC_URI[md5sum] = "9e1d0e06f4fed47a37cb390e135f453f"
+SRC_URI[sha256sum] = "2703a9dc619a2ac32352d65cfa58f8217e65abcabd33b77b0be02425dc896ae2"
+
+# Fix strip command failed: 'Unable to recognise the format of the input file'
+INHIBIT_PACKAGE_STRIP = "1"
+INHIBIT_SYSROOT_STRIP = "1"
+INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
+INSANE_SKIP:${PN} = "arch dev-so"
+
+FILES:${PN} += "${libdir}/imx-mm/audio-codec ${datadir}/imx-mm"
+COMPATIBLE_MACHINE = "(mx8qm|mx8qxp|mx8mp|mx8ulp)"

--- a/recipes-multimedia/imx-dsp/imx-dsp_1.2.0.bb
+++ b/recipes-multimedia/imx-dsp/imx-dsp_1.2.0.bb
@@ -1,0 +1,45 @@
+# Copyright 2017-2021 NXP
+
+DESCRIPTION = "i.MX DSP Wrapper, Firmware Binary, Codec Libraries"
+LICENSE = "Proprietary"
+LIC_FILES_CHKSUM = "file://COPYING;md5=03bcadc8dc0a788f66ca9e2b89f56c6f"
+
+inherit fsl-eula-unpack autotools pkgconfig
+
+SRC_URI = "${FSL_MIRROR}/${BP}.bin;fsl-eula=true"
+
+SRC_URI[md5sum] = "238d3f0256573ca657228d7090bcb7d3"
+SRC_URI[sha256sum] = "13f67f267d6d33e8be2a6c258a46cde3667258ac86435776cbf1a370de611476"
+
+EXTRA_OECONF += " \
+    -datadir=${base_libdir}/firmware --bindir=/unit_tests \
+    ${@bb.utils.contains('TUNE_FEATURES', 'aarch64', '--enable-armv8', ' ', d)} \
+"
+
+RDEPENDS:${PN} += " imx-dsp-codec-ext"
+
+HIFI4_BIN ?= "hifi4_imx8qmqxp.bin"
+HIFI4_BIN:mx8mp = "hifi4_imx8mp.bin"
+HIFI4_BIN:mx8ulp = "hifi4_imx8ulp.bin"
+
+do_install:append () {
+    # Rename DSP Firmware into hifi4.bin and remove unneeded binary
+    mv ${D}/lib/firmware/imx/dsp/${HIFI4_BIN} ${D}/lib/firmware/imx/dsp/hifi4.bin
+    find ${D}/lib/firmware/imx/dsp -name hifi4_*.bin -exec rm {} \;
+}
+
+FILES:${PN} = "${libdir}/imx-mm/audio-codec/dsp \
+               ${libdir}/imx-mm/audio-codec/wrap \
+               ${base_libdir}/firmware/imx/dsp \
+               /unit_tests \
+"
+
+INSANE_SKIP:${PN} = "already-stripped arch ldflags dev-so"
+
+# Fix strip command failed: 'Unable to recognise the format of the input file'
+INHIBIT_PACKAGE_STRIP = "1"
+INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
+INHIBIT_SYSROOT_STRIP = "1"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+COMPATIBLE_MACHINE = "(mx8qm|mx8qxp|mx8mp|mx8ulp)"


### PR DESCRIPTION
As per NXP BSP:
- https://source.codeaurora.org/external/imx/meta-imx/tree/meta-bsp/recipes-multimedia/imx-dsp?h=hardknott-5.10.72-2.2.0
- https://source.codeaurora.org/external/imx/meta-imx/commit/?h=hardknott-5.10.72-2.2.0&id=eb72f6dc37079f001106711cdeecdb00f2d8e6cf