### PR TITLE
qoriq-base: weak defaults for WKS_FILE

### DIFF
--- a/conf/machine/include/qoriq-base.inc
+++ b/conf/machine/include/qoriq-base.inc
@@ -34,7 +34,7 @@ SOC_DEFAULT_WKS_FILE ?= ""
 SOC_DEFAULT_WKS_FILE:ls1043a ?= "ls104x-uboot-bootpart.wks.in"
 SOC_DEFAULT_WKS_FILE:ls1046a ?= "ls104x-uboot-bootpart.wks.in"
 
-WKS_FILE ?= "${SOC_DEFAULT_WKS_FILE}"
+WKS_FILE ??= "${SOC_DEFAULT_WKS_FILE}"
 
 MACHINE_FEATURES ?= "pci ext2 ext3 serial"
 MACHINE_EXTRA_RRECOMMENDS += "udev-extraconf udev-rules-qoriq kernel-modules"


### PR DESCRIPTION
When maintaining a hardware support layer for a SOM there will be different
mainboards and BSP for this SOM. Depending on the use case there may be
different needs for SD / e-MMC images. When providing a valid weak default
in meta-freescale a machine definition can override this easier as well
a BSP for a specific mainboard.

Signed-off-by: Markus Niebel <Markus.Niebel@ew.tq-group.com>