### PR TITLE
u-boot-fslc: add gnutls-native dependency

### DIFF
--- a/recipes-bsp/u-boot/u-boot-fslc_2023.01.bb
+++ b/recipes-bsp/u-boot/u-boot-fslc_2023.01.bb
@@ -8,7 +8,7 @@ version, or because it is not applicable for upstreaming."
 
 inherit ${@oe.utils.ifelse(d.getVar('UBOOT_PROVIDES_BOOT_CONTAINER') == '1', 'imx-boot-container', '')}
 
-DEPENDS += "bc-native dtc-native python3-setuptools-native"
+DEPENDS += "bc-native dtc-native python3-setuptools-native gnutls-native"
 
 PROVIDES += "u-boot"
 


### PR DESCRIPTION
This fix comes from https://github.com/Freescale/meta-freescale/issues/1399

Since U-Boot 2022.04 the host tool mkeficapsule requires gnutls. Some boards, i.e. imx8mp_rsb3720a1, imx8mm-cl-iot-gate, etc. have EFI enabled by default and fail to find <gnutls/gnutls.h> when building.
Add gnutls-native to the dependency to solve building issues.

Signed-off-by: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>