### PR TITLE
linux-imx: change LOCALVERSION to not use underscore

### DIFF
--- a/recipes-kernel/linux/linux-imx_5.15.bb
+++ b/recipes-kernel/linux/linux-imx_5.15.bb
@@ -24,7 +24,7 @@ DEPENDS += "lzop-native bc-native"
 # | arch/arm/configs/imx_v7_defconfig   | linux-imx/imx-nxp-bsp/defconfig |
 # | arch/arm64/configs/imx_v8_defconfig | linux-imx/mx8-nxp-bsp/defconfig |
 SRCBRANCH = "lf-5.15.y"
-LOCALVERSION = "-5.15.32_2.0.0"
+LOCALVERSION = "-5.15.32-2.0.0"
 SRCREV = "fa6c3168595c02bd9d5366fcc28c9e7304947a3d"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition


### PR DESCRIPTION
Using underscore '_' in LOCALVERSION makes build failures if you use
deb packages.

Error message:
  Subprocess output:dpkg-deb: error: package name has characters that aren't lowercase alphanums or '-+.'

Change '_' to '-' to avoid this problem. It seems that linux-fslc-imx already have this convention
and previous versions of linux-imx also had.

Signed-off-by: Peter Bergin <peter@berginkonsult.se>