### PR TITLE
u-boot-fslc: Bump to 386ee4eecc8 revision

### DIFF
--- a/recipes-bsp/u-boot/u-boot-fslc-common_2023.01.inc
+++ b/recipes-bsp/u-boot/u-boot-fslc-common_2023.01.inc
@@ -10,7 +10,7 @@ DEPENDS += "flex-native bison-native"
 
 SRC_URI = "git://github.com/Freescale/u-boot-fslc.git;branch=${SRCBRANCH};protocol=https"
 
-SRCREV = "598f87fbdb6ce46b1959fda3ffbfaa41a64338e1"
+SRCREV = "386ee4eecc8ac5d41982daf20ef3a627a1e3e491"
 SRCBRANCH = "2023.01+fslc"
 
 PV = "2023.01+git${SRCPV}"


### PR DESCRIPTION
This merges following fixes:

386ee4eecc8 u-boot-initial-env: rework make target 5404dfcc4db arm: rmobile: rzg2_beacon: Enable alternative Ethernet PHY edd9c891d20 arm: dts: rz-g2-beacon-u-boot: Fix QSPI Regression 14165918766 pylibfdt: Fix disable version normalization 519e6641dbd cmd: pxe_utils: Limit fdtcontroladdr usage to non-fitImage bee3551e000 Revert "Revert "cmd: pxe_utils: Check fdtcontroladdr in label_boot"" ab644db9ba0 rockchip: Fix the broken Video out for rk3288 boards 4671435c54c i2c: uniphier-f: correct error recovery f8548ce0e09 imx7d-pico: Fix the name of the u-boot.dtsi file 1b697407aed powerpc/mpc85xx: socrates: Re-enable building u-boot-socrates.bin a2e0b041d66 arm: stm32mp: Fix board_get_usable_ram_top() again 60bba6e2052 efi_loader: populate console handles in system table 93cdb952382 efi_loader: adjust sorting of capsules 07355760b17 test: unit test for u16_strcasecmp()
7a9b366cd9b lib: add function u16_strcasecmp()
d7ddeb66a6c efi_loader: fix building aarch64 EFI binaries 673a92c5d2c efi_loader: defines for PE-COFF section flags fbc595b4124 doc: Fix eth_env_[gs]et_enetaddr() return value 566b7b2f518 doc: building documentation
532952f63cf cmd: avoid endless loop in sound play command

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>