### PR TITLE
imx-gpu-viv: Mark libvulkan-imx unavailable for 8M Mini

### DIFF
--- a/recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc
+++ b/recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc
@@ -71,8 +71,6 @@ PACKAGECONFIG ?= ""
 PACKAGECONFIG[valgrind] = ""
 
 # Note : If you add a package here, to prevent a naming conflict see the python_anonymous() futher below
-IMX_PACKAGES_GBM     = ""
-IMX_PACKAGES_GBM:mx8-nxp-bsp = "libgbm-imx libgbm-imx-dev"
 PACKAGES =+ "libclc-imx libclc-imx-dev \
 	libgl-imx libgl-imx-dev \
 	libgles1-imx libgles1-imx-dev \
@@ -85,13 +83,18 @@ PACKAGES =+ "libclc-imx libclc-imx-dev \
 	libegl-imx libegl-imx-dev \
 	libgal-imx libgal-imx-dev \
 	libvsc-imx \
-	${IMX_PACKAGES_GBM} \
+	${PACKAGES_GBM} \
 	imx-gpu-viv-tools \
 	imx-gpu-viv-demos \
-	libvulkan-imx libvulkan-imx-dev \
+	${PACKAGES_VULKAN} \
 	libopenvx-imx libopenvx-imx-dev \
 	libnn-imx \
 "
+PACKAGES_GBM             = ""
+PACKAGES_GBM:mx8-nxp-bsp = "libgbm-imx libgbm-imx-dev"
+PACKAGES_VULKAN               = ""
+PACKAGES_VULKAN:aarch64       = "libvulkan-imx libvulkan-imx-dev"
+PACKAGES_VULKAN:mx8mm-nxp-bsp = ""
 python __anonymous () {
         has_vivante_kernel_driver_support = (d.getVar('MACHINE_HAS_VIVANTE_KERNEL_DRIVER_SUPPORT') or '0')
         if has_vivante_kernel_driver_support != '1':


### PR DESCRIPTION
The GPU drivers do not support 8M Mini, so properly exclude them from PACKAGES so the user gets an earlier indication of a problem:

```
$ bitbake vulkan-loader
ERROR: Nothing RPROVIDES 'libvulkan-imx' (but /.../poky/meta/recipes-graphics/vulkan/vulkan-loader_1.3.216.0.bb RDEPENDS on or otherwise requires it)
ERROR: Required build target 'vulkan-loader' has no buildable providers.
Missing or unbuildable dependency chain was: ['vulkan-loader', 'libvulkan-imx']
```

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>