### PR TITLE
weston-init: Set bindir properly in weston.ini

### DIFF
--- a/recipes-graphics/wayland/weston-init.bbappend
+++ b/recipes-graphics/wayland/weston-init.bbappend
@@ -48,4 +48,5 @@ do_install:append() {
     for assignment in ${INI_UNCOMMENT_ASSIGNMENTS}; do
         uncomment "$assignment" ${D}${sysconfdir}/xdg/weston/weston.ini
     done
+    sed -i -e 's,@bindir@,${bindir},g' ${D}${sysconfdir}/xdg/weston/weston.ini
 }


### PR DESCRIPTION
The customized weston.ini is installed in the rootfs with an unresolved
bindir variable.

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>