### PR TITLE
weston: disable rdp as it pulls in some big dependencies

### DIFF
--- a/recipes-graphics/wayland/weston_10.0.0.imx.bb
+++ b/recipes-graphics/wayland/weston_10.0.0.imx.bb
@@ -177,9 +177,7 @@ PACKAGECONFIG_OPENGL:imxgpu2d     = ""
 PACKAGECONFIG_OPENGL:imxgpu3d     = "opengl"
 
 PACKAGECONFIG:remove = "wayland x11"
-PACKAGECONFIG:append = " \
-    rdp \
-    ${@bb.utils.filter('DISTRO_FEATURES', '${PACKAGECONFIG_OPENGL}', d)}"
+PACKAGECONFIG:append = "${@bb.utils.filter('DISTRO_FEATURES', '${PACKAGECONFIG_OPENGL}', d)}"
 
 PACKAGECONFIG:remove:imxfbdev = "kms"
 PACKAGECONFIG:append:imxfbdev = " fbdev clients"


### PR DESCRIPTION
The `weston_10.0.0.imx` now depends on `freerdp` which in turn pulls some unrelated big dependencies like `cups` and `gstreamer`.

```
| # meta-freescale/recipes-graphics/wayland/weston_10.0.0.imx.bb
| PACKAGECONFIG[rdp] = "-Dbackend-rdp=true,-Dbackend-rdp=false,freerdp"
|
| PACKAGECONFIG:append = " \
|    rdp \
|    ${@bb.utils.filter('DISTRO_FEATURES', '${PACKAGECONFIG_OPENGL}', d)}"
```

```
| # meta-openembedded/meta-oe/recipes-support/freerdp/freerdp_2.8.0.bb
| PACKAGECONFIG ??= " \
|     ${@bb.utils.filter('DISTRO_FEATURES', 'directfb pam pulseaudio wayland x11', d)}\
|     gstreamer cups pcsc \
| "
|
| PACKAGECONFIG[cups] = "-DWITH_CUPS=ON,-DWITH_CUPS=OFF,cups"
| PACKAGECONFIG[gstreamer] = "-DWITH_GSTREAMER_1_0=ON,-DWITH_GSTREAMER_1_0=OFF,gstreamer1.0 gstreamer1.0-plugins-base"
```
Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>