### PR TITLE
imx-base.inc: Set virtual/opencl-icd provider for i.MX

### DIFF
--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -423,6 +423,7 @@ PREFERRED_PROVIDER_virtual/libg2d:imxdpu     ?= "imx-dpu-g2d"
 PREFERRED_PROVIDER_opencl-clhpp:imxgpu       ?= "imx-gpu-viv"
 PREFERRED_PROVIDER_opencl-headers:imxgpu     ?= "imx-gpu-viv"
 PREFERRED_PROVIDER_opencl-icd-loader:imxgpu  ?= "imx-gpu-viv"
+PREFERRED_PROVIDER_virtual/opencl-icd:imxgpu ?= "imx-gpu-viv"
 
 PREFERRED_VERSION_weston:imx-nxp-bsp     ?= "9.0.0.imx"
 PREFERRED_VERSION_weston:imx-mainline-bsp = ""


### PR DESCRIPTION
Properly set provider for i.MX GPU, as noted by bitbake:
```
NOTE: Multiple providers are available for virtual/opencl-icd (imx-gpu-viv, opencl-icd-loader)
Consider defining a PREFERRED_PROVIDER entry to match virtual/opencl-icd
```

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>