### PR TITLE
imx-imkimage: install print_fit_hab.sh

### DIFF
--- a/recipes-bsp/imx-mkimage/files/0001-Add-LDFLAGS-to-link-step.patch
+++ b/recipes-bsp/imx-mkimage/files/0001-Add-LDFLAGS-to-link-step.patch
@@ -1,0 +1,28 @@
+From 2a6e2d40a4af78d4a0824e384c3aec55db758fee Mon Sep 17 00:00:00 2001
+From: Erik Larsson <erik.larsson@combitech.se>
+Date: Tue, 6 Mar 2018 12:28:39 +0100
+Subject: [PATCH] Add LDFLAGS to link step
+
+Upstream-Status: Pending
+
+Signed-off-by: Erik Larsson <karl.erik.larsson@gmail.com>
+---
+ iMX8M/soc.mak | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/iMX8M/soc.mak b/iMX8M/soc.mak
+index 03b05f7aafeb..4d5df0777704 100644
+--- a/iMX8M/soc.mak
++++ b/iMX8M/soc.mak
+@@ -84,7 +84,7 @@ FW_DIR = imx-boot/imx-boot-tools/$(PLAT)
+ $(MKIMG): mkimage_imx8.c
+ 	@echo "PLAT="$(PLAT) "HDMI="$(HDMI)
+ 	@echo "Compiling mkimage_imx8"
+-	$(CC) $(CFLAGS) mkimage_imx8.c -o $(MKIMG) -lz
++	$(CC) $(CFLAGS) mkimage_imx8.c -o $(MKIMG) $(LDFLAGS) -lz
+ 
+ lpddr4_imem_1d = lpddr4_pmu_train_1d_imem$(LPDDR_FW_VERSION).bin
+ lpddr4_dmem_1d = lpddr4_pmu_train_1d_dmem$(LPDDR_FW_VERSION).bin
+-- 
+2.35.1
+

--- a/recipes-bsp/imx-mkimage/files/0001-Add-support-for-overriding-BL31-BL32-and-BL33.patch
+++ b/recipes-bsp/imx-mkimage/files/0001-Add-support-for-overriding-BL31-BL32-and-BL33.patch
@@ -1,0 +1,62 @@
+From ff3204addcf737b7285a0c44eb0a34c9ca82be4e Mon Sep 17 00:00:00 2001
+From: Thomas Perrot <thomas.perrot@bootlin.com>
+Date: Tue, 26 Apr 2022 15:10:04 +0200
+Subject: [PATCH] Add support for overriding BL31, BL32 and BL33
+
+Upstream-Status: Pending
+
+Signed-off-by: Thomas Perrot <thomas.perrot@bootlin.com>
+---
+ iMX8M/print_fit_hab.sh | 14 +++++++++-----
+ 1 file changed, 9 insertions(+), 5 deletions(-)
+
+diff --git a/iMX8M/print_fit_hab.sh b/iMX8M/print_fit_hab.sh
+index b915115d1ecc..9e025b78c04d 100755
+--- a/iMX8M/print_fit_hab.sh
++++ b/iMX8M/print_fit_hab.sh
+@@ -1,12 +1,16 @@
+ #!/bin/bash
+
+-BL32="tee.bin"
+-
+ let fit_off=$1
+
+ # keep backward compatibility
+ [ -z "$TEE_LOAD_ADDR" ] && TEE_LOAD_ADDR="0xfe000000"
+
++[ -z "$BL31" ] && BL33="bl31.bin"
++
++[ -z "$BL32" ] && BL32="tee.bin"
++
++[ -z "$BL33" ] && BL33="u-boot-nodtb.bin"
++
+ if [ -z "$ATF_LOAD_ADDR" ]; then
+ 	echo "ERROR: BL31 load address is not set" >&2
+ 	exit 0
+@@ -26,7 +30,7 @@ else
+ 	let uboot_sign_off=$((fit_off - 0x8000 - ivt_off + 0x3000))
+ fi
+
+-let uboot_size=$(ls -lct u-boot-nodtb.bin | awk '{print $5}')
++let uboot_size=$(ls -lct $BL33 | awk '{print $5}')
+ let uboot_load_addr=0x40200000
+
+ let last_sign_off=$(((uboot_sign_off + uboot_size + 3) & ~3))
+@@ -64,13 +68,13 @@ done
+
+ let atf_sign_off=$((last_sign_off))
+ let atf_load_addr=$ATF_LOAD_ADDR
+-let atf_size=$(ls -lct bl31.bin | awk '{print $5}')
++let atf_size=$(ls -lct $BL31 | awk '{print $5}')
+
+ if [ ! -f $BL32 ]; then
+ 	let tee_size=0x0
+ 	let tee_sign_off=$((atf_sign_off + atf_size))
+ else
+-	let tee_size=$(ls -lct tee.bin | awk '{print $5}')
++	let tee_size=$(ls -lct $BL32 | awk '{print $5}')
+
+ 	let tee_sign_off=$(((atf_sign_off + atf_size + 3) & ~3))
+ 	let tee_load_addr=$TEE_LOAD_ADDR
+--
+2.35.1

