### PR TITLE
imx-atf: add mark quotation to prevent build issue with ccache 

### DIFF
--- a/recipes-bsp/imx-atf/imx-atf_2.4.bb
+++ b/recipes-bsp/imx-atf/imx-atf_2.4.bb
@@ -43,9 +43,9 @@ def remove_options_tail (in_string):
     from itertools import takewhile
     return ' '.join(takewhile(lambda x: not x.startswith('-'), in_string.split(' ')))
 
-EXTRA_OEMAKE += "LD=${@remove_options_tail(d.getVar('LD'))}"
+EXTRA_OEMAKE += 'LD="${@remove_options_tail(d.getVar('LD'))}"'
 
-EXTRA_OEMAKE += "CC=${@remove_options_tail(d.getVar('CC'))}"
+EXTRA_OEMAKE += 'CC="${@remove_options_tail(d.getVar('CC'))}"'
 
 do_compile() {
     # Clear LDFLAGS to avoid the option -Wl recognize issue


### PR DESCRIPTION
Otherwise, when ccache is enable the following issue occurs:
Log data follows:
| DEBUG: Executing shell function do_compile
| NOTE: make -j 8 CROSS_COMPILE=aarch64-oe-linux- PLAT=imx8qx LD=aarch64-oe-linux-ld CC=ccache aarch64-oe-linux-gcc bl31
| make: *** No rule to make target 'aarch64-oe-linux-gcc'.  Stop.
| ERROR: oe_runmake failed
| WARNING: exit code 1 from a shell command.

Fix #969

Signed-off-by: Thomas Perrot <thomas.perrot@bootlin.com>