### PR TITLE
qoriq-atf: Remove mbedtls from dependence list

### DIFF
--- a/recipes-bsp/atf/qoriq-atf_2.4.bb
+++ b/recipes-bsp/atf/qoriq-atf_2.4.bb
@@ -2,7 +2,7 @@ require recipes-bsp/atf/qoriq-atf-2.4.inc
 
 inherit deploy
 
-DEPENDS += "u-boot-mkimage-native u-boot openssl openssl-native mbedtls rcw cst-native bc-native"
+DEPENDS += "u-boot-mkimage-native u-boot openssl openssl-native rcw cst-native bc-native"
 DEPENDS:append:lx2160a = " ddr-phy"
 DEPENDS:append:lx2162a = " ddr-phy"
 do_compile[depends] += "u-boot:do_deploy rcw:do_deploy uefi:do_deploy"


### PR DESCRIPTION
It is already internally provided by the recipe, so
don't need to depends on a external provider.

Signed-off-by: Vinicius Aquino <vinicius.aquino@ossystems.com.br>