### PR TITLE
imx-atf: Use clang when using toolchain-clang defaults

### DIFF
--- a/recipes-bsp/imx-atf/imx-atf_2.6.bb
+++ b/recipes-bsp/imx-atf/imx-atf_2.6.bb
@@ -40,6 +40,9 @@ LD[unexport] = "1"
 INHIBIT_DEFAULT_DEPS = "1"
 DEPENDS = "virtual/${HOST_PREFIX}gcc"
 
+# Bring in clang compiler if using clang as default
+DEPENDS:append:toolchain-clang = " clang-cross-${TARGET_ARCH}"
+
 BUILD_OPTEE = "${@bb.utils.contains('MACHINE_FEATURES', 'optee', 'true', 'false', d)}"
 
 # CC and LD introduce arguments which conflict with those otherwise provided by

--- a/recipes-graphics/cairo/cairo_%.bbappend
+++ b/recipes-graphics/cairo/cairo_%.bbappend
@@ -1,2 +1,8 @@
 PACKAGECONFIG:append:imxgpu3d = " egl glesv2"
 PACKAGECONFIG:remove:imxgpu3d = "opengl"
+
+# links with imx-gpu libs which are pre-built for glibc
+# gcompat will address it during runtime
+LDFLAGS:append:imxgpu3d:libc-musl = " -Wl,--allow-shlib-undefined"
+LDFLAGS:append:imxgpu:libc-musl = " -Wl,--allow-shlib-undefined"
+

--- a/recipes-graphics/imx-gpu-viv/imx-gpu-viv_6.4.3.p4.2-aarch64.bb
+++ b/recipes-graphics/imx-gpu-viv/imx-gpu-viv_6.4.3.p4.2-aarch64.bb
@@ -1,5 +1,8 @@
 require imx-gpu-viv-6.inc
 
+DEPENDS:append:libc-musl = " gcompat"
+INSANE_SKIP:append:libc-musl = " file-rdeps"
+
 SRC_URI[md5sum] = "22de8a5f59a56a7ef499f590d1659b6f"
 SRC_URI[sha256sum] = "52921c0b59529f1598084e991eda1863100754f28a7744ba958158dff8074b3b"
 


### PR DESCRIPTION
When clang is default compiler, we need to ensure that its added as
dependency as well.

Reported-by: Cliff Brake <cbrake@bec-systems.com>
Signed-off-by: Khem Raj <raj.khem@gmail.com>