### PR TITLE
Update LICENSE variable to use SPDX license identifiers

### DIFF
--- a/recipes-bsp/boot-format/boot-format_git.bb
+++ b/recipes-bsp/boot-format/boot-format_git.bb
@@ -1,5 +1,5 @@
 DESCRIPTION = "Boot format utility for booting from eSDHC/eSPI"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 PR = "r6"
 LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 

--- a/recipes-bsp/fsl-tlu/fsl-tlu_1.0.0.bb
+++ b/recipes-bsp/fsl-tlu/fsl-tlu_1.0.0.bb
@@ -2,7 +2,7 @@ SUMMARY = "Freescale TLU(Table Lookup Unit) test package"
 DESCRIPTION = "This package includes the TLU(Table Lookup Unit) test scripts \
 and configuration files."
 
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=8a71d0475d08eee76d8b6d0c6dbec543"
 
 SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-yocto-sdk/fsl-tlu;protocol=https;nobranch=1"

--- a/recipes-bsp/imx-kobs/imx-kobs_git.bb
+++ b/recipes-bsp/imx-kobs/imx-kobs_git.bb
@@ -4,7 +4,7 @@
 
 SUMMARY = "Nand boot write source"
 SECTION = "base"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=393a5ca445f6965873eca0259a17f833"
 
 PV = "5.5+git${SRCPV}"

--- a/recipes-bsp/imx-lib/imx-lib_git.bb
+++ b/recipes-bsp/imx-lib/imx-lib_git.bb
@@ -3,7 +3,7 @@
 # Copyright 2017 NXP
 
 DESCRIPTION = "Platform specific libraries for imx platform"
-LICENSE = "LGPLv2.1"
+LICENSE = "LGPL-2.1-only"
 SECTION = "multimedia"
 
 LIC_FILES_CHKSUM = "file://COPYING-LGPL-2.1;md5=fbc093901857fcd118f065f900982c24"

--- a/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
+++ b/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
@@ -3,7 +3,7 @@
 require imx-mkimage_git.inc
 
 DESCRIPTION = "Generate Boot Loader for i.MX 8 device"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6"
 SECTION = "BSP"
 

--- a/recipes-bsp/imx-mkimage/imx-mkimage_git.bb
+++ b/recipes-bsp/imx-mkimage/imx-mkimage_git.bb
@@ -4,7 +4,7 @@
 require imx-mkimage_git.inc
 
 DESCRIPTION = "i.MX make image"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6"
 SECTION = "BSP"
 

--- a/recipes-bsp/imx-test/imx-test_git.bb
+++ b/recipes-bsp/imx-test/imx-test_git.bb
@@ -5,7 +5,7 @@
 SUMMARY = "Test programs for i.MX BSP"
 DESCRIPTION = "Unit tests for the i.MX BSP"
 SECTION = "base"
-LICENSE = "GPLv2+"
+LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-2.0-or-later;md5=fed54355545ffd980b814dab4a3b312c"
 
 DEPENDS = "alsa-lib libdrm"

--- a/recipes-bsp/imx-uuc/imx-uuc_git.bb
+++ b/recipes-bsp/imx-uuc/imx-uuc_git.bb
@@ -3,7 +3,7 @@
 SUMMARY = "A Daemon wait for NXP mfgtools host's command"
 SECTION = "base"
 DEPENDS = "virtual/kernel dosfstools-native"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 inherit autotools-brokensep

--- a/recipes-bsp/libimxdmabuffer/libimxdmabuffer_1.0.1.bb
+++ b/recipes-bsp/libimxdmabuffer/libimxdmabuffer_1.0.1.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = 'Library for allocating and managing physically contiguous memory \
                ("DMA memory" or "DMA buffers") on i.MX devices.'
 HOMEPAGE = "https://github.com/Freescale/libimxdmabuffer"
-LICENSE = "LGPLv2.1"
+LICENSE = "LGPL-2.1-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=38fa42a5a6425b26d2919b17b1527324"
 SECTION = "base"
 

