### PR TITLE
mfgtool-initramfs-image: Fix override of IMAGE_FSTYPES

### DIFF
--- a/classes/mfgtool-initramfs-image.bbclass
+++ b/classes/mfgtool-initramfs-image.bbclass
@@ -13,8 +13,8 @@ FEATURE_PACKAGES_extfs = "packagegroup-fsl-mfgtool-extfs"
 FEATURE_PACKAGES_f2fs = "packagegroup-fsl-mfgtool-f2fs"
 
 ZSTD_COMPRESSION_LEVEL ?= "-10"
-IMAGE_FSTYPES ?= "cpio.zst.u-boot"
-IMAGE_FSTYPES:mxs-generic-bsp ?= "cpio.gz.u-boot"
+SOC_DEFAULT_IMAGE_FSTYPES = "cpio.zst.u-boot"
+SOC_DEFAULT_IMAGE_FSTYPES:mxs-generic-bsp = "cpio.gz.u-boot"
 IMAGE_ROOTFS_SIZE ?= "8192"
 
 # Filesystems enabled by default


### PR DESCRIPTION
The fix to allow the user to override the IMAGE_FSTYPES setting for
mfgtool-initramfs-image [1] does break the default behavior by turning
the setting into a no-op:

```
# $IMAGE_FSTYPES [6 operations]
#   set? /.../sources/meta-freescale/conf/machine/include/imx-base.inc:463
#     "${SOC_DEFAULT_IMAGE_FSTYPES}"
#   set /.../sources/poky/meta/conf/documentation.conf:214
#     [doc] "Formats of root filesystem images that you want to have created."
#   set? /.../sources/poky/meta/conf/bitbake.conf:832
#     "tar.gz"
#   set? /.../sources/meta-freescale/classes/mfgtool-initramfs-image.bbclass:16
#     "cpio.zst.u-boot"
#   override[mxs-generic-bsp]:set? /.../sources/meta-freescale/classes/mfgtool-initramfs-image.bbclass:17
#     "cpio.gz.u-boot"
# pre-expansion value:
#     "${SOC_DEFAULT_IMAGE_FSTYPES}"
IMAGE_FSTYPES="wic.bmap wic.gz"
```

The layer uses an extra variable SOC_DEFAULT_IMAGE_FSTYPES to override
IMAGE_FSTYPES [2], so use it here.

[1] 0a29050 classes: IMAGE_FSTYPES as weak variable in mfgtool-initramfs-image
[2] 541b8b8 imx-base.inc: Move IMAGE_FSTYPES override to a SoC variable

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>