### PR TITLE
gtk+3: Fix logical error in removing x11

### DIFF
--- a/recipes-graphics/gtk+/gtk+3_%.bbappend
+++ b/recipes-graphics/gtk+/gtk+3_%.bbappend
@@ -1,6 +1,6 @@
 DEPENDS:append:imxgpu2d = " virtual/egl"
 
-WAYLAND = "${@bb.utils.contains('DISTRO_FEATURES', 'x11', '', 'wayland', d)}"
+WAYLAND = "${@bb.utils.contains('DISTRO_FEATURES', 'x11', '', 'x11', d)}"
 WAYLANDONLY = "${@bb.utils.contains('DISTRO_FEATURES', 'wayland', '${WAYLAND}', '', d)}"
 
 PACKAGECONFIG:remove:imxgpu2d = " ${WAYLANDONLY}"


### PR DESCRIPTION
Last commit had a thinko, where it should be removing x11 only if x11 is not in distro features, but it ended up doing that for wayland

Signed-off-by: Khem Raj <raj.khem@gmail.com>