### PR TITLE
Fix: master: imx6ul*: remove obsolete device tree entry

### DIFF
--- a/conf/machine/imx6ulevk.conf
+++ b/conf/machine/imx6ulevk.conf
@@ -13,7 +13,6 @@ MACHINE_FEATURES += "wifi bluetooth bcm4339 bcm43455"
 
 KERNEL_DEVICETREE = " \
 	imx6ul-14x14-evk-btwifi.dtb \
-	imx6ul-14x14-evk-btwifi-oob.dtb \
 	imx6ul-14x14-evk-csi.dtb \
 	imx6ul-14x14-evk.dtb \
 	imx6ul-14x14-evk-ecspi.dtb \

--- a/conf/machine/imx6ullevk.conf
+++ b/conf/machine/imx6ullevk.conf
@@ -17,7 +17,6 @@ KERNEL_DEVICETREE = " \
 
 KERNEL_DEVICETREE:append:use-nxp-bsp = " \
 	imx6ull-14x14-evk-btwifi.dtb \
-	imx6ull-14x14-evk-btwifi-oob.dtb \
 	imx6ull-14x14-evk-emmc.dtb \
 	imx6ull-14x14-evk-gpmi-weim.dtb \
 "


### PR DESCRIPTION

The commits to honister and hurdknoot are ready, just need the original cherry-pick commit hash to be updated in commit messages.

The imx6ul-14x14-evk-btwifi-oob.dtb and
imx6ull-14x14-evk-btwifi-oob.dtb are no longer available in the
kernel lf-5.10.y, it was removed in a1488e98156ea1a597353c93b76b4f7fd8dd7c7c

Remove entries for non-existent dtb files. This fixes building a
Linux kernel recipe for imx6ulevk/imx6ullevk.

Fixes: 3f93c925 ("linux-imx*: Upgrade to 5.10.52")
Signed-off-by: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>