### PR TITLE
imx8m*-evk: allow switch between `u-boot-imx` and `u-boot-fslc`

### DIFF
--- a/conf/machine/include/imx8mm-evk.inc
+++ b/conf/machine/include/imx8mm-evk.inc
@@ -1,4 +1,8 @@
-MACHINEOVERRIDES =. "imx-boot-container:mx8mm:"
+MACHINEOVERRIDES =. "mx8mm:"
+
+# FIXME: u-boot-imx should be converted to `binman` and then we can
+# avoid this specific overrides and handle it in a generic way.
+MACHINEOVERRIDES =. "${@bb.utils.contains('IMX_DEFAULT_BOOTLOADER', 'u-boot-imx', '', 'imx-boot-container:', d)}"
 
 require conf/machine/include/imx-base.inc
 require conf/machine/include/arm/armv8a/tune-cortexa53.inc

--- a/conf/machine/include/imx8mn-evk.inc
+++ b/conf/machine/include/imx8mn-evk.inc
@@ -1,4 +1,8 @@
-MACHINEOVERRIDES =. "imx-boot-container:mx8mn:"
+MACHINEOVERRIDES =. "mx8mn:"
+
+# FIXME: u-boot-imx should be converted to `binman` and then we can
+# avoid this specific overrides and handle it in a generic way.
+MACHINEOVERRIDES =. "${@bb.utils.contains('IMX_DEFAULT_BOOTLOADER', 'u-boot-imx', '', 'imx-boot-container:', d)}"
 
 require conf/machine/include/imx-base.inc
 require conf/machine/include/arm/armv8a/tune-cortexa53.inc

--- a/conf/machine/include/imx8mp-evk.inc
+++ b/conf/machine/include/imx8mp-evk.inc
@@ -1,4 +1,8 @@
-MACHINEOVERRIDES =. "imx-boot-container:mx8mp:"
+MACHINEOVERRIDES =. "mx8mp:"
+
+# FIXME: u-boot-imx should be converted to `binman` and then we can
+# avoid this specific overrides and handle it in a generic way.
+MACHINEOVERRIDES =. "${@bb.utils.contains('IMX_DEFAULT_BOOTLOADER', 'u-boot-imx', '', 'imx-boot-container:', d)}"
 
 require conf/machine/include/imx-base.inc
 require conf/machine/include/arm/armv8a/tune-cortexa53.inc


### PR DESCRIPTION
We ought to add `imx-boot-container` `MACHINEOVERRIDES` only if not
building for `u-boot-imx`. This can be removed once it uses `binman` as
`u-boot-imx` and u-boot-fslc would use same mechanism to build the
container.

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>