### PR TITLE
imx-cst: Use specific BSD license

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-devtools/cst/imx-cst_3.3.1.bb
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/cst/imx-cst_3.3.1.bb
@@ -1,7 +1,7 @@
 SUMMARY = "i.MX code signing tool"
 DESCRIPTION = "Provides software code signing support designed that integrate the HABv4 and AHAB library"
 SECTION = "cst"
-LICENSE = "BSD"
+LICENSE = "BSD-3-Clause"
 
 LIC_FILES_CHKSUM = "file://LICENSE.bsd3;md5=1fbcd66ae51447aa94da10cbf6271530"
 


### PR DESCRIPTION
Fixes
WARNING: imx-cst-3.3.1-r0 do_populate_lic: QA Issue: imx-cst: No generic license file exists for: BSD in any provider [license-exists]

Signed-off-by: Khem Raj <raj.khem@gmail.com>