### PR TITLE
machines: follow kernel deployment changes

### DIFF
--- a/conf/machine/imx8qm-mek.conf
+++ b/conf/machine/imx8qm-mek.conf
@@ -14,7 +14,7 @@ MACHINE_FEATURES += "pci optee bcm43455 bcm4356"
 MACHINE_FEATURES:append:use-nxp-bsp = " bcm4359"
 
 # Don't include kernels in standard images
-RDEPENDS:${KERNEL_PACKAGE_NAME}-base = ""
+RRECOMMENDS:${KERNEL_PACKAGE_NAME}-base = ""
 
 LOADADDR = ""
 

--- a/conf/machine/include/imx8dxl-evk.inc
+++ b/conf/machine/include/imx8dxl-evk.inc
@@ -9,7 +9,7 @@ MACHINE_FEATURES += "pci bcm43455 bcm4356"
 MACHINE_FEATURES:append:use-nxp-bsp = " bcm4359"
 
 # Don't include kernels in standard images
-RDEPENDS:${KERNEL_PACKAGE_NAME}-base = ""
+RRECOMMENDS:${KERNEL_PACKAGE_NAME}-base = ""
 
 LOADADDR = ""
 

--- a/conf/machine/include/imx8x-mek.inc
+++ b/conf/machine/include/imx8x-mek.inc
@@ -7,7 +7,7 @@ MACHINE_FEATURES += "pci optee bcm43455 bcm4356"
 MACHINE_FEATURES:append:use-nxp-bsp = " bcm4359"
 
 # Don't include kernels in standard images
-RDEPENDS:${KERNEL_PACKAGE_NAME}-base = ""
+RRECOMMENDS:${KERNEL_PACKAGE_NAME}-base = ""
 
 LOADADDR = ""
 

--- a/recipes-kernel/linux/linux-qoriq.inc
+++ b/recipes-kernel/linux/linux-qoriq.inc
@@ -9,7 +9,7 @@ S = "${WORKDIR}/git"
 
 DEPENDS:append = " libgcc"
 # not put Images into /boot of rootfs, install kernel-image if needed
-RDEPENDS:${KERNEL_PACKAGE_NAME}-base = ""
+RRECOMMENDS:${KERNEL_PACKAGE_NAME}-base = ""
 
 KERNEL_CC:append = " ${TOOLCHAIN_OPTIONS}"
 KERNEL_LD:append = " ${TOOLCHAIN_OPTIONS}"


### PR DESCRIPTION
With OE core commit [1c90b27d2c](https://github.com/openembedded/openembedded-core/commit/1c90b27d2c65cfb4f9debf0272820b6a95942f76) ("kernel: make kernel-base recommend kernel-image, not depend") the way the kernel is deployed into the rootfs silently changed, i.e. there is no build or run time error/warning that the kernel binary is deployed despite one did not want it. 

Note that commit 1c90b27d2c is already in the kirkstone branch.

