### PR TITLE
Remove lzop dependency dropped upstream

### DIFF
--- a/recipes-bsp/u-boot/u-boot-fslc_2022.04.bb
+++ b/recipes-bsp/u-boot/u-boot-fslc_2022.04.bb
@@ -8,7 +8,7 @@ version, or because it is not applicable for upstreaming."
 
 inherit ${@oe.utils.ifelse(d.getVar('UBOOT_PROVIDES_BOOT_CONTAINER') == '1', 'imx-boot-container', '')}
 
-DEPENDS += "bc-native dtc-native python3-setuptools-native lzop-native"
+DEPENDS += "bc-native dtc-native python3-setuptools-native"
 
 # Location known to imx-boot component, where U-Boot artifacts
 # should be additionally deployed.

--- a/recipes-kernel/linux/linux-fslc.inc
+++ b/recipes-kernel/linux/linux-fslc.inc
@@ -3,7 +3,7 @@
 
 require recipes-kernel/linux/linux-imx.inc
 
-DEPENDS += "lzop-native bc-native"
+DEPENDS += "bc-native"
 
 SRC_URI = "git://github.com/Freescale/linux-fslc.git;branch=${KBRANCH};protocol=https \
            file://defconfig"


### PR DESCRIPTION
Upstream commit [`dea5e88637 ("lzop: remove recipe from oe-core")`](https://github.com/openembedded/openembedded-core/commit/dea5e8863792dc7bb3324b543e04da4c94a060aa) dropped support of _lzop_ and removed recipe from OE-Core.

Drop _lzop_ dependencies in recipes across the layer, it is not available anymore.

Cc: @Ossanes 