--- a/recipes-bsp/mxsldr/mxsldr_git.bb
+++ b/recipes-bsp/mxsldr/mxsldr_git.bb
@@ -3,7 +3,7 @@
 
 DESCRIPTION = "Freescale i.MX233/i.MX28 USB loader"
 DEPENDS = "libusb1"
-LICENSE = "GPLv2+"
+LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 SRCREV = "c40d80472525e1d57dae5317c028b745968c0399"

--- a/recipes-bsp/u-boot/u-boot-fslc-common_2022.01.inc
+++ b/recipes-bsp/u-boot/u-boot-fslc-common_2022.01.inc
@@ -3,7 +3,7 @@
 
 inherit fsl-u-boot-localversion
 
-LICENSE = "GPLv2+"
+LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://Licenses/README;md5=5a7450c57ffe5ae63fd732446b988025"
 
 DEPENDS += "flex-native bison-native"

--- a/recipes-bsp/u-boot/u-boot-imx-common_2021.04.inc
+++ b/recipes-bsp/u-boot/u-boot-imx-common_2021.04.inc
@@ -1,6 +1,6 @@
 DESCRIPTION = "i.MX U-Boot suppporting i.MX reference boards."
 
-LICENSE = "GPLv2+"
+LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://Licenses/gpl-2.0.txt;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 SRCBRANCH = "lf_v2021.04"

--- a/recipes-bsp/u-boot/u-boot-qoriq_2021.04.bb
+++ b/recipes-bsp/u-boot/u-boot-qoriq_2021.04.bb
@@ -5,7 +5,7 @@ PROVIDES += "u-boot"
 
 inherit fsl-u-boot-localversion
 
-LICENSE = "GPLv2 & BSD-3-Clause & BSD-2-Clause & LGPL-2.0 & LGPL-2.1"
+LICENSE = "GPL-2.0-only & BSD-3-Clause & BSD-2-Clause & LGPL-2.0-only & LGPL-2.1-only"
 LIC_FILES_CHKSUM = " \
     file://Licenses/gpl-2.0.txt;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
     file://Licenses/bsd-2-clause.txt;md5=6a31f076f5773aabd8ff86191ad6fdd5 \

--- a/recipes-devtools/devregs/devregs_git.bb
+++ b/recipes-devtools/devregs/devregs_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "i.MX Register tool"
 SECTION = "devel"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=5003fa041d799dd5dd5f646b74e36924"
 
 SRCREV = "dcc3e3f26d3d867d5297a104dc32bd99f5e6fa71"

--- a/recipes-devtools/imx-usb-loader/imx-usb-loader_git.bb
+++ b/recipes-devtools/imx-usb-loader/imx-usb-loader_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "i.MX/Vybrid recovery utility"
 SECTION = "devel"
-LICENSE = "LGPLv2.1"
+LICENSE = "LGPL-2.1-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
 DEPENDS = "libusb1"

--- a/recipes-devtools/qemu/qemu.inc
+++ b/recipes-devtools/qemu/qemu.inc
@@ -4,7 +4,7 @@ machine's processor through dynamic binary translation and provides a set \
 of different hardware and device models for the machine, enabling it to run \
 a variety of guest operating systems"
 HOMEPAGE = "http://qemu.org"
-LICENSE = "GPLv2 & LGPLv2.1"
+LICENSE = "GPL-2.0-only & LGPL-2.1-only"
 
 RDEPENDS:${PN}-ptest = "bash make"
 

--- a/recipes-devtools/utp-com/utp-com_git.bb
+++ b/recipes-devtools/utp-com/utp-com_git.bb
@@ -1,5 +1,5 @@
 DESCRIPTION = "Tool used to send commands to hardware via NXP's UTP protocol"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=8264535c0c4e9c6c335635c4026a8022"
 
 DEPENDS = "sg3-utils"

--- a/recipes-dpaa/eth-config/eth-config_git.bb
+++ b/recipes-dpaa/eth-config/eth-config_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "Ethernet Configuration Files"
 SECTION = "eth-config"
-LICENSE = "BSD & GPLv2+"
+LICENSE = "BSD & GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=47716bd5b656aa5e298a132a64d2d1e4"
 
 PR = "r2"

