### PR TITLE
imx8mm-ddr4-evk.conf: Use a broader UBOOT_CONFIG_BASENAME to avoid er…

### DIFF
--- a/conf/machine/imx8mm-ddr4-evk.conf
+++ b/conf/machine/imx8mm-ddr4-evk.conf
@@ -12,7 +12,7 @@ KERNEL_DEVICETREE:append:use-nxp-bsp = " \
     freescale/${KERNEL_DEVICETREE_BASENAME}-revb.dtb \
 "
 
-UBOOT_CONFIG_BASENAME = "imx8mm_ddr4_evk"
+UBOOT_CONFIG_BASENAME = "imx8mm_evk"
 UBOOT_CONFIG[nand] = "${UBOOT_CONFIG_BASENAME}_nand_defconfig,ubifs"
 
 DDR_FIRMWARE_NAME = " \


### PR DESCRIPTION
…rors

It avoid errors while building imx-boot by the lack of imx8mm-ddr4-evk
specific components.

Signed-off-by: Vinicius Aquino <vinicius.aquino@ossystems.com.br>