### PR TITLE
ls1028ardb/ls1088ardb/ls1088ardb-pb: Correct MACHINEOVERRIDES

### DIFF
--- a/conf/machine/ls1028ardb.conf
+++ b/conf/machine/ls1028ardb.conf
@@ -4,12 +4,12 @@
 #@DESCRIPTION: Machine configuration for running LS1028ARDB in 64-bit mode
 #@MAINTAINER: Chunrong.Guo <chunrong.guo@nxp.com>
 
+MACHINEOVERRIDES =. "fsl-lsch3:ls1028a:"
+
 require conf/machine/include/qoriq-arm64.inc
 require conf/machine/include/arm/arch-arm64.inc
 
 MACHINE_FEATURES += "optee"
-
-MACHINEOVERRIDES =. "fsl-lsch3:ls1028a:"
 
 KERNEL_CLASSES  = " kernel-fitimage "
 KERNEL_IMAGETYPES = "fitImage"

--- a/conf/machine/ls1088ardb-pb.conf
+++ b/conf/machine/ls1088ardb-pb.conf
@@ -4,10 +4,10 @@
 #@DESCRIPTION: Machine configuration for running LS1088ARDB in 64-bit mode
 #@MAINTAINER: Chunrong Guo <Chunrong.Guo@nxp.com>
 
+MACHINEOVERRIDES =. "fsl-lsch3:ls1088a:"
+
 require conf/machine/include/qoriq-arm64.inc
 require conf/machine/include/arm/arch-arm64.inc
-
-MACHINEOVERRIDES =. "fsl-lsch3:ls1088a:"
 
 MACHINE_FEATURES += "optee"
 

--- a/conf/machine/ls1088ardb.conf
+++ b/conf/machine/ls1088ardb.conf
@@ -4,10 +4,10 @@
 #@DESCRIPTION: Machine configuration for running LS1088ARDB in 64-bit mode
 #@MAINTAINER: Zongchun Yu <Zongchun.Yu@nxp.com>
 
+MACHINEOVERRIDES =. "fsl-lsch3:ls1088a:"
+
 require conf/machine/include/qoriq-arm64.inc
 require conf/machine/include/arm/arch-arm64.inc
-
-MACHINEOVERRIDES =. "fsl-lsch3:ls1088a:"
 
 MACHINE_FEATURES += "optee"
 


### PR DESCRIPTION
Current setting cannot set the right overrider order as expected. For example:
 MACHINEOVERRIDES="fsl-lsch3:ls1088a:aarch64:use-nxp-bsp:qoriq:qoriq-arm64:ls1088ardb-pb"

Update them to align with other Layerscape machines.

Signed-off-by: Jun Zhu <junzhu@nxp.com>