### PR TITLE
linux-fslc-imx: upgrade to lf-5.15.52-2.1.0 from NXP

### DIFF
--- a/recipes-kernel/linux/linux-fslc-imx_5.15.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_5.15.bb
@@ -28,12 +28,12 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v5.15.50
+#    tag: v5.15.60
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: lf-5.15.32-2.0.0
+#    tag: lf-5.15.52-2.1.0
 #
 # ------------------------------------------------------------------------------
 # 3. Critical patches (SHA(s))
@@ -43,8 +43,6 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # 49c2d3b7964d gpio: fix enabling GPIO_VF610
 # c04a396fcbf7 ARM: mach-imx: conditionally disable some functions from busfreq-imx
 # 166a38557bf9 drm: bridge: it6161: add missing gpio consumer header
-# bc2e851e616a Revert "clk: imx: off by one in imx_lpcg_parse_clks_from_dt()"
-# 27d3c1285087 Revert "drm/bridge: Add missing pm_runtime_put_sync"
 #
 # NOTE to upgraders:
 # This recipe should NOT collect individual patches, they should be applied to
@@ -57,18 +55,18 @@ include linux-fslc.inc
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-KBRANCH = "5.15-2.0.x-imx"
-SRCREV = "845d53f13aac7d712b931a21df53bc8ccb22b31b"
+KBRANCH = "5.15-2.1.x-imx"
+SRCREV = "e1b43282a845dfb78e115a8e2dc4144ce0d335b5"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.15.67"
+LINUX_VERSION = "5.15.60"
 
 # Local version indicates the branch name in the NXP kernel tree where patches are collected from.
-LOCALVERSION = "-5.15.60-2.0.0"
+LOCALVERSION = "-5.15.60-2.1.0"
 
 DEFAULT_PREFERENCE = "1"
 


