### PR TITLE
qt4-imx-support: fix typo

### DIFF
--- a/dynamic-layers/qt4-layer/recipes-qt4/qt4/qt4-imx-support.inc
+++ b/dynamic-layers/qt4-layer/recipes-qt4/qt4/qt4-imx-support.inc
@@ -13,7 +13,7 @@ SRC_URI:append:imxgpu2d += " \
 	file://0002-i.MX-video-renderer-Allow-v4l-device-from-environmen.patch \
 	file://0003-i.MX6-force-egl-visual-ID-33.patch \
 	file://0001-config.tests-add-DEFINES-to-compile-egl-test-with-im.patch \
-	file://0002-config.tests-add-DEFINES-to-compile-egl4gles1-test-w.patch.patch \
+	file://0002-config.tests-add-DEFINES-to-compile-egl4gles1-test-w.patch \
 "
 
 DEPENDS:append:imxgpu2d = " virtual/kernel virtual/libgles2"


### PR DESCRIPTION
To be backported to LTS also. Sorry for the typo