### PR TITLE
layers: Bump to use kirkstone

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -8,7 +8,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 BBFILE_COLLECTIONS += "freescale-layer"
 BBFILE_PATTERN_freescale-layer := "^${LAYERDIR}/"
 BBFILE_PRIORITY_freescale-layer = "5"
-LAYERSERIES_COMPAT_freescale-layer = "honister"
+LAYERSERIES_COMPAT_freescale-layer = "kirkstone"
 
 # Add the Freescale-specific licenses into the metadata
 LICENSE_PATH += "${LAYERDIR}/custom-licenses"


### PR DESCRIPTION
its not going to be backward ABI compatible with honister due to variable renaming.

Signed-off-by: Khem Raj <raj.khem@gmail.com>