### PR TITLE
Fix building crconf with usrmerge

### DIFF
--- a/recipes-extended/crconf/crconf_git.bb
+++ b/recipes-extended/crconf/crconf_git.bb
@@ -13,5 +13,3 @@ S = "${WORKDIR}/git"
 do_install () {
        oe_runmake install  DESTDIR=${D}
 }
-
-FILES:${PN} += "/share/man/*  ${libdir}/* ${sbindir}/*"

--- a/recipes-extended/crconf/crconf_git.bb
+++ b/recipes-extended/crconf/crconf_git.bb
@@ -3,7 +3,7 @@ SECTION = "base"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://Makefile;beginline=1;endline=5;md5=0f77fc44eb5911007ae4ac9f6736e111"
 
-EXTRA_OEMAKE = "'CC=${CC}' 'HOSTCC=${CC}'"
+EXTRA_OEMAKE = "'CC=${CC}' 'HOSTCC=${CC}' SBINDIR='${sbindir}' MANDIR='${mandir}'"
 
 SRC_URI = "git://git.code.sf.net/p/crconf/code;protocol=https;nobranch=1"
 SRCREV = "c2b9595d739a9515a86ff3b1980b5cfdfcc42d68"


### PR DESCRIPTION
This fixes building crconf with usrmerge enabled. It also removes setting the `FILES` variable, since it is unnecessary.