### PR TITLE
fmlib: set precise BSD license

### DIFF
--- a/recipes-dpaa/fmlib/fmlib_git.bb
+++ b/recipes-dpaa/fmlib/fmlib_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "Frame Manager User Space Library"
 SECTION = "fman"
-LICENSE = "BSD & GPL-2.0-only"
+LICENSE = "BSD-3-Clause & GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=9c7bd5e45d066db084bdb3543d55b1ac"
 
 PR = "r1"


### PR DESCRIPTION
When building fmlib package based on Yocto 4.0, there is below
warning reported
WARNING: fmlib-git-r1 do_populate_lic: QA Issue: fmlib:
No generic license file exists for: BSD in any provider [license-exists]
Because "BSD" is ambiguous, and there is no corresponding license file
in COMMON_LICENSE_DIR directory. So, set precise BSD license to fix
this issue.

Signed-off-by: Meng Li <Meng.Li@windriver.com>