### PR TITLE
Add NXP WiFi/BT support

### DIFF
--- a/conf/machine/imx6qdlsabreauto.conf
+++ b/conf/machine/imx6qdlsabreauto.conf
@@ -73,4 +73,4 @@ SERIAL_CONSOLES = "115200;ttymxc3"
 
 MACHINE_FIRMWARE:append:mx6 = " linux-firmware-ath6k"
 
-MACHINE_FEATURES += " pci wifi bluetooth"
+MACHINE_FEATURES += " pci wifi bluetooth nxp8987-sdio"

--- a/conf/machine/imx6qdlsabresd.conf
+++ b/conf/machine/imx6qdlsabresd.conf
@@ -79,4 +79,4 @@ SERIAL_CONSOLES = "115200;ttymxc0"
 
 MACHINE_FIRMWARE:append:mx6 = " linux-firmware-ath6k"
 
-MACHINE_FEATURES += " pci wifi bluetooth"
+MACHINE_FEATURES += " pci wifi bluetooth nxp8987-sdio"

--- a/conf/machine/imx6slevk.conf
+++ b/conf/machine/imx6slevk.conf
@@ -34,6 +34,6 @@ OPTEE_BIN_EXT = "6slevk"
 
 SERIAL_CONSOLES = "115200;ttymxc0"
 
-MACHINE_FEATURES += "pci wifi bluetooth bcm4339 bcm43455"
+MACHINE_FEATURES += "pci wifi bluetooth bcm4339 bcm43455 nxp8987-sdio"
 
 MACHINE_FIRMWARE += "linux-firmware-ath6k firmware-imx-epdc"

--- a/conf/machine/imx6sllevk.conf
+++ b/conf/machine/imx6sllevk.conf
@@ -30,7 +30,7 @@ OPTEE_BIN_EXT:imx6sllevk = "6sllevk"
 
 SERIAL_CONSOLES = "115200;ttymxc0"
 
-MACHINE_FEATURES += "wifi bluetooth bcm4339 bcm43455"
+MACHINE_FEATURES += "wifi bluetooth bcm4339 bcm43455 nxp8987-sdio"
 
 # MESA DRI library
 XSERVER += "mesa-driver-swrast"

--- a/conf/machine/imx6sxsabreauto.conf
+++ b/conf/machine/imx6sxsabreauto.conf
@@ -31,4 +31,4 @@ SERIAL_CONSOLES = "115200;ttymxc3"
 
 MACHINE_FIRMWARE:append:mx6 = " linux-firmware-ath6k"
 
-MACHINE_FEATURES += " pci wifi bluetooth"
+MACHINE_FEATURES += " pci wifi bluetooth nxp8987-sdio"

--- a/conf/machine/imx6sxsabresd.conf
+++ b/conf/machine/imx6sxsabresd.conf
@@ -45,4 +45,4 @@ SERIAL_CONSOLES = "115200;ttymxc0"
 
 MACHINE_FIRMWARE:append:mx6 = " linux-firmware-ath6k"
 
-MACHINE_FEATURES += "pci wifi bluetooth bcm4339 bcm43455"
+MACHINE_FEATURES += "pci wifi bluetooth bcm4339 bcm43455 nxp8987-sdio"

--- a/conf/machine/imx6ulevk.conf
+++ b/conf/machine/imx6ulevk.conf
@@ -9,7 +9,7 @@ MACHINEOVERRIDES =. "mx6ul:"
 include conf/machine/include/imx-base.inc
 include conf/machine/include/arm/armv7a/tune-cortexa7.inc
 
-MACHINE_FEATURES += "wifi bluetooth bcm4339 bcm43455"
+MACHINE_FEATURES += "wifi bluetooth bcm4339 bcm43455 nxp8987-sdio"
 
 KERNEL_DEVICETREE = " \
     imx6ul-14x14-evk-btwifi.dtb \

--- a/conf/machine/imx6ullevk.conf
+++ b/conf/machine/imx6ullevk.conf
@@ -9,7 +9,7 @@ MACHINEOVERRIDES =. "mx6ull:"
 include conf/machine/include/imx-base.inc
 include conf/machine/include/arm/armv7a/tune-cortexa7.inc
 
