### PR TITLE
optee-imx: clarify BSD license

### DIFF
--- a/recipes-security/optee-imx/optee-client_3.10.0.imx.bb
+++ b/recipes-security/optee-imx/optee-client_3.10.0.imx.bb
@@ -2,7 +2,7 @@
 
 SUMMARY = "OPTEE Client libs"
 HOMEPAGE = "http://www.optee.org/"
-LICENSE = "BSD"
+LICENSE = "BSD-2-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=69663ab153298557a59c67a60a743e5b"
 
 SRCBRANCH = "imx_5.4.70_2.3.0"

--- a/recipes-security/optee-imx/optee-os_3.10.0.imx.bb
+++ b/recipes-security/optee-imx/optee-os_3.10.0.imx.bb
@@ -3,7 +3,7 @@
 SUMMARY = "OPTEE OS"
 DESCRIPTION = "OPTEE OS"
 HOMEPAGE = "http://www.optee.org/"
-LICENSE = "BSD"
+LICENSE = "BSD-2-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=c1f21c4f72f372ef38a5a4aee55ec173"
 
 DEPENDS = "python3-pycryptodomex-native python3-pyelftools-native u-boot-mkimage-native"

--- a/recipes-security/optee-imx/optee-test_3.10.0.imx.bb
+++ b/recipes-security/optee-imx/optee-test_3.10.0.imx.bb
@@ -3,7 +3,7 @@
 SUMMARY = "OPTEE test"
 HOMEPAGE = "http://www.optee.org/"
 
-LICENSE = "BSD"
+LICENSE = "BSD-2-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE.md;md5=daa2bcccc666345ab8940aab1315a4fa"
 
 DEPENDS = "python3-pycryptodome-native python3-pycryptodomex-native optee-os optee-client openssl"


### PR DESCRIPTION
Since upstream commit `14d4c007c4 ("common-licences: remove ambiguous "BSD" license")`, ambiguous "BSD" license has been removed from OE-Core.

This triggers the warning message in QA:
```
do_populate_lic_deploy: QA Issue: The license listed BSD was not in the licenses collected for recipe optee-os [license-file-missing]
```
OP-TEE is licensed under _"BSD-2-Clause"_ and license text clearly identifies it.

Correct LICENSE variable to indicate proper License SPDX identifier.