--- a/recipes-dpaa/flib/flib_git.bb
+++ b/recipes-dpaa/flib/flib_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "Foundation Library"
 SECTION = "flib"
-LICENSE = "BSD & GPLv2"
+LICENSE = "BSD & GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=9f6d1afdf6b0f6b3ba65c25ba589ee53"
 
 SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/flib;nobranch=1"

--- a/recipes-dpaa/fmlib/fmlib_git.bb
+++ b/recipes-dpaa/fmlib/fmlib_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "Frame Manager User Space Library"
 SECTION = "fman"
-LICENSE = "BSD & GPLv2"
+LICENSE = "BSD & GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=9c7bd5e45d066db084bdb3543d55b1ac"
 
 PR = "r1"

--- a/recipes-extended/crconf/crconf_git.bb
+++ b/recipes-extended/crconf/crconf_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "crconf -Linux crypto layer configuraton tool"
 SECTION = "base"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://Makefile;beginline=1;endline=5;md5=0f77fc44eb5911007ae4ac9f6736e111"
 
 EXTRA_OEMAKE = "'CC=${CC}' 'HOSTCC=${CC}' SBINDIR='${sbindir}' MANDIR='${mandir}'"

--- a/recipes-extended/dpdk/dpdk-20.11.inc
+++ b/recipes-extended/dpdk/dpdk-20.11.inc
@@ -1,6 +1,6 @@
 DESCRIPTION = "Data Plane Development Kit"
 HOMEPAGE = "http://dpdk.org"
-LICENSE = "BSD-3-Clause & LGPLv2.1 & GPLv2"
+LICENSE = "BSD-3-Clause & LGPL-2.1-only & GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://license/gpl-2.0.txt;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
                     file://license/lgpl-2.1.txt;md5=4b54a1fd55a448865a0b32d41598759d \
                     file://license/bsd-3-clause.txt;md5=0f00d99239d922ffd13cabef83b33444"

--- a/recipes-extended/dpdk/dpdk_19.11-20.12.bb
+++ b/recipes-extended/dpdk/dpdk_19.11-20.12.bb
@@ -1,4 +1,4 @@
-LICENSE = "BSD-3-Clause & LGPLv2.1 & GPLv2"
+LICENSE = "BSD-3-Clause & LGPL-2.1-only & GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://license/gpl-2.0.txt;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
                     file://license/lgpl-2.1.txt;md5=4b54a1fd55a448865a0b32d41598759d \
                     file://license/bsd-3-clause.txt;md5=0f00d99239d922ffd13cabef83b33444"

--- a/recipes-extended/jailhouse/jailhouse_0.12.bb
+++ b/recipes-extended/jailhouse/jailhouse_0.12.bb
@@ -1,7 +1,7 @@
 SUMMARY = "Jailhouse, i.MX fork"
 HOMEPAGE = "https://github.com/siemens/jailhouse"
 SECTION = "jailhouse"
-LICENSE = "GPL-2.0"
+LICENSE = "GPL-2.0-only"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=9fa7f895f96bde2d47fd5b7d95b6ba4d \
                  file://tools/root-cell-config.c.tmpl;beginline=6;endline=33;md5=2825581c1666c44a17955dc574cfbfb3 \

--- a/recipes-extended/libpkcs11/libpkcs11_git.bb
+++ b/recipes-extended/libpkcs11/libpkcs11_git.bb
@@ -1,5 +1,5 @@
 DESCRIPTION = "PKCS library"
-LICENSE = "GPLv2 & BSD"
+LICENSE = "GPL-2.0-only & BSD"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=803852533e29eb1d6d5e55ad3078b625"
 
 SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/libpkcs11;nobranch=1 \

--- a/recipes-extended/skmm-ep/skmm-ep_git.bb
+++ b/recipes-extended/skmm-ep/skmm-ep_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "SKMM application for PCIe endpoint"
 SECTION = "skmm-ep"
