### PR TITLE
vulkan-loader: Remove .so in main package

### DIFF
--- a/recipes-graphics/vulkan/vulkan-loader_1.2.182.0.bbappend
+++ b/recipes-graphics/vulkan/vulkan-loader_1.2.182.0.bbappend
@@ -1,6 +1,2 @@
-# libvulkan.so is loaded dynamically, so put it in the main package
-SOLIBS    = ".so*"
-SOLIBSDEV = ""
-
 # Override default mesa drivers with i.MX GPU drivers
 RRECOMMENDS:${PN}:imxvulkan = "libvulkan-imx"


### PR DESCRIPTION
Doing this causes a build failure in imx-gpu-sdk (meta-freescale-distro layer of BSP)

ERROR: imx-gpu-sdk-5.7.1-r0 do_package_qa: QA Issue: imx-gpu-sdk rdepends on vulkan-loader-dev [dev-deps]
ERROR: imx-gpu-sdk-5.7.1-r0 do_package_qa: Fatal QA errors were found, failing task.
ERROR: Logfile of failure stored in:
/backup/jenkins/jobs/yocto_kirkstone/workspace/build-boundary-xwayland-nitrogen8mp/tmp/work/cortexa53-mx8mp-fslc-linux/imx-gpu-sdk/5.7.1-r0/temp/log.do_package_qa.820 ERROR: Task
(/backup/jenkins/jobs/yocto_kirkstone/workspace/sources/meta-freescale-distro/recipes-graphics/imx-gpu-sdk/imx-gpu-sdk_5.7.1.bb:do_package_qa) failed with exit code '1'

This is a revert of the following commit:

https://github.com/Freescale/meta-freescale/commit/8648cedaa35519cad859207e25689889155760a9