### PR TITLE
License fixes

### DIFF
--- a/recipes-bsp/mc-utils/mc-utils_git.bb
+++ b/recipes-bsp/mc-utils/mc-utils_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "The Management Complex (MC) is a key component of DPAA"
 SECTION = "mc-utils"
-LICENSE = "BSD"
+LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=386a6287daa6504b7e7e5014ddfb3987"
 
 DEPENDS += "dtc-native"

--- a/recipes-dpaa2/restool/restool_git.bb
+++ b/recipes-dpaa2/restool/restool_git.bb
@@ -1,5 +1,5 @@
 SUMMARY = "DPAA2 Resource Manager Tool"
-LICENSE = "BSD"
+LICENSE = "BSD-3-Clause | GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=ec8d84e9cd4de287e290275d09db27f0"
 
 SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/restool;nobranch=1 \


### PR DESCRIPTION
This saves a QA warning per recipe an -if `create-spdx` an error for unknown license