### PR TITLE
qt4-imx-support: fix build for imxgpu2d SOCs

### DIFF
--- a/dynamic-layers/qt4-layer/recipes-qt4/qt4/qt4-imx-support.inc
+++ b/dynamic-layers/qt4-layer/recipes-qt4/qt4/qt4-imx-support.inc
@@ -12,6 +12,8 @@ SRC_URI:append:imxgpu2d += " \
 	file://0001-Add-support-for-i.MX-codecs-to-phonon.patch \
 	file://0002-i.MX-video-renderer-Allow-v4l-device-from-environmen.patch \
 	file://0003-i.MX6-force-egl-visual-ID-33.patch \
+	file://egl-pro-add-defines-to-compile-with-viv-fb.patch \
+	file://egl4gles1-pro-add-defines-to-compile-with-viv-fb.patch \
 "
 
 DEPENDS:append:imxgpu2d = " virtual/kernel virtual/libgles2"

--- a/dynamic-layers/qt4-layer/recipes-qt4/qt4/qt4/egl-pro-add-defines-to-compile-with-viv-fb.patch
+++ b/dynamic-layers/qt4-layer/recipes-qt4/qt4/qt4/egl-pro-add-defines-to-compile-with-viv-fb.patch
@@ -1,0 +1,9 @@
+--- a/config.tests/unix/egl/egl.pro	2015-05-07 16:14:42.000000000 +0200
++++ b/config.tests/unix/egl/egl.pro	2022-09-28 15:36:53.819893439 +0200
+@@ -6,5 +6,6 @@ for(p, QMAKE_LIBDIR_EGL) {
+ 
+ !isEmpty(QMAKE_INCDIR_EGL): INCLUDEPATH += $$QMAKE_INCDIR_EGL
+ !isEmpty(QMAKE_LIBS_EGL): LIBS += $$QMAKE_LIBS_EGL
++DEFINES += LINUX=1 EGL_API_FB=1
+ 
+ CONFIG -= qt

--- a/dynamic-layers/qt4-layer/recipes-qt4/qt4/qt4/egl4gles1-pro-add-defines-to-compile-with-viv-fb.patch
+++ b/dynamic-layers/qt4-layer/recipes-qt4/qt4/qt4/egl4gles1-pro-add-defines-to-compile-with-viv-fb.patch
@@ -1,0 +1,9 @@
+--- a/config.tests/unix/egl4gles1/egl4gles1.pro	2015-05-07 16:14:42.000000000 +0200
++++ b/config.tests/unix/egl4gles1/egl4gles1.pro	2022-09-28 15:36:53.827893490 +0200
+@@ -6,5 +6,6 @@ for(p, QMAKE_LIBDIR_EGL) {
+ 
+ !isEmpty(QMAKE_INCDIR_EGL): INCLUDEPATH += $$QMAKE_INCDIR_EGL
+ !isEmpty(QMAKE_LIBS_EGL): LIBS += $$QMAKE_LIBS_EGL
++DEFINES += LINUX=1 EGL_API_FB=1
+ 
+ CONFIG -= qt


### PR DESCRIPTION
Before this change, when imxgpu2d is selected, the qt4 do_configure fails because the -DLINUX=1 and -DEGL_API_FB=1 flags added to QT_CONFIG_FLAGS are not pushed down during configuration tests.
