### PR TITLE
qt4-imx-support: change format of patches added by commit 4aed4a5

### DIFF
--- a/dynamic-layers/qt4-layer/recipes-qt4/qt4/qt4-imx-support.inc
+++ b/dynamic-layers/qt4-layer/recipes-qt4/qt4/qt4-imx-support.inc
@@ -12,8 +12,8 @@ SRC_URI:append:imxgpu2d += " \
 	file://0001-Add-support-for-i.MX-codecs-to-phonon.patch \
 	file://0002-i.MX-video-renderer-Allow-v4l-device-from-environmen.patch \
 	file://0003-i.MX6-force-egl-visual-ID-33.patch \
-	file://egl-pro-add-defines-to-compile-with-viv-fb.patch \
-	file://egl4gles1-pro-add-defines-to-compile-with-viv-fb.patch \
+	file://0001-config.tests-add-DEFINES-to-compile-egl-test-with-im.patch \
+	file://0002-config.tests-add-DEFINES-to-compile-egl4gles1-test-w.patch.patch \
 "
 
 DEPENDS:append:imxgpu2d = " virtual/kernel virtual/libgles2"

--- a/dynamic-layers/qt4-layer/recipes-qt4/qt4/qt4/0001-config.tests-add-DEFINES-to-compile-egl-test-with-im.patch
+++ b/dynamic-layers/qt4-layer/recipes-qt4/qt4/qt4/0001-config.tests-add-DEFINES-to-compile-egl-test-with-im.patch
@@ -1,0 +1,25 @@
+From 234580de9d63fd79a8b444358cdaeac111a17061 Mon Sep 17 00:00:00 2001
+From: Mauro Salvini <m.salvini@koansoftware.com>
+Date: Thu, 29 Sep 2022 16:06:04 +0200
+Subject: [PATCH 1/2] config.tests: add DEFINES to compile egl test with
+ imxgpu2d (Vivante)
+
+Signed-off-by: Mauro Salvini <m.salvini@koansoftware.com>
+---
+ config.tests/unix/egl/egl.pro | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/config.tests/unix/egl/egl.pro b/config.tests/unix/egl/egl.pro
+index f04d0535..bc35b908 100644
+--- a/config.tests/unix/egl/egl.pro
++++ b/config.tests/unix/egl/egl.pro
+@@ -6,5 +6,6 @@ for(p, QMAKE_LIBDIR_EGL) {
+ 
+ !isEmpty(QMAKE_INCDIR_EGL): INCLUDEPATH += $$QMAKE_INCDIR_EGL
+ !isEmpty(QMAKE_LIBS_EGL): LIBS += $$QMAKE_LIBS_EGL
++DEFINES += LINUX=1 EGL_API_FB=1
+ 
+ CONFIG -= qt
+-- 
+2.17.1
+

--- a/dynamic-layers/qt4-layer/recipes-qt4/qt4/qt4/0002-config.tests-add-DEFINES-to-compile-egl4gles1-test-w.patch
+++ b/dynamic-layers/qt4-layer/recipes-qt4/qt4/qt4/0002-config.tests-add-DEFINES-to-compile-egl4gles1-test-w.patch
@@ -1,0 +1,25 @@
+From adb19c68d3c92eb1a88e49e447ce827f14943486 Mon Sep 17 00:00:00 2001
+From: Mauro Salvini <m.salvini@koansoftware.com>
+Date: Thu, 29 Sep 2022 16:12:11 +0200
+Subject: [PATCH 2/2] config.tests: add DEFINES to compile egl4gles1 test with
+ imxgpu2d (Vivante)
+
+Signed-off-by: Mauro Salvini <m.salvini@koansoftware.com>
+---
+ config.tests/unix/egl4gles1/egl4gles1.pro | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/config.tests/unix/egl4gles1/egl4gles1.pro b/config.tests/unix/egl4gles1/egl4gles1.pro
+index 667ea8e3..14cb4a76 100644
+--- a/config.tests/unix/egl4gles1/egl4gles1.pro
++++ b/config.tests/unix/egl4gles1/egl4gles1.pro
+@@ -6,5 +6,6 @@ for(p, QMAKE_LIBDIR_EGL) {
+ 
+ !isEmpty(QMAKE_INCDIR_EGL): INCLUDEPATH += $$QMAKE_INCDIR_EGL
+ !isEmpty(QMAKE_LIBS_EGL): LIBS += $$QMAKE_LIBS_EGL
++DEFINES += LINUX=1 EGL_API_FB=1
+ 
+ CONFIG -= qt
+-- 
+2.17.1
+

--- a/dynamic-layers/qt4-layer/recipes-qt4/qt4/qt4/egl-pro-add-defines-to-compile-with-viv-fb.patch
+++ b/dynamic-layers/qt4-layer/recipes-qt4/qt4/qt4/egl-pro-add-defines-to-compile-with-viv-fb.patch
@@ -1,9 +1,0 @@
---- a/config.tests/unix/egl/egl.pro	2015-05-07 16:14:42.000000000 +0200
-+++ b/config.tests/unix/egl/egl.pro	2022-09-28 15:36:53.819893439 +0200
-@@ -6,5 +6,6 @@ for(p, QMAKE_LIBDIR_EGL) {
- 
- !isEmpty(QMAKE_INCDIR_EGL): INCLUDEPATH += $$QMAKE_INCDIR_EGL
- !isEmpty(QMAKE_LIBS_EGL): LIBS += $$QMAKE_LIBS_EGL
-+DEFINES += LINUX=1 EGL_API_FB=1
- 
- CONFIG -= qt

--- a/dynamic-layers/qt4-layer/recipes-qt4/qt4/qt4/egl4gles1-pro-add-defines-to-compile-with-viv-fb.patch
+++ b/dynamic-layers/qt4-layer/recipes-qt4/qt4/qt4/egl4gles1-pro-add-defines-to-compile-with-viv-fb.patch
@@ -1,9 +1,0 @@
---- a/config.tests/unix/egl4gles1/egl4gles1.pro	2015-05-07 16:14:42.000000000 +0200
-+++ b/config.tests/unix/egl4gles1/egl4gles1.pro	2022-09-28 15:36:53.827893490 +0200
-@@ -6,5 +6,6 @@ for(p, QMAKE_LIBDIR_EGL) {
- 
- !isEmpty(QMAKE_INCDIR_EGL): INCLUDEPATH += $$QMAKE_INCDIR_EGL
- !isEmpty(QMAKE_LIBS_EGL): LIBS += $$QMAKE_LIBS_EGL
-+DEFINES += LINUX=1 EGL_API_FB=1
- 
- CONFIG -= qt


### PR DESCRIPTION
Patches are the same but now are in git format and have Signed-off-by and From fields as required