### PR TITLE
linux-fslc-lts: fix linux version

### DIFF
--- a/recipes-kernel/linux/linux-fslc-lts_5.15.bb
+++ b/recipes-kernel/linux/linux-fslc-lts_5.15.bb
@@ -19,7 +19,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.15.86"
+LINUX_VERSION = "5.15.91"
 
 KBRANCH = "5.15.x+fslc"
 SRCREV = "4d20f1dcda24d6b2ee234e91bf2ba00083058586"


### PR DESCRIPTION
Missed bumping LINUX_VERSION. Fix it.

Fixes: 9f2c6a40 ("linux-fslc-lts: update to v5.15.91")
Signed-off-by: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>