### PR TITLE
rcw: Use SPDX-style license

### DIFF
--- a/recipes-bsp/rcw/rcw_git.bb
+++ b/recipes-bsp/rcw/rcw_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Reset Configuration Word"
 DESCRIPTION = "Reset Configuration Word - hardware boot-time parameters for the QorIQ targets"
-LICENSE = "BSD"
+LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=44a0d0fad189770cc022af4ac6262cbe"
 
 DEPENDS += "tcl-native"


### PR DESCRIPTION
Specify the BSD variant used. This fixes the following warning when building on kirkstone:

    WARNING: rcw-git-r0 do_populate_lic: QA Issue: rcw: No generic license file exists for: BSD in any provider [license-exists]