### PR TITLE
classes: mfgtool-initramfs-image use weak variable for IMAGE_FSTYPES

### DIFF
--- a/classes/mfgtool-initramfs-image.bbclass
+++ b/classes/mfgtool-initramfs-image.bbclass
@@ -12,8 +12,8 @@ FEATURE_PACKAGES_mtd = "packagegroup-fsl-mfgtool-mtd"
 FEATURE_PACKAGES_extfs = "packagegroup-fsl-mfgtool-extfs"
 FEATURE_PACKAGES_f2fs = "packagegroup-fsl-mfgtool-f2fs"
 
-IMAGE_FSTYPES = "cpio.gz.u-boot"
-IMAGE_FSTYPES:mxs = "cpio.gz.u-boot"
+IMAGE_FSTYPES ?= "cpio.gz.u-boot"
+IMAGE_FSTYPES:mxs ?= "cpio.gz.u-boot"
 IMAGE_ROOTFS_SIZE ?= "8192"
 
 # Filesystems enabled by default


### PR DESCRIPTION
Close #951 by changing `IMAGE_FSTYPES` to a weak variable 