### PR TITLE
linux-fslc-imx: update to v5.15.86

### DIFF
--- a/recipes-kernel/linux/linux-fslc-imx_5.15.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_5.15.bb
@@ -28,7 +28,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v5.15.60
+#    tag: v5.15.86
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
@@ -65,17 +65,17 @@ LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
 KBRANCH = "5.15-2.1.x-imx"
-SRCREV = "9dcc132b0caa04022a9adbb76510258684fbfef7"
+SRCREV = "7f663d3247e310835206336a4d1f49659094ef3f"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.15.77"
+LINUX_VERSION = "5.15.86"
 
 # Local version indicates the branch name in the NXP kernel tree where patches are collected from.
-LOCALVERSION = "-5.15.77-2.1.0"
+LOCALVERSION = "-5.15.86-2.1.0"
 
 DEFAULT_PREFERENCE = "1"
 


### PR DESCRIPTION
Relevant changes:
- 7f663d3247e3 Merge pull request #617 from dv1/duplicate-sysfs-path-fix
- 437f5776f40f Merge pull request #619 from angolini/5.15-2.1.x-imx-bump
- d508464f2ca1 Merge tag 'v5.15.86' into 5.15-2.1.x-imx
- 347b86f408db Merge tag 'v5.15.85' into 5.15-2.1.x-imx
- f0b0000c0575 Merge tag 'v5.15.84' into 5.15-2.1.x-imx
...