### PR TITLE
reworked: "imx-atf: fix build error with binutils 2.39"

### DIFF
--- a/recipes-bsp/imx-atf/imx-atf/rwx-segments.patch
+++ b/recipes-bsp/imx-atf/imx-atf/rwx-segments.patch
@@ -1,0 +1,38 @@
+Binutils 2.39 now warns when a segment has RXW permissions[1]:
+
+aarch64-none-elf-ld.bfd: warning: bl31.elf has a LOAD segment with RWX
+permissions
+
+However, TF-A passes --fatal-warnings to LD, so this is a build failure.
+
+There is a ticket filed upstream[2], so until that is resolved just
+remove --fatal-warnings.
+
+[1] https://sourceware.org/git/?p=binutils-gdb.git;a=commit;h=ba951afb99912da01a6e8434126b8fac7aa75107
+[2] https://developer.trustedfirmware.org/T996
+
+Upstream-Status: Inappropriate
+Signed-off-by: Ross Burton <ross.burton@arm.com>
+
+diff --git a/Makefile b/Makefile
+index 3941f8698..13bbac348 100644
+--- a/Makefile
++++ b/Makefile
+@@ -418,7 +418,7 @@ TF_LDFLAGS		+=	$(TF_LDFLAGS_$(ARCH))
+ # LD = gcc (used when GCC LTO is enabled)
+ else ifneq ($(findstring gcc,$(notdir $(LD))),)
+ # Pass ld options with Wl or Xlinker switches
+-TF_LDFLAGS		+=	-Wl,--fatal-warnings -O1
++TF_LDFLAGS		+=	-O1
+ TF_LDFLAGS		+=	-Wl,--gc-sections
+ ifeq ($(ENABLE_LTO),1)
+ 	ifeq (${ARCH},aarch64)
+@@ -435,7 +435,7 @@ TF_LDFLAGS		+=	$(subst --,-Xlinker --,$(TF_LDFLAGS_$(ARCH)))
+ 
+ # LD = gcc-ld (ld) or llvm-ld (ld.lld) or other
+ else
+-TF_LDFLAGS		+=	--fatal-warnings -O1
++TF_LDFLAGS		+=	-O1
+ TF_LDFLAGS		+=	--gc-sections
+ # ld.lld doesn't recognize the errata flags,
+ # therefore don't add those in that case

--- a/recipes-bsp/imx-atf/imx-atf_2.6.bb
+++ b/recipes-bsp/imx-atf/imx-atf_2.6.bb
@@ -29,9 +29,7 @@ EXTRA_OEMAKE += " \
 
 # Let the Makefile handle setting up the CFLAGS and LDFLAGS as it is a standalone application
 CFLAGS[unexport] = "1"
-# Needed for binutils >= 2.39 to prevent build failure.
-# imx-atf links with ld, thus no '-Wl,' prefix
-LDFLAGS = "--no-warn-rwx-segments"
+LDFLAGS[unexport] = "1"
 AS[unexport] = "1"
 LD[unexport] = "1"
 
@@ -58,6 +56,7 @@ EXTRA_OEMAKE += 'IMX_BOOT_UART_BASE=${ATF_BOOT_UART_BASE}'
 do_configure[noexec] = "1"
 
 do_compile() {
+    # Clear LDFLAGS to avoid the option -Wl recognize issue
     oe_runmake bl31
     if ${BUILD_OPTEE}; then
         oe_runmake clean BUILD_BASE=build-optee

--- a/recipes-bsp/imx-atf/imx-atf_2.6.bb
+++ b/recipes-bsp/imx-atf/imx-atf_2.6.bb
@@ -7,8 +7,11 @@ LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/BSD-3-Clause;m
 
 PV .= "+git${SRCPV}"
 
-SRC_URI = "git://source.codeaurora.org/external/imx/imx-atf.git;protocol=https;branch=${SRCBRANCH} \
-           file://0001-Makefile-Suppress-array-bounds-error.patch"
+SRC_URI = " \
+    git://source.codeaurora.org/external/imx/imx-atf.git;protocol=https;branch=${SRCBRANCH} \
+    file://0001-Makefile-Suppress-array-bounds-error.patch \
+    file://rwx-segments.patch \
+"
 SRCBRANCH = "lf_v2.6"
 SRCREV = "c6a19b1a351308cc73443283f6aa56b2eff791b8"
 


### PR DESCRIPTION
Reverts #1179 in favour of a binutils agnostic fix. This now works also on kirkstone with binutils 2.38.