### PR TITLE
libimxvpuapi2 and gstreamer1.0-plugins-imx upgrades

### DIFF
--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-imx_2.1.0.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-imx_2.1.0.bb
@@ -15,7 +15,7 @@ RDEPENDS:gstreamer1.0-plugins-imx-imxvpu = "gstreamer1.0-plugins-bad-videoparser
 PV .= "+git${SRCPV}"
 
 SRCBRANCH ?= "master"
-SRCREV = "11e3a555a280f97d55d5243e8259a255b3ed14d0"
+SRCREV = "b1e5cca1a6df9d2c0dc505ae222775798108d340"
 SRC_URI = "git://github.com/Freescale/gstreamer-imx.git;branch=${SRCBRANCH};protocol=https"
 
 S = "${WORKDIR}/git"

--- a/recipes-multimedia/libimxvpuapi/libimxvpuapi2_2.2.1.bb
+++ b/recipes-multimedia/libimxvpuapi/libimxvpuapi2_2.2.1.bb
@@ -8,7 +8,7 @@ DEPENDS = "virtual/imxvpu libimxdmabuffer"
 PV .= "+git${SRCPV}"
 
 SRCBRANCH ?= "master"
-SRCREV = "a650f13fb5de94e0c7c9e77f4d07ea275ea80dac"
+SRCREV = "e81db32d10aee42c74ab50172487e04cbec6cbe0"
 SRC_URI = "git://github.com/Freescale/libimxvpuapi.git;branch=${SRCBRANCH};protocol=https"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
This pull request upgrades libimxvpuapi2 to version 2.2.1 and gstreamer1.0-plugins-imx to version 2.1.0. The changelogs are found in the individual commit messages.

This can also be applied to the master branch, but requires the libimxdmabuffer 1.1.2 upgrade (which is already in kirkstone) to be included into master as well.

A separate PR for backporting these two to dunfell will follow.