### PR TITLE
openssh: Disable rng-tools

### DIFF
--- a/recipes-connectivity/openssh/openssh_%.bbappend
+++ b/recipes-connectivity/openssh/openssh_%.bbappend
@@ -1,0 +1,3 @@
+PACKAGECONFIG:mx6-nxp-bsp ??= ""
+PACKAGECONFIG:mx7-nxp-bsp ??= ""
+PACKAGECONFIG:mx8-nxp-bsp ??= ""


### PR DESCRIPTION
All i.MX beginning with 6 have hardware support for entropy, so there is no need for rng-tools. Removing it helps startup performance.

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>