### PR TITLE
Consolidated Kernel update (v5.10.93 + 5.15.16)

### DIFF
--- a/recipes-kernel/linux/linux-fslc-imx_5.10.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_5.10.bb
@@ -28,7 +28,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v5.10.90
+#    tag: v5.10.91
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
@@ -73,14 +73,14 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
 KBRANCH = "5.10-2.1.x-imx"
-SRCREV = "e730e691a1edb8c38004d81b070529224e8df714"
+SRCREV = "3aeaa9e07d590a450f1ffc74f6db21acf1f0a16b"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.10.90"
+LINUX_VERSION = "5.10.91"
 
 # Local version indicates the branch name in the NXP kernel tree where patches are collected from.
 LOCALVERSION = "-5.10.52-2.1.0"

--- a/recipes-kernel/linux/linux-fslc-imx_5.10.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_5.10.bb
@@ -28,7 +28,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v5.10.91
+#    tag: v5.10.92
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
@@ -73,14 +73,14 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
 KBRANCH = "5.10-2.1.x-imx"
-SRCREV = "3aeaa9e07d590a450f1ffc74f6db21acf1f0a16b"
+SRCREV = "b536e818d3a1af4cba578ad3ff81f2aa03dbc05b"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.10.91"
+LINUX_VERSION = "5.10.92"
 
 # Local version indicates the branch name in the NXP kernel tree where patches are collected from.
 LOCALVERSION = "-5.10.52-2.1.0"

--- a/recipes-kernel/linux/linux-fslc-imx_5.10.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_5.10.bb
@@ -28,7 +28,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v5.10.92
+#    tag: v5.10.93
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
@@ -73,14 +73,14 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
 KBRANCH = "5.10-2.1.x-imx"
-SRCREV = "b536e818d3a1af4cba578ad3ff81f2aa03dbc05b"
+SRCREV = "f28a9b90c506241e614212f2ce314d8f5460819d"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.10.92"
+LINUX_VERSION = "5.10.93"
 
 # Local version indicates the branch name in the NXP kernel tree where patches are collected from.
 LOCALVERSION = "-5.10.52-2.1.0"

--- a/recipes-kernel/linux/linux-fslc-lts_5.10.bb
+++ b/recipes-kernel/linux/linux-fslc-lts_5.10.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.10.92"
+LINUX_VERSION = "5.10.93"
 
 KBRANCH = "5.10.x+fslc"
-SRCREV = "fce4fc0955e9ef0e08ffd59bf81a95810bbf8589"
+SRCREV = "de6a8455baae279feddb56c99056aa075175cd68"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"

--- a/recipes-kernel/linux/linux-fslc-lts_5.10.bb
+++ b/recipes-kernel/linux/linux-fslc-lts_5.10.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.10.90"
+LINUX_VERSION = "5.10.91"
 
 KBRANCH = "5.10.x+fslc"
-SRCREV = "da41da7f8aeec4cf0e6616615290b4a8c7a69a64"
+SRCREV = "c25a1d62e1722c91a8160e70f06101f36248fcf0"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"

--- a/recipes-kernel/linux/linux-fslc-lts_5.10.bb
+++ b/recipes-kernel/linux/linux-fslc-lts_5.10.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.10.91"
+LINUX_VERSION = "5.10.92"
 
 KBRANCH = "5.10.x+fslc"
-SRCREV = "c25a1d62e1722c91a8160e70f06101f36248fcf0"
+SRCREV = "fce4fc0955e9ef0e08ffd59bf81a95810bbf8589"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"

--- a/recipes-kernel/linux/linux-fslc_5.15.bb
+++ b/recipes-kernel/linux/linux-fslc_5.15.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.15.15"
+LINUX_VERSION = "5.15.16"
 
 KBRANCH = "5.15.x+fslc"
-SRCREV = "115dd438be2fecc93b693dd4b41627305f6334a5"
+SRCREV = "d084d166324389d09f73d8f2e91b989d69432335"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"

--- a/recipes-kernel/linux/linux-fslc_5.15.bb
+++ b/recipes-kernel/linux/linux-fslc_5.15.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.15.13"
+LINUX_VERSION = "5.15.14"
 
 KBRANCH = "5.15.x+fslc"
-SRCREV = "decdf16c686eb233ffa665ed540e0fa82d1dc745"
+SRCREV = "a1f897a47aa2fb289216d36d5b4110e9c09f5c67"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"

--- a/recipes-kernel/linux/linux-fslc_5.15.bb
+++ b/recipes-kernel/linux/linux-fslc_5.15.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.15.14"
+LINUX_VERSION = "5.15.15"
 
 KBRANCH = "5.15.x+fslc"
-SRCREV = "a1f897a47aa2fb289216d36d5b4110e9c09f5c67"
+SRCREV = "115dd438be2fecc93b693dd4b41627305f6334a5"
 
 COMPATIBLE_MACHINE = "(mxs|mx5|mx6|vf|use-mainline-bsp)"


### PR DESCRIPTION
Kernel branches were updated up to and including following versions for recipes from stable korg:
- `linux-fslc-imx`: _v5.10.93_
- `linux-fslc-lts`: _v5.10.93_
- `linux-fslc`: _v5.15.16_

Update recipe `SRCREV` to point to those versions now.

Upstream commits are recorded in corresponding recipe commit messages. 

`linux-fslc` has been boot-tested on following machines:
- `imx8mm-lpddr4-evk`: **PASS**
- `imx8mn-lpddr4-evk`: **PASS**
- `imx8mp-lpddr4-evk`: **PASS**
- `imx8mq-evk`: **PASS**

-- andrey