-MACHINE_FEATURES += "wifi bluetooth bcm4339 bcm43455"
+MACHINE_FEATURES += "wifi bluetooth bcm4339 bcm43455 nxp8801-sdio nxp8987-sdio"
 
 KERNEL_DEVICETREE = " \
     imx6ull-14x14-evk.dtb \

--- a/conf/machine/imx6ulz-14x14-evk.conf
+++ b/conf/machine/imx6ulz-14x14-evk.conf
@@ -9,7 +9,7 @@ MACHINEOVERRIDES =. "mx6ulz:"
 include conf/machine/include/imx-base.inc
 include conf/machine/include/arm/armv7a/tune-cortexa7.inc
 
-MACHINE_FEATURES += "wifi bluetooth bcm4339 bcm43455"
+MACHINE_FEATURES += "wifi bluetooth bcm4339 bcm43455 nxp8987-sdio"
 
 KERNEL_DEVICETREE = " \
     imx6ulz-14x14-evk.dtb \

--- a/conf/machine/imx7dsabresd.conf
+++ b/conf/machine/imx7dsabresd.conf
@@ -9,7 +9,7 @@ MACHINEOVERRIDES =. "mx7:mx7d:"
 require conf/machine/include/imx-base.inc
 include conf/machine/include/arm/armv7a/tune-cortexa7.inc
 
-MACHINE_FEATURES += "pci wifi bluetooth bcm4339 bcm43455"
+MACHINE_FEATURES += "pci wifi bluetooth bcm4339 bcm43455 nxp8987-sdio"
 
 KERNEL_DEVICETREE = "imx7d-sdb.dtb"
 KERNEL_DEVICETREE:append:use-nxp-bsp = " \

--- a/conf/machine/imx7ulpevk.conf
+++ b/conf/machine/imx7ulpevk.conf
@@ -9,7 +9,7 @@ MACHINEOVERRIDES =. "mx7:mx7ulp:"
 require conf/machine/include/imx-base.inc
 include conf/machine/include/arm/armv7a/tune-cortexa7.inc
 
-MACHINE_FEATURES += "pci wifi bluetooth bcm43430"
+MACHINE_FEATURES += "pci wifi bluetooth bcm43430 nxp8987-sdio"
 
 KERNEL_DEVICETREE = " \
 	imx7ulp-evk.dtb \

--- a/conf/machine/imx8mq-evk.conf
+++ b/conf/machine/imx8mq-evk.conf
@@ -18,7 +18,7 @@ require conf/machine/include/arm/armv8a/tune-cortexa53.inc
 # inline NEON and FPU code generation
 DEFAULTTUNE:use-mainline-bsp = "cortexa53-crypto"
 
-MACHINE_FEATURES += "pci wifi bluetooth bcm43455 bcm4356"
+MACHINE_FEATURES += "pci wifi bluetooth bcm43455 bcm4356 nxp8997-pcie nxp8997-sdio nxp9098-pcie nxp9098-sdio"
 MACHINE_FEATURES:append:use-nxp-bsp = " optee bcm4359"
 
 MACHINE_SOCARCH_FILTER:append:mx8mq = " virtual/libopenvg virtual/libgles1 virtual/libgles2 virtual/egl virtual/mesa virtual/libgl virtual/libg2d"

--- a/conf/machine/imx8qm-mek.conf
+++ b/conf/machine/imx8qm-mek.conf
@@ -11,7 +11,7 @@ require conf/machine/include/arm/armv8a/tune-cortexa72-cortexa53.inc
 
 IMX_DEFAULT_BSP = "nxp"
 
-MACHINE_FEATURES += "pci optee bcm43455 bcm4356"
+MACHINE_FEATURES += "pci optee bcm43455 bcm4356 nxp8997-pcie nxp9098-pcie"
 MACHINE_FEATURES:append:use-nxp-bsp = " bcm4359"
 
 # Don't include kernels in standard images

--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -400,7 +400,7 @@ MACHINE_FIRMWARE:append = " ${@bb.utils.contains('MACHINE_FEATURES', 'bcm4339', 
 MACHINE_FIRMWARE:append = " ${@bb.utils.contains('MACHINE_FEATURES', 'bcm43430', 'linux-firmware-bcm43430', '', d)}"
 MACHINE_FIRMWARE:append = " ${@bb.utils.contains('MACHINE_FEATURES', 'bcm43455', 'linux-firmware-bcm43455', '', d)}"
 MACHINE_FIRMWARE:append = " ${@bb.utils.contains('MACHINE_FEATURES', 'bcm4356', 'linux-firmware-bcm4356-pcie', '', d)}"
