### PR TITLE
imx-mkimage: fix patch

### DIFF
--- a/recipes-bsp/imx-mkimage/files/0001-Add-LDFLAGS-to-link-step.patch
+++ b/recipes-bsp/imx-mkimage/files/0001-Add-LDFLAGS-to-link-step.patch
@@ -19,7 +19,7 @@ index 03b05f7aafeb..4d5df0777704 100644
  	@echo "PLAT="$(PLAT) "HDMI="$(HDMI)
  	@echo "Compiling mkimage_imx8"
 -	$(CC) $(CFLAGS) mkimage_imx8.c -o $(MKIMG) -lz
-+	$(CC) $(CFLAGS) mkimage_imx8.c -o $(MKIMG) $(LDFLAGS) -lz
++	$(CC) $(CFLAGS) mkimage_imx8.c -o $(MKIMG) $(BUILD_LDFLAGS) -lz
  
  lpddr4_imem_1d = lpddr4_pmu_train_1d_imem$(LPDDR_FW_VERSION).bin
  lpddr4_dmem_1d = lpddr4_pmu_train_1d_dmem$(LPDDR_FW_VERSION).bin


### PR DESCRIPTION
I wonder why we need the explicit $(LDFLAGS) in the first place, i.e. what does it fix.
The patch is not very verbose on explaining the why.