### PR TITLE
u-boot-fslc-mxsboot: use OE-provided swig

### DIFF
--- a/recipes-bsp/u-boot/u-boot-fslc-mxsboot_2022.07.bb
+++ b/recipes-bsp/u-boot/u-boot-fslc-mxsboot_2022.07.bb
@@ -3,7 +3,7 @@ require u-boot-fslc-common_${PV}.inc
 DESCRIPTION = "U-boot bootloader mxsboot tool"
 SECTION = "bootloader"
 
-DEPENDS = "bison-native gnutls-native dtc openssl"
+DEPENDS = "swig-native bison-native gnutls-native dtc openssl"
 
 PROVIDES = "u-boot-mxsboot"
 


### PR DESCRIPTION
My build host's (openSUSE 15.3) swig is 3.x-based (3.0.12) and causes the
compile step of u-boot-fslc-mxsboot to fail:

	| error: command 'swig' failed with exit status 1

Use the swig provided with openembedded-core (currently 4.0.2) instead so
the build succeeds.

This affects:
	imx233-olinuxino-*
	imx23evk
	imx28evk

Signed-off-by: Trevor Woerner <twoerner@gmail.com>