### PR TITLE
u-boot-fslc-mxsboot: add dependency on gnutls-native

### DIFF
--- a/recipes-bsp/u-boot/u-boot-fslc-mxsboot_2022.04.bb
+++ b/recipes-bsp/u-boot/u-boot-fslc-mxsboot_2022.04.bb
@@ -3,7 +3,7 @@ require u-boot-fslc-common_${PV}.inc
 DESCRIPTION = "U-boot bootloader mxsboot tool"
 SECTION = "bootloader"
 
-DEPENDS = "bison-native dtc openssl"
+DEPENDS = "bison-native gnutls-native dtc openssl"
 
 PROVIDES = "u-boot-mxsboot"
 


### PR DESCRIPTION
gnutls is now required in order to build one of the host tools which are part
of U-Boot.

| .../build/tmp-glibc/work/x86_64-linux/u-boot-fslc-mxsboot-native/v2022.04+gitAUTOINC+f885198273-r0/git/tools/mkeficapsule.c:21:10: fatal error: gnutls/gnutls.h: No such file or directory
|  #include <gnutls/gnutls.h>
|           ^~~~~~~~~~~~~~~~~
| compilation terminated.
| make[2]: *** [scripts/Makefile.host:95: tools/mkeficapsule] Error 1
| make[2]: *** Waiting for unfinished jobs....
| make[1]: *** [.../build/tmp-glibc/work/x86_64-linux/u-boot-fslc-mxsboot-native/v2022.04+gitAUTOINC+f885198273-r0/git/Makefile:1894: tools] Error 2
| make[1]: Leaving directory '.../build/tmp-glibc/work/x86_64-linux/u-boot-fslc-mxsboot-native/v2022.04+gitAUTOINC+f885198273-r0/build'
| make: *** [Makefile:177: sub-make] Error 2
| make: Leaving directory '.../build/tmp-glibc/work/x86_64-linux/u-boot-fslc-mxsboot-native/v2022.04+gitAUTOINC+f885198273-r0/git'
| ERROR: oe_runmake failed
| WARNING: .../build/tmp-glibc/work/x86_64-linux/u-boot-fslc-mxsboot-native/v2022.04+gitAUTOINC+f885198273-r0/temp/run.do_compile.24796:186 exit 1 from 'exit 1'

Signed-off-by: Trevor Woerner <twoerner@gmail.com>