### PR TITLE
imx-atf: fix build error with binutils 2.39

### DIFF
--- a/recipes-bsp/imx-atf/imx-atf_2.6.bb
+++ b/recipes-bsp/imx-atf/imx-atf_2.6.bb
@@ -29,7 +29,9 @@ EXTRA_OEMAKE += " \
 
 # Let the Makefile handle setting up the CFLAGS and LDFLAGS as it is a standalone application
 CFLAGS[unexport] = "1"
-LDFLAGS[unexport] = "1"
+# Needed for binutils >= 2.39 to prevent build failure.
+# imx-atf links with ld, thus no '-Wl,' prefix
+LDFLAGS = "--no-warn-rwx-segments"
 AS[unexport] = "1"
 LD[unexport] = "1"
 
@@ -56,7 +58,6 @@ EXTRA_OEMAKE += 'IMX_BOOT_UART_BASE=${ATF_BOOT_UART_BASE}'
 do_configure[noexec] = "1"
 
 do_compile() {
-    # Clear LDFLAGS to avoid the option -Wl recognize issue
     oe_runmake bl31
     if ${BUILD_OPTEE}; then
         oe_runmake clean BUILD_BASE=build-optee


### PR DESCRIPTION

Fixes #1178

I tried to build imx-atf with this patch in kirkstone and it builds fine. However, I assume that binutils will not be backported to kirkstone in openbedded-core and this patch will not be needed in kirkstone.
