### PR TITLE
weston: fix build test-internal-screenshot

### DIFF
--- a/recipes-graphics/wayland/weston/0001-tests-Add-dependency-on-screenshooter-client-protoco.patch
+++ b/recipes-graphics/wayland/weston/0001-tests-Add-dependency-on-screenshooter-client-protoco.patch
@@ -1,0 +1,33 @@
+From 2ac6b6b084a877adde64db7faff2ed22eb3ea97a Mon Sep 17 00:00:00 2001
+From: Daniel Stone <daniels@collabora.com>
+Date: Tue, 8 Feb 2022 22:39:42 +0000
+Subject: [PATCH] tests: Add dependency on screenshooter client protocol
+
+Given that the test-helper code relies on the screenshooter protocol,
+make sure it's available for us to build, and the dependency ensures we
+build in order.
+
+Fixes: #588
+
+Signed-off-by: Daniel Stone <daniels@collabora.com>
+---
+ tests/meson.build | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/tests/meson.build b/tests/meson.build
+index 2d464ddcc..222091cd1 100644
+--- a/tests/meson.build
++++ b/tests/meson.build
+@@ -29,8 +29,9 @@ lib_test_client = static_library(
+ 		'weston-test-client-helper.c',
+ 		'weston-test-fixture-compositor.c',
+ 		weston_test_client_protocol_h,
+-		weston_screenshooter_protocol_c,
+ 		weston_test_protocol_c,
++		weston_screenshooter_client_protocol_h,
++		weston_screenshooter_protocol_c,
+ 		viewporter_client_protocol_h,
+ 		viewporter_protocol_c,
+ 		'color_util.h',
+
+

--- a/recipes-graphics/wayland/weston_10.0.0.imx.bb
+++ b/recipes-graphics/wayland/weston_10.0.0.imx.bb
@@ -163,6 +163,7 @@ SRC_URI:remove = "https://wayland.freedesktop.org/releases/${BPN}-${PV}.tar.xz"
 SRC_URI:prepend = "git://source.codeaurora.org/external/imx/weston-imx.git;protocol=https;branch=${SRCBRANCH} "
 SRC_URI += "file://0001-Revert-protocol-no-found-wayland-scanner-with-Yocto-.patch \
             file://0001-g2d-renderer.c-Include-sys-stat.h.patch \
+            file://0001-tests-Add-dependency-on-screenshooter-client-protoco.patch \
             "
 SRCBRANCH = "weston-imx-10.0"
 SRCREV = "c8c6e3106b03441db1037afa995f95fcb2f9f17d"


### PR DESCRIPTION
tests: Add dependency on screenshooter client protocol

Given that the test-helper code relies on the screenshooter protocol, make sure it's available for us to build, and the dependency ensures we build in order.

Link: https://github.com/wayland-project/weston
Commit: 2ac6b6b084a877adde64db7faff2ed22eb3ea97a

Fixes: #1273

Signed-off-by: Maxim Paymushkin <maxim.paymushkin@gmail.com>