### PR TITLE
imx-gpu-viv: Do not require wayland on i.MX8.

### DIFF
--- a/recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc
+++ b/recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc
@@ -61,8 +61,6 @@ PE = "1"
 
 inherit fsl-eula-unpack features_check
 
-REQUIRED_DISTRO_FEATURES:mx8-nxp-bsp = "wayland"
-
 SRC_URI = "${FSL_MIRROR}/${BPN}-${PV}.bin;fsl-eula=true"
 
 PACKAGECONFIG ?= ""


### PR DESCRIPTION
Do not require wayland on i.MX8.

This is a cherry-pick with changes of commit 14a48c1d546323ebecde37f25162bc69c59e3096 of meta-digi https://github.com/digi-embedded/meta-digi/commit/14a48c1d546323ebecde37f25162bc69c59e3096 with this commit message:
From 14a48c1d546323ebecde37f25162bc69c59e3096 Mon Sep 17 00:00:00 2001
From: Arturo Buzarra <arturo.buzarra@digi.com>
Date: Mon, 27 Apr 2020 19:51:16 +0200
Subject: [PATCH] imx-gpu-viv: remove wayland as a requirement for i.MX8
 platforms

Based on commit ed2c4974 ("imx-gpu-viv: remove wayland as a requirement for i.MX8 platforms"), this commit removes the requeriment of wayland as a backend for the i.MX8 platforms to build framebuffer images.

https://jira.digi.com/browse/DEL-7013

Signed-off-by: Arturo Buzarra <arturo.buzarra@digi.com>

This is not needed to depend on a full wayland stack when the library is just requesting one single wayland library

readelf -d libgbm-imx/usr/lib/libgbm_viv.so
 0x0000000000000001 (NEEDED)             Shared library: [libwayland-server.so.0]

see: https://www.yoctoproject.org/pipermail/meta-freescale/2018-September/023340.html

Reported-by: Paolo Doz <paolo.doz@abinsula.com>
Reported-by: Francesco Loi <francesco.loi@abinsula.com>
Signed-off-by: Gianfranco Costamagna <costamagnagianfranco@yahoo.it>