### PR TITLE
kernel modules: Explicitly depends on virtual/kernel

### DIFF
--- a/recipes-extended/dpdk/dpdk-module_20.11.bb
+++ b/recipes-extended/dpdk/dpdk-module_20.11.bb
@@ -9,7 +9,7 @@ SRC_URI += " \
 inherit module
 
 #kernel module needs 'rte_build_config.h', which is generated at buid time
-DEPENDS += "dpdk"
+DEPENDS += "dpdk virtual/kernel"
 
 export S
 export STAGING_KERNEL_DIR

--- a/recipes-extended/jailhouse/jailhouse_0.12.bb
+++ b/recipes-extended/jailhouse/jailhouse_0.12.bb
@@ -25,6 +25,7 @@ DEPENDS = " \
     python3-mako-native \
     python3-mako \
     dtc-native \
+    virtual/kernel \
 "
 
 inherit module python3native bash-completion deploy setuptools3

--- a/recipes-extended/odp/odp-counters_git.bb
+++ b/recipes-extended/odp/odp-counters_git.bb
@@ -1,5 +1,7 @@
 require odp.inc
 
+DEPENDS = "virtual/kernel"
+
 inherit module
 
 do_compile:prepend () {

--- a/recipes-extended/odp/odp-module_git.bb
+++ b/recipes-extended/odp/odp-module_git.bb
@@ -1,5 +1,7 @@
 require odp.inc
 
+DEPENDS = "virtual/kernel"
+
 inherit module
 
 do_compile:prepend () {

--- a/recipes-kernel/kernel-modules/kernel-module-ar_git.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-ar_git.bb
@@ -2,6 +2,8 @@ SUMMARY = "Auto Response Control Module"
 LICENSE = "GPL-2.0-only & BSD"
 LIC_FILES_CHKSUM = "file://COPYING;md5=b5881ecf398da8a03a3f4c501e29d287"
 
+DEPENDS = "virtual/kernel"
+
 inherit module
 
 SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-yocto-sdk/auto-resp;branch=nxp/sdk-v2.0.x"
@@ -22,7 +24,7 @@ do_install(){
 	install -d ${D}${nonarch_base_libdir}/modules/${KERNEL_VERSION}
 	install -d ${D}${bindir}
 	install -m 644 ${B}/bin/ar.ko ${D}${nonarch_base_libdir}/modules/${KERNEL_VERSION}/
-	cp -f ${S}/bin/ar_* ${D}${bindir}/ 
+	cp -f ${S}/bin/ar_* ${D}${bindir}/
 }
 
 FILES:${PN} += "${bindir}/"

--- a/recipes-kernel/kernel-modules/kernel-module-imx-gpu-viv_6.4.3.p2.4+fslc.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-imx-gpu-viv_6.4.3.p2.4+fslc.bb
@@ -14,6 +14,8 @@ SRC_URI = "git://github.com/Freescale/kernel-module-imx-gpu-viv.git;protocol=htt
 
 S = "${WORKDIR}/git"
 
+DEPENDS = "virtual/kernel"
+
 inherit module
 
 KERNEL_MODULE_AUTOLOAD = "galcore"

--- a/recipes-kernel/kernel-modules/kernel-module-imx-gpu-viv_6.4.3.p4.0.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-imx-gpu-viv_6.4.3.p4.0.bb
@@ -18,6 +18,8 @@ SRCREV = "e47e5ff6895a7aa2f75dcb2e2c7257e25cf77901"
 
 S = "${WORKDIR}/git"
 
+DEPENDS = "virtual/kernel"
+
 inherit module
 
 EXTRA_OEMAKE += "CONFIG_MXC_GPU_VIV=m"

--- a/recipes-kernel/kernel-modules/kernel-module-ipc.inc
+++ b/recipes-kernel/kernel-modules/kernel-module-ipc.inc
@@ -3,6 +3,8 @@ DESCRIPTION = "DSP boot application and ipc test application"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://COPYING;md5=fa38cd73d71527dc6efb546474f64d10"
 
+DEPENDS = "virtual/kernel"
+
 inherit module qoriq_build_64bit_kernel
 
 SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-yocto-sdk/ipc;protocol=https;nobranch=1"

--- a/recipes-kernel/kernel-modules/kernel-module-isp-vvcam_4.2.2.16.0.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-isp-vvcam_4.2.2.16.0.bb
@@ -15,6 +15,8 @@ SRCREV = "b2321c0c513322aca8187ebf0328b74fe45a0f01"
 
 S = "${WORKDIR}/git/vvcam/v4l2"
 
+DEPENDS = "virtual/kernel"
+
 inherit module
 
 COMPATIBLE_MACHINE = "(mx8mp-nxp-bsp)"

--- a/recipes-kernel/kernel-modules/kernel-module-ls-debug_git.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-ls-debug_git.bb
@@ -5,6 +5,8 @@ SECTION = "ls-debug"
 LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=94263f12f9416f9fd0493c8f9e8085a3"
 
+DEPENDS = "virtual/kernel"
+
 inherit module autotools-brokensep
 
 SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-yocto-sdk/ls-dbg;branch=nxp/master"

--- a/recipes-kernel/kernel-modules/kernel-module-nxp89xx_git.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-nxp89xx_git.bb
@@ -9,9 +9,10 @@ SRCREV = "3c2a3c2cd25e9dce95f34c21bb4e728647eb64ee"
 
 S = "${WORKDIR}/git/mxm_wifiex/wlan_src"
 
+DEPENDS = "virtual/kernel"
+
 inherit module
 
 EXTRA_OEMAKE = "KERNELDIR=${STAGING_KERNEL_BUILDDIR} -C ${STAGING_KERNEL_BUILDDIR} M=${S}"
 
 COMPATIBLE_MACHINE = "(imx-nxp-bsp)"
-

--- a/recipes-kernel/kernel-modules/kernel-module-perf-qoriq_0.8.2.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-perf-qoriq_0.8.2.bb
@@ -7,6 +7,8 @@ SRCREV = "7beb3783edac66bab00c85d99a7b073f569af7fd"
 
 S = "${WORKDIR}/git"
 
+DEPENDS = "virtual/kernel"
+
 inherit module autotools-brokensep qoriq_build_64bit_kernel
 
 PROCESSOR_REV ?= "B4860_R1"

--- a/recipes-kernel/kernel-modules/kernel-module-scatter-gather_git.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-scatter-gather_git.bb
@@ -2,6 +2,8 @@ SUMMARY = "Scatter-gather logic for multiple tables"
 LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=e9605a22ea50467bd2bfe4cdd66e69ae"
 
+DEPENDS = "virtual/kernel"
+
 inherit module
 
 SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-yocto-sdk/scatter-gather;branch=nxp/master"

--- a/recipes-kernel/kernel-modules/kernel-module-uio-seville_0.1.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-uio-seville_0.1.bb
@@ -5,6 +5,8 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e"
 SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-yocto-sdk/l2switch-uio;branch=nxp/sdk-v2.0.x"
 SRCREV = "0f31fbcbe9ab1ab9c424da34f70c82314b16f8de"
 
+DEPENDS = "virtual/kernel"
+
 inherit module
 
 S = "${WORKDIR}/git/uio-driver"


### PR DESCRIPTION
Although it is not needed for build or runtime dependency, the
dependency is needed to be explicit to link the spdx chain correctly and
avoid broken task dependencies.

Signed-off-by: Daiane Angolini <daiane.angolini@foundries.io>