### PR TITLE
[Backport Kirkstone] imx-mkimage: Simplify compile and install tasks

### DIFF
--- a/recipes-bsp/imx-mkimage/imx-mkimage_git.bb
+++ b/recipes-bsp/imx-mkimage/imx-mkimage_git.bb
@@ -10,17 +10,11 @@ SECTION = "BSP"
 
 inherit deploy native
 
+EXTRA_OEMAKE = "SOC=iMX8M mkimage_imx8"
+
 CFLAGS = "-O2 -Wall -std=c99 -I ${STAGING_INCDIR} -L ${STAGING_LIBDIR}"
 
-do_compile () {
-    cd ${S}
-    oe_runmake clean
-    oe_runmake bin
-    oe_runmake -C iMX8M -f soc.mak mkimage_imx8
-}
-
-do_install () {
-    cd ${S}
+do_install() {
     install -d ${D}${bindir}
     install -m 0755 iMX8M/mkimage_imx8 ${D}${bindir}/mkimage_imx8m
     install -m 0755 iMX8M/mkimage_fit_atf.sh ${D}${bindir}/mkimage_fit_atf.sh


### PR DESCRIPTION
Replace do_compile() with EXTRA_OEMAKE:
- The cd ${S} is redundant
- The clean operation is already done in do_configure()
- The two steps building the bin and mkimage_mx8 are the default behavior of the top-level Makefile with target mkimage_mx8

Drop redundant cd ${S} in do_install().

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>