### PR TITLE
[dunfell]: linux-fslc Kernel update (up to v5.4.172)

### DIFF
--- a/recipes-kernel/linux/linux-fslc_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc_5.4.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.148"
+LINUX_VERSION = "5.4.149"
 
 SRCBRANCH = "5.4.x+fslc"
-SRCREV = "7487805e90b88d3cad2cf30fb243a2bc2d160f35"
+SRCREV = "de41569873f898a0d6d19b16a856e0d1e210d471"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"

--- a/recipes-kernel/linux/linux-fslc_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc_5.4.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.158"
+LINUX_VERSION = "5.4.159"
 
 SRCBRANCH = "5.4.x+fslc"
-SRCREV = "08f882d2fb67138c659be4c0679793168fdb4c3a"
+SRCREV = "976629e8e719a29a570f87f766d3260e14b4c83e"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"

--- a/recipes-kernel/linux/linux-fslc_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc_5.4.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.147"
+LINUX_VERSION = "5.4.148"
 
 SRCBRANCH = "5.4.x+fslc"
-SRCREV = "b938f3a7ff06e9e1fb20657d76c6e7552d3bf0c7"
+SRCREV = "7487805e90b88d3cad2cf30fb243a2bc2d160f35"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"

--- a/recipes-kernel/linux/linux-fslc_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc_5.4.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.150"
+LINUX_VERSION = "5.4.152"
 
 SRCBRANCH = "5.4.x+fslc"
-SRCREV = "8490508b1fffd3d9ba2598a36b9b4f96711c437e"
+SRCREV = "b91d10d1f5c99e2897e204856a1c3e9a1d3d216a"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"

--- a/recipes-kernel/linux/linux-fslc_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc_5.4.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.154"
+LINUX_VERSION = "5.4.156"
 
 SRCBRANCH = "5.4.x+fslc"
-SRCREV = "408a0d8ce7ae0227231ac5e5e45f946533b9fe98"
+SRCREV = "6f00ffabde7ff76c1eabda1b2e6016b9ac61b690"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"

--- a/recipes-kernel/linux/linux-fslc_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc_5.4.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.152"
+LINUX_VERSION = "5.4.153"
 
 SRCBRANCH = "5.4.x+fslc"
-SRCREV = "b91d10d1f5c99e2897e204856a1c3e9a1d3d216a"
+SRCREV = "097768384bdb56cce132d5f93a2abbfaee2f1561"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"

--- a/recipes-kernel/linux/linux-fslc_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc_5.4.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.153"
+LINUX_VERSION = "5.4.154"
 
 SRCBRANCH = "5.4.x+fslc"
-SRCREV = "097768384bdb56cce132d5f93a2abbfaee2f1561"
+SRCREV = "408a0d8ce7ae0227231ac5e5e45f946533b9fe98"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"

--- a/recipes-kernel/linux/linux-fslc_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc_5.4.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.171"
+LINUX_VERSION = "5.4.172"
 
 SRCBRANCH = "5.4.x+fslc"
-SRCREV = "1f412653a2bf2c7fd760471be03f585d5c4f57bb"
+SRCREV = "9eb5a8b554ee8bd41c6c52ae6f5c74e3c60d16f9"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"

--- a/recipes-kernel/linux/linux-fslc_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc_5.4.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.163"
+LINUX_VERSION = "5.4.170"
 
 SRCBRANCH = "5.4.x+fslc"
-SRCREV = "67637182284dc63ba16c22380138eb826c1f4805"
+SRCREV = "ca6471e045330e016e5674da8c1fff1f42440f34"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"

--- a/recipes-kernel/linux/linux-fslc_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc_5.4.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.156"
+LINUX_VERSION = "5.4.158"
 
 SRCBRANCH = "5.4.x+fslc"
-SRCREV = "6f00ffabde7ff76c1eabda1b2e6016b9ac61b690"
+SRCREV = "08f882d2fb67138c659be4c0679793168fdb4c3a"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"

--- a/recipes-kernel/linux/linux-fslc_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc_5.4.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.159"
+LINUX_VERSION = "5.4.160"
 
 SRCBRANCH = "5.4.x+fslc"
-SRCREV = "976629e8e719a29a570f87f766d3260e14b4c83e"
+SRCREV = "04852b3a93f27a49c8a02e57395f8f4fddd671b9"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"

--- a/recipes-kernel/linux/linux-fslc_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc_5.4.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.160"
+LINUX_VERSION = "5.4.163"
 
 SRCBRANCH = "5.4.x+fslc"
-SRCREV = "04852b3a93f27a49c8a02e57395f8f4fddd671b9"
+SRCREV = "67637182284dc63ba16c22380138eb826c1f4805"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"

--- a/recipes-kernel/linux/linux-fslc_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc_5.4.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.170"
+LINUX_VERSION = "5.4.171"
 
 SRCBRANCH = "5.4.x+fslc"
-SRCREV = "ca6471e045330e016e5674da8c1fff1f42440f34"
+SRCREV = "1f412653a2bf2c7fd760471be03f585d5c4f57bb"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"

--- a/recipes-kernel/linux/linux-fslc_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc_5.4.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.4.149"
+LINUX_VERSION = "5.4.150"
 
 SRCBRANCH = "5.4.x+fslc"
-SRCREV = "de41569873f898a0d6d19b16a856e0d1e210d471"
+SRCREV = "8490508b1fffd3d9ba2598a36b9b4f96711c437e"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"


### PR DESCRIPTION
Kernel branch for linux-fslc was updated up to and including v5.4.172 from stable korg, recipe SRCREV are updated to point to that version now.

Upstream commits and resolved conflicts are recorded in corresponding recipe commit messages.

Recipe commits are separated based on PRs in linux-fslc repository in order to provide a possibility to bisect kernel versions in case of faults (both build and runtime).