### PR TITLE
u-boot-fslc: Bump to 3b524eeb247 revision

### DIFF
--- a/recipes-bsp/u-boot/u-boot-fslc-common_2023.01.inc
+++ b/recipes-bsp/u-boot/u-boot-fslc-common_2023.01.inc
@@ -10,7 +10,7 @@ DEPENDS += "flex-native bison-native"
 
 SRC_URI = "git://github.com/Freescale/u-boot-fslc.git;branch=${SRCBRANCH};protocol=https"
 
-SRCREV = "32e6373fad552569a37843cc9cfa4a6358b31680"
+SRCREV = "3b524eeb247425edbfe5bb10c3fd289b0f34855a"
 SRCBRANCH = "2023.01+fslc"
 
 PV = "2023.01+git${SRCPV}"


### PR DESCRIPTION
This merges following fixes:
- 452c07a6410 arm: dts: imx8mn-u-boot: use versioned ddr4 firmware
- ee92ca28498 Revert "config: tools only: add VIDEO to build bmp_logo"

Signed-off-by: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>