-LICENSE = "BSD & GPLv2"
+LICENSE = "BSD & GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://Makefile;endline=30;md5=39e58bedc879163c9338596e52df5b1f"
 
 DEPENDS = "libedit openssl virtual/kernel"

--- a/recipes-extended/tsntool/tsntool_git.bb
+++ b/recipes-extended/tsntool/tsntool_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Configure TSN funtionalitie"
 DESCRIPTION = "A tool to configure TSN funtionalities in user space"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=ef58f855337069acd375717db0dbbb6d"
 
 DEPENDS = "cjson libnl readline"

--- a/recipes-kernel/ceetm/ceetm_git.bb
+++ b/recipes-kernel/ceetm/ceetm_git.bb
@@ -1,5 +1,5 @@
 DESCRIPTION = "CEETM TC QDISC"
-LICENSE = "GPLv2 & BSD"
+LICENSE = "GPL-2.0-only & BSD"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bac620b9883d38a84dfb73ca7122d915"
 
 SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/ceetm;nobranch=1"

--- a/recipes-kernel/kernel-modules/kernel-module-ar_git.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-ar_git.bb
@@ -1,5 +1,5 @@
 SUMMARY = "Auto Response Control Module"
-LICENSE = "GPLv2 & BSD"
+LICENSE = "GPL-2.0-only & BSD"
 LIC_FILES_CHKSUM = "file://COPYING;md5=b5881ecf398da8a03a3f4c501e29d287"
 
 inherit module

--- a/recipes-kernel/kernel-modules/kernel-module-imx-gpu-viv_6.4.3.p2.4+fslc.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-imx-gpu-viv_6.4.3.p2.4+fslc.bb
@@ -4,7 +4,7 @@
 SUMMARY = "Kernel loadable module for Vivante GPU"
 DESCRIPTION = "This package uses an exact copy of the GPU kernel driver source code of \
 the same version as base and include fixes and improvements developed by FSL Community"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e"
 
 PV .= "+git${SRCPV}"

--- a/recipes-kernel/kernel-modules/kernel-module-imx-gpu-viv_6.4.3.p2.4.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-imx-gpu-viv_6.4.3.p2.4.bb
@@ -4,7 +4,7 @@
 SUMMARY = "Kernel loadable module for Vivante GPU"
 DESCRIPTION = "Builds the Vivante GPU kernel driver as a loadable kernel module, \
 allowing flexibility to use a newer graphics release with an older kernel."
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6"
 
 SRCBRANCH = "lf-5.10.y"

--- a/recipes-kernel/kernel-modules/kernel-module-isp-vvcam_4.2.2.16.0.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-isp-vvcam_4.2.2.16.0.bb
@@ -1,7 +1,7 @@
 # Copyright 2020-2021 NXP
 
 DESCRIPTION = "Kernel loadable module for ISP"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://${WORKDIR}/git/vvcam/LICENSE;md5=64381a6ea83b48c39fe524c85f65fb44"
 
 SRCBRANCH = "lf-5.10.y_2.2.0"

--- a/recipes-kernel/kernel-modules/kernel-module-ls-debug_git.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-ls-debug_git.bb
@@ -2,7 +2,7 @@ SUMMARY = "Layerscape Debug File System Module"
 DESCRIPTION = "This package is the kernel module which is used for \
 ls102xa targets debug."
 SECTION = "ls-debug"
-LICENSE = "GPLv2+"
+LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=94263f12f9416f9fd0493c8f9e8085a3"
 
 inherit module autotools-brokensep

--- a/recipes-kernel/kernel-modules/kernel-module-nxp89xx_git.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-nxp89xx_git.bb
@@ -1,5 +1,5 @@
 SUMMARY = "NXP Wi-Fi driver for module 88w8997/8987"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://gpl-2.0.txt;md5=ab04ac0f249af12befccb94447c08b77"
 
 SRCBRANCH = "lf-5.10.72_2.2.0"

--- a/recipes-kernel/kernel-modules/kernel-module-perf-qoriq_0.8.2.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-perf-qoriq_0.8.2.bb
@@ -1,5 +1,5 @@
 DESCRIPTION = "QorIQ extension to Perf for supporting non core counters"
