### PR TITLE
vulkan-loader: Fix library packaging

### DIFF
--- a/recipes-graphics/vulkan/vulkan-loader_1.2.182.0.bbappend
+++ b/recipes-graphics/vulkan/vulkan-loader_1.2.182.0.bbappend
@@ -1,6 +1,7 @@
 # libvulkan.so is loaded dynamically, so put it in the main package
-SOLIBS    = ".so*"
-SOLIBSDEV = ""
+SOLIBS          = ".so*"
+FILES_SOLIBSDEV = ""
+INSANE_SKIP:${PN} += "dev-so"
 
 # Override default mesa drivers with i.MX GPU drivers
 RRECOMMENDS:${PN}:imxvulkan = "libvulkan-imx"


### PR DESCRIPTION
The logic to move the .so into the main package is incorrect and results in all libraries being moved to the dev package, causing a QA error like the following:

```
ERROR: imx-gpu-sdk-5.7.1-r0 do_package_qa: QA Issue: imx-gpu-sdk rdepends on vulkan-loader-dev [dev-deps]
```

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>