### PR TITLE
optee-test: replace old pycrypto with pycryptodome

### DIFF
--- a/recipes-security/optee-imx/optee-test_3.10.0.imx.bb
+++ b/recipes-security/optee-imx/optee-test_3.10.0.imx.bb
@@ -6,7 +6,7 @@ HOMEPAGE = "http://www.optee.org/"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://LICENSE.md;md5=daa2bcccc666345ab8940aab1315a4fa"
 
-DEPENDS = "python3-pycrypto-native python3-pycryptodomex-native optee-os optee-client openssl"
+DEPENDS = "python3-pycryptodome-native python3-pycryptodomex-native optee-os optee-client openssl"
 
 SRCBRANCH = "imx_5.4.70_2.3.0"
 


### PR DESCRIPTION
For security reason, pycrypto is no longer available, but it can be replaced by
pycryptodome.

Signed-off-by: Thomas Perrot <thomas.perrot@bootlin.com>