### PR TITLE
Revert "qoriq-base: weak defaults for WKS_FILE"

### DIFF
--- a/conf/machine/include/qoriq-base.inc
+++ b/conf/machine/include/qoriq-base.inc
@@ -34,7 +34,7 @@ SOC_DEFAULT_WKS_FILE ?= ""
 SOC_DEFAULT_WKS_FILE:ls1043a ?= "ls104x-uboot-bootpart.wks.in"
 SOC_DEFAULT_WKS_FILE:ls1046a ?= "ls104x-uboot-bootpart.wks.in"
 
-WKS_FILE ??= "${SOC_DEFAULT_WKS_FILE}"
+WKS_FILE ?= "${SOC_DEFAULT_WKS_FILE}"
 
 MACHINE_FEATURES ?= "pci ext2 ext3 serial"
 MACHINE_EXTRA_RRECOMMENDS += "udev-extraconf udev-rules-qoriq kernel-modules"


### PR DESCRIPTION
This reverts commit 451bafe6d6e0523d0f6143f6862bb6c5b42ac8f6.

This is necessary to follow the pattern used by imx-base.inc.

Also prevents the following error: "No kickstart files from
WKS_FILES were found"
It happens because WKS_FILE was already assigned and can't be
reassigned by SOC_DEFAULT_WKS_FILE due to a weaker assignment
(??=).

Signed-off-by: Vinicius Aquino <vinicius.aquino@ossystems.com.br>