### PR TITLE
isp-imx: use bfd linker in case of ld-is-gold DISTRO_FEATURE (gold li…

### DIFF
--- a/recipes-bsp/isp-imx/isp-imx_4.2.2.16.0.bb
+++ b/recipes-bsp/isp-imx/isp-imx_4.2.2.16.0.bb
@@ -21,6 +21,9 @@ OECMAKE_SOURCEPATH = "${S}/appshell"
 # Use make instead of ninja
 OECMAKE_GENERATOR = "Unix Makefiles"
 
+# Workaround for linking issues seen with gold linker
+LDFLAGS:append = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-gold', ' -fuse-ld=bfd ', '', d)}"
+
 SYSTEMD_SERVICE:${PN} = "imx8-isp.service"
 
 EXTRA_OECMAKE += " \


### PR DESCRIPTION
…nker)

When ld-is-gold is defined as a DISTRO_FEATURE, the gold linker is used
by default, which causes the following do_compile errors to arise:

| ../../generated/release/lib/libvvdisplay_shared.so: error: undefined
reference to 'wl_buffer_interface'
| ../../generated/release/lib/libvvdisplay_shared.so: error: undefined
reference to 'wl_surface_interface'
| ../../generated/release/lib/libvvdisplay_shared.so: error: undefined
reference to 'wl_seat_interface'
| ../../generated/release/lib/libvvdisplay_shared.so: error: undefined
reference to 'wl_output_interface'
| ../../generated/release/lib/libvvdisplay_shared.so: error: undefined
reference to 'wl_proxy_marshal'
| ../../generated/release/lib/libvvdisplay_shared.so: error: undefined
reference to 'wl_proxy_add_listener'
| ../../generated/release/lib/libvvdisplay_shared.so: error: undefined
reference to 'wl_proxy_destroy'
| ../../generated/release/lib/libvvdisplay_shared.so: error: undefined
reference to 'wl_display_flush'
| ../../generated/release/lib/libvvdisplay_shared.so: error: undefined
reference to 'wl_display_disconnect'
| ../../generated/release/lib/libvvdisplay_shared.so: error: undefined
reference to 'wl_proxy_marshal_constructor_versioned'
| ../../generated/release/lib/libvvdisplay_shared.so: error: undefined
reference to 'wl_compositor_interface'
| ../../generated/release/lib/libvvdisplay_shared.so: error: undefined
reference to 'wl_display_dispatch'
| ../../generated/release/lib/libvvdisplay_shared.so: error: undefined
reference to 'wl_proxy_marshal_constructor'
| ../../generated/release/lib/libvvdisplay_shared.so: error: undefined
reference to 'wl_display_roundtrip'
| ../../generated/release/lib/libvvdisplay_shared.so: error: undefined
reference to 'wl_display_connect'
| ../../generated/release/lib/libvvdisplay_shared.so: error: undefined
reference to 'wl_registry_interface'

so use bfd linker instead.