-MACHINE_FIRMWARE:append = " ${@bb.utils.contains('MACHINE_FEATURES', 'bcm4359', 'linux-firmware-bcm4359-pcie', '', d)}"
+MACHINE_FIRMWARE:append = " ${@bb.utils.contains('MACHINE_FEATURES', 'bcm4359', 'firmware-nxp-wifi-bcm4359-pcie', '', d)}"
 
 # Extra NXP Wi-Fi and Bluetooth driver firmware and driver
 MACHINE_FIRMWARE:append = " ${@bb.utils.contains('MACHINE_FEATURES', 'nxp8801-sdio', 'firmware-nxp-wifi-nxp8801-sdio', '', d)}"

--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -402,8 +402,24 @@ MACHINE_FIRMWARE:append = " ${@bb.utils.contains('MACHINE_FEATURES', 'bcm43455',
 MACHINE_FIRMWARE:append = " ${@bb.utils.contains('MACHINE_FEATURES', 'bcm4356', 'linux-firmware-bcm4356-pcie', '', d)}"
 MACHINE_FIRMWARE:append = " ${@bb.utils.contains('MACHINE_FEATURES', 'bcm4359', 'linux-firmware-bcm4359-pcie', '', d)}"
 
-# Extra NXP89xx Wi-Fi and Bluetooth driver
-MACHINE_EXTRA_RRECOMMENDS:append = " ${@bb.utils.contains('MACHINE_FEATURES', 'nxp8987', 'kernel-module-nxp89xx', '', d)}"
+# Extra NXP Wi-Fi and Bluetooth driver firmware and driver
+MACHINE_FIRMWARE:append = " ${@bb.utils.contains('MACHINE_FEATURES', 'nxp8801-sdio', 'firmware-nxp-wifi-nxp8801-sdio', '', d)}"
+MACHINE_EXTRA_RRECOMMENDS:append = " ${@bb.utils.contains('MACHINE_FEATURES', 'nxp8801-sdio', 'kernel-module-nxp89xx', '', d)}"
+
+MACHINE_FIRMWARE:append = " ${@bb.utils.contains('MACHINE_FEATURES', 'nxp8987-sdio', 'firmware-nxp-wifi-nxp8987-sdio', '', d)}"
+MACHINE_EXTRA_RRECOMMENDS:append = " ${@bb.utils.contains('MACHINE_FEATURES', 'nxp8987-sdio', 'kernel-module-nxp89xx', '', d)}"
+
+MACHINE_FIRMWARE:append = " ${@bb.utils.contains('MACHINE_FEATURES', 'nxp8997-pcie', 'firmware-nxp-wifi-nxp8997-pcie', '', d)}"
+MACHINE_EXTRA_RRECOMMENDS:append = " ${@bb.utils.contains('MACHINE_FEATURES', 'nxp8997-pcie', 'kernel-module-nxp89xx', '', d)}"
+
+MACHINE_FIRMWARE:append = " ${@bb.utils.contains('MACHINE_FEATURES', 'nxp8997-sdio', 'firmware-nxp-wifi-nxp8997-sdio', '', d)}"
+MACHINE_EXTRA_RRECOMMENDS:append = " ${@bb.utils.contains('MACHINE_FEATURES', 'nxp8997-sdio', 'kernel-module-nxp89xx', '', d)}"
+
+MACHINE_FIRMWARE:append = " ${@bb.utils.contains('MACHINE_FEATURES', 'nxp9098-pcie', 'firmware-nxp-wifi-nxp9098-pcie', '', d)}"
+MACHINE_EXTRA_RRECOMMENDS:append = " ${@bb.utils.contains('MACHINE_FEATURES', 'nxp9098-pcie', 'kernel-module-nxp89xx', '', d)}"
+
+MACHINE_FIRMWARE:append = " ${@bb.utils.contains('MACHINE_FEATURES', 'nxp9098-sdio', 'firmware-nxp-wifi-nxp9098-sdio', '', d)}"
+MACHINE_EXTRA_RRECOMMENDS:append = " ${@bb.utils.contains('MACHINE_FEATURES', 'nxp9098-sdio', 'kernel-module-nxp89xx', '', d)}"
 
 # Extra QCA Wi-Fi & BTE driver and firmware
 MACHINE_EXTRA_RRECOMMENDS:append = " ${@bb.utils.contains('MACHINE_FEATURES', 'qca6174', 'packagegroup-fsl-qca6174', '', d)}"

