### PR TITLE
imx-boot: Use public key injected DTB when FIT signature is enabled

### DIFF
--- a/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
+++ b/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
@@ -7,7 +7,7 @@ LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6"
 SECTION = "BSP"
 
-inherit use-imx-security-controller-firmware
+inherit use-imx-security-controller-firmware uboot-sign
 
 IMX_EXTRA_FIRMWARE      = "firmware-imx-8 imx-sc-firmware imx-seco"
 IMX_EXTRA_FIRMWARE:mx8m-generic-bsp = "firmware-imx-8m"
@@ -86,6 +86,10 @@ compile_mx8m() {
     cp ${DEPLOY_DIR_IMAGE}/u-boot-spl.bin-${MACHINE}-${UBOOT_CONFIG} \
                                                              ${BOOT_STAGING}/u-boot-spl.bin
     cp ${DEPLOY_DIR_IMAGE}/${BOOT_TOOLS}/${UBOOT_DTB_NAME}   ${BOOT_STAGING}
+    if [ "x${UBOOT_SIGN_ENABLE}" = "x1" ] ; then
+        # Use DTB binary patched with signature node
+        cp ${DEPLOY_DIR_IMAGE}/${UBOOT_DTB_BINARY} ${BOOT_STAGING}/${UBOOT_DTB_NAME}
+    fi
     cp ${DEPLOY_DIR_IMAGE}/${BOOT_TOOLS}/u-boot-nodtb.bin-${MACHINE}-${UBOOT_CONFIG} \
                                                              ${BOOT_STAGING}/u-boot-nodtb.bin
     cp ${DEPLOY_DIR_IMAGE}/${ATF_MACHINE_NAME}               ${BOOT_STAGING}/bl31.bin


### PR DESCRIPTION
When UBOOT_SIGN_ENABLE we want to use the DTB in which mkimage has
added the signature node.

This fix missing signature check in u-boot, same as reported here:
https://community.nxp.com/t5/i-MX-Processors/iMX8-U-Boot-FIT-Image-Signature/m-p/1429547

Should be merged to LTS branches, dunfell & co...