### PR TITLE
conf: imx7ulpevk: Remove unrelated imx7ulp-com.dtb entry

### DIFF
--- a/conf/machine/imx7ulpevk.conf
+++ b/conf/machine/imx7ulpevk.conf
@@ -14,9 +14,6 @@ MACHINE_FEATURES += "pci wifi bluetooth bcm43430"
 KERNEL_DEVICETREE = " \
 	imx7ulp-evk.dtb \
 "
-KERNEL_DEVICETREE:append:use-mainline-bsp = " \
-	imx7ulp-com.dtb \
-"
 KERNEL_DEVICETREE:append:use-nxp-bsp = " \
 	imx7ulp-evk-ft5416.dtb \
 	imx7ulp-evk-mipi.dtb \


### PR DESCRIPTION
The imx7ulp-com.dtb describes a completely different board: the Embedded
Artists i.MX7ULP COM board, which has no relationship with the NXP
i.MX7ULP EVK board.

Remove the imx7ulp-com.dtb entry.

Signed-off-by: Fabio Estevam <festevam@gmail.com>