### PR TITLE
Clean-up obsolete ATF load address for i.MX8M machines

### DIFF
--- a/classes/imx-boot-container.bbclass
+++ b/classes/imx-boot-container.bbclass
@@ -33,16 +33,9 @@ do_resolve_and_populate_binaries[depends] += " \
     ${@bb.utils.contains('MACHINE_FEATURES', 'optee', 'optee-os:do_deploy', '', d)} \
 "
 
-# Append make flags to include ATF load address
-EXTRA_OEMAKE += "ATF_LOAD_ADDR=${ATF_LOAD_ADDR}"
-
 # Define an additional task that collects binary output from dependent packages
 # and deploys them into the U-Boot build folder
 do_resolve_and_populate_binaries() {
-    if [ ! -n "${ATF_LOAD_ADDR}" ]; then
-        bberror "ATF_LOAD_ADDR is undefined, result binary would be unusable!"
-    fi
-
     if [ -n "${UBOOT_CONFIG}" ]; then
         for config in ${UBOOT_MACHINE}; do
             i=$(expr $i + 1);

--- a/conf/machine/imx8mq-evk.conf
+++ b/conf/machine/imx8mq-evk.conf
@@ -67,7 +67,6 @@ UBOOT_DTB_NAME = "imx8mq-evk.dtb"
 
 # Set ATF platform name
 ATF_PLATFORM = "imx8mq"
-ATF_LOAD_ADDR = "0x910000"
 
 # Extra firmware package name, that is required to build boot container for fslc bsp
 IMX_EXTRA_FIRMWARE = "firmware-imx-8m"

--- a/conf/machine/include/imx8mm-evk.inc
+++ b/conf/machine/include/imx8mm-evk.inc
@@ -39,7 +39,6 @@ UBOOT_CONFIG[mfgtool]  = "${UBOOT_CONFIG_BASENAME}_defconfig"
 SPL_BINARY = "spl/u-boot-spl.bin"
 
 ATF_PLATFORM = "imx8mm"
-ATF_LOAD_ADDR = "0x920000"
 
 # Extra firmware package name, that is required to build boot container for fslc bsp
 IMX_EXTRA_FIRMWARE = "firmware-imx-8m"

--- a/conf/machine/include/imx8mn-evk.inc
+++ b/conf/machine/include/imx8mn-evk.inc
@@ -40,7 +40,6 @@ UBOOT_CONFIG[mfgtool] = "${UBOOT_CONFIG_BASENAME}_defconfig"
 SPL_BINARY = "spl/u-boot-spl.bin"
 
 ATF_PLATFORM = "imx8mn"
-ATF_LOAD_ADDR = "0x960000"
 
 # Extra firmware package name, that is required to build boot container for fslc bsp
 IMX_EXTRA_FIRMWARE = "firmware-imx-8m"

--- a/conf/machine/include/imx8mp-evk.inc
+++ b/conf/machine/include/imx8mp-evk.inc
@@ -36,7 +36,6 @@ UBOOT_CONFIG[mfgtool] = "${UBOOT_CONFIG_BASENAME}_defconfig"
 SPL_BINARY = "spl/u-boot-spl.bin"
 
 ATF_PLATFORM = "imx8mp"
-ATF_LOAD_ADDR = "0x970000"
 
 # Extra firmware package name, that is required to build boot container for fslc bsp
 IMX_EXTRA_FIRMWARE = "firmware-imx-8m"


### PR DESCRIPTION
Upstream U-Boot commit `d9a6f0eed66a ("tree: imx: remove old fit generator script")` dropped the FIT generator script, which was using environment variable setting the ATF load address into the FIT ITS file.

This has been replaced by binman node description, where ATF address is defined, hence the environment variable is not required anymore.

Clean-up the layer's class and machine description to remove the variable, which is not used anymore.

_NOTE_: NXP BSP is not affected by this change, as `ATF_LOAD_ADDR` is defined in `iMX8M/soc.mak` file of `imx-boot` package based on ATF machine definition.

**Cc**: @thochstein