### PR TITLE
mfgtool-initramfs-image: Switch to zstd compression

### DIFF
--- a/classes/kernel-itbimage.bbclass
+++ b/classes/kernel-itbimage.bbclass
@@ -383,7 +383,7 @@ fitimage_assemble() {
 	#
 	if [ "x${ramdiskcount}" = "x1" ] ; then
 		# Find and use the first initramfs image archive type we find
-		for img in cpio.lz4 cpio.lzo cpio.lzma cpio.xz cpio.gz ext2.gz cpio; do
+		for img in cpio.lz4 cpio.lzo cpio.lzma cpio.zst cpio.xz cpio.gz ext2.gz cpio; do
 			initramfs_path="${DEPLOY_DIR_IMAGE}/${INITRAMFS_IMAGE_NAME}.${img}"
 			echo "Using $initramfs_path"
 			if [ -e "${initramfs_path}" ]; then

--- a/classes/mfgtool-initramfs-image.bbclass
+++ b/classes/mfgtool-initramfs-image.bbclass
@@ -12,7 +12,8 @@ FEATURE_PACKAGES_mtd = "packagegroup-fsl-mfgtool-mtd"
 FEATURE_PACKAGES_extfs = "packagegroup-fsl-mfgtool-extfs"
 FEATURE_PACKAGES_f2fs = "packagegroup-fsl-mfgtool-f2fs"
 
-IMAGE_FSTYPES = "cpio.gz.u-boot"
+ZSTD_COMPRESSION_LEVEL ?= "-10"
+IMAGE_FSTYPES = "cpio.zst.u-boot"
 IMAGE_FSTYPES:mxs-generic-bsp = "cpio.gz.u-boot"
 IMAGE_ROOTFS_SIZE ?= "8192"
 


### PR DESCRIPTION
The initramfs memory size is limited, so use zstd compression level 10
to cut the cpio archive size by some 30%.

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>