### PR TITLE
imx-base.inc: Enable Crypto for all 8X

### DIFF
--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -128,7 +128,7 @@ DEFAULTTUNE:vf-generic-bsp     ?= "cortexa5thf-neon"
 
 DEFAULTTUNE:mx8m-generic-bsp   ?= "cortexa53-crypto"
 DEFAULTTUNE:mx8qm-generic-bsp  ?= "cortexa72-cortexa53-crypto"
-DEFAULTTUNE:mx8qxp-generic-bsp ?= "cortexa35-crypto"
+DEFAULTTUNE:mx8x-generic-bsp   ?= "cortexa35-crypto"
 
 INHERIT += "machine-overrides-extender"
 


### PR DESCRIPTION
Align with 8M family. Enabling Crypto enables FP and SIMD as well.

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>