### PR TITLE
Add i.MX 8ULP Machines

### DIFF
--- a/classes/use-imx-security-controller-firmware.bbclass
+++ b/classes/use-imx-security-controller-firmware.bbclass
@@ -23,6 +23,7 @@ SECO_FIRMWARE_NAME:mx8qxp-nxp-bsp = \
                                                            'mx8qxc0-ahab-container.img', d)}"
 SECO_FIRMWARE_NAME:mx8dx-nxp-bsp  = "mx8qxc0-ahab-container.img"
 SECO_FIRMWARE_NAME:mx8dxl-nxp-bsp = "mx8dxla1-ahab-container.img"
+SECO_FIRMWARE_NAME:mx8ulp-nxp-bsp = "mx8ulpa1-ahab-container.img"
 
 python () {
     if "mx8m-generic-bsp" in d.getVar('MACHINEOVERRIDES').split(":"):

--- a/conf/machine/imx8ulp-lpddr4-evk.conf
+++ b/conf/machine/imx8ulp-lpddr4-evk.conf
@@ -1,0 +1,27 @@
+#@TYPE: Machine
+#@NAME: i.MX 8ULP EVK
+#@SOC: i.MX8ULP
+#@DESCRIPTION: Machine configuration for NXP i.MX 8ULP Evaluation Kit with LPDDR4
+#@MAINTAINER: Jun Zhu <junzhu@nxp.com>
+
+require include/imx8ulp-evk.inc
+
+KERNEL_DEVICETREE_BASENAME = "imx8ulp-evk"
+
+KERNEL_DEVICETREE += " \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-epdc.dtb \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-flexio-i2c.dtb \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-i3c.dtb \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-lpa.dtb \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-lpspi-slave.dtb \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-nd.dtb \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-rk055hdmipi4m.dtb \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-rk055hdmipi4mv2.dtb \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-sof-btsco.dtb \
+"
+
+UBOOT_CONFIG_BASENAME = "imx8ulp_evk"
+
+MACHINE_FEATURES += "soc-reva1"
+UPOWER_FIRMWARE_NAME = "upower_a1.bin"
+IMX_DEFAULT_BSP = "nxp"

--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -163,6 +163,7 @@ DEFAULTTUNE:vf-generic-bsp     ?= "cortexa5thf-neon"
 DEFAULTTUNE:mx8m-generic-bsp   ?= "cortexa53-crypto"
 DEFAULTTUNE:mx8qm-generic-bsp  ?= "cortexa72-cortexa53-crypto"
 DEFAULTTUNE:mx8x-generic-bsp   ?= "cortexa35-crypto"
+DEFAULTTUNE:mx8ulp-generic-bsp ?= "cortexa35-crypto"
 
 INHERIT += "machine-overrides-extender"
 
@@ -197,6 +198,8 @@ MACHINEOVERRIDES_EXTENDER:mx8mq:use-nxp-bsp  = "imx-generic-bsp:imx-nxp-bsp:imxd
 MACHINEOVERRIDES_EXTENDER:mx8qxp:use-nxp-bsp = "imx-generic-bsp:imx-nxp-bsp:imxdrm:imxdpu:imxgpu:imxgpu2d:imxgpu3d:imxvulkan:mx8-generic-bsp:mx8-nxp-bsp:mx8x-generic-bsp:mx8x-nxp-bsp:mx8qxp-generic-bsp:mx8qxp-nxp-bsp"
 MACHINEOVERRIDES_EXTENDER:mx8dx:use-nxp-bsp  = "imx-generic-bsp:imx-nxp-bsp:imxdrm:imxdpu:imxgpu:imxgpu2d:imxgpu3d:imxvulkan:mx8-generic-bsp:mx8-nxp-bsp:mx8x-generic-bsp:mx8x-nxp-bsp:mx8dx-generic-bsp:mx8dx-nxp-bsp"
 MACHINEOVERRIDES_EXTENDER:mx8dxl:use-nxp-bsp = "imx-generic-bsp:imx-nxp-bsp:imxfbdev:mx8dxl-generic-bsp:mx8-generic-bsp:mx8-nxp-bsp:mx8x-generic-bsp:mx8x-nxp-bsp:mx8dxl-nxp-bsp"
+
+MACHINEOVERRIDES_EXTENDER:mx8ulp:use-nxp-bsp = "imx-generic-bsp:imx-nxp-bsp:mx8-generic-bsp:mx8-nxp-bsp:mx8ulp-generic-bsp:mx8ulp-nxp-bsp"
 
 #######
 ### Mainline BSP specific overrides
@@ -238,6 +241,8 @@ MACHINEOVERRIDES_EXTENDER:mx8qxp:use-mainline-bsp = "imx-generic-bsp:imx-mainlin
 MACHINEOVERRIDES_EXTENDER:mx8dx:use-mainline-bsp  = "imx-generic-bsp:imx-mainline-bsp:mx8-generic-bsp:mx8-mainline-bsp:mx8x-generic-bsp:mx8x-mainline-bsp:mx8dx-generic-bsp:mx8dx-mainline-bsp"
 MACHINEOVERRIDES_EXTENDER:mx8dxl:use-mainline-bsp = "imx-generic-bsp:imx-mainline-bsp:mx8-generic-bsp:mx8-mainline-bsp:mx8x-generic-bsp:mx8x-mainline-bsp:mx8dxl-generic-bsp:mx8dxl-mainline-bsp"
 
+MACHINEOVERRIDES_EXTENDER:mx8ulp:use-mainline-bsp = "imx-generic-bsp:imx-mainline-bsp:mx8-generic-bsp:mx8-mainline-bsp:mx8ulp-generic-bsp:mx8ulp-mainline-bsp"
+
 MACHINEOVERRIDES_EXTENDER_FILTER_OUT = " \
     mx6 \
     mx6q \
@@ -265,6 +270,7 @@ MACHINEOVERRIDES_EXTENDER_FILTER_OUT = " \
     mx8qxp \
     mx8dx \
     mx8dxl \
+    mx8ulp \
 "
 
 MACHINEOVERRIDES_FILTERED_OUT_QA_ERROR = "%s overrides cannot be used and need conversion to use the new BSP-specific overrides. Check 'meta-freescale/scripts/convert-bsp-specific-overrides'."
@@ -290,6 +296,7 @@ MACHINE_SOCARCH_SUFFIX:mx8mq-nxp-bsp  = "-mx8m"
 MACHINE_SOCARCH_SUFFIX:mx8qxp-nxp-bsp = "-mx8"
 MACHINE_SOCARCH_SUFFIX:mx8dx-nxp-bsp  = "-mx8"
 MACHINE_SOCARCH_SUFFIX:mx8dxl-nxp-bsp = "-mx8xl"
+MACHINE_SOCARCH_SUFFIX:mx8ulp-nxp-bsp = "-mx8ulp"
 
 # For Mainline we use a single SoC suffix as we don't have different build options
 MACHINE_SOCARCH_SUFFIX:imx-mainline-bsp = "-imx"
@@ -364,6 +371,7 @@ IMX_EXTRA_FIRMWARE                  ?= ""
 IMX_EXTRA_FIRMWARE:mx8-generic-bsp   = "firmware-imx-8 imx-sc-firmware imx-seco"
 IMX_EXTRA_FIRMWARE:mx8m-generic-bsp  = "firmware-imx-8m"
 IMX_EXTRA_FIRMWARE:mx8x-generic-bsp  = "imx-sc-firmware imx-seco"
+IMX_EXTRA_FIRMWARE:mx8ulp-generic-bsp = "firmware-upower firmware-sentinel"
 
 # Firmware
 MACHINE_FIRMWARE ?= ""
@@ -449,6 +457,7 @@ MACHINE_GSTREAMER_1_0_PLUGIN:mx8mq-nxp-bsp  ?= "gstreamer1.0-plugins-imx-meta"
 MACHINE_GSTREAMER_1_0_PLUGIN:mx8qm-nxp-bsp  ?= "imx-gst1.0-plugin"
 MACHINE_GSTREAMER_1_0_PLUGIN:mx8qxp-nxp-bsp ?= "imx-gst1.0-plugin"
 MACHINE_GSTREAMER_1_0_PLUGIN:mx8dx-nxp-bsp  ?= "imx-gst1.0-plugin"
+MACHINE_GSTREAMER_1_0_PLUGIN:mx8ulp-nxp-bsp ?= "imx-gst1.0-plugin"
 
 PREFERRED_VERSION_gstreamer1.0:mx8-nxp-bsp              ??= "1.20.3.imx"
 PREFERRED_VERSION_gstreamer1.0-plugins-base:mx8-nxp-bsp ??= "1.20.3.imx"

--- a/conf/machine/include/imx8ulp-evk.inc
+++ b/conf/machine/include/imx8ulp-evk.inc
@@ -1,0 +1,44 @@
+MACHINEOVERRIDES =. "mx8:mx8ulp:"
+
+require conf/machine/include/imx-base.inc
+require conf/machine/include/arm/armv8a/tune-cortexa35.inc
+
+MACHINE_FEATURES += "pci wifi bluetooth optee jailhouse"
+
+KERNEL_DEVICETREE = " \
+    freescale/${KERNEL_DEVICETREE_BASENAME}.dtb \
+"
+
+IMX_DEFAULT_BOOTLOADER:use-nxp-bsp = "u-boot-imx"
+IMX_DEFAULT_BOOTLOADER:use-mainline-bsp = "u-boot-fslc"
+
+LOADADDR = ""
+UBOOT_SUFFIX = "bin"
+UBOOT_MAKE_TARGET = ""
+
+SPL_BINARY = "spl/u-boot-spl.bin"
+
+UBOOT_CONFIG ??= "sd"
+UBOOT_CONFIG[sd]   = "${UBOOT_CONFIG_BASENAME}_defconfig,sdcard"
+UBOOT_CONFIG[fspi] = "${UBOOT_CONFIG_BASENAME}_defconfig"
+UBOOT_CONFIG[nd]   = "${UBOOT_CONFIG_BASENAME}_nd_defconfig"
+
+# Set ATF platform name
+ATF_PLATFORM = "imx8ulp"
+
+IMXBOOT_TARGETS_SD   = "flash_singleboot flash_dualboot"
+IMXBOOT_TARGETS_FSPI = "flash_dualboot_flexspi"
+IMXBOOT_TARGETS_ND   = ""
+
+IMXBOOT_TARGETS = "${@bb.utils.contains('UBOOT_CONFIG',   'sd', '${IMXBOOT_TARGETS_SD}', \
+                      bb.utils.contains('UBOOT_CONFIG', 'fspi', '${IMXBOOT_TARGETS_FSPI}', \
+                                                                '${IMXBOOT_TARGETS_ND}', d), d)}"
+
+IMX_BOOT_SOC_TARGET = "iMX8ULP"
+IMX_BOOT_SEEK = "32"
+
+# We have to disable SERIAL_CONSOLE due to auto-serial-console
+SERIAL_CONSOLES = "115200;ttyLP1"
+
+# Add additional firmware
+MACHINE_FIRMWARE:append = " firmware-imx-epdc"

--- a/recipes-bsp/firmware-sentinel/firmware-sentinel_0.8.bb
+++ b/recipes-bsp/firmware-sentinel/firmware-sentinel_0.8.bb
@@ -1,0 +1,23 @@
+# Copyright 2021-2022 NXP
+SUMMARY = "NXP i.MX Sentinel firmware"
+DESCRIPTION = "Firmware for i.MX Sentinel Security Controller"
+SECTION = "base"
+LICENSE = "Proprietary"
+LIC_FILES_CHKSUM = "file://COPYING;md5=5a0bf11f745e68024f37b4724a5364fe"
+
+inherit fsl-eula-unpack use-imx-security-controller-firmware deploy nopackages
+
+SRC_URI = "${FSL_MIRROR}/${BP}.bin;fsl-eula=true"
+SRC_URI[md5sum] = "be47a5e59c1192ee36246af97d5d1532"
+SRC_URI[sha256sum] = "1003d4c6773c153ea341911a74e25c249423644f70f3d8f8d085599e00770b3f"
+
+do_compile[noexec] = "1"
+do_install[noexec] = "1"
+
+do_deploy () {
+    # Deploy the related firmware to be package by imx-boot
+    install -m 0644 ${S}/${SECO_FIRMWARE_NAME}  ${DEPLOYDIR}
+}
+addtask deploy after do_install before do_build
+
+COMPATIBLE_MACHINE = "(mx8ulp-nxp-bsp)"

--- a/recipes-bsp/firmware-upower/firmware-upower_1.1.0.bb
+++ b/recipes-bsp/firmware-upower/firmware-upower_1.1.0.bb
@@ -1,0 +1,31 @@
+# Copyright 2021-2022 NXP
+DESCRIPTION = "NXP i.MX uPower firmware"
+LICENSE = "Proprietary"
+SECTION = "BSP"
+LIC_FILES_CHKSUM = "file://COPYING;md5=5a0bf11f745e68024f37b4724a5364fe"
+
+SRC_URI = "${FSL_MIRROR}/${PN}-${PV}.bin;fsl-eula=true"
+
+S = "${WORKDIR}/${PN}-${PV}"
+
+inherit fsl-eula-unpack pkgconfig deploy
+
+SRC_URI[md5sum] = "d2cbe8d2f8fa170e5d48c599c4caac5e"
+SRC_URI[sha256sum] = "c02595917744769abe810107a08506e4055b8077b5fc4ed17c353b833756c8b0"
+
+do_configure[noexec] = "1"
+
+do_compile[noexec] = "1"
+
+do_install[noexec] = "1"
+
+BOOT_TOOLS = "imx-boot-tools"
+
+do_deploy () {
+    # Deploy the related firmware to be package by imx-boot
+    install -d ${DEPLOYDIR}/${BOOT_TOOLS}
+    install -m 0644 ${S}/${UPOWER_FIRMWARE_NAME}  ${DEPLOYDIR}/${BOOT_TOOLS}/upower.bin
+}
+addtask deploy after do_install before do_build
+
+COMPATIBLE_MACHINE = "(mx8ulp-nxp-bsp)"


### PR DESCRIPTION
I have only built the source code. I don't have the board so I cannot test it. In case anyone is available to test, please, let me know the result.

It's important to note that the `IMXBOOT_TARGETS` tries to use dualboot, but the `m33` binaries are not included:

```
IMXBOOT_TARGETS_SD   = "flash_singleboot flash_dualboot"
IMXBOOT_TARGETS_FSPI = "flash_dualboot_flexspi"
IMXBOOT_TARGETS_ND   = ""
```