--- a/recipes-bsp/imx-mkimage/files/0001-Add-support-for-overriding-BL32-and-BL33-not-only-BL.patch
+++ b/recipes-bsp/imx-mkimage/files/0001-Add-support-for-overriding-BL32-and-BL33-not-only-BL.patch
@@ -1,0 +1,69 @@
+From 4e4e06602f594b335b4c264a3b062bc7af961078 Mon Sep 17 00:00:00 2001
+From: Erik Larsson <erik.larsson@combitech.se>
+Date: Thu, 8 Mar 2018 19:04:37 +0100
+Subject: [PATCH] Add support for overriding BL32 and BL33 not only BL31
+
+Upstream-Status: Pending
+
+Signed-off-by: Erik Larsson <karl.erik.larsson@gmail.com>
+Signed-off-by: Christopher Dahlberg <crille.dahlberg@gmail.com>
+Signed-off-by: Marcus Folkesson <marcus.folkesson@gmail.com>
+Signed-off-by: Thomas Perrot <thomas.perrot@bootlin.com>
+---
+ iMX8M/mkimage_fit_atf.sh | 15 ++++++++-------
+ 1 file changed, 8 insertions(+), 7 deletions(-)
+
+diff --git a/iMX8M/mkimage_fit_atf.sh b/iMX8M/mkimage_fit_atf.sh
+index 10903ea3bbf5..85ea6ffcc71d 100755
+--- a/iMX8M/mkimage_fit_atf.sh
++++ b/iMX8M/mkimage_fit_atf.sh
+@@ -6,6 +6,7 @@
+ # usage: $0 <dt_name> [<dt_name> [<dt_name] ...]
+
+ [ -z "$BL31" ] && BL31="bl31.bin"
++
+ # keep backward compatibility
+ [ -z "$TEE_LOAD_ADDR" ] && TEE_LOAD_ADDR="0xfe000000"
+
+@@ -18,23 +19,23 @@ if [ ! -f $BL31 ]; then
+ 	echo "ERROR: BL31 file $BL31 NOT found" >&2
+ 	exit 0
+ else
+-	echo "bl31.bin size: " >&2
+-	ls -lct bl31.bin | awk '{print $5}' >&2
++	echo "$BL31 size: " >&2
++	ls -lct $BL31 | awk '{print $5}' >&2
+ fi
+
+-BL32="tee.bin"
++[ -z "$BL32" ] && BL32="tee.bin"
+ LOADABLES="\"atf-1\""
+
+ if [ ! -f $BL32 ]; then
+ 	BL32=/dev/null
+ else
+ 	echo "Building with TEE support, make sure your bl31 is compiled with spd. If you do not want tee, please delete tee.bin" >&2
+-	echo "tee.bin size: " >&2
++	echo "$BL32 size: " >&2
+ 	ls -lct tee.bin | awk '{print $5}' >&2
+ 	LOADABLES="$LOADABLES, \"tee-1\""
+ fi
+
+-BL33="u-boot-nodtb.bin"
++[ -z "$BL33" ] && BL33="u-boot-nodtb.bin"
+ DEK_BLOB="dek_blob_fit_dummy.bin"
+
+ if [ ! -f $DEK_BLOB ]; then
+@@ -49,8 +50,8 @@ if [ ! -f $BL33 ]; then
+ 	exit 0
+ else
+
+-	echo "u-boot-nodtb.bin size: " >&2
+-	ls -lct u-boot-nodtb.bin | awk '{print $5}' >&2
++	echo "$BL33 size: " >&2
++	ls -lct $BL33 | awk '{print $5}' >&2
+ fi
+
+ for dtname in $*
+--
+2.35.1

--- a/recipes-bsp/imx-mkimage/imx-mkimage_git.bb
+++ b/recipes-bsp/imx-mkimage/imx-mkimage_git.bb
@@ -23,5 +23,7 @@ do_install () {
     cd ${S}
     install -d ${D}${bindir}
     install -m 0755 iMX8M/mkimage_imx8 ${D}${bindir}/mkimage_imx8m
+    install -m 0755 iMX8M/mkimage_fit_atf.sh ${D}${bindir}/mkimage_fit_atf.sh
+    install -m 0755 iMX8M/print_fit_hab.sh ${D}${bindir}/print_fit_hab.sh
     install -m 0755 mkimage_imx8 ${D}${bindir}/mkimage_imx8
 }

--- a/recipes-bsp/imx-mkimage/imx-mkimage_git.inc
+++ b/recipes-bsp/imx-mkimage/imx-mkimage_git.inc
@@ -6,6 +6,9 @@ SRCBRANCH = "lf-5.10.72_2.2.0"
 SRC_URI = "git://source.codeaurora.org/external/imx/imx-mkimage.git;protocol=https;branch=${SRCBRANCH} \
            file://0001-mkimage_fit_atf-fix-fit-generator-node-naming.patch \
            file://0001-iMX8M-soc.mak-use-native-mkimage-from-sysroot.patch \
+           file://0001-Add-support-for-overriding-BL32-and-BL33-not-only-BL.patch \
+           file://0001-Add-LDFLAGS-to-link-step.patch \
+           file://0001-Add-support-for-overriding-BL31-BL32-and-BL33.patch \
 "
 SRCREV = "7a277c8a1a21ff921d217889dde6a9f84e6d2168"
 S = "${WORKDIR}/git"


### PR DESCRIPTION
This script gives the address, the offset and the size of binaries have been
stored into U-Boot FIT image that contains TF-A, U-Boot and OP-TEE.

Signed-off-by: Thomas Perrot <thomas.perrot@bootlin.com>