### PR TITLE
libsdl2: follow oe-core's move to cmake

### DIFF
--- a/recipes-graphics/libsdl2/libsdl2_%.bbappend
+++ b/recipes-graphics/libsdl2/libsdl2_%.bbappend
@@ -1,6 +1,6 @@
 # what vivante driver does libsdl2 mean? Anyway it fails with missing functions as
 # VIVANTE_Create VIVANTE_GLES_GetProcAddress VIVANTE_GLES_UnloadLibrary ...
-EXTRA_OECONF:append:imxgpu2d = " --disable-video-vivante"
+EXTRA_OECMAKE:append:imxgpu = " -DSDL_VIVANTE=OFF"
 
 CFLAGS:append:imxgpu = " -DLINUX \
     ${@bb.utils.contains('DISTRO_FEATURES', 'x11', '', '-DEGL_API_FB', d)} \


### PR DESCRIPTION
openembedded-core commit c00f79c2f1 ("libsdl2: Move to CMake build")
moved the recipe to CMake. Follow this in this bbappend.

Signed-off-by: Max Krummenacher <max.krummenacher@toradex.com>