### PR TITLE
imx-atf: Suppress array-bounds error

### DIFF
--- a/recipes-bsp/imx-atf/imx-atf/0001-Makefile-Suppress-array-bounds-error.patch
+++ b/recipes-bsp/imx-atf/imx-atf/0001-Makefile-Suppress-array-bounds-error.patch
@@ -1,0 +1,42 @@
+From 85f576054a4d5496706bbd37a520942f51cb74b9 Mon Sep 17 00:00:00 2001
+From: Tom Hochstein <tom.hochstein@nxp.com>
+Date: Mon, 16 May 2022 13:45:16 -0500
+Subject: [PATCH] Makefile: Suppress array-bounds error
+
+The array-bounds error is triggered now in cases where it was silent before,
+causing errors like:
+
+```
+plat/imx/imx8m/hab.c: In function 'imx_hab_handler':
+plat/imx/imx8m/hab.c:64:57: error: array subscript 0 is outside array bounds of 'uint32_t[0]' {aka 'unsigned int[]'} [-Werror=array-bounds]
+   64 | #define HAB_RVT_CHECK_TARGET_ARM64      ((unsigned long)*(uint32_t *)(HAB_RVT_BASE + 0x18))
+      |                                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+It appears that these new cases will be silenced soon in gcc [1], so for
+now just silence the warning locally as a workaround.
+
+[1] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=99578#c39
+
+Upstream-Status: Inappropriate [other]
+Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index c87c3ae08..2d6b90f47 100644
+--- a/Makefile
++++ b/Makefile
+@@ -346,7 +346,7 @@ WARNINGS	+=		-Wshift-overflow -Wshift-sign-overflow \
+ endif
+ 
+ ifneq (${E},0)
+-ERRORS := -Werror
++ERRORS := -Werror -Wno-error=array-bounds
+ endif
+ 
+ CPPFLAGS		=	${DEFINES} ${INCLUDES} ${MBEDTLS_INC} -nostdinc	\
+-- 
+2.17.1
+

--- a/recipes-bsp/imx-atf/imx-atf_2.4.bb
+++ b/recipes-bsp/imx-atf/imx-atf_2.4.bb
@@ -9,7 +9,7 @@ PV .= "+git${SRCPV}"
 
 SRCBRANCH = "lf_v2.4"
 SRC_URI = "git://source.codeaurora.org/external/imx/imx-atf.git;protocol=https;branch=${SRCBRANCH} \
-"
+           file://0001-alsa-state-Remove-PCM-devices-mapped-by-5.15-kernel.patch"
 SRCREV = "05f788b9bbb13d002997e35008a4b945f7e2957b"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
The array-bounds error is triggered now in cases where it was silent before,
causing errors like:

```
plat/imx/imx8m/hab.c: In function 'imx_hab_handler':
plat/imx/imx8m/hab.c:64:57: error: array subscript 0 is outside array bounds of 'uint32_t[0]' {aka 'unsigned int[]'} [-Werror=array-bounds]
   64 | #define HAB_RVT_CHECK_TARGET_ARM64      ((unsigned long)*(uint32_t *)(HAB_RVT_BASE + 0x18))
      |                                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

It appears that these new cases will be silenced soon in gcc [1], so for
now just silence the warning locally as workaround.

[1] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=99578#c39

Fixes: #1084
Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>