### PR TITLE
linux-mfgtool.inc: Fix KERNEL_PACKAGE_NAME

### DIFF
--- a/recipes-kernel/linux/linux-mfgtool.inc
+++ b/recipes-kernel/linux/linux-mfgtool.inc
@@ -4,4 +4,4 @@
 
 PROVIDES = "linux-mfgtool"
 
-KERNEL_PACKAGE_NAME = "mfgtool"
+KERNEL_PACKAGE_NAME = "linux-mfgtool"


### PR DESCRIPTION
Using a KERNEL_PACKAGE_NAME without the "linux-" prefix causes parsing errors like:

```
ERROR: [...]/meta-freescale/recipes-kernel/linux/linux-fslc-mfgtool_5.4.bb: QA Issue: [...]/meta-freescale/recipes-kernel/linux/linux-fslc-mfgtool_5.4.bb: Variable RDEPENDS is set as not being package specific, please fix this. [pkgvarcheck]
```

Fix this by setting KERNEL_PACKAGE_NAME to "linux-mfgtools", which also reflects the value mentioned in the [original commit's message](https://github.com/Freescale/meta-freescale/commit/9a5a143d97345871d4c258ce6ce13567d87f5ba7).