### PR TITLE
gstreamer: Lockin the versions for imx machines

### DIFF
--- a/recipes-multimedia/gstreamer/gstreamer1.0-libav_1.18.0.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-libav_1.18.0.bb
@@ -22,3 +22,5 @@ inherit meson pkgconfig upstream-version-is-even
 
 FILES:${PN} += "${libdir}/gstreamer-1.0/*.so"
 FILES:${PN}-staticdev += "${libdir}/gstreamer-1.0/*.a"
+
+COMPATIBLE_MACHINE = "(imx)"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly_1.18.0.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly_1.18.0.bb
@@ -41,3 +41,5 @@ EXTRA_OEMESON += " \
 
 FILES:${PN}-amrnb += "${datadir}/gstreamer-1.0/presets/GstAmrnbEnc.prs"
 FILES:${PN}-x264 += "${datadir}/gstreamer-1.0/presets/GstX264Enc.prs"
+
+COMPATIBLE_MACHINE = "(imx)"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-rtsp-server_1.18.0.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-rtsp-server_1.18.0.bb
@@ -28,3 +28,5 @@ GIR_MESON_DISABLE_FLAG = "disabled"
 
 # Starting with 1.8.0 gst-rtsp-server includes dependency-less plugins as well
 require recipes-multimedia/gstreamer/gstreamer1.0-plugins-packaging.inc
+
+COMPATIBLE_MACHINE = "(imx)"


### PR DESCRIPTION
Having open recipes in a high priority layer means they will override
always even when its not building for machines not coming from this
layer

Pin them to imx

Signed-off-by: Khem Raj <raj.khem@gmail.com>