### PR TITLE
imx-boot: Add dependency on xxd-native

### DIFF
--- a/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
+++ b/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
@@ -18,6 +18,8 @@ DEPENDS += " \
     imx-atf \
     ${@bb.utils.contains('MACHINE_FEATURES', 'optee', 'optee-os', '', d)} \
 "
+# xxd is a dependency of fspi_packer.sh
+DEPENDS += "xxd-native"
 DEPENDS_append_mx8m = " u-boot-mkimage-native dtc-native"
 BOOT_NAME = "imx-boot"
 PROVIDES = "${BOOT_NAME}"


### PR DESCRIPTION
***This is a simple cherry-pick of a fix in master to dunfell. Without it, under certain circumstances, imx8mm won't boot from spi-nor.***

The fspi_packer.sh script uses xxd in order to generate the SPI flash
configuration header. If xxd is missing no error is produced and the
output image does not work. The log however contains the following error
messages (e.g. for iMX8MP flash_evk_flexspi target):

    ./../scripts/fspi_packer.sh ../scripts/fspi_header
    ./../scripts/fspi_packer.sh: 5: xxd: not found
    dd: failed to open 'qspi-header': No such file or directory
    3333+1 records in
    3333+1 records out
    3413776 bytes (3.4 MB, 3.3 MiB) copied, 0.00566483 s, 603 MB/s
    dd: failed to open 'qspi-header.off': No such file or directory
    cp: cannot stat 'qspi-header.off': No such file or directory
    rm: cannot remove 'qspi-header*': No such file or directory
    F(Q)SPI IMAGE PACKED

xxd is not in HOSTTOOLS or HOSTTOOLS_NONFATAL, as such the explicit
DEPENDS is required.

Signed-off-by: Nathan Rossi <nathan.rossi@digi.com>
(cherry picked from commit 71a0623ada456790778213a0ea2bb6b1535bd069)