### PR TITLE
imx-g2d-samples: Ping to imxgpu2d machines

### DIFF
--- a/recipes-graphics/imx-g2d/imx-g2d-samples_1.0.0.bb
+++ b/recipes-graphics/imx-g2d/imx-g2d-samples_1.0.0.bb
@@ -20,3 +20,6 @@ do_install() {
 }
 
 FILES:${PN} += "/opt"
+
+COMPATIBLE_MACHINE = "(imxgpu2d)"
+


### PR DESCRIPTION
It depends on imx-gpu-g2d recipe which is specific to imxgpu2d machine
types

Signed-off-by: Khem Raj <raj.khem@gmail.com>