### PR TITLE
kernel-module-isp-vvcam: fix LIC_FILES_CHKSUM when using devtool

### DIFF
--- a/recipes-kernel/kernel-modules/kernel-module-isp-vvcam_4.2.2.16.0.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-isp-vvcam_4.2.2.16.0.bb
@@ -2,7 +2,7 @@
 
 DESCRIPTION = "Kernel loadable module for ISP"
 LICENSE = "GPL-2.0-only"
-LIC_FILES_CHKSUM = "file://${WORKDIR}/git/vvcam/LICENSE;md5=64381a6ea83b48c39fe524c85f65fb44"
+LIC_FILES_CHKSUM = "file://${S}/../LICENSE;md5=64381a6ea83b48c39fe524c85f65fb44"
 
 SRCBRANCH = "lf-5.10.y_2.2.0"
 ISP_KERNEL_SRC ?= "git://source.codeaurora.org/external/imx/isp-vvcam.git;protocol=https;branch=master"


### PR DESCRIPTION
This recipe fails when using devtool:

  ERROR: [...] do_populate_lic: QA Issue: kernel-module-isp-vvcam: LIC_FILES_CHKSUM points to an invalid file: [...]/build/tmp/work/nitrogen8mp-fslc-linux/kernel-module-isp-vvcam/4.2.2.16.0-r0/git/vvcam/LICENSE [license-checksum]

How to reproduce:

  devtool modify kernel-module-isp-vvcam
  bitbake kernel-module-isp-vvcam

Fix by pointing to a path relative to S.

Signed-off-by: Luca Ceresoli <luca.ceresoli@bootlin.com>