### PR TITLE
Switch NXP QorIQ repositories to github.com

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-dpaa/fmc/fmc_git.bb
+++ b/dynamic-layers/openembedded-layer/recipes-dpaa/fmc/fmc_git.bb
@@ -6,7 +6,7 @@ PR = "r2"
 
 DEPENDS = "libxml2 fmlib tclap"
 
-SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/fmc;nobranch=1"
+SRC_URI = "git://github.com/nxp-qoriq/fmc;protocol=https;nobranch=1"
 SRCREV = "c2ed7c269e86ac6a0aac361f5876c96e700443f4"
 
 S = "${WORKDIR}/git"

--- a/recipes-bsp/atf/qoriq-atf-2.4.inc
+++ b/recipes-bsp/atf/qoriq-atf-2.4.inc
@@ -3,7 +3,7 @@ DESCRIPTION = "ARM Trusted Firmware"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://license.rst;md5=1dd070c98a281d18d9eefd938729b031"
 
-SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/atf.git;nobranch=1"
+SRC_URI = "git://github.com/nxp-qoriq/atf.git;protocol=https;nobranch=1"
 SRCREV = "bb4957067d4b96a6ee197a333425948e409e990d"
 
 S = "${WORKDIR}/git"

--- a/recipes-bsp/mc-utils/mc-utils_git.bb
+++ b/recipes-bsp/mc-utils/mc-utils_git.bb
@@ -7,7 +7,7 @@ DEPENDS += "dtc-native"
 
 inherit deploy
 
-SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/mc-utils;nobranch=1"
+SRC_URI = "git://github.com/nxp-qoriq/mc-utils;protocol=https;nobranch=1"
 SRCREV = "12ffee82d210cb6b5c8fa30fbc6f5d29e4be2e6f"
 
 S = "${WORKDIR}/git"

--- a/recipes-bsp/rcw/rcw_git.bb
+++ b/recipes-bsp/rcw/rcw_git.bb
@@ -7,7 +7,7 @@ DEPENDS += "tcl-native"
 
 inherit deploy siteinfo
 
-SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/rcw;nobranch=1"
+SRC_URI = "git://github.com/nxp-qoriq/rcw;protocol=https;nobranch=1"
 SRCREV = "1f431891c7f0e7d4f52327f1fe19504a284491c4"
 
 S = "${WORKDIR}/git"

--- a/recipes-bsp/u-boot/u-boot-qoriq_2021.04.bb
+++ b/recipes-bsp/u-boot/u-boot-qoriq_2021.04.bb
@@ -14,7 +14,7 @@ LIC_FILES_CHKSUM = " \
     file://Licenses/lgpl-2.1.txt;md5=4fbd65380cdd255951079008b364516c \
 "
 
-SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/u-boot;nobranch=1"
+SRC_URI = "git://github.com/nxp-qoriq/u-boot;protocol=https;nobranch=1"
 SRCREV= "1c0116f3da250c5a52858c53efb8b38c0963f477"
 
 S = "${WORKDIR}/git"

--- a/recipes-devtools/qemu/qemu-qoriq_4.2.bb
+++ b/recipes-devtools/qemu/qemu-qoriq_4.2.bb
@@ -9,7 +9,7 @@ DEPENDS = "glib-2.0 zlib pixman bison-native"
 LIC_FILES_CHKSUM = "file://COPYING;md5=441c28d2cf86e15a37fa47e15a72fbac \
                     file://COPYING.LIB;endline=24;md5=8c5efda6cf1e1b03dcfd0e6c0d271c7f"
 
-SRC_URI = "gitsm://source.codeaurora.org/external/qoriq/qoriq-components/qemu;nobranch=1 \
+SRC_URI = "gitsm://github.com/nxp-qoriq/qemu;protocol=https;nobranch=1 \
            file://powerpc_rom.bin \
            file://run-ptest \
            file://0002-Add-subpackage-ptest-which-runs-all-unit-test-cases-.patch \

--- a/recipes-devtools/qoriq-cst/qoriq-cst_git.bb
+++ b/recipes-devtools/qoriq-cst/qoriq-cst_git.bb
@@ -16,7 +16,7 @@ inherit kernel-arch
 #SECURE_PRI_KEY = "/path/srk.pri"
 #SECURE_PUB_KEY = "/path/srk.pub"
 
-SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/cst;nobranch=1 \
+SRC_URI = "git://github.com/nxp-qoriq/cst;protocol=https;nobranch=1 \
            file://0001-tools-Mark-struct-input_field-file_field-extern.patch \
 "
 SRCREV = "dfe30d3f05cfe281896482839e57ed49c52f2088"

