### PR TITLE
Fix misc recipes to build with imx  gpu drivers

### DIFF
--- a/recipes-graphics/imx-gpu-apitrace/imx-gpu-apitrace_10.0.0.bb
+++ b/recipes-graphics/imx-gpu-apitrace/imx-gpu-apitrace_10.0.0.bb
@@ -43,6 +43,13 @@ FILES:${PN} += " \
     ${libdir}/apitrace/scripts/* \
     ${libdir}/apitrace/wrappers/* \
 "
-
+EXTRA_OECMAKE += "\
+    -DENABLE_GUI=OFF \
+    -DENABLE_STATIC_LIBGCC=OFF \
+    -DENABLE_STATIC_LIBSTDCXX=OFF \
+    -DPython3_ROOT_DIR=/usr/bin/python3-native \
+"
 PACKAGE_ARCH = "${MACHINE_SOCARCH}"
 COMPATIBLE_MACHINE = "(imxgpu)"
+SECURITY_CFLAGS:toolchain-clang = ""
+

--- a/recipes-graphics/libva/libva_%.bbappend
+++ b/recipes-graphics/libva/libva_%.bbappend
@@ -1,0 +1,1 @@
+PACKAGECONFIG:remove:imxgpu = "glx"

--- a/recipes-graphics/piglit/piglit_%.bbappend
+++ b/recipes-graphics/piglit/piglit_%.bbappend
@@ -1,4 +1,4 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
-PACKAGECONFIG:remove:imxgpu = "glx"
+PACKAGECONFIG:remove:imxgpu = "x11 glx"
 PACKAGECONFIG:append:mx8-nxp-bsp = " opencl"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-omx_%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-omx_%.bbappend
@@ -1,0 +1,1 @@
+EXTRA_OEMESON:append:imx-nxp-bsp = " -Dtests=disabled -Dexamples=disabled"

--- a/recipes-sato/webkit/webkitgtk_%.bbappend
+++ b/recipes-sato/webkit/webkitgtk_%.bbappend
@@ -1,0 +1,4 @@
+# Fixes compile errors like
+# Source/WebCore/platform/graphics/egl/GLContextEGL.cpp:198:59: error: invalid 'static_cast' from type 'GLNativeWindowType' {aka 'long unsigned int'} to type 'EGLNativeWindowType' {aka 'wl_egl_window*'}
+PACKAGECONFIG:remove:imxgpu3d = "opengl opengl-or-es"
+PACKAGECONFIG:append:imxgpu3d = " gles2"


### PR DESCRIPTION
Fixes build errors like
2.38.3-r0/webkitgtk-2.38.3/Source/WebCore/platform/graphics/egl/GLContextEGL.cpp:198:59: error: invalid 'static_cast' from type 'GLNativeWindowType' {aka 'long unsigned int'} to type 'EGLNativeWindowType' {aka 'wl_egl_window*'}
  198 |         surface = eglCreateWindowSurface(display, config, static_cast<EGLNativeWindowType>(window), nullptr);
      |                                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Signed-off-by: Khem Raj <raj.khem@gmail.com>