### PR TITLE
optee-os: Use gcc compiler

### DIFF
--- a/recipes-security/optee-imx/optee-os_3.17.0.imx.bb
+++ b/recipes-security/optee-imx/optee-os_3.17.0.imx.bb
@@ -111,3 +111,5 @@ RDEPENDS:${PN}-dev += "${PN}-staticdev"
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 COMPATIBLE_MACHINE = "(imx-nxp-bsp)"
+
+TOOLCHAIN = "gcc"

--- a/recipes-security/optee-imx/optee-test_3.17.0.imx.bb
+++ b/recipes-security/optee-imx/optee-test_3.17.0.imx.bb
@@ -58,3 +58,5 @@ FILES:${PN} += "${nonarch_base_libdir}/optee_armtz/ ${libdir}/tee-supplicant/plu
 RDEPENDS:${PN} = "optee-os"
 
 COMPATIBLE_MACHINE = "(imx-nxp-bsp)"
+
+TOOLCHAIN = "gcc"


### PR DESCRIPTION
It does not compile with clang, all work to get it compiling with clang has gone into 3.18+ ( see meta-arm ) until imx version revs up to 3.18 lets use gcc always to build it

Signed-off-by: Khem Raj <raj.khem@gmail.com>