### PR TITLE
weston_10.0.0.imx: add build dependency on libdrm

### DIFF
--- a/recipes-graphics/wayland/weston_10.0.0.imx.bb
+++ b/recipes-graphics/wayland/weston_10.0.0.imx.bb
@@ -34,6 +34,7 @@ require ${THISDIR}/required-distro-features.inc
 
 DEPENDS = "libxkbcommon gdk-pixbuf pixman cairo glib-2.0"
 DEPENDS += "wayland wayland-protocols libinput virtual/egl pango wayland-native"
+DEPENDS:append:imxfbdev = " libdrm"
 
 LDFLAGS += "${@bb.utils.contains('DISTRO_FEATURES', 'lto', '-Wl,-z,undefs', '', d)}"
 


### PR DESCRIPTION
When removing rdp as default dependency a hidden buildtime dependency on libdrm is uncovered for targets using fbdev as backend and g2d as renderer. As a result compiling for i.MX6 will fail due to missing libdrm headers.

Add libdrm to DEPENDS for imxfbdev.

Signed-off-by: Markus Niebel <Markus.Niebel@ew.tq-group.com>