### PR TITLE
imx-gpu-viv: inherit features_check in  imx-gpu-viv bb file

### DIFF
--- a/recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc
+++ b/recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc
@@ -66,7 +66,7 @@ RPROVIDES:${PN}:imxgpu3d += "imx-gpu-viv"
 
 PE = "1"
 
-inherit fsl-eula-unpack
+inherit fsl-eula-unpack features_check
 
 SRC_URI = "${FSL_MIRROR}/${BPN}-${PV}.bin;fsl-eula=true \
            file://imx_icd.json"


### PR DESCRIPTION
After rebase meta-freescale, there is a building warning as below: WARNING: imx-gpu-viv-1_6.4.3.p4.2-aarch64-r0 do_package_qa: QA Issue: imx-gpu-viv: recipe doesn't inherit features_check Because the features_check was missed when NXP upgraded imx-gpu-viv package, add it back.

Signed-off-by: Meng Li <Meng.Li@windriver.com>