### PR TITLE
optee-os: fix build with binutils 2.39

### DIFF
--- a/recipes-security/optee-imx/optee-os/0008-no-warn-rwx-segments.patch
+++ b/recipes-security/optee-imx/optee-os/0008-no-warn-rwx-segments.patch
@@ -1,0 +1,64 @@
+Signed-off-by: Anton Antonov <Anton.Antonov@arm.com>
+Upstream-Status: Backport [https://github.com/OP-TEE/optee_os/pull/5474]
+
+From 0b8a917fa51a366806edc0f04b88cd23b24098c4 Mon Sep 17 00:00:00 2001
+From: Jerome Forissier <jerome.forissier@linaro.org>
+Date: Fri, 5 Aug 2022 09:48:03 +0200
+Subject: [PATCH] core: link: add --no-warn-rwx-segments
+
+binutils ld.bfd generates one RWX LOAD segment by merging several sections
+with mixed R/W/X attributes (.text, .rodata, .data). After version 2.38 it
+also warns by default when that happens [1], which breaks the build due to
+--fatal-warnings. The RWX segment is not a problem for the TEE core, since
+that information is not used to set memory permissions. Therefore, silence
+the warning.
+
+Link: [1] https://sourceware.org/git/?p=binutils-gdb.git;a=commit;h=ba951afb99912da01a6e8434126b8fac7aa75107
+Link: https://sourceware.org/bugzilla/show_bug.cgi?id=29448
+Reported-by: Dominique Martinet <dominique.martinet@atmark-techno.com>
+Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>
+Acked-by: Jens Wiklander <jens.wiklander@linaro.org>
+---
+ core/arch/arm/kernel/link.mk | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/core/arch/arm/kernel/link.mk b/core/arch/arm/kernel/link.mk
+index 7eed333a32..c39d43cbfc 100644
+--- a/core/arch/arm/kernel/link.mk
++++ b/core/arch/arm/kernel/link.mk
+@@ -31,6 +31,7 @@ link-ldflags += -T $(link-script-pp) -Map=$(link-out-dir)/tee.map
+ link-ldflags += --sort-section=alignment
+ link-ldflags += --fatal-warnings
+ link-ldflags += --gc-sections
++link-ldflags += $(call ld-option,--no-warn-rwx-segments)
+ 
+ link-ldadd  = $(LDADD)
+ link-ldadd += $(ldflags-external)
+@@ -55,6 +56,7 @@ link-script-cppflags := \
+ 		$(cppflagscore))
+ 
+ ldargs-all_objs := -T $(link-script-dummy) --no-check-sections \
++		   $(call ld-option,--no-warn-rwx-segments) \
+ 		   $(link-objs) $(link-ldadd) $(libgcccore)
+ cleanfiles += $(link-out-dir)/all_objs.o
+ $(link-out-dir)/all_objs.o: $(objs) $(libdeps) $(MAKEFILE_LIST)
+@@ -67,7 +69,8 @@ $(link-out-dir)/unpaged_entries.txt: $(link-out-dir)/all_objs.o
+ 	$(q)$(NMcore) $< | \
+ 		$(AWK) '/ ____keep_pager/ { printf "-u%s ", $$3 }' > $@
+ 
+-unpaged-ldargs = -T $(link-script-dummy) --no-check-sections --gc-sections
++unpaged-ldargs := -T $(link-script-dummy) --no-check-sections --gc-sections \
++		 $(call ld-option,--no-warn-rwx-segments)
+ unpaged-ldadd := $(objs) $(link-ldadd) $(libgcccore)
+ cleanfiles += $(link-out-dir)/unpaged.o
+ $(link-out-dir)/unpaged.o: $(link-out-dir)/unpaged_entries.txt
+@@ -95,7 +98,8 @@ $(link-out-dir)/init_entries.txt: $(link-out-dir)/all_objs.o
+ 	$(q)$(NMcore) $< | \
+ 		$(AWK) '/ ____keep_init/ { printf "-u%s ", $$3 }' > $@
+ 
+-init-ldargs := -T $(link-script-dummy) --no-check-sections --gc-sections
++init-ldargs := -T $(link-script-dummy) --no-check-sections --gc-sections \
++	       $(call ld-option,--no-warn-rwx-segments)
+ init-ldadd := $(link-objs-init) $(link-out-dir)/version.o  $(link-ldadd) \
+ 	      $(libgcccore)
+ cleanfiles += $(link-out-dir)/init.o

--- a/recipes-security/optee-imx/optee-os_3.17.0.imx.bb
+++ b/recipes-security/optee-imx/optee-os_3.17.0.imx.bb
@@ -12,6 +12,10 @@ SRC_URI = "git://source.codeaurora.org/external/imx/imx-optee-os.git;protocol=ht
 SRCBRANCH = "lf-5.15.32_2.0.0"
 SRCREV = "984996422c25c99ebfc5194c1bb393028605bb0c"
 
+SRC_URI:append = " \
+    file://0008-no-warn-rwx-segments.patch \
+    "
+
 S = "${WORKDIR}/git"
 
 inherit deploy python3native autotools features_check


### PR DESCRIPTION
binutils 2.39 started to produce warning on RWX LOAD segments, which breaks the linking process of `optee-os`.

Upstream `optee-os` package has patch [`ac425901 ("arm/optee-os: backport RWX permission error patch")`](https://github.com/jonmason/meta-arm/commit/ac4259011f4c8cec01191828014487ccc5de73ca) integrated, which has been backported in OP-TEE from [`PR #5475`](https://github.com/OP-TEE/optee_os/pull/5474) targeting master in upstream.

Port upstream `optee-os` commit into NXP fork of `optee-os`.

**Cc**: @thochstein 