--- a/recipes-dpaa/eth-config/eth-config_git.bb
+++ b/recipes-dpaa/eth-config/eth-config_git.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=47716bd5b656aa5e298a132a64d2d1e4"
 
 PR = "r2"
 
-SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/eth-config;nobranch=1"
+SRC_URI = "git://github.com/nxp-qoriq/eth-config;protocol=https;nobranch=1"
 SRCREV = "6164664070e45810c793f112781ebcedc979e132"
 
 S = "${WORKDIR}/git"

--- a/recipes-dpaa/flib/flib_git.bb
+++ b/recipes-dpaa/flib/flib_git.bb
@@ -3,7 +3,7 @@ SECTION = "flib"
 LICENSE = "BSD-3-Clause & GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=9f6d1afdf6b0f6b3ba65c25ba589ee53"
 
-SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/flib;nobranch=1"
+SRC_URI = "git://github.com/nxp-qoriq/flib;protocol=https;nobranch=1"
 SRCREV = "cbb31427466649c07d2ac2739a41bb42f5f6be7c"
 
 S = "${WORKDIR}/git"

--- a/recipes-dpaa/fmlib/fmlib_git.bb
+++ b/recipes-dpaa/fmlib/fmlib_git.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=9c7bd5e45d066db084bdb3543d55b1ac"
 
 PR = "r1"
 
-SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/fmlib;nobranch=1"
+SRC_URI = "git://github.com/nxp-qoriq/fmlib;protocol=https;nobranch=1"
 SRCREV = "69a70474cd8411d5a099c34f40760b6567d781d6"
 
 S = "${WORKDIR}/git"

--- a/recipes-dpaa2/aiopsl/aiopsl_git.bb
+++ b/recipes-dpaa2/aiopsl/aiopsl_git.bb
@@ -7,7 +7,7 @@ BASEDEPENDS = ""
 
 S = "${WORKDIR}/git"
 
-SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/aiopsl;nobranch=1"
+SRC_URI = "git://github.com/nxp-qoriq/aiopsl;protocol=https;nobranch=1"
 SRCREV = "87d83d8e99770325cc7ad9e10965c9959e7cb828"
 
 do_configure[noexec] = "1"

--- a/recipes-dpaa2/dce/dce_git.bb
+++ b/recipes-dpaa2/dce/dce_git.bb
@@ -3,8 +3,8 @@ SECTION = "dpaa2"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=956df5ea6cfe0a1dcf2dee7ca37c0cdf"
 
-SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/dce;nobranch=1 \
-      git://source.codeaurora.org/external/qoriq/qoriq-components/qbman_userspace;nobranch=1;name=qbman;destsuffix=git/lib/qbman_userspace \
+SRC_URI = "git://github.com/nxp-qoriq/dce;protocol=https;nobranch=1 \
+      git://github.com/nxp-qoriq/qbman_userspace;protocol=https;nobranch=1;name=qbman;destsuffix=git/lib/qbman_userspace \
       file://0001-support-user-merge.patch \
 "
 SRCREV = "9db9c08379aa89f45f514f4f3f0a8e8212198758"

--- a/recipes-dpaa2/gpp-aioptool/gpp-aioptool_git.bb
+++ b/recipes-dpaa2/gpp-aioptool/gpp-aioptool_git.bb
@@ -6,7 +6,7 @@ SECTION = "dpaa2"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=386a6287daa6504b7e7e5014ddfb3987"
 
-SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/gpp-aioptool;nobranch=1 \
+SRC_URI = "git://github.com/nxp-qoriq/gpp-aioptool;protocol=https;nobranch=1 \
     file://0001-remove-libio.h.patch \
     file://0001-add-fcommon-to-fix-gcc-10-build-issue.patch \
 "

--- a/recipes-dpaa2/restool/restool_git.bb
+++ b/recipes-dpaa2/restool/restool_git.bb
@@ -2,7 +2,7 @@ SUMMARY = "DPAA2 Resource Manager Tool"
 LICENSE = "BSD-3-Clause | GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=ec8d84e9cd4de287e290275d09db27f0"
 
-SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/restool;nobranch=1 \
+SRC_URI = "git://github.com/nxp-qoriq/restool;protocol=https;nobranch=1 \
     file://disable-manpage-generation.patch \
 "
 SRCREV = "d29522aef9f92ff2557978d5d3979b771a9576fe"

--- a/recipes-dpaa2/spc/spc_git.bb
+++ b/recipes-dpaa2/spc/spc_git.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=163b09a1c249a6ff2b28da1ceca2e0a8"
 
 DEPENDS = "libxml2 fmlib tclap"
 
-SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/spc;nobranch=1"
+SRC_URI = "git://github.com/nxp-qoriq/spc;protocol=https;nobranch=1"
 SRCREV = "398138687a3d3d6ef174501221711de74ff7bc40"
 
 S = "${WORKDIR}/git"