--- a/conf/machine/include/imx8dxl-evk.inc
+++ b/conf/machine/include/imx8dxl-evk.inc
@@ -5,7 +5,7 @@ require conf/machine/include/arm/armv8a/tune-cortexa35.inc
 
 IMX_DEFAULT_BSP = "nxp"
 
-MACHINE_FEATURES += "pci bcm43455 bcm4356"
+MACHINE_FEATURES += "pci bcm43455 bcm4356 nxp8997-pcie nxp9098-pcie"
 MACHINE_FEATURES:append:use-nxp-bsp = " bcm4359"
 
 # Don't include kernels in standard images

--- a/conf/machine/include/imx8mm-evk.inc
+++ b/conf/machine/include/imx8mm-evk.inc
@@ -12,7 +12,7 @@ require conf/machine/include/arm/armv8a/tune-cortexa53.inc
 # inline NEON and FPU code generation
 DEFAULTTUNE:use-mainline-bsp = "cortexa53-crypto"
 
-MACHINE_FEATURES += "pci wifi bluetooth bcm43455 bcm4356"
+MACHINE_FEATURES += "pci wifi bluetooth bcm43455 bcm4356 nxp8987-sdio"
 
 # NXP BSP can consume proprietary jailhouse and BCM4359 firmware
 # Since the firmware is not available publicly, and rather distributed

--- a/conf/machine/include/imx8mn-evk.inc
+++ b/conf/machine/include/imx8mn-evk.inc
@@ -12,7 +12,7 @@ require conf/machine/include/arm/armv8a/tune-cortexa53.inc
 # inline NEON and FPU code generation
 DEFAULTTUNE:use-mainline-bsp = "cortexa53-crypto"
 
-MACHINE_FEATURES += "wifi bluetooth bcm43455 bcm4356"
+MACHINE_FEATURES += "wifi bluetooth bcm43455 bcm4356 nxp8987-sdio"
 
 # NXP BSP can consume proprietary jailhouse and Broadcom drivers
 # OP-TEE is also applicable to NXP BSP, mainline BSP seems not to have

--- a/conf/machine/include/imx8mp-evk.inc
+++ b/conf/machine/include/imx8mp-evk.inc
@@ -12,7 +12,7 @@ require conf/machine/include/arm/armv8a/tune-cortexa53.inc
 # inline NEON and FPU code generation
 DEFAULTTUNE:use-mainline-bsp = "cortexa53-crypto"
 
-MACHINE_FEATURES += "pci wifi bluetooth"
+MACHINE_FEATURES += "pci wifi bluetooth nxp8997-pcie nxp8997-sdio nxp9098-pcie nxp9098-sdio"
 
 # NXP BSP can consume proprietary jailhouse and Marvell drivers
 # OP-TEE is also applicable to NXP BSP, mainline BSP seems not to have

--- a/conf/machine/include/imx8x-mek.inc
+++ b/conf/machine/include/imx8x-mek.inc
@@ -3,7 +3,7 @@ require conf/machine/include/arm/armv8a/tune-cortexa35.inc
 
 IMX_DEFAULT_BSP = "nxp"
 
-MACHINE_FEATURES += "pci optee bcm43455 bcm4356"
+MACHINE_FEATURES += "pci optee bcm43455 bcm4356 nxp8997-pcie nxp9098-pcie"
 MACHINE_FEATURES:append:use-nxp-bsp = " bcm4359"
 
 # Don't include kernels in standard images

--- a/recipes-bsp/firmware-imx/firmware-nxp-wifi_1.0.bb
+++ b/recipes-bsp/firmware-imx/firmware-nxp-wifi_1.0.bb
@@ -82,7 +82,6 @@ FILES:${PN}-bcm4359-pcie = " \
     ${nonarch_base_libdir}/firmware/brcm/brcmfmac4359-pcie.* \
     ${sysconfdir}/firmware/BCM4349B1_*.hcd \
 "
