### PR TITLE
linux-imx-headers: whitelist version.h header (Fixes Hantro VPU for honister/master)

### DIFF
--- a/recipes-kernel/linux/linux-imx-headers_5.10.bb
+++ b/recipes-kernel/linux/linux-imx-headers_5.10.bb
@@ -34,6 +34,7 @@ IMX_UAPI_HEADERS = " \
     mxcfb.h \
     pxp_device.h \
     pxp_dma.h \
+    version.h \
     videodev2.h \
 "
 


### PR DESCRIPTION
As some recipes, like imx-vpu-hantro, need to know the imx kernel
version instead of the toolchain header version.
As an example, Honister toolchain uses 5.14 kernel headers. In that
case, imx-vpu-hantro believes it needs to use dmabuf allocation
mechanism although this latter will only be enabled in upcoming NXP
kernel 5.15.

Signed-off-by: Gary Bisson <gary.bisson@boundarydevices.com>