### PR TITLE
imx-gpu-viv: Limit dependency on kernel-module-imx-gpu-viv

### DIFF
--- a/classes/fsl-vivante-kernel-driver-handler.bbclass
+++ b/classes/fsl-vivante-kernel-driver-handler.bbclass
@@ -1,7 +1,6 @@
 # Freescale Kernel Vivante Kernel Driver handler
 #
-# Enable the kernel to provide or not the Vivante kernel driver and
-#  dynamically set the proper providers per machine.
+# Enable the kernel to provide or not the Vivante kernel driver.
 #
 # The following options are supported:
 #
@@ -32,22 +31,6 @@ MACHINE_HAS_VIVANTE_KERNEL_DRIVER_SUPPORT ??= "0"
 #   0 - enable the builtin kernel driver module
 #   1 - enable the external kernel module
 MACHINE_USES_VIVANTE_KERNEL_DRIVER_MODULE ??= "${@d.getVar('MACHINE_HAS_VIVANTE_KERNEL_DRIVER_SUPPORT', False) or '0'}"
-
-python fsl_vivante_kernel_driver_handler () {
-    has_vivante_kernel_driver_support = e.data.getVar('MACHINE_HAS_VIVANTE_KERNEL_DRIVER_SUPPORT', True) or "0"
-    use_vivante_kernel_driver_module = e.data.getVar('MACHINE_USES_VIVANTE_KERNEL_DRIVER_MODULE', True) or "0"
-
-    if has_vivante_kernel_driver_support != "1":
-        return
-
-    if use_vivante_kernel_driver_module != "1":
-        e.data.appendVar('RPROVIDES:${KERNEL_PACKAGE_NAME}-base', ' kernel-module-imx-gpu-viv')
-        e.data.appendVar('RREPLACES:${KERNEL_PACKAGE_NAME}-base', ' kernel-module-imx-gpu-viv')
-        e.data.appendVar('RCONFLICTS:${KERNEL_PACKAGE_NAME}-base', ' kernel-module-imx-gpu-viv')
-}
-
-addhandler fsl_vivante_kernel_driver_handler
-fsl_vivante_kernel_driver_handler[eventmask] = "bb.event.RecipePreFinalise"
 
 do_configure:append () {
     if [ "${MACHINE_HAS_VIVANTE_KERNEL_DRIVER_SUPPORT}" = "1" ]; then

--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -111,7 +111,10 @@ XSERVER = "xserver-xorg \
            ${XSERVER_DRIVER}"
 
 # Ship kernel modules
-MACHINE_EXTRA_RRECOMMENDS = "kernel-modules"
+MACHINE_EXTRA_RRECOMMENDS = "kernel-modules \
+    ${@bb.utils.contains('MACHINE_HAS_VIVANTE_KERNEL_DRIVER_SUPPORT', '1', \
+       bb.utils.contains('MACHINE_USES_VIVANTE_KERNEL_DRIVER_MODULE', '1', 'kernel-module-imx-gpu-viv', '', d), '', d)} \
+"
 
 # Tunes for hard/soft float-point selection. Note that we allow building for
 # thumb support giving distros the chance to enable thumb by setting

--- a/recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc
+++ b/recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc
@@ -282,7 +282,6 @@ FILES:libgal-imx = "${libdir}/libGAL${SOLIBS} ${libdir}/libGAL_egl${SOLIBS}"
 FILES:libgal-imx-dev = "${libdir}/libGAL${SOLIBSDEV} ${includedir}/HAL"
 RDEPENDS:libgal-imx += "${@bb.utils.contains('PACKAGECONFIG', 'valgrind', 'valgrind', '', d)}"
 RPROVIDES:libgal-imx += "libgal-imx"
-RRECOMMENDS:libgal-imx += "kernel-module-imx-gpu-viv"
 INSANE_SKIP:libgal-imx += "build-deps"
 
 FILES:libvsc-imx = "${libdir}/libVSC${SOLIBS}"


### PR DESCRIPTION
Building core-image-weston with multilib support and builtin graphics
fails:

```
ERROR: Trying to resolve runtime dependency kernel-module-imx-gpu-viv resulted in conflicting PREFERRED_PROVIDER entries being found.
The providers found were: ['virtual:multilib:lib32:/opt/work/upstream/sources/meta-freescale/recipes-kernel/linux/linux-imx-mfgtool_5.10.bb', '/opt/work/upstream/sources/meta-freescale/recipes-kernel/linux/linux-imx-mfgtool_5.10.bb']
The PREFERRED_PROVIDER entries resulting in this conflict were: ['PREFERRED_PROVIDER_lib32-linux-imx-mfgtool = lib32-linux-imx-mfgtool', 'PREFERRED_PROVIDER_linux-imx-mfgtool = linux-imx-mfgtool']. You could set PREFERRED_RPROVIDER_kernel-module-imx-gpu-viv
ERROR: Required build target 'core-image-weston' has no buildable providers.
Missing or unbuildable dependency chain was: ['core-image-weston', 'matchbox-terminal', 'gtk+3', 'virtual/egl', 'kernel-module-imx-gpu-viv']
```

This is the configuration added in local.conf:

```
require conf/multilib.conf
MULTILIBS = "multilib:lib32"
DEFAULTTUNE:virtclass-multilib-lib32 = "armv7athf-neon"
IMAGE_INSTALL:append = " lib32-glibc lib32-libgcc lib32-libstdc++"
MACHINE_USES_VIVANTE_KERNEL_DRIVER_MODULE = "0"
```

The error is confusing since it refers to _module_ graphics and to
linux-imx-mfgtool, neither of which are relevant to the build.

Rework the implementation so that the module graphics are recommended
only when configured and the logic marking the kernel as a provider of
module graphics can be dropped. Also, move the dependency to the
machine level to avoid making imx-gpu-viv machine-specific.

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>
