### PR TITLE
[imx8mq-evk]: Add Mainline BSP support

### DIFF
--- a/conf/machine/imx8mq-evk.conf
+++ b/conf/machine/imx8mq-evk.conf
@@ -4,15 +4,18 @@
 #@DESCRIPTION: Machine configuration for NXP i.MX 8M Quad Evaluation Kit
 #@MAINTAINER: Jun Zhu <junzhu@nxp.com>
 
-MACHINEOVERRIDES =. "mx8:mx8m:mx8mq:"
+MACHINEOVERRIDES =. "imx-boot-container:mx8:mx8m:mx8mq:"
 
 require conf/machine/include/imx-base.inc
 require conf/machine/include/arm/armv8a/tune-cortexa53.inc
 
-IMX_DEFAULT_BSP = "nxp"
+# Mainline BSP defaults to "generic" cortexa53 configuration,
+# adjust it here to include crypto extension which enables
+# inline NEON and FPU code generation
+DEFAULTTUNE:use-mainline-bsp = "cortexa53-crypto"
 
-MACHINE_FEATURES += "pci wifi bluetooth optee bcm43455 bcm4356"
-MACHINE_FEATURES:append:use-nxp-bsp = " bcm4359"
+MACHINE_FEATURES += "pci wifi bluetooth bcm43455 bcm4356"
+MACHINE_FEATURES:append:use-nxp-bsp = " optee bcm4359"
 
 MACHINE_SOCARCH_FILTER:append:mx8mq = " virtual/libopenvg virtual/libgles1 virtual/libgles2 virtual/egl virtual/mesa virtual/libgl virtual/libg2d"
 
@@ -64,10 +67,33 @@ UBOOT_DTB_NAME = "imx8mq-evk.dtb"
 
 # Set ATF platform name
 ATF_PLATFORM = "imx8mq"
+ATF_LOAD_ADDR = "0x910000"
+
+# Extra firmware package name, that is required to build boot container for fslc bsp
+IMX_EXTRA_FIRMWARE = "firmware-imx-8m"
 
 # Set imx-mkimage boot target
 IMXBOOT_TARGETS = "flash_evk flash_evk_no_hdmi flash_dp_evk"
 IMX_BOOT_SOC_TARGET = "iMX8M"
+
+# Add support for Syslinux to mainline BSP.
+# U-Boot has the Distro Boot mode enabled by default, which
+# require that either Syslinux to be enabled, or a boot script
+# to be used to define the boot process.
+# We opt-in for Syslinux, since it is designated as a preferred
+# distro boot mode according to the U-Boot documentation.
+UBOOT_EXTLINUX:use-mainline-bsp = "1"
+UBOOT_EXTLINUX_LABELS:use-mainline-bsp = "default"
+UBOOT_EXTLINUX_DEFAULT_LABEL:use-mainline-bsp = "i.MX8M Quad EVK"
+
+UBOOT_EXTLINUX_MENU_DESCRIPTION:default:use-mainline-bsp = "i.MX8M Quad EVK"
+UBOOT_EXTLINUX_FDT:default:use-mainline-bsp     = "../imx8mq-evk.dtb"
+UBOOT_EXTLINUX_CONSOLE:default:use-mainline-bsp = "console=${console}"
+UBOOT_EXTLINUX_ROOT:default:use-mainline-bsp    ??= "root=/dev/mmcblk1p2"
+
+# Add extlinux.conf to the lis of files, which are deployed onto the
+# boot partition
+IMAGE_BOOT_FILES:append:use-mainline-bsp = " extlinux.conf;extlinux/extlinux.conf"
 
 LOADADDR = ""
 UBOOT_SUFFIX = "bin"


### PR DESCRIPTION
Recent versions of upstream U-Boot and Kernel do provide support for i.MX8MQ derivative, and it can be built using Mainline BSP.

Convert machine definition to include all parts, that are required to build Mainline BSP:
- Drop hardcoded BSP flavor setting in machine configuration
- Add boot container machine override
- Split machine features
- Define ATF load address
- Add dependency to firmware package
- Provide `extlinux` configuration to utilize _distro boot_ feature

Tested on `imx8mq-evk` machine for both `nxp` and `mainline` setting in `IMX_DEFAULT_BSP`.

-- andrey