-LICENSE = "GPLv2+"
+LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=e29234dd5d40dc352cc60cc0c93437ba"
 
 SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-yocto-sdk/qoriq-perf;branch=nxp/master"

--- a/recipes-kernel/kernel-modules/kernel-module-scatter-gather_git.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-scatter-gather_git.bb
@@ -1,5 +1,5 @@
 SUMMARY = "Scatter-gather logic for multiple tables"
-LICENSE = "GPLv2+"
+LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=e9605a22ea50467bd2bfe4cdd66e69ae"
 
 inherit module

--- a/recipes-kernel/kernel-modules/kernel-module-uio-seville_0.1.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-uio-seville_0.1.bb
@@ -1,5 +1,5 @@
 DESCRIPTION = "UIO driver for T1040 L2 Switch"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e"
 
 SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-yocto-sdk/l2switch-uio;branch=nxp/sdk-v2.0.x"

--- a/recipes-kernel/linux/linux-fslc-imx_5.10.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_5.10.bb
@@ -69,7 +69,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 
 include linux-fslc.inc
 
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
 KBRANCH = "5.10-2.1.x-imx"

--- a/recipes-kernel/linux/linux-imx-headers_5.10.bb
+++ b/recipes-kernel/linux/linux-imx-headers_5.10.bb
@@ -4,7 +4,7 @@
 SUMMARY = "Installs i.MX-specific kernel headers"
 DESCRIPTION = "Installs i.MX-specific kernel headers to userspace. \
 New headers are installed in ${includedir}/imx."
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
 SRCBRANCH = "lf-5.10.y"

--- a/recipes-kernel/linux/linux-imx.inc
+++ b/recipes-kernel/linux/linux-imx.inc
@@ -1,7 +1,7 @@
 # Copyright (C) 2012, 2015 O.S. Systems Software LTDA.
 # Released under the MIT license (see COPYING.MIT for the terms)
 
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=d7810fab7487fb0aad327b76f1be7cd7"
 
 inherit kernel-yocto kernel fsl-kernel-localversion fsl-vivante-kernel-driver-handler

--- a/recipes-kernel/linux/linux-imx_5.10.bb
+++ b/recipes-kernel/linux/linux-imx_5.10.bb
@@ -12,7 +12,7 @@ i.MX Family Reference Boards. It includes support for many IPs such as GPU, VPU 
 
 require recipes-kernel/linux/linux-imx.inc
 
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
 DEPENDS += "lzop-native bc-native"

--- a/recipes-kernel/linux/linux-qoriq.inc
+++ b/recipes-kernel/linux/linux-qoriq.inc
@@ -3,7 +3,7 @@ inherit fsl-kernel-localversion
 
 SUMMARY = "Linux Kernel for NXP QorIQ platforms"
 SECTION = "kernel"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-kernel/skmm-host/skmm-host_git.bb
+++ b/recipes-kernel/skmm-host/skmm-host_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "skmm host driver offload data to PCIe EP and push the data en-decrypted back to application"
 SECTION = "c293-skmm-host"
-LICENSE = "BSD & GPLv2+"
+LICENSE = "BSD & GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=99803d8e9a595c0bdb45ca710f353813"
 
 inherit  module qoriq_build_64bit_kernel

--- a/recipes-multimedia/alsa/imx-alsa-plugins_1.0.26.bb
+++ b/recipes-multimedia/alsa/imx-alsa-plugins_1.0.26.bb
@@ -3,7 +3,7 @@
 # Released under the MIT license (see COPYING.MIT for the terms)
 
 DESCRIPTION = "Freescale alsa-lib plugins"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 SECTION = "multimedia"
 DEPENDS = "alsa-lib"
 

--- a/recipes-multimedia/gstreamer/gstreamer1.0-libav_1.18.0.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-libav_1.18.0.bb
@@ -6,7 +6,7 @@ SECTION = "multimedia"
 
 # ffmpeg has comercial license flags so add it as we need ffmpeg as a dependency
 LICENSE_FLAGS = "commercial"
