### PR TITLE
Update xorg.conf

### DIFF
--- a/recipes-graphics/xorg-xserver/xserver-xf86-config/use-mainline-bsp/xorg.conf
+++ b/recipes-graphics/xorg-xserver/xserver-xf86-config/use-mainline-bsp/xorg.conf
@@ -1,7 +1,7 @@
 Section "Device"
     Identifier "etnaviv"
     Driver     "modesetting"
-    Option     "kmsdev"      "/dev/dri/card0"
+    Option     "kmsdev"      "/dev/dri/card1"
     Option     "AccelMethod" "glamor"
     Option     "Atomic"      "On"
 EndSection


### PR DESCRIPTION
Change kmsdev to more correct /dev/dri/card1

On my imx6-platform, I had to change card0 to card1 to get Xorg working. So this might be a flaw in the repo. But better be acknowledged by other using xorg on mainline