### PR TITLE
fsl-eula-unpack.bbclass: Unpack NXP EULA archives last

### DIFF
--- a/classes/fsl-eula-unpack.bbclass
+++ b/classes/fsl-eula-unpack.bbclass
@@ -162,13 +162,12 @@ python do_unpack() {
     else:
         bb.note("Freescale EULA has been accepted for '%s'" % pkg)
 
-    # The binary unpack needs to be done first so 'S' is valid
-    bb.build.exec_func('fsl_bin_do_unpack', d)
-
     try:
         bb.build.exec_func('base_do_unpack', d)
     except:
         raise
+
+    bb.build.exec_func('fsl_bin_do_unpack', d)
 }
 
 do_unpack[vardepsexclude] += "FSL_EULA_FILE"


### PR DESCRIPTION
NXP EULA archive-based builds like imx-gpu-viv fail because the unpacked
folder is empty:

```
ERROR: imx-gpu-viv-1_6.4.3.p2.4-aarch64-r0 do_populate_lic: QA Issue: imx-gpu-viv: LIC_FILES_CHKSUM points to an invalid file: /opt/work/upstream/fsl-xwayland/tmp/work/cortexa53-crypto-mx8m-fsl-linux/imx-gpu-viv/1_6.4.3.p2.4-aarch64-r0/imx-gpu-viv-6.4.3.p2.4-aarch64/COPYING [license-checksum]
```

This is traced to a change in bitbake:

```
b074f4a ast: Improve function flags handling for EXPORT_FUNCTIONS
```

That change includes a fix for cleandirs, so now the call to base_unpack,
done after the NXP EULA archive unpack, does now remove the folder(s)
created by the NXP EULA archive unpack.

Fix the problem by simply unpacking the NXP EULA archives last.

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>