### PR TITLE
fsl-vivante-kernel-driver-handler.bbclass: Fix multilib support

### DIFF
--- a/classes/fsl-vivante-kernel-driver-handler.bbclass
+++ b/classes/fsl-vivante-kernel-driver-handler.bbclass
@@ -41,9 +41,9 @@ python fsl_vivante_kernel_driver_handler () {
         return
 
     if use_vivante_kernel_driver_module != "1":
-        e.data.appendVar('RPROVIDES:${KERNEL_PACKAGE_NAME}-base', ' kernel-module-imx-gpu-viv')
-        e.data.appendVar('RREPLACES:${KERNEL_PACKAGE_NAME}-base', ' kernel-module-imx-gpu-viv')
-        e.data.appendVar('RCONFLICTS:${KERNEL_PACKAGE_NAME}-base', ' kernel-module-imx-gpu-viv')
+        e.data.appendVar('RPROVIDES:${KERNEL_PACKAGE_NAME}-base', ' ${MLPREFIX}kernel-module-imx-gpu-viv')
+        e.data.appendVar('RREPLACES:${KERNEL_PACKAGE_NAME}-base', ' ${MLPREFIX}kernel-module-imx-gpu-viv')
+        e.data.appendVar('RCONFLICTS:${KERNEL_PACKAGE_NAME}-base', ' ${MLPREFIX}kernel-module-imx-gpu-viv')
 }
 
 addhandler fsl_vivante_kernel_driver_handler


### PR DESCRIPTION
Building core-image-weston with multilib support and builtin graphics
fails:

```
ERROR: Nothing PROVIDES 'virtual/arm-oelmllib32-linux-gnueabi-binutils'. Close matches:
  virtual/lib32-arm-oelmllib32-linux-gnueabi-binutils
  virtual/lib32-arm-oelmllib32-linux-gnueabi-go-runtime
  virtual/lib32-arm-oelmllib32-linux-gnueabi-rust
ERROR: Nothing PROVIDES 'virtual/arm-oelmllib32-linux-gnueabi-gcc'. Close matches:
  virtual/lib32-arm-oelmllib32-linux-gnueabi-g++
  virtual/lib32-arm-oelmllib32-linux-gnueabi-gcc
  virtual/lib32-arm-oelmllib32-linux-gnueabi-rust
```

This is the configuration added in local.conf:

```
require conf/multilib.conf
MULTILIBS = "multilib:lib32"
DEFAULTTUNE:virtclass-multilib-lib32 = "armv7athf-neon"
IMAGE_INSTALL:append = " lib32-glibc lib32-libgcc lib32-libstdc++"
MACHINE_USES_VIVANTE_KERNEL_DRIVER_MODULE = "0"
```

This commit fixes the provides so BitBake can properly handle the
dependencies.

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>