--- a/recipes-extended/dpdk/dpdk-20.11.inc
+++ b/recipes-extended/dpdk/dpdk-20.11.inc
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://license/gpl-2.0.txt;md5=b234ee4d69f5fce4486a80fdaf4a4
                     file://license/lgpl-2.1.txt;md5=4b54a1fd55a448865a0b32d41598759d \
                     file://license/bsd-3-clause.txt;md5=0f00d99239d922ffd13cabef83b33444"
 
-SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/dpdk;nobranch=1"
+SRC_URI = "git://github.com/nxp-qoriq/dpdk;protocol=https;nobranch=1"
 SRCREV = "f74b8bd5ab1c6ff76e956fc202a56aea2d200270"
 
 S = "${WORKDIR}/git"

--- a/recipes-extended/dpdk/dpdk_19.11-20.12.bb
+++ b/recipes-extended/dpdk/dpdk_19.11-20.12.bb
@@ -3,7 +3,7 @@ LIC_FILES_CHKSUM = "file://license/gpl-2.0.txt;md5=b234ee4d69f5fce4486a80fdaf4a4
                     file://license/lgpl-2.1.txt;md5=4b54a1fd55a448865a0b32d41598759d \
                     file://license/bsd-3-clause.txt;md5=0f00d99239d922ffd13cabef83b33444"
 
-SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/dpdk;nobranch=1 \
+SRC_URI = "git://github.com/nxp-qoriq/dpdk;protocol=https;nobranch=1 \
            file://add-RTE_KERNELDIR_OUT-to-split-kernel-bu.patch \
            file://0001-add-Wno-cast-function-type.patch \
            file://0001-Add-RTE_KERNELDIR_OUT.patch \

--- a/recipes-extended/libpkcs11/libpkcs11_git.bb
+++ b/recipes-extended/libpkcs11/libpkcs11_git.bb
@@ -2,7 +2,7 @@ DESCRIPTION = "PKCS library"
 LICENSE = "GPL-2.0-only & BSD"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=803852533e29eb1d6d5e55ad3078b625"
 
-SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/libpkcs11;nobranch=1 \
+SRC_URI = "git://github.com/nxp-qoriq/libpkcs11;protocol=https;nobranch=1 \
     file://0001-fix-multiple-definition-error.patch \
 "
 SRCREV = "8d85182b7a7cd393ab6dd72930f8d1b69468f741"

--- a/recipes-extended/odp/odp.inc
+++ b/recipes-extended/odp/odp.inc
@@ -9,9 +9,9 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=ca6103dc75397fb6bec596187d6b7829"
 FILESEXTRAPATHS:prepend := "${THISDIR}/odp:"
 
 SRC_URI = " \
-git://source.codeaurora.org/external/qoriq/qoriq-components/odp;nobranch=1 \
-git://source.codeaurora.org/external/qoriq/qoriq-components/qbman_userspace;nobranch=1;name=qbman;destsuffix=git/platform/linux-dpaa2/flib/qbman \
-git://source.codeaurora.org/external/qoriq/qoriq-components/flib;nobranch=1;name=rta;destsuffix=git/platform/linux-dpaa2/flib/rta \
+git://github.com/nxp-qoriq/odp;protocol=https;nobranch=1 \
+git://github.com/nxp-qoriq/qbman_userspace;protocol=https;nobranch=1;name=qbman;destsuffix=git/platform/linux-dpaa2/flib/qbman \
+git://github.com/nxp-qoriq/flib;protocol=https;nobranch=1;name=rta;destsuffix=git/platform/linux-dpaa2/flib/rta \
 "
 
 SRC_URI += "file://0001-Fix-this-build-error.patch"

--- a/recipes-extended/ofp/ofp_git.bb
+++ b/recipes-extended/ofp/ofp_git.bb
@@ -6,7 +6,7 @@ SECTION = "console/network"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=fbe4957c430eed6cc20521d4eb429fae"
 
-SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/ofp;nobranch=1"
+SRC_URI = "git://github.com/nxp-qoriq/ofp;protocol=https;nobranch=1"
 
 SRCREV = "fe66f4659f7d356f7aa73a8fb32fcf67c6cf1108"
 

--- a/recipes-extended/ovs-dpdk/ovs-dpdk_2.15.bb
+++ b/recipes-extended/ovs-dpdk/ovs-dpdk_2.15.bb
@@ -7,7 +7,7 @@ RDEPENDS:${PN} = "bash libcrypto libssl python3"
 
 inherit python3native pkgconfig
 
-SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/ovs-dpdk;nobranch=1"
+SRC_URI = "git://github.com/nxp-qoriq/ovs-dpdk;protocol=https;nobranch=1"
 SRCREV = "f2c0744d2f68c4cd2840d6e409d7b0520e4caf99"
 
 S = "${WORKDIR}/git"

--- a/recipes-extended/secure-obj/secure-obj.inc
+++ b/recipes-extended/secure-obj/secure-obj.inc
@@ -10,7 +10,7 @@ inherit python3native
 
 LDFLAGS += "${TOOLCHAIN_OPTIONS}"
 
-SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/secure_obj;nobranch=1"
+SRC_URI = "git://github.com/nxp-qoriq/secure_obj;protocol=https;nobranch=1"
 SRCREV = "5ff1231f74b4b01744be95a3137a14ad0a483e61"
 
 WRAP_TARGET_PREFIX ?= "${TARGET_PREFIX}"

--- a/recipes-extended/tsntool/tsntool_git.bb
+++ b/recipes-extended/tsntool/tsntool_git.bb
@@ -7,7 +7,7 @@ DEPENDS = "cjson libnl readline"
 
 inherit pkgconfig
 
-SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/tsntool;protocol=https;nobranch=1"
+SRC_URI = "git://github.com/nxp-qoriq/tsntool;protocol=https;nobranch=1"
 SRCREV = "b767c260b851aac94828ed26c6a9a327e4e98334"
 
 S = "${WORKDIR}/git"

--- a/recipes-kernel/ceetm/ceetm_git.bb
+++ b/recipes-kernel/ceetm/ceetm_git.bb
@@ -2,7 +2,7 @@ DESCRIPTION = "CEETM TC QDISC"
 LICENSE = "GPL-2.0-only & BSD"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bac620b9883d38a84dfb73ca7122d915"
 
-SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/ceetm;nobranch=1"
+SRC_URI = "git://github.com/nxp-qoriq/ceetm;protocol=https;nobranch=1"
 SRCREV = "6a7f2ec2091df2f4380cb8d25a36c399aed5af1b"
 SRC_URI:append = " file://0001-Makefile-update-CFLAGS.patch \
     file://0001-use-new-api-tc_print_rate.patch \

--- a/recipes-kernel/linux/linux-qoriq_5.10.bb
+++ b/recipes-kernel/linux/linux-qoriq_5.10.bb
@@ -2,7 +2,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
 LINUX_VERSION = "5.10.52"
 
-SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/linux;nobranch=1"
+SRC_URI = "git://github.com/nxp-qoriq/linux;protocol=https;nobranch=1"
 SRCREV = "a11753a89ec610768301d4070e10b8bd60fde8cd"
 
 require recipes-kernel/linux/linux-qoriq.inc

--- a/recipes-security/optee-qoriq/optee-client.nxp.inc
+++ b/recipes-security/optee-qoriq/optee-client.nxp.inc
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=69663ab153298557a59c67a60a743e5b"
 
 inherit python3native systemd
 
-SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/optee_client.git;nobranch=1"
+SRC_URI = "git://github.com/nxp-qoriq/optee_client.git;protocol=https;nobranch=1"
 SRCREV = "7c9c423d00e96bf51debd5fe10fd70dce83be5cc"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/optee-client:"

--- a/recipes-security/optee-qoriq/optee-os.nxp.inc
+++ b/recipes-security/optee-qoriq/optee-os.nxp.inc
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=c1f21c4f72f372ef38a5a4aee55ec173"
 inherit deploy python3native autotools
 DEPENDS = "python3-pycryptodome-native python3-pyelftools-native python3-pycryptodomex-native dtc-native"
 
-SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/optee_os.git;nobranch=1"
+SRC_URI = "git://github.com/nxp-qoriq/optee_os.git;protocol=https;nobranch=1"
 SRCREV = "735d98806dc26fbeeecad7f5e60ffeab8170c67e"
 
 S = "${WORKDIR}/git"

--- a/recipes-security/optee-qoriq/optee-test.nxp.inc
+++ b/recipes-security/optee-qoriq/optee-test.nxp.inc
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = "file://LICENSE.md;md5=daa2bcccc666345ab8940aab1315a4fa"
 DEPENDS = "python3-pycryptodome-native python3-pycryptodomex-native openssl"
 inherit python3native cmake
 
-SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/optee_test.git;nobranch=1"
+SRC_URI = "git://github.com/nxp-qoriq/optee_test.git;protocol=https;nobranch=1"
 SRCREV = "69722dab8c1f2683e30e0ee3b536053367e37aad"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Fetch QorIQ's source code from github.com/nxp-qoriq, as original source.codeaurora.org/external/qoriq will stop to access from April 2023.

Signed-off-by: Jun Zhu <junzhu@nxp.com>