### PR TITLE
Consolidated Kernel (v5.15.46 + v5.18.3)

### DIFF
--- a/recipes-kernel/linux/linux-fslc-imx_5.15.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_5.15.bb
@@ -28,7 +28,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v5.15.45
+#    tag: v5.15.46
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
@@ -70,14 +70,14 @@ LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
 KBRANCH = "5.15-1.0.x-imx"
-SRCREV = "e6ad415b02af0d025969cbf0ba1d48870b6687bf"
+SRCREV = "2badd023089aeeadb482300d5d409d6deece659c"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.15.45"
+LINUX_VERSION = "5.15.46"
 
 # Local version indicates the branch name in the NXP kernel tree where patches are collected from.
 LOCALVERSION = "-5.15.5-1.0.0"

--- a/recipes-kernel/linux/linux-fslc-lts_5.15.bb
+++ b/recipes-kernel/linux/linux-fslc-lts_5.15.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.15.45"
+LINUX_VERSION = "5.15.46"
 
 KBRANCH = "5.15.x+fslc"
-SRCREV = "b3ea37332bac1eacbb0110bbb2d7792e23951ef9"
+SRCREV = "b0d7488836b992745e42ac055cb9bd59ba29c3ae"
 
 COMPATIBLE_MACHINE = "(imx-generic-bsp)"

--- a/recipes-kernel/linux/linux-fslc_5.18.bb
+++ b/recipes-kernel/linux/linux-fslc_5.18.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.18.2"
+LINUX_VERSION = "5.18.3"
 
 KBRANCH = "5.18.x+fslc"
-SRCREV = "617988c95e786e71d25d739d5a497335058b361c"
+SRCREV = "3e911e32b6228ba4a05f476830c0179aa99d5985"
 
 COMPATIBLE_MACHINE = "(imx-generic-bsp)"


### PR DESCRIPTION
Kernel branches were updated up to and including following versions for recipes from stable korg:
- `linux-fslc-imx`: _v5.15.46_
- `linux-fslc-lts`: _v5.15.46_
- `linux-fslc`: _v5.18.3_

Update recipe `SRCREV` to point to those versions now.

Upstream commits and resolved conflicts are recorded in corresponding recipe commit messages.

`linux-fslc` has been boot-tested on `imx8mn-lpddr4-evk` and `imx8mp-lpddr4-evk` machines, result: **PASS**.

-- andrey