### PR TITLE
imx-boot: Create missing build directories

### DIFF
--- a/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
+++ b/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
@@ -72,6 +72,12 @@ REV_OPTION:mx8qxp-generic-bsp = \
                                                            'REV=C0', d)}"
 REV_OPTION:mx8dx-generic-bsp  = "REV=C0"
 
+do_uboot_assemble_fitimage:prepend:imx-generic-bsp() {
+    for config in ${UBOOT_MACHINE}; do
+        mkdir -p ${B}/${config}
+    done
+}
+
 compile_mx8m() {
     bbnote 8MQ/8MM/8MN/8MP boot binary build
     for ddr_firmware in ${DDR_FIRMWARE_NAME}; do


### PR DESCRIPTION
These are needed by do_uboot_assemble_fitimage code after https://git.openembedded.org/openembedded-core/commit/?id=5e12dc911d0c541f43aa6d0c046fb87e8b7c1f7e

since this code now expects these directories to exist even if we are not using it

Fixes
run.do_uboot_assemble_fitimage.2153024: line 1
64: cd: /mnt/b/yoe/master/build/tmp/work/imx8qm_var_som-yoe-linux-musl/imx-boot/1.0-r0/git/imx8qm_var_som_defconfig: No such file or
 directory

Signed-off-by: Khem Raj <raj.khem@gmail.com>