### PR TITLE
weston-init: Drop redundant xwayland=true setting

### DIFF
--- a/dynamic-layers/ivi/recipes-graphics/wayland/weston-init/weston.ini
+++ b/dynamic-layers/ivi/recipes-graphics/wayland/weston-init/weston.ini
@@ -4,7 +4,6 @@ modules=hmi-controller.so
 #gbm-format=argb8888
 idle-time=0
 #use-g2d=1
-#xwayland=true
 #repaint-window=16
 #enable-overlay-view=1
 

--- a/recipes-graphics/wayland/weston-init.bbappend
+++ b/recipes-graphics/wayland/weston-init.bbappend
@@ -12,9 +12,6 @@ SRC_URI:append:mx6sl-nxp-bsp = " file://weston.config"
 # commented out. For example:
 #     #xwayland=true
 # Then add the assignment to INI_UNCOMMENT_ASSIGNMENTS.
-INI_UNCOMMENT_ASSIGNMENTS:append:imx-nxp-bsp = " \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'x11 wayland', 'xwayland=true', '', d)} \
-"
 INI_UNCOMMENT_ASSIGNMENTS:append:mx8-nxp-bsp = " \
     repaint-window=16 \
 "

--- a/recipes-graphics/wayland/weston-init/imx-nxp-bsp/weston.ini
+++ b/recipes-graphics/wayland/weston-init/imx-nxp-bsp/weston.ini
@@ -2,7 +2,6 @@
 #gbm-format=argb8888
 idle-time=0
 #use-g2d=1
-#xwayland=true
 #repaint-window=16
 #enable-overlay-view=1
 modules=screen-share.so


### PR DESCRIPTION
The main recipe now sets xwayland=true in weston.ini, so drop it from here.

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>