### PR TITLE
Consolidated Kernel update (v5.10.109+ 5.15.32)

### DIFF
--- a/recipes-kernel/linux/linux-fslc-imx_5.10.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_5.10.bb
@@ -38,6 +38,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 3. Critical patches (SHA(s))
 # ------------------------------------------------------------------------------
+#    27b6c760cc7f ("thermal: imx: fix a merging issue")
 #    8ef27ae9f200 ("gpio: fix enabling GPIO_VF610")
 #    12099c38577a ("ASoC: fsl_sai: Correct the clock source for mclk0")
 #    db172377e6e2 ("Revert "MLK-12786-2: ASoC: fsl_sai: correct the clock source for mclk0"")
@@ -73,7 +74,7 @@ LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
 KBRANCH = "5.10-2.1.x-imx"
-SRCREV = "2c5ae913f94c3aef3b2ba5480444eef5b28409e6"
+SRCREV = "185a13076e02ee241bc1149b90f0fed051bf2649"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.

--- a/recipes-kernel/linux/linux-fslc-imx_5.10.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_5.10.bb
@@ -28,7 +28,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v5.10.103
+#    tag: v5.10.104
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
@@ -74,14 +74,14 @@ LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
 KBRANCH = "5.10-2.1.x-imx"
-SRCREV = "d4426a4df6c506c01ff99084410709c10f187715"
+SRCREV = "3fa9f3a534cf208307b2f0a21ad80b3563cb1bd8"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.10.103"
+LINUX_VERSION = "5.10.104"
 
 # Local version indicates the branch name in the NXP kernel tree where patches are collected from.
 LOCALVERSION = "-5.10.52-2.1.0"

--- a/recipes-kernel/linux/linux-fslc-imx_5.10.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_5.10.bb
@@ -28,7 +28,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v5.10.93
+#    tag: v5.10.96
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
@@ -73,14 +73,14 @@ LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
 KBRANCH = "5.10-2.1.x-imx"
-SRCREV = "f28a9b90c506241e614212f2ce314d8f5460819d"
+SRCREV = "2c5ae913f94c3aef3b2ba5480444eef5b28409e6"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.10.93"
+LINUX_VERSION = "5.10.96"
 
 # Local version indicates the branch name in the NXP kernel tree where patches are collected from.
 LOCALVERSION = "-5.10.52-2.1.0"

--- a/recipes-kernel/linux/linux-fslc-imx_5.10.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_5.10.bb
@@ -28,7 +28,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v5.10.104
+#    tag: v5.10.109
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
@@ -74,14 +74,14 @@ LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
 KBRANCH = "5.10-2.1.x-imx"
-SRCREV = "3fa9f3a534cf208307b2f0a21ad80b3563cb1bd8"
+SRCREV = "882b6357e0d9303c747ac47dbf1e624a84fcb8dc"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.10.104"
+LINUX_VERSION = "5.10.109"
 
 # Local version indicates the branch name in the NXP kernel tree where patches are collected from.
 LOCALVERSION = "-5.10.52-2.1.0"

--- a/recipes-kernel/linux/linux-fslc-imx_5.10.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_5.10.bb
@@ -28,7 +28,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v5.10.96
+#    tag: v5.10.98
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
@@ -74,14 +74,14 @@ LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
 KBRANCH = "5.10-2.1.x-imx"
-SRCREV = "185a13076e02ee241bc1149b90f0fed051bf2649"
+SRCREV = "13d6a9ec4e27f0d6567ca4e2c027e6652575aab0"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.10.96"
+LINUX_VERSION = "5.10.98"
 
 # Local version indicates the branch name in the NXP kernel tree where patches are collected from.
 LOCALVERSION = "-5.10.52-2.1.0"

--- a/recipes-kernel/linux/linux-fslc-imx_5.10.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_5.10.bb
@@ -28,7 +28,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v5.10.98
+#    tag: v5.10.103
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
@@ -74,14 +74,14 @@ LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
 KBRANCH = "5.10-2.1.x-imx"
-SRCREV = "13d6a9ec4e27f0d6567ca4e2c027e6652575aab0"
+SRCREV = "d4426a4df6c506c01ff99084410709c10f187715"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.10.98"
+LINUX_VERSION = "5.10.103"
 
 # Local version indicates the branch name in the NXP kernel tree where patches are collected from.
 LOCALVERSION = "-5.10.52-2.1.0"

--- a/recipes-kernel/linux/linux-fslc-lts_5.10.bb
+++ b/recipes-kernel/linux/linux-fslc-lts_5.10.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.10.96"
+LINUX_VERSION = "5.10.98"
 
 KBRANCH = "5.10.x+fslc"
-SRCREV = "2046142a7638b0a71c210ad1e3742cbd313a0582"
+SRCREV = "6d455e0e717018139ee17b7c94b814b513fdd389"
 
 COMPATIBLE_MACHINE = "(imx-generic-bsp)"

--- a/recipes-kernel/linux/linux-fslc-lts_5.10.bb
+++ b/recipes-kernel/linux/linux-fslc-lts_5.10.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.10.93"
+LINUX_VERSION = "5.10.96"
 
 KBRANCH = "5.10.x+fslc"
