### PR TITLE
linux-fslc-lts: update to v5.15.86

### DIFF
--- a/recipes-kernel/linux/linux-fslc-lts_5.15.bb
+++ b/recipes-kernel/linux/linux-fslc-lts_5.15.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.15.78"
+LINUX_VERSION = "5.15.86"
 
 KBRANCH = "5.15.x+fslc"
-SRCREV = "97c2965ca43009d0850d25e38488db06d8620aec"
+SRCREV = "a86fe5cb4fe96228e358108d0ed91d2c49bce097"
 
 COMPATIBLE_MACHINE = "(imx-generic-bsp)"


### PR DESCRIPTION
Kernel repository has been upgraded up to v5.15.78 from stable korg.

Following upstream commits are included in this version:

Relevant changes:
- a86fe5cb4fe9 Merge pull request #618 from angolini/5.15.x+fslc-bump
- 252c1d02bdc0 Merge tag 'v5.15.86' into 5.15.x+fslc
- a0f39cf81199 Merge tag 'v5.15.85' into 5.15.x+fslc
- 84f811fea1c5 Merge tag 'v5.15.84' into 5.15.x+fslc
- 0892f11a056f Merge tag 'v5.15.83' into 5.15.x+fslc
- ff29b3af0c5e Merge tag 'v5.15.82' into 5.15.x+fslc
- 65648211dafe Merge tag 'v5.15.81' into 5.15.x+fslc
- ef2e16b43d6d Merge tag 'v5.15.80' into 5.15.x+fslc
- 90ffbb727c51 Linux 5.15.86
- 3082f8705e82 pwm: tegra: Fix 32 bit build
- caa40d1f8524 mfd: qcom_rpm: Use devm_of_platform_populate() to simplify code
- 408dbaa06578 extcon: usbc-tusb320: Call the Type-C IRQ handler only if a port is registered
- 2471a44769b5 media: dvbdev: fix refcnt bug
- 579fb0a3320b media: dvbdev: fix build warning due to comments
- 1115e77c4fdd net: stmmac: fix errno when create_singlethread_workqueue() fails
- d3871af13aa0 scsi: qla2xxx: Fix crash when I/O abort times out
- 50f993da9450 btrfs: do not BUG_ON() on ENOMEM when dropping extent items for a range
- 1c65d50315db ovl: fix use inode directly in rcu-walk mode
- 88ec6d11052d fbdev: fbcon: release buffer when fbcon_do_set_font() failed
- ca8bcb348aa8 gcov: add support for checksum field
- f36d8c865150 floppy: Fix memory leak in do_floppy_init()
- 4193a6745b83 regulator: core: fix deadlock on regulator enable
- ce5d0ef1cf56 iio: adc128s052: add proper .data members in adc128_of_match table
- aec1058f2a92 iio: adc: ad_sigma_delta: do not use internal iio_dev lock
- dc6afd6070f3 iio: fix memory leak in iio_device_register_eventset()
- 38c257ee6a5a reiserfs: Add missing calls to reiserfs_security_free()
- 8a4236456a3a security: Restrict CONFIG_ZERO_CALL_USED_REGS to gcc or clang > 15.0.6
- 1cabce56626a 9p: set req refcount to zero to avoid uninitialized usage
- dd2157a98f92 loop: Fix the max_loop commandline argument treatment when it is set to 0
- fd03bd4c7b0a HID: mcp2221: don't connect hidraw
- 6c886be1ff76 HID: wacom: Ensure bootloader PID is usable in hidraw mode
- 4d640eb1129d xhci: Prevent infinite loop in transaction errors recovery for streams
- 936c5f96c896 usb: dwc3: core: defer probe on ulpi_read_id timeout
- e6bf6c40225a usb: dwc3: Fix race between dwc3_set_mode and __dwc3_set_mode
- 0e883f3bc897 arm64: dts: qcom: sm8250: fix USB-DP PHY registers
- ffb14aac2658 usb: xhci-mtk: fix leakage of shared hcd when fail to set wakeup irq
- fcacd970e011 usb: cdnsp: fix lack of ZLP for ep0
- bcac79df0838 ALSA: hda/hdmi: Add HP Device 0x8711 to force connect list
- 50c23a110779 ALSA: hda/realtek: Add quirk for Lenovo TianYi510Pro-14IOB
- 76574b34657e ALSA: usb-audio: add the quirk for KT0206 device
- 9e787dab98b6 ima: Simplify ima_lsm_copy_rule
- 2cd365029c23 pstore: Make sure CONFIG_PSTORE_PMSG selects CONFIG_RT_MUTEXES
- 2068d41a3de9 afs: Fix lost servers_outstanding count
- 0def8af038c1 perf debug: Set debug_peo_args and redirect_to_stderr variable to correct values in perf_quiet_option()
- 41cccae10e10 pstore: Switch pmsg_lock to an rt_mutex to avoid priority inversion
- 8877df8135b7 LoadPin: Ignore the "contents" argument of the LSM hooks
- 584202b0f1a1 drm/i915/display: Don't disable DDI/Transcoder when setting phy test pattern
- b253e075b13d ASoC: rt5670: Remove unbalanced pm_runtime_put()
- 59f797a913dc ASoC: rockchip: spdif: Add missing clk_disable_unprepare() in rk_spdif_runtime_resume()
- 132844d92fed ASoC: wm8994: Fix potential deadlock
- 82f7c814edda ASoC: mediatek: mt8183: fix refcount leak in mt8183_mt6358_ts3a227_max98357_dev_probe()
- e5d6bf3e5ad0 ASoC: rockchip: pdm: Add missing clk_disable_unprepare() in rockchip_pdm_runtime_resume()
- 85eb5c952b7f ASoC: audio-graph-card: fix refcount leak of cpu_ep in __graph_for_each_link()
- 9ff07316cad2 ASoC: mediatek: mt8173-rt5650-rt5514: fix refcount leak in mt8173_rt5650_rt5514_dev_probe()
- 7643909cf06d ASoC: Intel: Skylake: Fix driver hang during shutdown
- 33ff0f9f9cb5 ALSA: hda: add snd_hdac_stop_streams() helper
- 78649a624dfa ALSA/ASoC: hda: move/rename snd_hdac_ext_stop_streams to hdac_stream.c
- 98b0f50fec38 hwmon: (jc42) Fix missing unlock on error in jc42_write()
- 5e6923350830 KVM: selftests: Fix build regression by using accessor function
