### PR TITLE
use-imx-headers: replace COMPATIBLE_HOST with COMPATIBLE_MACHINE

### DIFF
--- a/classes/use-imx-headers.bbclass
+++ b/classes/use-imx-headers.bbclass
@@ -25,13 +25,10 @@ PACKAGE_ARCH:imx-nxp-bsp ?= "${MACHINE_SOCARCH}"
 STAGING_INCDIR_IMX = "${STAGING_INCDIR}/imx"
 
 # Recipes that inherit this class are contracted to use NXP BSP only.
-# This is done by overriding the COMPATIBLE_HOST, as this would effectively
-# cause recipes to be skipped in case if 'use-nxp-bsp' override is not
-# defined for them. This effectively marks recipes that should only be
-# built using NXP BSP, and gives an indication to mainline BSP creators
-# that recipe is not compatible with mainline.
-#
-# Typical example here would be imx-vpu-hantro recipe, which requires NXP
-# BSP and is not compatible with mainline.
-COMPATIBLE_HOST = '(null)'
-COMPATIBLE_HOST:use-nxp-bsp = '.*'
+# This is done by explicitly overriding the COMPATIBLE_MACHINE, as this
+# would effectively cause recipes to be skipped in case if 'use-nxp-bsp'
+# override is not defined in MACHINEOVERRIDES for them. This effectively
+# marks recipes that should only be built using NXP BSP, and gives an
+# indication to mainline BSP creators that recipe is not compatible with
+# mainline.
+COMPATIBLE_MACHINE:forcevariable = "(use-nxp-bsp)"

--- a/recipes-kernel/linux/linux-imx-headers_5.10.bb
+++ b/recipes-kernel/linux/linux-imx-headers_5.10.bb
@@ -75,5 +75,4 @@ PACKAGE_ARCH = "${MACHINE_SOCARCH}"
 
 # Restrict this recipe to NXP BSP only, this recipe is not compatible
 # with mainline BSP
-COMPATIBLE_HOST = '(null)'
-COMPATIBLE_HOST:use-nxp-bsp = '.*'
+COMPATIBLE_MACHINE = "(use-nxp-bsp)"


### PR DESCRIPTION
It's very strange and not proper to use COMPATIBLE_HOST as the sanity
check for NXP BSPs, change to directly use COMPATIBLE_MACHINE since
'use-nxp-bsp' is a machine overrides already.

A 'forcevariable' overrides would effectively ensure all recipes
inheriting use-imx-headers should only be built with NXP BSP.

Signed-off-by: Ming Liu <liu.ming50@gmail.com>