### PR TITLE
linux-qoriq: Fix task order of merge_delta_config task

### DIFF
--- a/recipes-kernel/linux/linux-qoriq.inc
+++ b/recipes-kernel/linux/linux-qoriq.inc
@@ -53,7 +53,7 @@ do_merge_delta_config() {
     done
     cp .config ${WORKDIR}/defconfig
 }
-addtask merge_delta_config before do_preconfigure after do_patch
+addtask merge_delta_config before do_kernel_localversion after do_patch
 
 # The link of dts folder is needed for 32b compile of aarch64 targets(e.g. ls1043ardb-32b)
 do_compile_prepend_fsl-lsch2-32b() {


### PR DESCRIPTION
The merge_delta_config must run before do_kernel_localversion task,
which is what fsl-kernel-localversion now use.

Fixes: #721.
Fixes: 49299998 ("classes: fsl-kernel-localversion: Fix task dependency")

Also an issue on dunfell.

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>
Signed-off-by: Jeremy A. Puhlman <jpuhlman@mvista.com>