-RPROVIDES:${PN}-bcm4359-pcie = "linux-firmware-bcm4359-pcie"
 
 FILES:${PN}-nxp-common = " \
     ${nonarch_base_libdir}/firmware/nxp/wifi_mod_para.conf \

--- a/recipes-bsp/firmware-imx/firmware-nxp-wifi_1.0.bb
+++ b/recipes-bsp/firmware-imx/firmware-nxp-wifi_1.0.bb
@@ -8,10 +8,11 @@ recipe in favor of upstream."
 
 SECTION = "kernel"
 LICENSE = "Proprietary"
-LIC_FILES_CHKSUM = "file://cyw-wifi-bt/EULA.txt;md5=80c0478f4339af024519b3723023fe28"
+LIC_FILES_CHKSUM = "file://EULA.txt;md5=be5ff43682ed6c57dfcbeb97651c2829"
 
-SRC_URI = "git://github.com/NXP/imx-firmware.git;protocol=https;branch=master"
-SRCREV = "484d38224fa2c26b8859a7bf20b7c4d49100f5bc"
+SRC_URI = "git://github.com/NXP/imx-firmware.git;protocol=https;branch=${SRCBRANCH}"
+SRCBRANCH = "lf-5.15.52_2.1.0"
+SRCREV = "b6f070e3d4cab23932d9e6bc29e3d884a7fd68f4"
 
 S = "${WORKDIR}/git"
 
