### PR TITLE
classes: mfgtool-initramfs-image use weak variable for IMAGE_FSTYPES

### DIFF
--- a/classes/mfgtool-initramfs-image.bbclass
+++ b/classes/mfgtool-initramfs-image.bbclass
@@ -13,8 +13,8 @@ FEATURE_PACKAGES_extfs = "packagegroup-fsl-mfgtool-extfs"
 FEATURE_PACKAGES_f2fs = "packagegroup-fsl-mfgtool-f2fs"
 
 ZSTD_COMPRESSION_LEVEL ?= "-10"
-IMAGE_FSTYPES = "cpio.zst.u-boot"
-IMAGE_FSTYPES:mxs-generic-bsp = "cpio.gz.u-boot"
+IMAGE_FSTYPES ?= "cpio.zst.u-boot"
+IMAGE_FSTYPES:mxs-generic-bsp ?= "cpio.gz.u-boot"
 IMAGE_ROOTFS_SIZE ?= "8192"
 
 # Filesystems enabled by default


### PR DESCRIPTION
Close #951 by changing `IMAGE_FSTYPES` to a weak variable 