-LICENSE = "LGPLv2+"
+LICENSE = "LGPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6762ed442b3822387a51c92d928ead0d \
                     file://ext/libav/gstav.h;beginline=1;endline=18;md5=a752c35267d8276fd9ca3db6994fca9c \
                     "

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.18.0.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.18.0.imx.bb
@@ -20,7 +20,7 @@ SRCREV = "227af57d23cb6b3564fc94446ab2c9fe8c8cff22"
 
 S = "${WORKDIR}/git"
 
-LICENSE = "GPLv2+ & LGPLv2+ & LGPLv2.1+"
+LICENSE = "GPL-2.0-or-later & LGPL-2.0-or-later & LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=73a5855a8119deb017f5f13cf327095d \
                     file://COPYING.LIB;md5=21682e4e8fea52413fd26c60acb907e5 "
 

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.18.0.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.18.0.imx.bb
@@ -3,7 +3,7 @@ require recipes-multimedia/gstreamer/gstreamer1.0-plugins-common.inc
 DESCRIPTION = "'Base' GStreamer plugins and helper libraries"
 HOMEPAGE = "https://gstreamer.freedesktop.org/"
 BUGTRACKER = "https://gitlab.freedesktop.org/gstreamer/gst-plugins-base/-/issues"
-LICENSE = "GPLv2+ & LGPLv2+"
+LICENSE = "GPL-2.0-or-later & LGPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6762ed442b3822387a51c92d928ead0d"
 
 GST1.0-PLUGINS-BASE_SRC ?= "gitsm://source.codeaurora.org/external/imx/gst-plugins-base.git;protocol=https;branch=master"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.18.0.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.18.0.imx.bb
@@ -12,7 +12,7 @@ DEFAULT_PREFERENCE = "-1"
 
 S = "${WORKDIR}/git"
 
-LICENSE = "GPLv2+ & LGPLv2.1+"
+LICENSE = "GPL-2.0-or-later & LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=a6f89e2100d9b6cdffcea4f398e37343 \
                     file://gst/replaygain/rganalysis.c;beginline=1;endline=23;md5=b60ebefd5b2f5a8e0cab6bfee391a5fe"
 

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-imx_2.0.0.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-imx_2.0.0.bb
@@ -1,6 +1,6 @@
 # Copyright (C) 2018 O.S. Systems Software LTDA.
 DESCRIPTION = "GStreamer 1.0 plugins for i.MX platforms"
-LICENSE = "LGPLv2+"
+LICENSE = "LGPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=55ca817ccb7d5b5b66355690e9abc605"
 SECTION = "multimedia"
 DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base libimxdmabuffer"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly_1.18.0.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly_1.18.0.bb
@@ -7,7 +7,7 @@ BUGTRACKER = "https://gitlab.freedesktop.org/gstreamer/gst-plugins-ugly/-/issues
 LIC_FILES_CHKSUM = "file://COPYING;md5=a6f89e2100d9b6cdffcea4f398e37343 \
                     file://tests/check/elements/xingmux.c;beginline=1;endline=21;md5=4c771b8af188724855cb99cadd390068"
 
-LICENSE = "GPLv2+ & LGPLv2.1+ & LGPLv2+"
+LICENSE = "GPL-2.0-or-later & LGPL-2.1-or-later & LGPL-2.0-or-later"
 LICENSE_FLAGS = "commercial"
 
 SRC_URI = " \

--- a/recipes-multimedia/gstreamer/gstreamer1.0-rtsp-server_1.18.0.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-rtsp-server_1.18.0.bb
@@ -1,7 +1,7 @@
 SUMMARY = "A library on top of GStreamer for building an RTSP server"
 HOMEPAGE = "http://cgit.freedesktop.org/gstreamer/gst-rtsp-server/"
 SECTION = "multimedia"
-LICENSE = "LGPLv2"
+LICENSE = "LGPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6762ed442b3822387a51c92d928ead0d"
 
 DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base"

