### PR TITLE
weston-init: fix some invalid overrides

### DIFF
--- a/recipes-graphics/wayland/weston-init.bbappend
+++ b/recipes-graphics/wayland/weston-init.bbappend
@@ -28,8 +28,8 @@ INI_UNCOMMENT_ASSIGNMENTS:append:mx8mq-nxp-bsp = " \
 # Ideally, this should be seamless and Vivante ought to handle it internally and take the fastest
 # rendering code.
 INI_UNCOMMENT_USE_G2D:imxgpu2d ?= "use-g2d=1"
-INI_UNCOMMENT_USE_G2D:mx8qm-nxp-bsp = ""
-INI_UNCOMMENT_USE_G2D:mx8qxp-nxp-bsp = ""
+INI_UNCOMMENT_USE_G2D:imxgpu2d:mx8qm-nxp-bsp = ""
+INI_UNCOMMENT_USE_G2D:imxgpu2d:mx8qxp-nxp-bsp = ""
 INI_UNCOMMENT_ASSIGNMENTS:append:imxgpu2d = " \
     ${INI_UNCOMMENT_USE_G2D} \
 "


### PR DESCRIPTION
The mx8qm-nxp-bsp/mx8qxp-nxp-bsp overrides would not work because
imxgpu2d would take effect in the end since it has higher priority
in MACHINEOVERRIDES.

Append mx8qm-nxp-bsp/mx8qxp-nxp-bsp after imxgpu2d can fix the problem.

Signed-off-by: Ming Liu <liu.ming50@gmail.com>