### PR TITLE
weston: Fix the append logic

### DIFF
--- a/recipes-graphics/wayland/weston_10.0.0.imx.bb
+++ b/recipes-graphics/wayland/weston_10.0.0.imx.bb
@@ -177,7 +177,7 @@ PACKAGECONFIG_OPENGL:imxgpu2d     = ""
 PACKAGECONFIG_OPENGL:imxgpu3d     = "opengl"
 
 PACKAGECONFIG:remove = "wayland x11"
-PACKAGECONFIG:append = "${@bb.utils.filter('DISTRO_FEATURES', ' ${PACKAGECONFIG_OPENGL}', d)}"
+PACKAGECONFIG:append = " ${@bb.utils.filter('DISTRO_FEATURES', '${PACKAGECONFIG_OPENGL}', d)}"
 
 PACKAGECONFIG:remove:imxfbdev = "kms"
 PACKAGECONFIG:append:imxfbdev = " fbdev clients"


### PR DESCRIPTION
Previous commit did not really work because we are using bb.utils.filter and that removed the artificial space sadly. Therefore add it outside this function call.

Signed-off-by: Khem Raj <raj.khem@gmail.com>