### PR TITLE
qoriq-base: weak defaults for u-boot/bootloader/kernel PREFERRED_PROVIDER

### DIFF
--- a/conf/machine/include/qoriq-base.inc
+++ b/conf/machine/include/qoriq-base.inc
@@ -1,7 +1,7 @@
 # common providers of QorIQ targets
-PREFERRED_PROVIDER_u-boot ?= "u-boot-qoriq"
-PREFERRED_PROVIDER_virtual/bootloader ?= "${PREFERRED_PROVIDER_u-boot}"
-PREFERRED_PROVIDER_virtual/kernel ?= "linux-qoriq"
+PREFERRED_PROVIDER_u-boot ??= "u-boot-qoriq"
+PREFERRED_PROVIDER_virtual/bootloader ??= "${PREFERRED_PROVIDER_u-boot}"
+PREFERRED_PROVIDER_virtual/kernel ??= "linux-qoriq"
 PREFERRED_PROVIDER_u-boot-tools-native ??= "u-boot-tools-native"
 PREFERRED_PROVIDER_u-boot-mkimage-native ??= "u-boot-tools-native"
 PREFERRED_PROVIDER_u-boot-mkimage ??= "u-boot-tools"


### PR DESCRIPTION
When using a kernel/bootloader fork maintained by board vendor and there are
somer flavours ist would be good to have only weak assignments here. This enables
to override the default by machine config and set final by distro or local.conf.

This is essentually the same as dine in imx-base.inc with the exception that is is don directly here instead via an additional overwritable variable.