### PR TITLE
imx8x: The mx8x override is handled in extender so drop it

### DIFF
--- a/conf/machine/include/imx8dxl-evk.inc
+++ b/conf/machine/include/imx8dxl-evk.inc
@@ -1,4 +1,4 @@
-MACHINEOVERRIDES =. "mx8:mx8x:mx8dxl:"
+MACHINEOVERRIDES =. "mx8dxl:"
 
 require conf/machine/include/imx-base.inc
 require conf/machine/include/arm/armv8a/tune-cortexa35.inc

--- a/conf/machine/include/imx8x-mek.inc
+++ b/conf/machine/include/imx8x-mek.inc
@@ -1,5 +1,3 @@
-MACHINEOVERRIDES =. "mx8:mx8x:"
-
 require conf/machine/include/imx-base.inc
 require conf/machine/include/arm/armv8a/tune-cortexa35.inc
 


### PR DESCRIPTION
Refs: 9b9f9bb1 ("imx-base.inc: Add missing mx8x overrides")
Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>