### PR DESCRIPTION
Change log:
- 4b8b3fd681df Merge pull request #602 from angolini/5.15-2.1.x-imx-bump
- d0ee47da9a09 Merge tag 'v5.15.60' into 5.15-2.1.x-imx
- 6bc02055c373 Merge tag 'v5.15.59' into 5.15-2.1.x-imx
- 647349ddd965 Merge tag 'v5.15.58' into 5.15-2.1.x-imx
- 8c8464177402 Merge tag 'v5.15.57' into 5.15-2.1.x-imx
- 143ca87ada4a Merge tag 'v5.15.56' into 5.15-2.1.x-imx
- a34846a37808 Merge tag 'v5.15.55' into 5.15-2.1.x-imx
- 19ac7f0d6628 Merge tag 'v5.15.54' into 5.15-2.1.x-imx
- dea6099cfa06 Merge tag 'v5.15.53' into 5.15-2.1.x-imx
- 39a72c404f21 drm: bridge: it6161: add missing gpio consumer header
- 200ac21eb0f5 ARM: mach-imx: conditionally disable some functions from busfreq-imx
- 4af46d106d63 gpio: fix enabling GPIO_VF610
- 7af0d9d37f0c cert host tools: Stop complaining about deprecated OpenSSL functions
- d8ef41bf21af fec_uio: fix implicit declaration
- 36363d8623ba fsl_qbman: ceetm: errata A-010383 workaround for LNI shapers
- 75563f29b17a fsl_qbman: fix debugfs WQ number reporting
- 74f0607a9dd9 LF-6946-3 drm/imx: imx8qm-ldb: Initialize encoder only for enabled LVDS channel
- 2cc539efd8c8 LF-6946-2 drm/imx: imx8qxp-ldb: Initialize encoder only for enabled LVDS channel
- 4b88652d983c LF-6946-1 drm/imx: imx8mp-ldb: Initialize encoder only for enabled LVDS channel
- 1cf103252e70 LF-6960 gpio: mxc: fix system crashes issue when using pad wakeup
- 1453ea12a02f fsl_qbman: Pass interface name as a string instead of pointer
- 7ed964e32135 LF-6992 soc: imx93-pd: initialize domain->dev
- dee36e10a1e9 LF-6899-2 soc: imx93-blk-ctrl: hide regmap from debugfs
- bb11bb045501 dmaengine: fsl-dpaa2-qdma: Fix dpdmai unbind call trace issue
- a8b927e5cb7f LF-6744 firmware: coverity fix ele-mu
- 0c4f0cebc3a2 LF-5584 coverity: fix for Unused value (UNUSED_VALUE)
- 900ac0938f37 LF-6840 clk: imx: Add some delay before deassert the reset
- 1c3dd1427637 LF-6899 soc: imx: imx93-blk-ctrl: restrict register range with access table
- 5957cfad2897 LF-6892: ARM: dts: imx7d-12x12-lpddr3-val: update audio mclk for wm8958
- a76648b8c72c LF-6172: ASoC: fsl_sai: Remove unnecessary FIFO reset in ISR
- a73cf59f30bf LF-6878: LF-6658: media: imx-jpeg: Support contiguous and non contiguous format
- 4f717113db7a LF-6878: LF-6654: media: imx-jpeg: Implement g_selection and s_selection
- 629de230cc39 LF-6814-2 Revert "LF-6797 arm64: dts: imx8mp: correct usb clock"
- 434a5be922a0 LF-6814-1 Revert "clk: imx8mp: fix usb_root_clk parent"
- a7aa868b21e5 dpaa2-switch: fix bridge port and context passed to switchdev_bridge_port_unoffload
- 28290559d8e7 dpaa2-eth: fixup the error path in dpaa2_xsk_enable_pool()
- 7be1dfb794aa dpaa2-eth: move the percpu_stats setup to avoid a uninitialized access
- 7217df812798 Linux 5.15.60
- 5c5c77746ce1 x86/speculation: Add LFENCE to RSB fill sequence
- 7fcd99e889c0 x86/speculation: Add RSB VM Exit protections
- c81d1bb58c88 macintosh/adb: fix oob read in do_adb_query() function
- d98cf2b40c20 Bluetooth: btusb: Add Realtek RTL8852C support ID 0x13D3:0x3586
- ee421ad8973b Bluetooth: btusb: Add Realtek RTL8852C support ID 0x13D3:0x3587
- 59689a843bc9 Bluetooth: btusb: Add Realtek RTL8852C support ID 0x0CB8:0xC558
- b653eeaa8cf8 Bluetooth: btusb: Add Realtek RTL8852C support ID 0x04C5:0x1675
- d4f921efb4bf Bluetooth: btusb: Add Realtek RTL8852C support ID 0x04CA:0x4007
- 04e3388eeb47 Bluetooth: btusb: Add support of IMC Networks PID 0x3568
- 6a5ec48fb752 dt-bindings: bluetooth: broadcom: Add BCM4349B1 DT binding
- 88e088e29487 Bluetooth: hci_bcm: Add DT compatible for CYW55572
- 2aa38f0af306 Bluetooth: hci_bcm: Add BCM4349B1 variant
- 37b385c78cd5 btrfs: zoned: fix critical section of relocation inode writeback
- 5e04c8bf42d8 btrfs: zoned: prevent allocation from previous data relocation BG
- 775871d4be0d arm64: set UXN on swapper page tables
- a619a0312099 KVM: x86/svm: add __GFP_ACCOUNT to __sev_dbg_{en,de}crypt_user()
- e423893fe320 selftests: KVM: Handle compiler optimizations in ucall
- bc2cee443c74 tools/kvm_stat: fix display of error when multiple processes are found
- 9acd899d2feb KVM: selftests: Make hyperv_clock selftest more stable
- ad6fd99d5feb KVM: x86: do not set st->preempted when going back to user space
- 92343314d34e KVM: x86: do not report a vCPU as preempted outside instruction boundaries
- 3d4c28475ee3 crypto: arm64/poly1305 - fix a read out-of-bound
- 397c2116cbe2 ACPI: APEI: Better fix to avoid spamming the console with old error logs
- e7170bcda613 ACPI: video: Shortening quirk list by identifying Clevo by board_name only
- 3a5fab5c4505 ACPI: video: Force backlight native for some TongFang devices
- 9894717519cc tools/vm/slabinfo: Handle files in debugfs
- 7ad47f414b40 block: fix default IO priority handling again
- e889a4c440eb selftests/bpf: Check dst_port only on the client socket
- 119debdb9f25 selftests/bpf: Extend verifier and bpf_sock tests for dst_port loads
- df9692b8a319 x86/speculation: Make all RETbleed mitigations 64-bit only
- 627b759bb69e mtd: rawnand: gpmi: Set WAIT_FOR_READY timeout based on program/erase times
- 6079b3785ab9 LF-6808: arm64: dts: imx8mp-evk: switch MCLK from SoC to external 24M oscillator for OS08A20
- 2284027522b9 LF-6806: dma: pxp: workaround for PXP when do RGB to gray color conversion
- 7213f629b29d LF-6741: dma: pxp: fix coverity issue: Uninitialized scalar variable
- 2371225b0928 LF-6805 arm64: dts: imx93: add a55 pmu
- 4a817d4eb458 LF-2780: dma: fsl-qdma: fix coverity issue: Dereference after null check
- 9c86ff503c70 LF-6742 soc: imx: Fix Coverity Issue: 22703614 Uninitialized scalar variable
- f61b0b2cbc57 LF-6799: arm64: dts: imx8mm-evk: modify the pmic_rohm interrupts trigger type
- 208fcb8de1ee LF-6247-4: arm64: configs: imx_v8_defconfig: build module for PCA995X
- 08b2965711c1 LF-6797 arm64: dts: imx8mp: correct usb clock
- 8d95b5f8d03c LF-6247-3: driver: leds: pca995x: Add support for PCA995X chips
- a251f3358ffe LF-6247-2: dt-bindings: leds: PCA995X Add support for PCA995X chips
- b9544e4358b8 LF-6247-1: dts: arm64: freescale: Add support for RGB leds
- 6f9d1fe16c1c LF-6752-3 usb: chipidea: core: add wakeup support for usb role switch
- 201020e41ea7 LF-6752-2 usb: chipidea: ci_hdrc_imx: add wakeup clock and keep it always on
- ca71a9b077a5 LF-6752-1 arm64: dts: imx93: add wakeup clk for usb controller nodes
- 56d96539e7e2 arm64: dts: imx8m: Disable job ring 0 nodes
- e0c3de84b351 LF-6743: dma: pxp: fix coverity issue: dereference before null check
- 16d5e478a2dd LF-5163 video: epdc_v2: Fix Coverity Issue: 18996754 Unsigned compared against 0
- f2404671cff4 LF-5082 media: epdc: Fix Coverity Issue: 3298979 Negative loop bound
- f5390a6b7773 LF-2861 media: mipi csi: Fix Coverity Issue: 17695 Dereference before null check
- 4bab4e351b7f LF-2859 media: mxc_capture: Fix Coverity Issue: 17678 Dereference before null check
- e30302aa4486 LF-6711-6:imx8q:vpu: media: amphion: set bytesperline of compressed formats to 0
- 1b746a55a705 LF-6794 remoteproc: imx_rproc: initialize workqueue earlier
- eff6f686accc Revert "LF-6630-1 mailbox: imx: clear pending interrupts"
- 5ec92248a548 AIR-7443 ethosu: Fix kernel call trace before rpmsg dev probe
- e3456b7842df LF-6775 soc: imx: Change the rpmsg lifecycle suspend to noirq stage
- dcb81b04d58e LF-6751:imx8q: media: imx-jpeg: Disable useless interrupt to avoid kernel panic
- 2d740d8d6468 nvmem: auto load kernel-mod imx_fsb_s400_fuse_match
- f34c390dea6a LF-6750-2 arm64: dts: enable dynamic buffer size for i2c-rpmsg of 8ulp
- 4d1fccc217cb LF-6750-1 i2c: rpmsg-imx: Add dynamic i2c buffer size support
- 61c9849e831c LF-4057 remoteproc: imx_rproc: correct parameter for devm_kcalloc
- 65d47bbe663e net: dpaa2: AF_XDP TX zero copy support
- 30a74a3ff12b samples/bpf: add new options to configure frame headroom for AF_XDP sockets
- 24ef30acdad8 libbpf: add Tx headroom support for AF_XDP buffers
- 6d40a921401e add cpu_relax() as a workaround for phy issue
- e77a60fab247 net: dpaa2: AF_XDP RX zero copy support
- c98333bbd115 net: dpaa2: add support for multiple buffer pools per DPNI
- 03dc74487c32 net: dpaa2: add support to query channels using ethtool
- 723bb2a2b350 xsk: Batched buffer allocation for the pool
- b6e6a60aa30e selftests: xsk: Move num_frames and frame_headroom to xsk_umem_info
- 1e9d88a704c6 ASoC: SOF: compress: Add support for timestamp display
- 395c76670b92 ASoC: SOF: compress: sof-priv: Save channel count and sample bytes
- 5f1713fdb342 LF-6745 tty: serial: fsl_lpuart: error status check and async_tx_ack() required on all platforms
- 4726cdce0741 dpaa2-switch: say that the bond device is offloaded as a bridge port
- 88ff2a59f857 dpaa2-switch: cleanup the egress flood of an unused FDB
- 7a3c6c5578ea dpaa2-switch: offload port objects on the BOND interface
- afc6affaf423 dpaa2-switch: add support for offloading upper bond devices
- 189299ff6946 dpaa2-switch: take into account bond bridge ports when setting up the FDB
- 27b32be87fac dpaa2-switch: create initial software infrastructure for LAG HW setup
- b9a89886e570 dpaa2-switch: reorganize the [pre]changeupper events
- f4d655ba9858 dpaa2-switch: Add the necessary MC API for HW LAG configuration
- 577ef86bc000 dpaa2-switch: fix size of the dma_unmap
- 8afe045c563f dpaa2-switch: print an error when the vlan is already configured
- b5a10e5a666f dpaa2-switch: declare the netdev as IFF_LIVE_ADDR_CHANGE capable
- cd1a5e5f1448 dpaa2-switch: set interface MAC address only on endpoint change
- ffaa1a941b92 LF-6739: arm64: dts: imx93: Update the clocks of FEC
- f5b86075f10f LF-6737 arm64: dts: imx93: correct clock usage of eqos
- d676d6149a2f Linux 5.15.59
- f0e42e43795d x86/bugs: Do not enable IBPB at firmware entry when IBPB is not available
- d10e819d13f7 locking/rwsem: Allow slowpath writer to ignore handoff bit if not set by first waiter
- 66d31cef4806 docs/kernel-parameters: Update descriptions for "mitigations=" param with retbleed
- 7bada8b0bdf1 EDAC/ghes: Set the DIMM label unconditionally
- 30dc2effc74a ARM: 9216/1: Fix MAX_DMA_ADDRESS overflow
- 86e83233dd01 page_alloc: fix invalid watermark check on a negative value
- 51a772c34ea4 mm/hmm: fault non-owner device private entries
- 350fcb5e7bbb ARM: crypto: comment out gcc warning that breaks clang builds
- e796e1fe20ec sctp: leave the err path free in sctp_stream_init to sctp_stream_free
- f7c2a9c5435a sfc: disable softirqs for ptp TX
- fe0e602f0502 perf symbol: Correct address for bss symbols
- 871168abe6d8 virtio-net: fix the race between refill work and close
- 91c11008aab0 netfilter: nf_queue: do not allow packet truncation below transport header offset
- be5cd347ba22 octeontx2-pf: cn10k: Fix egress ratelimit configuration
- 3688939cd3e8 sctp: fix sleep in atomic context bug in timer handlers
- 186fcdb68f42 i40e: Fix interface init with MSI interrupts (no MSI-X)
- 4685f16b3a5d ipv4: Fix data-races around sysctl_fib_notify_on_flag_change.
- eaccca7a0bb8 tcp: Fix data-races around sysctl_tcp_reflect_tos.
- 4cc070e0ef2d tcp: Fix a data-race around sysctl_tcp_comp_sack_nr.
- 34c9977b4dca tcp: Fix a data-race around sysctl_tcp_comp_sack_slack_ns.
- 6842c94de9d5 tcp: Fix a data-race around sysctl_tcp_comp_sack_delay_ns.
- 618116a273b7 net: Fix data-races around sysctl_[rw]mem(_offset)?.
- a610feb170bf tcp: Fix data-races around sk_pacing_rate.
- b01b4f5b45ff net: mld: fix reference count leak in mld_{query | report}_work()
- 5831ccf37a31 net: macsec: fix potential resource leak in macsec_add_rxsa() and macsec_add_txsa()
- 2959a86a472f macsec: always read MACSEC_SA_ATTR_PN as a u64
- a706a40d42f4 macsec: limit replay window size with XPN
- 6ad56d5c4f98 macsec: fix error message in macsec_add_rxsa and _txsa
- 8991687d3bcf macsec: fix NULL deref in macsec_add_rxsa
- 830582c16be1 Documentation: fix sctp_wmem in ip-sysctl.rst
- dac5644a823e tcp: Fix a data-race around sysctl_tcp_invalid_ratelimit.
- 6f446677ebb3 tcp: Fix a data-race around sysctl_tcp_autocorking.
- bd07f2e70a4b tcp: Fix a data-race around sysctl_tcp_min_rtt_wlen.
- 922ca9fd221b tcp: Fix a data-race around sysctl_tcp_min_tso_segs.
- 777d18e65d09 net: sungem_phy: Add of_node_put() for reference returned by of_get_parent()
- 40f4739bbd36 net: pcs: xpcs: propagate xpcs_read error to xpcs_get_state_c37_sgmii
- c721324afc58 igmp: Fix data-races around sysctl_igmp_qrv.
- ad6d6ae4a34c net/tls: Remove the context from the list in tls_device_down
- 189e370b8250 ipv6/addrconf: fix a null-ptr-deref bug for ip6_ptr
- 4845d3ef6445 net: ping6: Fix memleak in ipv6_renew_options().
- 6a4a1c70e446 scsi: mpt3sas: Stop fw fault watchdog work item during system shutdown
- 3d3e41069b65 scsi: core: Fix warning in scsi_alloc_sgtables()
- ff2932ac8ee1 tcp: Fix a data-race around sysctl_tcp_challenge_ack_limit.
- a88de75673e4 tcp: Fix a data-race around sysctl_tcp_limit_output_bytes.
- 664a3311e671 tcp: Fix data-races around sysctl_tcp_moderate_rcvbuf.
- 59e2332846d8 octeontx2-pf: Fix UDP/TCP src and dst port tc filters
- 927c5cf0ba3e Revert "tcp: change pingpong threshold to 3"
- bdaf56e0df15 scsi: ufs: host: Hold reference returned by of_parse_phandle()
- 7f0a36506809 ice: do not setup vlan for loopback VSI
- cef4c1d0fb48 ice: check (DD | EOF) bits on Rx descriptor rather than (EOP | RS)
- 62e721dee8cc tcp: Fix data-races around sysctl_tcp_no_ssthresh_metrics_save.
- aa2ca5b5629d tcp: Fix a data-race around sysctl_tcp_nometrics_save.
- 6e167ed68999 tcp: Fix a data-race around sysctl_tcp_frto.
- 0d8fa3c2a442 tcp: Fix a data-race around sysctl_tcp_adv_win_scale.
- 74753ec663d7 tcp: Fix a data-race around sysctl_tcp_app_win.
- 807b028115eb tcp: Fix data-races around sysctl_tcp_dsack.
- c9c01dd38975 watch_queue: Fix missing locking in add_watch_to_object()
- 093610f216d0 watch_queue: Fix missing rcu annotation
- 11c1cc3f6e42 drm/simpledrm: Fix return type of simpledrm_simple_display_pipe_mode_valid()
- 121c8993d4f3 nouveau/svm: Fix to migrate all requested pages
- 8bd9747d3066 s390/archrandom: prevent CPACF trng invocations in interrupt context
- 71f71150115a asm-generic: remove a broken and needless ifdef conditional
- dc124c849c72 hugetlb: fix memoryleak in hugetlb_mcopy_atomic_pte
- 2722fb0f7028 mm: fix page leak with multiple threads mapping the same page
- 70d0ce332d26 secretmem: fix unhandled fault in truncate
- 3ef8040afce7 fs: sendfile handles O_NONBLOCK of out_fd
- 518df26b5238 ntfs: fix use-after-free in ntfs_ucsncmp()
- 46f6301fb4f1 Revert "ocfs2: mount shared volume without ha stack"
- f32d5615a78a Bluetooth: L2CAP: Fix use-after-free caused by l2cap_chan_put
- 440e346e510a LF-6690-4:imx8m:vpu: simplify the calculation of sizeimage
- 016676e45825 LF-6690-3: imx8m: vpu: recalculate sizeimage after source change
- e9beb9fb4901 LF-6734: media: isi: fill discard buffer num_planes parameters
- 264250a8d122 LF-6710 i2c: rpmsg-imx: expand i2c transfer buffer to 478 bytes
- 2e7a485551c8 MLK-25996 i2c: imx-lpi2c: enable runtime pm of i2c temporarily when do system suspend/resume
- 99c947ebf042 LF-6711-5:imx8q:vpu: media: amphion: negotiate bytesperline with user
- 11580ebbab22 LF-6732 arm64: dts: imx93: add gpio clk
- 8dcac21eef74 arm64: dts: ls1028a-qds-65bb: don't use in-band autoneg for 2500base-x
- 1223e9d6eb14 arm64: dts: freescale: Use overlay target for simplicity
- 19fe13059871 arm64: dts: fsl-ls1028a-qds: Drop overlay syntax hard coding
- 79e0262f019f LF-6586: dts: arm64: freescale: enable RMII interface on imx8dxl/qxp
- 16cf24940214 MA-20476: imx8m:vpu: clear resolution change count when reset decoder
- 519c5ac88e70 LF-6719: media: isi: fix kernel dump when convert format after running camera test
- 921faca3f778 LF-6723-10 arm64: dts: imx93: add MU clock for mailbox
- 5afce040ac26 LF-6723-9 clk: imx93: add clk ignore unused flag for usb/enet
- 6b8bfa1dbe7f LF-6723-8 clk: imx93: correct enet clock
- 32bdb780fd58 LF-6723-7 clk: imx93: correct MU clock
- 3fd855e25590 LF-6723-6 clk: imx93: switch to use new clk gate API
- 80a11e209395 LF-6723-5 clk: imx: add i.MX93 clk gate
- 02b5c968611a LF-6723-4 clk: imx: clk-composite-93: check white_list
- 984b4c030877 LF-6723-3 clk: imx: clk-composite-93: check slice busy
- c6d03de91991 LF-6723-2 clk: imx93: simplify SAI registration
- aa06f07e1a21 LF-6723-1 dt-bindings: clock: imx93-clock: add more MU clocks
- 79afdb7af2b4 MLK-25928-1 arm64: dts: imx93: add dma support for lpi2c and lpspi
- 7d380b62624b LF-6714 arm64: dts: add the missing pwm node of adp5585
- 9f6263423f63 MGS-6746: arm64: dts: Enable GPU memory region on i.MX8QXP
- 893d7c1a19f7 ele-mu: enable auto-loading the kernel module-el_enclave
- 197c79c1421e LF-6689 drm/imx: dpu: plane: Check plane_state->src_{w,h,x,y} in ->atomic_check()
- cfc0f7026ac4 LF-6715 arm64: dts: imx93-11x11-evk: set W_DISABLE2 high for M.2 connector to enable BT HFP function
- e2554ed98c81 LF-6705: dmaengine: fsl-edma-v3: Fix residue issue with MLOFF exist
- 1da5cc2bf7d4 LF-6712: arm64: imx8ulp: Add ethernet-phy address
- b3a4d5869c04 LF-6703: media: isi: cap: fix kernel dump issue when run AP1302 stress test
- 0c934b397e7d LF-6704: media: ap1302: change stream control sequence for new firmware
- 86897408a98b LF-6680 spi: imx: add dma support for slave mode
- a936730dd3f4 LF-6560-2 i3c: master: svc: add NACK check after start byte sent
- c24f3dc96796 LF-6560-1 i3c: master: svc: fix cpu schedule in spin lock
- 6197d8a04b05 LF-6711-4:imx8q:vpu: media: amphion: encoder add support for contiguous planes
- 2100a18d4d1c LF-6711-3:imx8q:vpu: media: amphion: decoder add support for contiguous planes
- 244283d6353a LF-6711-2:imx8q:vpu: media: amphion: tell and handle contiguous and non contiguous format
- 1fce6d2e1637 LF-6711-1:imx8q:vpu: media: add nv12_8l128 and nv12_10be_8l128 video format.
- c75ec3034769 firmware ele-mu: fix compilation error
- 5c260f40dfc2 LF-6690-2:imx8m:vpu: correct the sizeimage of nv16 and nv24
- 3f7d6ebbb0a1 LF-4920 el-enclave: making it a kernel module
- 34fb627cb257 LF-4920 crypto: caam - add defer probe support for imx8ulp
- 6993ba1d125d LF-4290 ele-mu: updated the imx_soc_register
- 8019cc268d2f LF-6706: arm64: dts: imx93-11x11-evk-aud-hat: Modify the name of cs42448 sound card
- 997f73e74843 LF-5606: libata: pmp: refine the workaround for ERR051238
- 7d8048d4e064 Linux 5.15.58
- c6e4817ab622 drm/amd/display: Fix wrong format specifier in amdgpu_dm.c
- 198a6f40822e x86/entry_32: Fix segment exceptions
- ec9ec3bc08b1 drm/amdgpu: Off by one in dm_dmub_outbox1_low_irq()
- e4481000ac68 x86: drop bogus "cc" clobber from __try_cmpxchg_user_asm()
- 9444462d6343 KVM: x86: fix typo in __try_cmpxchg_user causing non-atomicness
- b6c24afba608 x86/extable: Prefer local labels in .set directives
- f85a6046f771 drm/amd/display: invalid parameter check in dmub_hpd_callback
- 760fe3203493 drm/amd/display: Don't lock connection_mutex for DMUB HPD
- d026ed6eda29 watch-queue: remove spurious double semicolon
- b34229f4b212 net: usb: ax88179_178a needs FLAG_SEND_ZLP
- b2d1e4cd558c tty: use new tty_insert_flip_string_and_push_buffer() in pty_write()
- 816c301b6a73 tty: extract tty_flip_buffer_commit() from tty_flip_buffer_push()
- 35545303454a tty: drop tty_schedule_flip()
- 6219f5b54ad8 tty: the rest, stop using tty_schedule_flip() ??? from here until ???END lines may have been inserted/deleted
- ea255921c4b5 tty: drivers/tty/, stop using tty_schedule_flip()
- ba3a8af8a21a watchqueue: make sure to serialize 'wqueue->defunct' properly
- 49338b651f5a x86/alternative: Report missing return thunk details
- 8842d5d70713 x86/amd: Use IBPB for firmware calls
- c2b484d784c8 drm/amd/display: Fix surface optimization regression on Carrizo
- 958151194858 drm/amd/display: Optimize bandwidth on following fast update
- b3f16976b9ed drm/amd/display: Reset DMCUB before HW init
- 4b4b1f8dfeb7 exfat: use updated exfat_chain directly during renaming
- 000473ac997a Bluetooth: Fix bt_skb_sendmmsg not allocating partial chunks
- d01605a01f01 Bluetooth: SCO: Fix sco_send_frame returning skb->len
- 5ae749f40d01 Bluetooth: Fix passing NULL to PTR_ERR
- 367becefb8a1 Bluetooth: RFCOMM: Replace use of memcpy_from_msg with bt_skb_sendmmsg
- 1864e820a5ac Bluetooth: SCO: Replace use of memcpy_from_msg with bt_skb_sendmsg
- cb7ed8c7fe5b Bluetooth: Add bt_skb_sendmmsg helper
- a4e8071be337 Bluetooth: Add bt_skb_sendmsg helper
- 59f132fda50d um: virtio_uml: Fix broken device handling in time-travel
- 38a28bb80f00 um: virtio_uml: Allow probing from devicetree
- d8413b16feee tracing: Fix return value of trace_pid_write()
- d9777061727b tracing: Place trace_pid_list logic into abstract functions
- 6107b014163f tracing: Have event format check not flag %p* on __get_dynamic_array()
- 621c1d8c1bd1 exfat: fix referencing wrong parent directory information after renaming
- 72e0ec16f172 crypto: qat - re-enable registration of algorithms
- e7f979ed51f9 crypto: qat - add param check for DH
- 4d6d2adce087 crypto: qat - add param check for RSA
- 2488286d3e77 crypto: qat - remove dma_free_coherent() for DH
- 6e8606e7ae40 crypto: qat - remove dma_free_coherent() for RSA
- a843925e0287 crypto: qat - fix memory leak in RSA
- ef5594895df2 crypto: qat - add backlog mechanism
- 9cac903b6303 crypto: qat - refactor submission logic
- f576c7e01a6a crypto: qat - use pre-allocated buffers in datapath
- 343cee3eafda crypto: qat - set to zero DH parameters before free
- c1f6637fe1c2 iwlwifi: fw: uefi: add missing include guards
- 4448327b4173 mt76: fix use-after-free by removing a non-RCU wcid pointer
- 829baf398f2c xhci: Set HCD flag to defer primary roothub registration
- 813f4b49e81c xhci: dbc: Rename xhci_dbc_init and xhci_dbc_exit
- 413c5f751f7c xhci: dbc: create and remove dbc structure in dbgtty driver.
- d7afb4a13f6c xhci: dbc: refactor xhci_dbc_init()
- d97c0667c1e6 KVM: x86: Use __try_cmpxchg_user() to emulate atomic accesses
- 88eded8104d2 x86/futex: Remove .fixup usage
- 6875d2425be8 x86/msr: Remove .fixup usage
- f637fbc7bda6 x86/extable: Extend extable functionality

Signed-off-by: Daiane Angolini <daiane.angolini@foundries.io>

???END