### PR TITLE
bb.data.update_data is deprecated

### DIFF
--- a/classes/fsl-eula-unpack.bbclass
+++ b/classes/fsl-eula-unpack.bbclass
@@ -141,7 +141,6 @@ python fsl_bin_do_unpack() {
         return
 
     localdata = bb.data.createCopy(d)
-    bb.data.update_data(localdata)
 
     rootdir = localdata.getVar('WORKDIR', True)
     fetcher = bb.fetch2.Fetch(src_uri, localdata)


### PR DESCRIPTION
bb.data.update_data is removed in poky. https://github.com/yoctoproject/poky/commit/d8e9ee8fd53b7620e72b2dfebb2e8d464b737dbb . Fixes https://github.com/Freescale/meta-freescale/issues/1295