### PR TITLE
imx8m: Set LPDDR4 machines to use IMX BSP only

### DIFF
--- a/conf/machine/imx8mm-lpddr4-evk.conf
+++ b/conf/machine/imx8mm-lpddr4-evk.conf
@@ -34,3 +34,8 @@ DDR_FIRMWARE_NAME = " \
 "
 
 IMXBOOT_TARGETS_BASENAME = "flash_evk"
+
+# Mainline BSP doesn't support LPDDR4 so it must be set to nxp.
+# Also this machine isn't supported by u-boot-fslc but imx8mn-evk.inc already
+# set the bootloader to u-boot-imx instead when NXP BSP is used.
+IMX_DEFAULT_BSP = "nxp"

--- a/conf/machine/imx8mn-lpddr4-evk.conf
+++ b/conf/machine/imx8mn-lpddr4-evk.conf
@@ -19,3 +19,8 @@ DDR_FIRMWARE_NAME = " \
     lpddr4_pmu_train_2d_dmem.bin \
 "
 IMXBOOT_TARGETS_BASENAME = "flash_evk"
+
+# Mainline BSP doesn't support LPDDR4 so it must be set to nxp.
+# Also this machine isn't supported by u-boot-fslc but imx8mn-evk.inc already
+# set the bootloader to u-boot-imx instead when NXP BSP is used.
+IMX_DEFAULT_BSP = "nxp"

--- a/conf/machine/imx8mp-lpddr4-evk.conf
+++ b/conf/machine/imx8mp-lpddr4-evk.conf
@@ -53,3 +53,8 @@ DDR_FIRMWARE_NAME = " \
 "
 
 IMXBOOT_TARGETS_BASENAME = "flash_evk"
+
+# Mainline BSP doesn't support LPDDR4 so it must be set to nxp.
+# Also this machine isn't supported by u-boot-fslc but imx8mn-evk.inc already
+# set the bootloader to u-boot-imx instead when NXP BSP is used.
+IMX_DEFAULT_BSP = "nxp"


### PR DESCRIPTION
This is necessary because mainline U-Boot doesn't supports LPDDR4 for
i.MX8M EVK.
Also these machines aren't supported by mainline kernel.

Signed-off-by: Thomas Perrot <thomas.perrot@bootlin.com>