--- a/recipes-multimedia/gstreamer/gstreamer1.0_1.18.0.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0_1.18.0.imx.bb
@@ -4,7 +4,7 @@ It supports a wide range of formats including mp3, ogg, avi, mpeg and quicktime.
 HOMEPAGE = "http://gstreamer.freedesktop.org/"
 BUGTRACKER = "https://bugzilla.gnome.org/enter_bug.cgi?product=Gstreamer"
 SECTION = "multimedia"
-LICENSE = "LGPLv2+"
+LICENSE = "LGPL-2.0-or-later"
 
 DEPENDS = "glib-2.0 glib-2.0-native libxml2 bison-native flex-native"
 

--- a/recipes-multimedia/gstreamer/imx-gst1.0-plugin_4.6.1.bb
+++ b/recipes-multimedia/gstreamer/imx-gst1.0-plugin_4.6.1.bb
@@ -4,7 +4,7 @@
 # Released under the MIT license (see COPYING.MIT for the terms)
 
 DESCRIPTION = "Gstreamer freescale plugins"
-LICENSE = "GPLv2 & LGPLv2 & LGPLv2.1"
+LICENSE = "GPL-2.0-only & LGPL-2.0-only & LGPL-2.1-only"
 SECTION = "multimedia"
 
 DEPENDS = "imx-codec imx-parser gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-bad"

--- a/recipes-multimedia/libimxvpuapi/libimxvpuapi2_2.2.0.bb
+++ b/recipes-multimedia/libimxvpuapi/libimxvpuapi2_2.2.0.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "frontend for the i.MX6 / i.MX8 VPU hardware video engines"
 HOMEPAGE = "https://github.com/Freescale/libimxvpuapi"
-LICENSE = "LGPLv2.1"
+LICENSE = "LGPL-2.1-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=38fa42a5a6425b26d2919b17b1527324"
 SECTION = "multimedia"
 DEPENDS = "virtual/imxvpu libimxdmabuffer"

--- a/recipes-multimedia/libimxvpuapi/libimxvpuapi_git.bb
+++ b/recipes-multimedia/libimxvpuapi/libimxvpuapi_git.bb
@@ -1,7 +1,7 @@
 # Copyright 2018 (C) O.S. Systems Software LTDA.
 DESCRIPTION = "frontend for the i.MX6 VPU hardware video engine"
 HOMEPAGE = "https://github.com/Freescale/libimxvpuapi"
-LICENSE = "LGPLv2.1"
+LICENSE = "LGPL-2.1-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=38fa42a5a6425b26d2919b17b1527324"
 SECTION = "multimedia"
 DEPENDS = "imx-vpu"

--- a/recipes-multimedia/tinycompress/tinycompress_1.1.6.bb
+++ b/recipes-multimedia/tinycompress/tinycompress_1.1.6.bb
@@ -1,5 +1,5 @@
 DESCRIPTION = "A library to handle compressed formats like MP3 etc."
-LICENSE = "LGPLv2.1 | BSD-3-Clause"
+LICENSE = "LGPL-2.1-only | BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://COPYING;md5=cf9105c1a2d4405cbe04bbe3367373a0"
 DEPENDS = "alsa-lib"
 

--- a/recipes-security/optee/optee-test.nxp.inc
+++ b/recipes-security/optee/optee-test.nxp.inc
@@ -3,7 +3,7 @@
 SUMMARY = "OPTEE test"
 HOMEPAGE = "http://www.optee.org/"
 
-LICENSE = "BSD & GPLv2"
+LICENSE = "BSD & GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE.md;md5=daa2bcccc666345ab8940aab1315a4fa"
 
 DEPENDS = "python3-pycryptodome-native python3-pycryptodomex-native openssl"


### PR DESCRIPTION
Since OE-Core commit [`9379f80f48 ("license/insane: Show warning forobsolete license usage")`](https://github.com/openembedded/openembedded-core/commit/9379f80f484f94686a4d494e9e237fadfb72a938), `LICENSE` field not containing SPDX identifiers are treated with _WARNING_.

An automated conversion using OE-Core `scripts/contrib/convert-spdx-licenses.py` to convert to use the standard SPDX license identifiers has been done on the entire layer.
