### PR TITLE
conf/machine/ls1046ardb.conf: Add DTB fsl-ls1046a-rdb-usdpaa-shared.dtb

### DIFF
--- a/conf/machine/ls1046ardb.conf
+++ b/conf/machine/ls1046ardb.conf
@@ -29,6 +29,7 @@ KERNEL_DEVICETREE ?= "\
 KERNEL_DEVICETREE:prepend:use-nxp-bsp = "\
     freescale/fsl-ls1046a-rdb-sdk.dtb \
     freescale/fsl-ls1046a-rdb-usdpaa.dtb \
+    freescale/fsl-ls1046a-rdb-usdpaa-shared.dtb \
     freescale/fsl-ls1046a-qds-sdk.dtb \
 "
 KERNEL_DEFCONFIG ?= "defconfig"


### PR DESCRIPTION
LS1046A add shared MAC DTB from Kernel 5.10

Signed-off-by: Jun Zhu <junzhu@nxp.com>