### PR TITLE
imx8mq-evk.conf: Extend fix for `u-boot-imx` and `u-boot-fslc`

### DIFF
--- a/conf/machine/imx8mq-evk.conf
+++ b/conf/machine/imx8mq-evk.conf
@@ -4,7 +4,11 @@
 #@DESCRIPTION: Machine configuration for NXP i.MX 8M Quad Evaluation Kit
 #@MAINTAINER: Jun Zhu <junzhu@nxp.com>
 
-MACHINEOVERRIDES =. "imx-boot-container:mx8mq:"
+MACHINEOVERRIDES =. "mx8mq:"
+
+# FIXME: u-boot-imx should be converted to `binman` and then we can
+# avoid this specific overrides and handle it in a generic way.
+MACHINEOVERRIDES =. "${@bb.utils.contains('IMX_DEFAULT_BOOTLOADER', 'u-boot-imx', '', 'imx-boot-container:', d)}"
 
 require conf/machine/include/imx-base.inc
 require conf/machine/include/arm/armv8a/tune-cortexa53.inc


### PR DESCRIPTION
Extend the recent fix to properly configure `imx-boot-container`
machine overide.

Extends: 1650359
Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>