### PR TITLE
gstreamer1.0-plugins-bad: Force gcc compiler always

### DIFF
--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.20.0.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.20.0.imx.bb
@@ -210,4 +210,7 @@ EXTRA_OEMESON += " \
 
 COMPATIBLE_MACHINE = "(imx-nxp-bsp)"
 
+# it uses nested functions sadly, in ext/wayland/gstwaylandsink.c for GST_ELEMENT_REGISTER_DEFINE
+#
+TOOLCHAIN = "gcc"
 ########### End of i.MX overrides #########


### PR DESCRIPTION
This ensures that clang based distributions can compile this recipe, since it uses nested functions ( bad bad ) which is not supported by clang

Signed-off-by: Khem Raj <raj.khem@gmail.com>