### PR TITLE
libimxdmabuffer, libimxvpuapi2, gstreamer1.0-plugins-imx upgrades and backports for dunfell

### DIFF
--- a/recipes-bsp/libimxdmabuffer/files/0001-g2d-Fix-typo.patch
+++ b/recipes-bsp/libimxdmabuffer/files/0001-g2d-Fix-typo.patch
@@ -1,0 +1,28 @@
+From 41825b11289be251fed64470893d18b89b0dd38b Mon Sep 17 00:00:00 2001
+From: Carlos Rafael Giani <crg7475@mailbox.org>
+Date: Sun, 8 May 2022 16:25:44 +0200
+Subject: [PATCH] g2d: Fix typo
+
+Signed-off-by: Carlos Rafael Giani <crg7475@mailbox.org>
+
+Upstream-Status: Backport [41825b11289be251fed64470893d18b89b0dd38b]
+---
+ imxdmabuffer/imxdmabuffer_g2d_allocator.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/imxdmabuffer/imxdmabuffer_g2d_allocator.c b/imxdmabuffer/imxdmabuffer_g2d_allocator.c
+index f10a909..497dcea 100644
+--- a/imxdmabuffer/imxdmabuffer_g2d_allocator.c
++++ b/imxdmabuffer/imxdmabuffer_g2d_allocator.c
+@@ -139,7 +139,7 @@ static uint8_t* imx_dma_buffer_g2d_allocator_map(ImxDmaBufferAllocator *allocato
+ 	 * (Other allocators perform more steps than this.) */
+ 	if (imx_g2d_buffer->mapping_refcount > 0)
+ 	{
+-		assert((imx_dwl_buffer->map_flags & flags & IMX_DMA_BUFFER_MAPPING_READWRITE_FLAG_MASK) == (flags & IMX_DMA_BUFFER_MAPPING_READWRITE_FLAG_MASK));
++		assert((imx_g2d_buffer->map_flags & flags & IMX_DMA_BUFFER_MAPPING_READWRITE_FLAG_MASK) == (flags & IMX_DMA_BUFFER_MAPPING_READWRITE_FLAG_MASK));
+ 		imx_g2d_buffer->mapping_refcount++;
+ 	}
+ 	else
+-- 
+2.32.0
+

--- a/recipes-bsp/libimxdmabuffer/libimxdmabuffer_1.1.2.bb
+++ b/recipes-bsp/libimxdmabuffer/libimxdmabuffer_1.1.2.bb
@@ -8,8 +8,9 @@ SECTION = "base"
 PV .= "+git${SRCPV}"
 
 SRCBRANCH ?= "master"
-SRCREV = "d2058aa404ee1e8e8abd552c6a637787bcdcf514"
+SRCREV = "5410b44fb0c5bbd9fb1f3ba0681e65068d8cde57"
 SRC_URI = "git://github.com/Freescale/libimxdmabuffer.git;branch=${SRCBRANCH};protocol=https \
+           file://0001-g2d-Fix-typo.patch \
            file://run-ptest \
           "
 
@@ -18,8 +19,10 @@ S = "${WORKDIR}/git"
 
 inherit pkgconfig waf use-imx-headers ptest
 
+# dma-heap allocator is unavailable because it requires kernel 5.6 or newer.
 EXTRA_OECONF = "--imx-linux-headers-path=${STAGING_INCDIR_IMX} \
                 --libdir=${libdir} \
+                --with-dma-heap-allocator=no \
                 ${PACKAGECONFIG_CONFARGS}"
 
 # If imxdpu is in use, the DPU is also used for implementing

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-imx_2.1.0.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-imx_2.1.0.bb
@@ -1,0 +1,70 @@
+# Copyright (C) 2018 O.S. Systems Software LTDA.
+DESCRIPTION = "GStreamer 1.0 plugins for i.MX platforms"
+LICENSE = "LGPLv2+"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=55ca817ccb7d5b5b66355690e9abc605"
+SECTION = "multimedia"
+DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base libimxdmabuffer"
+# add the audioparsers and the videoparsersbad plugins as RDEPENDS ; audioparsers
+# for the uniaudio decoder, videoparsersbad for the VPU video decoder
+# the gstreamer1.0-plugins-imx RDEPENDS is necessary to ensure the -good recipe is
+# built (it is not a compile-time dependency however, hence RDEPENDS and not DEPENDS)
+RDEPENDS_gstreamer1.0-plugins-imx = "gstreamer1.0-plugins-good gstreamer1.0-plugins-bad"
+RDEPENDS_gstreamer1.0-plugins-imx-imxaudio = "gstreamer1.0-plugins-good-audioparsers"
+RDEPENDS_gstreamer1.0-plugins-imx-imxvpu = "gstreamer1.0-plugins-bad-videoparsersbad"
+
+PV .= "+git${SRCPV}"
+
+SRCBRANCH ?= "master"
+SRCREV = "b1e5cca1a6df9d2c0dc505ae222775798108d340"
+SRC_URI = "git://github.com/Freescale/gstreamer-imx.git;branch=${SRCBRANCH};protocol=https"
+
+S = "${WORKDIR}/git"
+
+# Setting DEFAULT_PREFERENCE to -1 since dunfell has had gstreamer-imx version
+# 0.13.1 for a long time already, so silently replacing it with version 2.1.0
+# may break existing BSPs.
+DEFAULT_PREFERENCE = "-1"
+
+inherit pkgconfig meson use-imx-headers
+
+# libg2d on i.MX8 SoCs with a DPU is emulated via the DPU.
+# That particular libg2d .so depends on libdrm, however.
+# Also, due to behavioral differences, an additional flag
+# is needed to improve performance.
+LIBG2D_DPU_OPTION = "-Dg2d-based-on-dpu=false"
+LIBG2D_DEPENDENCIES = "virtual/libg2d"
+LIBG2D_DPU_OPTION_imxdpu = "-Dg2d-based-on-dpu=true"
+LIBG2D_DEPENDENCIES_imxdpu = "virtual/libg2d libdrm"
+
+# OE dunfell's meson version does not have the necessary
+# functionality for build scripts to query the sysroot path,
+# so it must be specified manually via the -Dsysroot option.
+EXTRA_OEMESON += "-Dimx-headers-path=${STAGING_INCDIR_IMX} -Dsysroot=${RECIPE_SYSROOT}"
+
+PACKAGECONFIG ?= "uniaudiodec"
+PACKAGECONFIG_append_imxgpu2d = " g2d"
+PACKAGECONFIG_append_imxvpu   = " vpu"
+PACKAGECONFIG_append_imxipu   = " ipu"
+PACKAGECONFIG_append_imxpxp   = " pxp"
+# The custom imxv4l2 elements are only available on the i.MX6.
+# The 2D blitter sinks require an MXC framebuffer, which
+# is not available anymore on the i.MX8 (since these SoCs
+# now use KMS instead of the old Linux framebuffer).
+PACKAGECONFIG_append_mx6      = " imx2dvideosink v4l2"
+PACKAGECONFIG_append_mx7      = " imx2dvideosink"
+
+PACKAGECONFIG[g2d] = "-Dg2d=enabled ${LIBG2D_DPU_OPTION},-Dg2d=disabled,${LIBG2D_DEPENDENCIES}"
+PACKAGECONFIG[pxp] = "-Dpxp=enabled,-Dpxp=disabled,"
+PACKAGECONFIG[ipu] = "-Dipu=enabled,-Dipu=disabled,"
+PACKAGECONFIG[vpu] = "-Dvpu=enabled,-Dvpu=disabled,libimxvpuapi2"
+PACKAGECONFIG[imx2dvideosink] = "-Dimx2d-videosink=true,-Dimx2d-videosink=false,"
+PACKAGECONFIG[v4l2] = "-Dv4l2=true,-Dv4l2=false,"
+PACKAGECONFIG[uniaudiodec] = "-Duniaudiodec=enabled,-Duniaudiodec=disabled,imx-codec"
+PACKAGECONFIG[mp3encoder] = "-Dmp3encoder=enabled,-Dmp3encoder=disabled,imx-codec"
+
+require recipes-multimedia/gstreamer/gstreamer1.0-plugins-packaging.inc
+
+# the following line is required to produce one package for each plugin
+PACKAGES_DYNAMIC = "^${PN}-.*"
+
+COMPATIBLE_MACHINE = "(mx6dl|mx6q|mx6sl|mx6sx|mx6ul|mx6ull|mx7d|mx8)"

--- a/recipes-multimedia/libimxvpuapi/libimxvpuapi2_2.2.1.bb
+++ b/recipes-multimedia/libimxvpuapi/libimxvpuapi2_2.2.1.bb
@@ -8,7 +8,7 @@ DEPENDS = "virtual/imxvpu libimxdmabuffer"
 PV .= "+git${SRCPV}"
 
 SRCBRANCH ?= "master"
-SRCREV = "a650f13fb5de94e0c7c9e77f4d07ea275ea80dac"
+SRCREV = "e81db32d10aee42c74ab50172487e04cbec6cbe0"
 SRC_URI = "git://github.com/Freescale/libimxvpuapi.git;branch=${SRCBRANCH};protocol=https"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
This pull request upgrades libimxdmabuffer and libimxvpuapi2 to versions 1.1.2 and 2.2.1, respectively, upgrading them to the same version as in [this kirkstone PR](https://github.com/Freescale/meta-freescale/pull/1074).

In addition, gstreamer1.0-plugins-imx v2.1.0 is backported from that kirkstone PR. It is set to not be the default (gstreamer1.0-plugins-imx 0.13.1 remains the default gstreamer1.0-plugins-imx version).