### PR TITLE
libimxvpuapi2: Upgrade to version 2.2.2

### DIFF
--- a/recipes-multimedia/libimxvpuapi/libimxvpuapi2_2.2.2.bb
+++ b/recipes-multimedia/libimxvpuapi/libimxvpuapi2_2.2.2.bb
@@ -8,7 +8,7 @@ DEPENDS = "virtual/imxvpu libimxdmabuffer"
 PV .= "+git${SRCPV}"
 
 SRCBRANCH ?= "master"
-SRCREV = "e81db32d10aee42c74ab50172487e04cbec6cbe0"
+SRCREV = "b6486118d47937cd717c4881158dda6e72cf2855"
 SRC_URI = "git://github.com/Freescale/libimxvpuapi.git;branch=${SRCBRANCH};protocol=https"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
* imx6-coda: Skip incomplete frames instead of just reporting them
* imx6-coda: Only flush bit buffer when framebuffers were registered This prevents misleading error-level log lines from occurring
* imx6-coda: Prefer semi planar modes over fully planar ones
* imx8m-hantro: Reset decoder write_offset to fill_level when moving read_offset
* Add imx_vpu_api_is_color_format_tiled() function
* update waf to 2.0.24
* Add closed_gop_interval field to ImxVpuApiEncOpenParams This allows for enforcing regularly occurring IDR boundaries when encoding to h.264
* imx8m-hantro: Fix supported decoder color formats and include tiled formats
* Fix and improve h.264 max level estimation for encoding
* imx6-coda: Use 2-row alignment in encoder
* imx6-coda: Fix JPEG encoding quantization parameter handling in encoder

Signed-off-by: Carlos Rafael Giani <crg7475@mailbox.org>