@@ -26,21 +27,101 @@ do_compile() {
 
 do_install() {
     install -d ${D}${sysconfdir}/firmware
-    install -d ${D}${nonarch_base_libdir}/firmware/brcm
 
     # Install various flavors of Broadcom firmware provided by Murata:
     # - bcm4359-pcie
+    install -d ${D}${nonarch_base_libdir}/firmware/brcm
     install -m 0644 cyw-wifi-bt/*_CYW*/brcmfmac4359-pcie* ${D}${nonarch_base_libdir}/firmware/brcm
     install -m 0644 cyw-wifi-bt/*_CYW*/BCM4349B1*.hcd ${D}${sysconfdir}/firmware
+
+    # Install NXP Connectivity common
+    install -d ${D}${nonarch_base_libdir}/firmware/nxp
+    install -m 0644 nxp/wifi_mod_para.conf ${D}${nonarch_base_libdir}/firmware/nxp
+
+    # Install NXP Connectivity SD8801 firmware
+    install -m 0644 nxp/FwImage_8801_SD/ed_mac_ctrl_V1_8801.conf  ${D}${nonarch_base_libdir}/firmware/nxp
+    install -m 0644 nxp/FwImage_8801_SD/sd8801_uapsta.bin         ${D}${nonarch_base_libdir}/firmware/nxp
+
+    # Install NXP Connectivity SDIO8987 firmware
+    install -m 0644 nxp/FwImage_8987/ed_mac_ctrl_V3_8987.conf  ${D}${nonarch_base_libdir}/firmware/nxp
+    install -m 0644 nxp/FwImage_8987/sdiouart8987_combo_v0.bin ${D}${nonarch_base_libdir}/firmware/nxp
+    install -m 0644 nxp/FwImage_8987/txpwrlimit_cfg_8987.conf  ${D}${nonarch_base_libdir}/firmware/nxp
+
+    # Install NXP Connectivity PCIE8997 firmware
+    install -m 0644 nxp/FwImage_8997/ed_mac_ctrl_V3_8997.conf  ${D}${nonarch_base_libdir}/firmware/nxp
+    install -m 0644 nxp/FwImage_8997/pcieuart8997_combo_v4.bin ${D}${nonarch_base_libdir}/firmware/nxp
+    install -m 0644 nxp/FwImage_8997/txpwrlimit_cfg_8997.conf  ${D}${nonarch_base_libdir}/firmware/nxp
+
+    # Install NXP Connectivity SDIO8997 firmware
+    install -m 0644 nxp/FwImage_8997_SD/ed_mac_ctrl_V3_8997.conf  ${D}${nonarch_base_libdir}/firmware/nxp
+    install -m 0644 nxp/FwImage_8997_SD/sdiouart8997_combo_v4.bin ${D}${nonarch_base_libdir}/firmware/nxp
+    install -m 0644 nxp/FwImage_8997_SD/txpwrlimit_cfg_8997.conf  ${D}${nonarch_base_libdir}/firmware/nxp
+
+    # Install NXP Connectivity PCIE9098 firmware
+    install -m 0644 nxp/FwImage_9098_PCIE/ed_mac_ctrl_V3_909x.conf  ${D}${nonarch_base_libdir}/firmware/nxp
+    install -m 0644 nxp/FwImage_9098_PCIE/pcieuart9098_combo_v1.bin ${D}${nonarch_base_libdir}/firmware/nxp
+    install -m 0644 nxp/FwImage_9098_PCIE/txpwrlimit_cfg_9098.conf  ${D}${nonarch_base_libdir}/firmware/nxp
+
+    # Install NXP Connectivity SDIO9098 firmware
+    install -m 0644 nxp/FwImage_9098_SD/sdiouart9098_combo_v1.bin ${D}${nonarch_base_libdir}/firmware/nxp
 }
 
 PACKAGES =+ " \
     ${PN}-bcm4359-pcie \
+    ${PN}-nxp-common \
+    ${PN}-nxp8801-sdio \
+    ${PN}-nxp8987-sdio \
+    ${PN}-nxp8997-common \
+    ${PN}-nxp8997-pcie \
+    ${PN}-nxp8997-sdio \
+    ${PN}-nxp9098-pcie \
+    ${PN}-nxp9098-sdio \
 "
 
 FILES:${PN}-bcm4359-pcie = " \
     ${nonarch_base_libdir}/firmware/brcm/brcmfmac4359-pcie.* \
     ${sysconfdir}/firmware/BCM4349B1_*.hcd \
 "
-
 RPROVIDES:${PN}-bcm4359-pcie = "linux-firmware-bcm4359-pcie"
+
+FILES:${PN}-nxp-common = " \
+    ${nonarch_base_libdir}/firmware/nxp/wifi_mod_para.conf \
+"
+
+FILES:${PN}-nxp8801-sdio = " \
+    ${nonarch_base_libdir}/firmware/nxp/*8801* \
+"
+RDEPENDS:${PN}-nxp8801-sdio += "${PN}-nxp-common"
+
+FILES:${PN}-nxp8987-sdio = " \
+    ${nonarch_base_libdir}/firmware/nxp/*8987* \
+"
+RDEPENDS:${PN}-nxp8987-sdio += "${PN}-nxp-common"
+
+FILES:${PN}-nxp8997-common = " \
+    ${nonarch_base_libdir}/firmware/nxp/ed_mac_ctrl_V3_8997.conf \
+    ${nonarch_base_libdir}/firmware/nxp/txpwrlimit_cfg_8997.conf \
+"
+RDEPENDS:${PN}-nxp8997-common += "${PN}-nxp-common"
+
+FILES:${PN}-nxp8997-pcie = " \
+    ${nonarch_base_libdir}/firmware/nxp/pcieuart8997* \
+"
+RDEPENDS:${PN}-nxp8997-pcie += "${PN}-nxp8997-common"
+
+FILES:${PN}-nxp8997-sdio = " \
+    ${nonarch_base_libdir}/firmware/nxp/sdiouart8997* \
+"
+RDEPENDS:${PN}-nxp8997-sdio += "${PN}-nxp8997-common"
+
+FILES:${PN}-nxp9098-pcie = " \
+    ${nonarch_base_libdir}/firmware/nxp/ed_mac_ctrl_V3_909x.conf \
+    ${nonarch_base_libdir}/firmware/nxp/pcieuart9098* \
+    ${nonarch_base_libdir}/firmware/nxp/txpwrlimit_cfg_9098.conf \
+"
+RDEPENDS:${PN}-nxp9098-pcie += "${PN}-nxp-common"
+
+FILES:${PN}-nxp9098-sdio = " \
+    ${nonarch_base_libdir}/firmware/nxp/sdiouart9098* \
+"
+RDEPENDS:${PN}-nxp9098-sdio += "${PN}-nxp-common"


### PR DESCRIPTION
Add NXP WiFi/BT firmware support, enabled by `MACHINE_FEATURES`, and tied into existing NXP development boards.