### PR TITLE
kernel-module-nxp89xx: Pin to imx machine kernel

### DIFF
--- a/recipes-kernel/kernel-modules/kernel-module-nxp89xx_git.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-nxp89xx_git.bb
@@ -12,3 +12,6 @@ S = "${WORKDIR}/git/mxm_wifiex/wlan_src"
 inherit module
 
 EXTRA_OEMAKE = "KERNELDIR=${STAGING_KERNEL_BUILDDIR} -C ${STAGING_KERNEL_BUILDDIR} M=${S}"
+
+COMPATIBLE_MACHINE = "(imx)"
+


### PR DESCRIPTION
It fails to build with linux-yocto 5.15 e.g.

TOPDIR/build/tmp/work/qemumips-yoe-linux/kernel-module-nxp89xx/git-r0/git/mxm_wifiex/wlan_src/mlinux/moal_shim.c:1405:49: error: 'RX_PKT_FATE_DRV_DROP_NOBUFS' undeclared (first use in this function)
 1405 |                                                 RX_PKT_FATE_DRV_DROP_NOBUFS,
      |                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~

Signed-off-by: Khem Raj <raj.khem@gmail.com>