### PR TITLE
optee-os: Fix RPMB build break

### DIFF
--- a/recipes-security/optee-imx/optee-os/0001-arm-imx-fix-RPMB-header-include.patch
+++ b/recipes-security/optee-imx/optee-os/0001-arm-imx-fix-RPMB-header-include.patch
@@ -1,0 +1,29 @@
+From d965393256e32a93dae41765543523598fca5d00 Mon Sep 17 00:00:00 2001
+From: Clement Faure <clement.faure@nxp.com>
+Date: Mon, 7 Mar 2022 10:21:04 -0600
+Subject: [PATCH] arm: imx: fix RPMB header include
+
+Replace <drivers/imx_snvs.h> by <drivers/nxp_snvs.h>
+
+Upstream-Status: Backport from NXP 5.15.5-1.0.0
+Signed-off-by: Clement Faure <clement.faure@nxp.com>
+---
+ core/arch/arm/plat-imx/imx_rpmb.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/core/arch/arm/plat-imx/imx_rpmb.c b/core/arch/arm/plat-imx/imx_rpmb.c
+index 9f0eb384d..2dd41105e 100644
+--- a/core/arch/arm/plat-imx/imx_rpmb.c
++++ b/core/arch/arm/plat-imx/imx_rpmb.c
+@@ -2,7 +2,7 @@
+ /*
+  * Copyright 2020 Pengutronix, Rouven Czerwinski <entwicklung@pengutronix.de>
+  */
+-#include <drivers/imx_snvs.h>
++#include <drivers/nxp_snvs.h>
+ #include <imx.h>
+ #include <tee/tee_fs.h>
+ 
+-- 
+2.17.1
+

--- a/recipes-security/optee-imx/optee-os_3.15.0.imx.bb
+++ b/recipes-security/optee-imx/optee-os_3.15.0.imx.bb
@@ -11,6 +11,7 @@ DEPENDS = "python3-pycryptodomex-native python3-pyelftools-native u-boot-mkimage
 SRCBRANCH = "lf-5.10.72_2.2.0"
 SRC_URI = "\
 	git://source.codeaurora.org/external/imx/imx-optee-os.git;protocol=https;branch=${SRCBRANCH} \
+	file://0001-arm-imx-fix-RPMB-header-include.patch \
 "
 
 SRCREV = "c939619d64dea014ad1b8382356eee4d1cbfbb22"


### PR DESCRIPTION
When CFG_RPMB_FS=y, OP-TEE os no longer compiles because imx_rpmb.c
tries to include a header that doesn't exist. This issue seems linked
to a rework that allows to compile i.MX Secure Non-Volatile Storage
driver without RPMB.

```
|   CC      optee-os/3.15.0.imx-r0/build/core/arch/arm/plat-imx/imx_rpmb.o
| core/arch/arm/plat-imx/imx_rpmb.c:5:10: fatal error: drivers/imx_snvs.h: No such file or directory
|     5 | #include <drivers/imx_snvs.h>
|       |          ^~~~~~~~~~~~~~~~~~~~
| compilation terminated.
| make: *** [mk/compile.mk:159: optee-os/3.15.0.imx-r0/build/core/arch/arm/plat-imx/imx_rpmb.o] Error 1
| make: *** Waiting for unfinished jobs....
|   CC     optee-os/3.15.0.imx-r0/build/core/crypto/crypto.o
|   CC      optee-os/3.15.0.imx-r0/build/core/arch/arm/plat-imx/imx_dt.o
| make: Leaving directory 'optee-os/3.15.0.imx-r0/git'
| ERROR: oe_runmake failed
| WARNING: exit code 1 from a shell command.
ERROR: Task (optee-imx/optee-os_3.15.0.imx.bb:do_compile) failed with exit code '1'
```

This is fixed in the upcoming release NXP 5.15.5-1.0.0. Backport the
patch.

Fixes: #997
Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>