-SRCREV = "de6a8455baae279feddb56c99056aa075175cd68"
+SRCREV = "2046142a7638b0a71c210ad1e3742cbd313a0582"
 
 COMPATIBLE_MACHINE = "(imx-generic-bsp)"

--- a/recipes-kernel/linux/linux-fslc-lts_5.10.bb
+++ b/recipes-kernel/linux/linux-fslc-lts_5.10.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.10.98"
+LINUX_VERSION = "5.10.103"
 
 KBRANCH = "5.10.x+fslc"
-SRCREV = "6d455e0e717018139ee17b7c94b814b513fdd389"
+SRCREV = "4f60363fbfbe875460637d73d8d42ad8a977d14e"
 
 COMPATIBLE_MACHINE = "(imx-generic-bsp)"

--- a/recipes-kernel/linux/linux-fslc-lts_5.10.bb
+++ b/recipes-kernel/linux/linux-fslc-lts_5.10.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.10.103"
+LINUX_VERSION = "5.10.104"
 
 KBRANCH = "5.10.x+fslc"
-SRCREV = "4f60363fbfbe875460637d73d8d42ad8a977d14e"
+SRCREV = "1e597d2e2702421d058bea09d41fe4ed8f2e2174"
 
 COMPATIBLE_MACHINE = "(imx-generic-bsp)"

--- a/recipes-kernel/linux/linux-fslc-lts_5.10.bb
+++ b/recipes-kernel/linux/linux-fslc-lts_5.10.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.10.104"
+LINUX_VERSION = "5.10.109"
 
 KBRANCH = "5.10.x+fslc"
-SRCREV = "1e597d2e2702421d058bea09d41fe4ed8f2e2174"
+SRCREV = "ad946caa1bfa863f02a56d0741ad3c3dcc772ef8"
 
 COMPATIBLE_MACHINE = "(imx-generic-bsp)"

--- a/recipes-kernel/linux/linux-fslc_5.15.bb
+++ b/recipes-kernel/linux/linux-fslc_5.15.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.15.26"
+LINUX_VERSION = "5.15.27"
 
 KBRANCH = "5.15.x+fslc"
-SRCREV = "7381c10fc6bbbc0311f5332b71a999ce172da505"
+SRCREV = "058a5f0db1975951a9380e4afc65764fef68ed8e"
 
 COMPATIBLE_MACHINE = "(imx-generic-bsp)"

--- a/recipes-kernel/linux/linux-fslc_5.15.bb
+++ b/recipes-kernel/linux/linux-fslc_5.15.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.15.27"
+LINUX_VERSION = "5.15.32"
 
 KBRANCH = "5.15.x+fslc"
-SRCREV = "058a5f0db1975951a9380e4afc65764fef68ed8e"
+SRCREV = "0cd0faf39b15007499be2f444034c0f62a3eea9a"
 
 COMPATIBLE_MACHINE = "(imx-generic-bsp)"

--- a/recipes-kernel/linux/linux-fslc_5.15.bb
+++ b/recipes-kernel/linux/linux-fslc_5.15.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.15.16"
+LINUX_VERSION = "5.15.19"
 
 KBRANCH = "5.15.x+fslc"
-SRCREV = "d084d166324389d09f73d8f2e91b989d69432335"
+SRCREV = "904dcdc72e94f869e66ff8b25dba91f01ed66286"
 
 COMPATIBLE_MACHINE = "(imx-generic-bsp)"

--- a/recipes-kernel/linux/linux-fslc_5.15.bb
+++ b/recipes-kernel/linux/linux-fslc_5.15.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.15.21"
+LINUX_VERSION = "5.15.26"
 
 KBRANCH = "5.15.x+fslc"
-SRCREV = "67b4b41971663518f6f3ba9f91894382372f02a4"
+SRCREV = "7381c10fc6bbbc0311f5332b71a999ce172da505"
 
 COMPATIBLE_MACHINE = "(imx-generic-bsp)"

--- a/recipes-kernel/linux/linux-fslc_5.15.bb
+++ b/recipes-kernel/linux/linux-fslc_5.15.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.15.19"
+LINUX_VERSION = "5.15.21"
 
 KBRANCH = "5.15.x+fslc"
-SRCREV = "904dcdc72e94f869e66ff8b25dba91f01ed66286"
+SRCREV = "67b4b41971663518f6f3ba9f91894382372f02a4"
 
 COMPATIBLE_MACHINE = "(imx-generic-bsp)"


### PR DESCRIPTION
Kernel branches were updated up to and including following versions for recipes from stable korg:
- `linux-fslc-imx`: _v5.10.109_
- `linux-fslc-lts`: _v5.10.109_
- `linux-fslc`: _v5.15.32_

Update recipe `SRCREV` to point to those versions now.

Upstream commits are recorded in corresponding recipe commit messages. 

`linux-fslc-imx` has additional commit included:
```
27b6c760cc7f thermal: imx: fix a merging issue
```

`linux-fslc` has been boot-tested on following machines:
- `imx8mm-lpddr4-evk`: **PASS**
- `imx8mn-lpddr4-evk`: **PASS**
- `imx8mp-lpddr4-evk`: **PASS**
- `imx8mq-evk`: **PASS**

-- andrey