### PR TITLE
imx8m: Set DDR4 machines to use IMX BSP only

### DIFF
--- a/conf/machine/imx8mm-ddr4-evk.conf
+++ b/conf/machine/imx8mm-ddr4-evk.conf
@@ -23,3 +23,8 @@ DDR_FIRMWARE_NAME = " \
 "
 
 IMXBOOT_TARGETS_BASENAME = "flash_ddr4_evk"
+
+# Mainline BSP doesn't support DDR4 so it must be set to nxp.
+# Also this machine isn't supported by u-boot-fslc but imx8mm-evk.inc already
+# set the bootloader to u-boot-imx instead when NXP BSP is used.
+IMX_DEFAULT_BSP = "nxp"

--- a/conf/machine/imx8mn-ddr4-evk.conf
+++ b/conf/machine/imx8mn-ddr4-evk.conf
@@ -20,3 +20,8 @@ DDR_FIRMWARE_NAME = " \
     ddr4_dmem_2d_${DDR_FIRMWARE_VERSION}.bin \
 "
 IMXBOOT_TARGETS_BASENAME = "flash_ddr4_evk"
+
+# Mainline BSP doesn't support DDR4 so it must be set to nxp.
+# Also this machine isn't supported by u-boot-fslc but imx8mn-evk.inc already
+# set the bootloader to u-boot-imx instead when NXP BSP is used.
+IMX_DEFAULT_BSP = "nxp"

--- a/conf/machine/imx8mp-ddr4-evk.conf
+++ b/conf/machine/imx8mp-ddr4-evk.conf
@@ -25,3 +25,8 @@ DDR_FIRMWARE_NAME = " \
 "
 
 IMXBOOT_TARGETS_BASENAME = "flash_ddr4_evk"
+
+# Mainline BSP doesn't support DDR4 so it must be set to nxp.
+# Also this machine isn't supported by u-boot-fslc but imx8mp-evk.inc already
+# set the bootloader to u-boot-imx instead when NXP BSP is used.
+IMX_DEFAULT_BSP = "nxp"


### PR DESCRIPTION
This is necessary because mainline U-Boot doesn't supports DDR4 for i.MX8M EVK.
Also these machines aren't supported by mainline kernel.

Signed-off-by: Vinicius Aquino <vinicius.aquino@ossystems.com.br>