### PR TITLE
Support upstream TF-A usage for i.MX8M machines

### DIFF
--- a/classes/imx-boot-container.bbclass
+++ b/classes/imx-boot-container.bbclass
@@ -47,7 +47,7 @@ do_resolve_and_populate_binaries() {
                         cp ${DEPLOY_DIR_IMAGE}/${ddr_firmware} ${B}/${config}/
                     done
                     if [ -n "${ATF_MACHINE_NAME}" ]; then
-                        cp ${DEPLOY_DIR_IMAGE}/${BOOT_TOOLS}/${ATF_MACHINE_NAME} ${B}/${config}/bl31.bin
+                        cp ${DEPLOY_DIR_IMAGE}/${ATF_MACHINE_NAME} ${B}/${config}/bl31.bin
                     else
                         bberror "ATF binary is undefined, result binary would be unusable!"
                     fi

--- a/classes/imx-boot-container.bbclass
+++ b/classes/imx-boot-container.bbclass
@@ -29,7 +29,7 @@ ATF_MACHINE_NAME:append = "${@bb.utils.contains('MACHINE_FEATURES', 'optee', '-o
 # appropriate dependencies for populate binaries task
 do_resolve_and_populate_binaries[depends] += " \
     ${@' '.join('%s:do_deploy' % r for r in '${IMX_EXTRA_FIRMWARE}'.split() )} \
-    imx-atf:do_deploy \
+    ${IMX_DEFAULT_ATF_PROVIDER}:do_deploy \
     ${@bb.utils.contains('MACHINE_FEATURES', 'optee', 'optee-os:do_deploy', '', d)} \
 "
 

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -40,6 +40,8 @@ BBFILES_DYNAMIC += " \
     ivi:${LAYERDIR}/dynamic-layers/ivi/*/*/*.bb \
     ivi:${LAYERDIR}/dynamic-layers/ivi/*/*/*.bbappend \
     \
+    meta-arm:${LAYERDIR}/dynamic-layers/meta-arm/*/*/*.bbappend \
+    \
     openembedded-layer:${LAYERDIR}/dynamic-layers/openembedded-layer/*/*/*.bb \
     openembedded-layer:${LAYERDIR}/dynamic-layers/openembedded-layer/*/*/*.bbappend \
     \

--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -96,6 +96,23 @@ UBOOT_ENTRYPOINT:vf-generic-bsp     = "0x80008000"
 UBOOT_PROVIDES_BOOT_CONTAINER = "0"
 UBOOT_PROVIDES_BOOT_CONTAINER:imx-boot-container = "1"
 
+# Trusted Firmware for Cortex-A (TF-A) can have different providers, either
+# from upstream or from NXP downstream fork. Below variable defines which TF-A
+# shall be taken into the build, and will be integrated into runtime image.
+#
+# Upstream TF-A recipe resides in the meta-arm layer and in maintained by OE
+# community. Therefore, in order to add upstream TF-A - additional layer has
+# to be included in the bblayers.con file. Compatible machines are added to
+# this layer via dynamic-layers mechanism.
+#
+# NOTE: Current upstream TF-A version (v2.7) does not support HAB feature of
+# i.MX8M family. If the upstream TF-A version is chosen, then HAB will not be
+# available for all SoCs that are opting-in. This might change with future TF-A
+# release, so this statement shall be kept here until support is added.
+#
+# Default TF-A provider to NXP downstream fork
+IMX_DEFAULT_ATF_PROVIDER ??= "imx-atf"
+
 PREFERRED_PROVIDER_virtual/xserver      = "xserver-xorg"
 XSERVER_DRIVER                          = "xf86-video-fbdev"
 XSERVER_DRIVER:vf-generic-bsp           = "xf86-video-modesetting"

--- a/dynamic-layers/meta-arm/recipes-bsp/trusted-firmware-a/trusted-firmware-a_%.bbappend
+++ b/dynamic-layers/meta-arm/recipes-bsp/trusted-firmware-a/trusted-firmware-a_%.bbappend
@@ -1,0 +1,16 @@
+# Common Build targets
+TFA_BUILD_TARGET = "all"
+TFA_INSTALL_TARGET = "bl31"
+
+# List of supported machines from this layer
+COMPATIBLE_MACHINE:imx8mm-lpddr4-evk = "imx8mm-lpddr4-evk"
+TFA_PLATFORM:imx8mm-lpddr4-evk = "imx8mm"
+
+COMPATIBLE_MACHINE:imx8mn-ddr4-evk = "imx8mn-ddr4-evk"
+TFA_PLATFORM:imx8mn-ddr4-evk = "imx8mn"
+
+COMPATIBLE_MACHINE:imx8mp-lpddr4-evk = "imx8mp-lpddr4-evk"
+TFA_PLATFORM:imx8mp-lpddr4-evk = "imx8mp"
+
+COMPATIBLE_MACHINE:imx8mq-evk = "imx8mq-evk"
+TFA_PLATFORM:imx8mq-evk = "imx8mq"

--- a/recipes-bsp/imx-atf/imx-atf_2.4.bb
+++ b/recipes-bsp/imx-atf/imx-atf_2.4.bb
@@ -61,9 +61,9 @@ do_compile() {
 do_install[noexec] = "1"
 
 do_deploy() {
-    install -Dm 0644 ${S}/build/${ATF_PLATFORM}/release/bl31.bin ${DEPLOYDIR}/${BOOT_TOOLS}/bl31-${ATF_PLATFORM}.bin
+    install -Dm 0644 ${S}/build/${ATF_PLATFORM}/release/bl31.bin ${DEPLOYDIR}/bl31-${ATF_PLATFORM}.bin
     if ${BUILD_OPTEE}; then
-       install -m 0644 ${S}/build-optee/${ATF_PLATFORM}/release/bl31.bin ${DEPLOYDIR}/${BOOT_TOOLS}/bl31-${ATF_PLATFORM}.bin-optee
+       install -m 0644 ${S}/build-optee/${ATF_PLATFORM}/release/bl31.bin ${DEPLOYDIR}/bl31-${ATF_PLATFORM}.bin-optee
     fi
 }
 addtask deploy after do_compile

--- a/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
+++ b/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
@@ -88,13 +88,13 @@ compile_mx8m() {
     cp ${DEPLOY_DIR_IMAGE}/${BOOT_TOOLS}/${UBOOT_DTB_NAME}   ${BOOT_STAGING}
     cp ${DEPLOY_DIR_IMAGE}/${BOOT_TOOLS}/u-boot-nodtb.bin-${MACHINE}-${UBOOT_CONFIG} \
                                                              ${BOOT_STAGING}/u-boot-nodtb.bin
-    cp ${DEPLOY_DIR_IMAGE}/${BOOT_TOOLS}/${ATF_MACHINE_NAME} ${BOOT_STAGING}/bl31.bin
+    cp ${DEPLOY_DIR_IMAGE}/${ATF_MACHINE_NAME}               ${BOOT_STAGING}/bl31.bin
     cp ${DEPLOY_DIR_IMAGE}/${UBOOT_NAME}                     ${BOOT_STAGING}/u-boot.bin
 }
 compile_mx8() {
     bbnote 8QM boot binary build
     cp ${DEPLOY_DIR_IMAGE}/${BOOT_TOOLS}/${SC_FIRMWARE_NAME} ${BOOT_STAGING}/scfw_tcm.bin
-    cp ${DEPLOY_DIR_IMAGE}/${BOOT_TOOLS}/${ATF_MACHINE_NAME} ${BOOT_STAGING}/bl31.bin
+    cp ${DEPLOY_DIR_IMAGE}/${ATF_MACHINE_NAME}               ${BOOT_STAGING}/bl31.bin
     cp ${DEPLOY_DIR_IMAGE}/${UBOOT_NAME}                     ${BOOT_STAGING}/u-boot.bin
     cp ${DEPLOY_DIR_IMAGE}/${SECO_FIRMWARE_NAME}             ${BOOT_STAGING}
     if [ -e ${DEPLOY_DIR_IMAGE}/u-boot-spl.bin-${MACHINE}-${UBOOT_CONFIG} ] ; then
@@ -107,7 +107,7 @@ compile_mx8x() {
     bbnote 8QX boot binary build
     cp ${DEPLOY_DIR_IMAGE}/${SECO_FIRMWARE_NAME}             ${BOOT_STAGING}
     cp ${DEPLOY_DIR_IMAGE}/${BOOT_TOOLS}/${SC_FIRMWARE_NAME} ${BOOT_STAGING}/scfw_tcm.bin
-    cp ${DEPLOY_DIR_IMAGE}/${BOOT_TOOLS}/${ATF_MACHINE_NAME} ${BOOT_STAGING}/bl31.bin
+    cp ${DEPLOY_DIR_IMAGE}/${ATF_MACHINE_NAME}               ${BOOT_STAGING}/bl31.bin
     cp ${DEPLOY_DIR_IMAGE}/${UBOOT_NAME}                     ${BOOT_STAGING}/u-boot.bin
     if [ -e ${DEPLOY_DIR_IMAGE}/u-boot-spl.bin-${MACHINE}-${UBOOT_CONFIG} ] ; then
         cp ${DEPLOY_DIR_IMAGE}/u-boot-spl.bin-${MACHINE}-${UBOOT_CONFIG} \


### PR DESCRIPTION
This PR adds an extension to be able to build and use [_TF-A  from upstream_](https://git.trustedfirmware.org/TF-A/trusted-firmware-a.git/).

In order to use the upstream _TF-A_ in the BSP, one need to pull `meta-arm` layer into the setup to get the `trusted-firmware-a` recipe and package.

Additional variable `DEFAULT_ATF_PROVIDER` shall be set to point to `trusted-firmware-a` recipe name, so that it would be picked up instead of NXP one. As a continuation of this work, TF-A provider can be made distro-specific, for the moment it is left open in this PR.

Above provider choice (when upstream TF-A is set) requires `COMPATIBLE_MACHINE` definition, which is added via _dynamic-layers_ mechanism.

Verified booting for following machines (upstream TF-A version `v2.7`):
- _imx8mm-lpddr4-evk_: **PASS**
- _imx8mn-ddr4-evk_: **PASS**
- _imx8mp-lpddr4-evk_: **PASS**

**Cc:** @thochstein @MaxKrummenacher @gibsson @grembeter @htho-lgs @Ossanes 

-- andrey
