### PR TITLE
imx-atf: Refine array-bounds patch commit message

### DIFF
--- a/recipes-bsp/imx-atf/imx-atf/0001-Makefile-Suppress-array-bounds-error.patch
+++ b/recipes-bsp/imx-atf/imx-atf/0001-Makefile-Suppress-array-bounds-error.patch
@@ -3,8 +3,8 @@ From: Tom Hochstein <tom.hochstein@nxp.com>
 Date: Mon, 16 May 2022 13:45:16 -0500
 Subject: [PATCH] Makefile: Suppress array-bounds error
 
-The array-bounds error is triggered now in cases where it was silent before,
-causing errors like:
+The array-bounds error is triggered now in cases where it was silent
+before, causing errors like:
 
 ```
 plat/imx/imx8m/hab.c: In function 'imx_hab_handler':
@@ -13,10 +13,15 @@ plat/imx/imx8m/hab.c:64:57: error: array subscript 0 is outside array bounds of 
       |                                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ```
 
-It appears that these new cases will be silenced soon in gcc [1], so for
-now just silence the warning locally as a workaround.
+The error is a false-positive and is entered as a bug [1]. The problem
+is fixed partially in GCC 12 and fully in GCC 13 [2].
 
-[1] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=99578#c39
+The partial fix does not work here because the constant addresses used
+are less than the 4kB boundary chosen for the partial fix, so suppress
+the error until GCC is upgraded to 13.
+
+[1] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=99578
+[2] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=99578#c39
 
 Upstream-Status: Inappropriate [other]
 Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>


### PR DESCRIPTION
Refine the commit message for the patch 0001-Makefile-Suppress-array-bounds-error.patch,
making it clear that the patch is a workaround for an issue in GCC 12,
and that the issue is fixed in GCC 13.

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>