### PR TITLE
gtk+3: Drop x11 config logic

### DIFF
--- a/recipes-graphics/gtk+/gtk+3_%.bbappend
+++ b/recipes-graphics/gtk+/gtk+3_%.bbappend
@@ -1,6 +1,1 @@
 DEPENDS:append:imxgpu2d = " virtual/egl"
-
-WAYLAND = "${@bb.utils.contains('DISTRO_FEATURES', 'x11', '', 'x11', d)}"
-WAYLANDONLY = "${@bb.utils.contains('DISTRO_FEATURES', 'wayland', '${WAYLAND}', '', d)}"
-
-PACKAGECONFIG:remove:imxgpu2d = " ${WAYLANDONLY}"


### PR DESCRIPTION
The original intent of dropping x11 support from the package was so only wayland would be supported. The fix in efcb2fe and 7447f7c removes that. However, it keeps the idea that the x11 packageconfig should be disallowed from being added if x11 is not in the distro features. This was never the intent of the original logic, and since the default is to enable x11 packageconfig if and only if x11 is a distro feature, just drop the logic entirely.

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>