### PR TITLE
weston: Add missing space before appending to PACKAGECONFIG

### DIFF
--- a/recipes-graphics/wayland/weston_10.0.0.imx.bb
+++ b/recipes-graphics/wayland/weston_10.0.0.imx.bb
@@ -177,7 +177,7 @@ PACKAGECONFIG_OPENGL:imxgpu2d     = ""
 PACKAGECONFIG_OPENGL:imxgpu3d     = "opengl"
 
 PACKAGECONFIG:remove = "wayland x11"
-PACKAGECONFIG:append = "${@bb.utils.filter('DISTRO_FEATURES', '${PACKAGECONFIG_OPENGL}', d)}"
+PACKAGECONFIG:append = "${@bb.utils.filter('DISTRO_FEATURES', ' ${PACKAGECONFIG_OPENGL}', d)}"
 
 PACKAGECONFIG:remove:imxfbdev = "kms"
 PACKAGECONFIG:append:imxfbdev = " fbdev clients"


### PR DESCRIPTION
This can cause problem by creating unknown packageconfigs by concatenating the strings

Signed-off-by: Khem Raj <raj.khem@gmail.com>