### PR TITLE
[Backport kirkstone] linux-fslc-lts: update to v5.15.91

### DIFF
--- a/recipes-kernel/linux/linux-fslc-lts_5.15.bb
+++ b/recipes-kernel/linux/linux-fslc-lts_5.15.bb
@@ -19,9 +19,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.15.78"
+LINUX_VERSION = "5.15.91"
 
 KBRANCH = "5.15.x+fslc"
-SRCREV = "97c2965ca43009d0850d25e38488db06d8620aec"
+SRCREV = "4d20f1dcda24d6b2ee234e91bf2ba00083058586"
 
 COMPATIBLE_MACHINE = "(imx-generic-bsp)"


### PR DESCRIPTION
Kernel repository has been upgraded up to v5.15.91 from stable korg.

Relevant changes:
- 4d20f1dcda24 Merge pull request #622 from MrCry0/5.15.x+fslc
- dd6ac8bf3555 Merge tag 'v5.15.91' into 5.15.x+fslc
- 9cf4111cdf94 Linux 5.15.91
- 14cc13e433e1 perf/x86/amd: fix potential integer overflow on shift of a int
- 033636b32258 netfilter: conntrack: unify established states for SCTP paths
- 0b08201158f1 x86/i8259: Mark legacy PIC interrupts with IRQ_LEVEL
- b57740036792 block: fix and cleanup bio_check_ro
- 1d152437e46f kbuild: Allow kernel installation packaging to override pkg-config
- a1964688582d cpufreq: governor: Use kobject release() method to free dbs_data
- 7c513ced0dec cpufreq: Move to_gov_attr_set() to cpufreq.h
- cf7a08622d2b Revert "Input: synaptics - switch touchpad on HP Laptop 15-da3001TU to RMI mode"
- 53c5d61198c1 tools: gpio: fix -c option of gpio-event-mon
- a7d1a303ff0f treewide: fix up files incorrectly marked executable
- 046fe53907c5 net: mdio-mux-meson-g12a: force internal PHY off on mux switch
- 86bdccde7842 net/tg3: resolve deadlock in tg3_reset_task() during EEH
- 4364bf79d829 thermal: intel: int340x: Add locking to int340x_thermal_get_trip_type()
- e69c3a0d9d3d net: mctp: mark socks as dead on unhash, prevent re-add
- 954cc215cd7a net: ravb: Fix possible hang if RIS2_QFF1 happen
- 0f7218bf0a00 net: ravb: Fix lack of register setting after system resumed for Gen3
- 3db4ca2938eb ravb: Rename "no_ptp_cfg_active" and "ptp_cfg_active" variables
- 621f296f11cf gpio: mxc: Unlock on error path in mxc_flip_edge()
- 071a8392869f nvme: fix passthrough csi check
- 614471b7f7cd riscv/kprobe: Fix instruction simulation of JALR
- 3391bd42351b sctp: fail if no bound addresses can be used for a given scope
- b0784860e145 net/sched: sch_taprio: do not schedule in taprio_reset()
- d2d3ab1b1de3 netrom: Fix use-after-free of a listening socket.
- 9df5ab02c65e netfilter: conntrack: fix vtag checks for ABORT/SHUTDOWN_COMPLETE
- ca3cf947760d ipv4: prevent potential spectre v1 gadget in fib_metrics_match()
- d50e7348b44f ipv4: prevent potential spectre v1 gadget in ip_metrics_convert()
- ead06e3449f2 netlink: annotate data races around sk_state
- c4eb423c6b9b netlink: annotate data races around dst_portid and dst_group
- fac9b69a9370 netlink: annotate data races around nlk->portid
- 8a13595600f7 netfilter: nft_set_rbtree: skip elements in transaction from garbage collection
- 2bf1435fa19d netfilter: nft_set_rbtree: Switch to node list walk for overlap detection
- e481654426b6 drm/i915/selftest: fix intel_selftest_modify_policy argument types
- 66689a72ba73 net: fix UaF in netns ops registration error path
- 41b74e95f297 netlink: prevent potential spectre v1 gadgets
- 2f29d780bd69 i2c: designware: use casting of u64 in clock multiplication to avoid overflow
- b03f7ed9af6e scsi: ufs: core: Fix devfreq deadlocks
- 858d7e9218e1 net: mana: Fix IRQ name - add PCI and queue number
- bff5243bd326 EDAC/qcom: Do not pass llcc_driv_data as edac_device_ctl_info's pvt_info
- 5eedf4568d34 EDAC/device: Respect any driver-supplied workqueue polling value
- 4b7dfd0a6811 ARM: 9280/1: mm: fix warning on phys_addr_t to void pointer assignment
- 7807871f28f8 ipv6: fix reachability confirmation with proxy_ndp
- f9a22f6fa187 thermal: intel: int340x: Protect trip temperature from concurrent updates
- 036093c08d83 KVM: arm64: GICv4.1: Fix race with doorbell on VPE activation/deactivation
- c56683c0623e KVM: x86/vmx: Do not skip segment attributes if unusable bit is set
- e91308e63710 ovl: fail on invalid uid/gid mapping at copy up
- 33a9657d67a4 ksmbd: limit pdu length size according to connection status
- 8d83a758ee21 ksmbd: downgrade ndr version error message to debug
- 87a7f38a9058 ksmbd: do not sign response to session request for guest login
- 4210c3555db4 ksmbd: add max connections parameter
- cc6742b160fa ksmbd: add smbd max io size parameter
- 3c8a5648a591 i2c: mv64xxx: Add atomic_xfer method to driver
- e619ab4fb3e9 i2c: mv64xxx: Remove shutdown method from driver
- 4b83bc6f87ee cifs: Fix oops due to uncleared server->smbd_conn in reconnect
- 89042d3d8542 ftrace/scripts: Update the instructions for ftrace-bisect.sh
- 592ba7116fa6 trace_events_hist: add check for return value of 'create_hist_field'
- b0af180514ed tracing: Make sure trace_printk() can output as soon as it can be used
- 91135d723388 module: Don't wait for GOING modules
- 85ee9919add9 KVM: SVM: fix tsc scaling cache logic
- f0227eca972c scsi: hpsa: Fix allocation size for scsi_host_alloc()
- e5af9a458a13 drm/amdgpu: complete gfxoff allow signal during suspend without delay
- 62b9e9f92109 Bluetooth: hci_sync: cancel cmd_timer if hci_open failed
- 21998acd31fb exit: Use READ_ONCE() for all oops/warn limit reads
- e82b1598eb2c docs: Fix path paste-o for /sys/kernel/warn_count
- 1c51698ad6f6 panic: Expose "warn_count" to sysfs
- 0691ddae56cd panic: Introduce warn_limit
- 7b98914a6c26 panic: Consolidate open-coded panic_on_warn checks
- fc636b136272 exit: Allow oops_limit to be disabled
- 339f8a8e5211 exit: Expose "oops_count" to sysfs
- f80fb0001f11 exit: Put an upper limit on how often we can oops
- 2857ce7f475f panic: Separate sysctl logic from CONFIG_SMP
- e156d4dcb036 ia64: make IA64_MCA_RECOVERY bool instead of tristate
- 9024f772248e csky: Fix function name in csky_alignment() and die()
- 2ea497d153da h8300: Fix build errors from do_exit() to make_task_dead() transition
- a452ca0228bb hexagon: Fix function name in die()
- 3b39f47474a2 objtool: Add a missing comma to avoid string concatenation
- 39a26d872178 exit: Add and use make_task_dead.
- b5c1acaa43b6 kasan: no need to unset panic_on_warn in end_report()
- b5c967dc6822 ubsan: no need to unset panic_on_warn in ubsan_epilogue()
- e4cd2100324e panic: unset panic_on_warn inside panic()
- 191f1f1f6a42 kernel/panic: move panic sysctls to its own file
- 654f6e851271 sysctl: add a new register_sysctl_init() interface
- 3aa991cde94b fs: reiserfs: remove useless new_opts in reiserfs_remount
- d830531f8fff x86: ACPI: cstate: Optimize C3 entry on AMD CPUs
- 1f5476223100 drm/i915: Remove unused variable
- 6e1012709320 Revert "selftests/bpf: check null propagation only neither reg is PTR_TO_BTF_ID"
- 619ee31b9641 drm/i915: Allow switching away via vga-switcheroo if uninitialized
- ea435ba9eb85 firmware: coreboot: Check size of table entry and use flex-array
- a4e70bcf2e87 lockref: stop doing cpu_relax in the cmpxchg loop
- b0ee61f5eeab platform/x86: asus-nb-wmi: Add alternate mapping for KEY_SCREENLOCK
- e8d2f7f56691 platform/x86: touchscreen_dmi: Add info for the CSL Panther Tab HD
- 2e0a8bacbe1d r8152: add vendor/device ID pair for Microsoft Devkit
- d4b717e34dac scsi: hisi_sas: Set a port invalid only if there are no devices attached when refreshing port id
- e15750aa28a6 KVM: s390: interrupt: use READ_ONCE() before cmpxchg()
- 9300c65207f3 spi: spidev: remove debug messages that access spidev->spi without locking
- 48ff5d381298 ASoC: fsl-asoc-card: Fix naming of AC'97 CODEC widgets
- 5001ffb31d63 ASoC: fsl_ssi: Rename AC'97 streams to avoid collisions with AC'97 CODEC
- b76120e20683 cpufreq: armada-37xx: stop using 0 as NULL pointer
- eda26fa8560d perf/x86/intel/uncore: Add Emerald Rapids
- 544f9d4e9d8a perf/x86/msr: Add Emerald Rapids
- b1eb964d785f s390: expicitly align _edata and _end symbols on page boundary
- fb45ec279b00 s390/debug: add _ASM_S390_ prefix to header guard
- cd488abed97e drm: Add orientation quirk for Lenovo ideapad D330-10IGL
- ff7ab370b855 net: usb: cdc_ether: add support for Thales Cinterion PLS62-W modem
- d6935084e444 ASoC: fsl_micfil: Correct the number of steps on SX controls
- ac07316b2d57 cpufreq: Add SM6375 to cpufreq-dt-platdev blocklist
- f0e6dcae1491 kcsan: test: don't put the expect array on the stack
- c51c0b37543a cpufreq: Add Tegra234 to cpufreq-dt-platdev blocklist
- 28e4e8ca9e95 scsi: iscsi: Fix multiple iSCSI session unbind events sent to userspace
- 14b1df2004fe tcp: fix rate_app_limited to default to 1
- 120b8e527e07 net: stmmac: enable all safety features by default
- a7d736cc3c6c thermal: core: call put_device() only after device_register() fails
- ed08f958e481 thermal/core: fix error code in __thermal_cooling_device_register()
- 108a6f91e276 thermal: Validate new state in cur_state_store()
- bd0ea77edf46 thermal/core: Rename 'trips' to 'num_trips'
- 521c6ebd4f6e thermal/core: Remove duplicate information when an error occurs
- 6504afa2632a net: dsa: microchip: ksz9477: port map correction in ALU table entry register
- 18346db1854a selftests/net: toeplitz: fix race on tpacket_v3 block close
- caa28c7c83e3 driver core: Fix test_async_probe_init saves device in wrong array
- 89c62cee5d4d w1: fix WARNING after calling w1_process()
- 3d0eafe413a7 w1: fix deadloop in __w1_remove_master_device()
- 7701a4bd45c1 device property: fix of node refcount leak in fwnode_graph_get_next_endpoint()
- ed0d8f731e0b ptdma: pt_core_execute_cmd() should use spinlock
- 29e9c67bf327 octeontx2-pf: Fix the use of GFP_KERNEL in atomic context on rt
- 03bff5819ad3 tcp: avoid the lookup process failing to get sk in ehash table
- 5bd69d2ea897 nvme-pci: fix timeout request state check
- 39178dfe8677 drm/amd/display: fix issues with driver unload
- 9a5a537e1444 phy: phy-can-transceiver: Skip warning if no "max-bitrate"
- 4095065b59bc dmaengine: xilinx_dma: call of_node_put() when breaking out of for_each_child_of_node()
- 5bd3c1c1bce1 cifs: fix potential deadlock in cache_refresh_path()
- 1a2a47b85cab HID: betop: check shape of output reports
- b2a730974373 l2tp: prevent lockdep issue in l2tp_tunnel_register()
- edf0e509cedd virtio-net: correctly enable callback during start_xmit
- d3401c7624ec net: macb: fix PTP TX timestamp failure due to packet padding
- 71c601965532 dmaengine: Fix double increment of client_count in dma_chan_get()
- 1e7919f0b156 drm/panfrost: fix GENERIC_ATOMIC64 dependency
- a1b3e50e2140 net: mlx5: eliminate anonymous module_init & module_exit
- 09e3fb6f53bc net/mlx5: E-switch, Fix setting of reserved fields on MODIFY_SCHEDULING_ELEMENT
- 01a6e108101f net: ipa: disable ipa interrupt during suspend
- 98aec50ff7f6 Bluetooth: Fix possible deadlock in rfcomm_sk_state_change
- 0e59f60b74cd usb: gadget: f_fs: Ensure ep0req is dequeued before free_request
- ae8e136bcaae usb: gadget: f_fs: Prevent race during ffs_ep0_queue_wait
- f25cd2b731d7 HID: revert CHERRY_MOUSE_000C quirk
- 39483511fd59 pinctrl: rockchip: fix mux route data for rk3568
- 1dae88a0b4df net: stmmac: fix invalid call to mdiobus_get_phy()
- 6716838bf801 HID: check empty report_list in bigben_probe()
- 2b4956825436 HID: check empty report_list in hid_validate_values()
- ad67de330d83 net: mdio: validate parameter addr in mdiobus_get_phy()
- 486912937933 net: usb: sr9700: Handle negative len
- 2827c4eb429d octeontx2-pf: Avoid use of GFP_KERNEL in atomic context
- 77e8ed776cdb l2tp: close all race conditions in l2tp_tunnel_register()
- af22d2c0b47f l2tp: convert l2tp_tunnel_list to idr
- 22c7d45ca3d7 l2tp: Don't sleep and disable BH under writer-side sk_callback_lock
- 87d9205d9a57 l2tp: Serialize access to sk_user_data with sk_callback_lock
- c53acbf2facf net/sched: sch_taprio: fix possible use-after-free
- 40516d042b65 net: stmmac: Fix queue statistics reading
- 620aa67f8059 pinctrl: rockchip: fix reading pull type on rk3568
- ddca674af1ba pinctrl/rockchip: add error handling for pull/drive register getters
- 259ab8fb8c7e pinctrl/rockchip: Use temporary variable for struct device
- 8cbf932c5c40 wifi: rndis_wlan: Prevent buffer overflow in rndis_query_oid
- f792d26e5ce7 gpio: mxc: Always set GPIOs used as interrupt source to INPUT mode
- 8335f877efe7 gpio: mxc: Protect GPIO irqchip RMW with bgpio spinlock
- fb4fb3d267c9 gpio: use raw spinlock for gpio chip shadowed data
- 52e3eebfe670 sch_htb: Avoid grafting on htb_destroy_class_offload when destroying htb
- 8232e5a84d25 net: enetc: avoid deadlock in enetc_tx_onestep_tstamp()
- 95347e41cac6 net: wan: Add checks for NULL for utdm in undo_uhdlc_init and unmap_si_regs
- 7f129927feaf net: nfc: Fix use-after-free in local_cleanup()
- 397aaac88469 phy: rockchip-inno-usb2: Fix missing clk_disable_unprepare() in rockchip_usb2phy_power_on()
- 01bdcc73dbe7 bpf: Fix pointer-leak due to insufficient speculative store bypass mitigation
- 261e2f12b653 amd-xgbe: Delay AN timeout during KR training
- a8cf4af5441f amd-xgbe: TX Flow Ctrl Registers are h/w ver dependent
- 8e897cb67421 ARM: dts: at91: sam9x60: fix the ddr clock for sam9x60
- 0a27dcd53430 NFSD: fix use-after-free in nfsd4_ssc_setup_dul()
- 24af570c99b4 phy: ti: fix Kconfig warning and operator precedence
- 631fc3668539 arm64: dts: qcom: msm8992-libra: Fix the memory map
- dda20ffec8fb arm64: dts: qcom: msm8992-libra: Add CPU regulators
- 37ba5e929349 arm64: dts: qcom: msm8992: Don't use sfpb mutex
- bab87524f6d4 PM: AVS: qcom-cpr: Fix an error handling path in cpr_probe()
- b7a479c76481 affs: initialize fsdata in affs_truncate()
- 623d1116898e IB/hfi1: Remove user expected buffer invalidate race
- 47d5fc0dcd57 IB/hfi1: Immediately remove invalid memory from hardware
- 85caef2cfd1d IB/hfi1: Fix expected receive setup error exit issues
- cb193984d424 IB/hfi1: Reserve user expected TIDs
- 891ddfae39f1 IB/hfi1: Reject a zero-length user expected buffer
- 362c9489720b RDMA/core: Fix ib block iterator counter overflow
- e26c571c3b0d tomoyo: fix broken dependency on *.conf.default
- 7dfe83ecc341 firmware: arm_scmi: Harden shared memory access in fetch_notification
- a653dbb70cce firmware: arm_scmi: Harden shared memory access in fetch_response
- caffa7fed139 EDAC/highbank: Fix memory leak in highbank_mc_probe()
- 95de286200b2 reset: uniphier-glue: Fix possible null-ptr-deref
- 4773a8cf9a53 reset: uniphier-glue: Use reset_control_bulk API
- 7b33accc8ff9 soc: imx8m: Fix incorrect check for of_clk_get_by_name()
- f07427f8d9c6 arm64: dts: imx8mm-venice-gw7901: fix USB2 controller OC polarity
- c4cb73febe35 HID: intel_ish-hid: Add check for ishtp_dma_tx_map
- 25f97c9883bf ARM: imx: add missing of_node_put()
- 3e9d79ded9d6 arm64: dts: imx8mm-beacon: Fix ecspi2 pinmux
- 538135076191 ARM: dts: imx6qdl-gw560x: Remove incorrect 'uart-has-rtscts'
- 0e4bba1656a4 ARM: dts: imx7d-pico: Use 'clock-frequency'
- 108cf4c6d510 ARM: dts: imx6ul-pico-dwarf: Use 'clock-frequency'
- 207c9e64edba arm64: dts: imx8mp-phycore-som: Remove invalid PMIC property
- 7ce380fe7574 dmaengine: ti: k3-udma: Do conditional decrement of UDMA_CHAN_RT_PEER_BCNT_REG
- edba9b7a7037 memory: mvebu-devbus: Fix missing clk_disable_unprepare in mvebu_devbus_probe()
- e66f6949da63 memory: atmel-sdramc: Fix missing clk_disable_unprepare in atmel_ramc_probe()
- eda11ab55614 memory: tegra: Remove clients SID override programming
- aabd5ba7e9b0 Linux 5.15.90
- 4b6f8263e931 io_uring/rw: remove leftover debug statement
- b10acfcd61b2 io_uring/rw: ensure kiocb_end_write() is always called
- 124fb13cc757 io_uring: fix double poll leak on repolling
- e944f1e37b97 io_uring: Clean up a false-positive warning from GCC 9.3.0
- 940e8922c1f5 mm/khugepaged: fix collapse_pte_mapped_thp() to allow anon_vma
- e83cc8a780e6 soc: qcom: apr: Make qcom,protection-domain optional again
- 982c8b1e95c0 Revert "wifi: mac80211: fix memory leak in ieee80211_if_add()"
- 40a4797e08ec block: mq-deadline: Rename deadline_is_seq_writes()
- 3abf10b4c473 net/mlx5: fix missing mutex_unlock in mlx5_fw_fatal_reporter_err_work()
- 1aab00aa4192 net/ulp: use consistent error code when blocking ULP
- 2e4c95a404f3 io_uring/net: fix fast_iov assignment in io_setup_async_msg()
- 311b298a3337 io_uring: io_kiocb_update_pos() should not touch file for non -1 offset
- 487a086595b5 tracing: Use alignof__(struct {type b;}) instead of offsetof()
- 430443f8565e x86/fpu: Use _Alignof to avoid undefined behavior in TYPE_ALIGN
- f114717dfa74 Revert "drm/amdgpu: make display pinning more flexible (v2)"
- 7a993c1be595 efi: rt-wrapper: Add missing include
- de2af657cab9 arm64: efi: Execute runtime services from a dedicated stack
- 9cca110cf8bb fs/ntfs3: Fix attr_punch_hole() null pointer derenference
- d4d112e5c458 drm/amdgpu: drop experimental flag on aldebaran
- c82fa690da7c drm/amd/display: Fix COLOR_SPACE_YCBCR2020_TYPE matrix
- 88c33752248e drm/amd/display: Calculate output_color_space after pixel encoding adjustment
- 87e605b16111 drm/amd/display: Fix set scaling doesn's work
- 8687b8cdc3a3 drm/i915/display: Check source height is > 0
- 5d961791663d drm/i915: re-disable RC6p on Sandy Bridge
- e9a7ec188b26 mei: me: add meteor lake point M DID
- eb0421d90f91 gsmi: fix null-deref in gsmi_get_variable
- b8d99cda526b serial: atmel: fix incorrect baudrate setup
- b85498385afc serial: amba-pl011: fix high priority character transmission in rs486 mode
- 0f150134dd79 dmaengine: idxd: Let probe fail when workqueue cannot be enabled
- 1e8c127c2e81 dmaengine: tegra210-adma: fix global intr clear
- 473e2281f712 dmaengine: lgm: Move DT parsing after initialization
- 73337724cbd8 serial: pch_uart: Pass correct sg to dma_unmap_sg()
- 4307a41cbc44 dt-bindings: phy: g12a-usb3-pcie-phy: fix compatible string documentation
- c9d55f564a69 dt-bindings: phy: g12a-usb2-phy: fix compatible string documentation
- 78aa45bb7a42 usb-storage: apply IGNORE_UAS only for HIKSEMI MD202 on RTL9210
- a69c8dfb85b4 usb: gadget: f_ncm: fix potential NULL ptr deref in ncm_bitrate()
- 1ab67e87b178 usb: gadget: g_webcam: Send color matching descriptor per frame
- b08167d8f07c usb: typec: altmodes/displayport: Fix pin assignment calculation
- 7fb1322e7a8c usb: typec: altmodes/displayport: Add pin assignment helper
- 59f9ee379640 usb: typec: tcpm: Fix altmode re-registration causes sysfs create fail
- a1c8a5c2f8aa usb: host: ehci-fsl: Fix module alias
- f073d10cd5a7 usb: cdns3: remove fetched trb from cache before dequeuing
- 73f4bde9730f USB: serial: cp210x: add SCALANCE LPE-9000 device id
- a2e075f40122 USB: gadgetfs: Fix race between mounting and unmounting
- 2da67bff29ab tty: fix possible null-ptr-defer in spk_ttyio_release
- cb53a3366eb2 tty: serial: qcom-geni-serial: fix slab-out-of-bounds on RX FIFO buffer
- f322dd2e4a1c staging: mt7621-dts: change some node hex addresses to lower case
- 6508788b2c3b bpf: restore the ebpf program ID for BPF_AUDIT_UNLOAD and PERF_BPF_EVENT_PROG_UNLOAD
- 7b122c33bd31 riscv: dts: sifive: fu740: fix size of pcie 32bit memory
- 701f9c3da692 thunderbolt: Use correct function to calculate maximum USB3 link rate
- 5b1b03a3d3e4 cifs: do not include page data when checking signature
- 64287cd456a2 btrfs: fix race between quota rescan and disable leading to NULL pointer deref
- f2e0e1615d65 btrfs: do not abort transaction on failure to write log tree when syncing log
- f653abe6195c mmc: sdhci-esdhc-imx: correct the tuning start tap and step setting
- 9881436f01ce mmc: sunxi-mmc: Fix clock refcount imbalance during unbind
- 33bd0db750fc ACPI: PRM: Check whether EFI runtime is available
- 87e1ee6058e5 comedi: adv_pci1760: Fix PWM instruction handling
- b5d24a8e4a61 usb: core: hub: disable autosuspend for TI TUSB8041
- 61a0890cb95a misc: fastrpc: Fix use-after-free race condition for maps
- 1b7b7bb400dd misc: fastrpc: Don't remove map on creater_process and device_release
- e7e41fcf909f USB: misc: iowarrior: fix up header size for USB_DEVICE_ID_CODEMERCS_IOW100
- f3de34d90d90 staging: vchiq_arm: fix enum vchiq_status return types
- 16d09c4bc99b USB: serial: option: add Quectel EM05CN modem
- 34d769f0c607 USB: serial: option: add Quectel EM05CN (SG) modem
- 768d56ed2411 USB: serial: option: add Quectel EC200U modem
- 829916f069a7 USB: serial: option: add Quectel EM05-G (RS) modem
- eb8808f769c6 USB: serial: option: add Quectel EM05-G (CS) modem
- 6e0430db195e USB: serial: option: add Quectel EM05-G (GR) modem
- f01aefe374d3 prlimit: do_prlimit needs to have a speculation check
- 418e2c756d65 xhci: Detect lpm incapable xHC USB3 roothub ports from ACPI tables
- 10cb7d53be5f usb: acpi: add helper to check port lpm capability using acpi _DSM
- 1818e2a97dab xhci: Add a flag to disable USB3 lpm on a xhci root port level.
- 8911ff796336 xhci: Add update_hub_device override for PCI xHCI hosts
- c462ac871f49 xhci: Fix null pointer dereference when host dies
- f39c813af0b6 usb: xhci: Check endpoint is valid before dereferencing it
- 0f175cebc46c xhci-pci: set the dma max_seg_size
- 89a410dbd0f1 io_uring/rw: defer fsnotify calls to task context
- 05d69b372b3b io_uring: do not recalculate ppos unnecessarily
- ff8a070253d9 io_uring: update kiocb->ki_pos at execution time
- b7958caf415b io_uring: remove duplicated calls to io_kiocb_ppos
- 86e2d6901a37 io_uring: ensure that cached task references are always put on exit
- 30b90689344b io_uring: fix async accept on O_NONBLOCK sockets
- a79b13f24967 io_uring: allow re-poll if we made progress
- 3c1a3d02690f io_uring: support MSG_WAITALL for IORING_OP_SEND(MSG)
- 390b8816317f io_uring: add flag for disabling provided buffer recycling
- 9b7b0f2116d5 io_uring: ensure recv and recvmsg handle MSG_WAITALL correctly
- cdc68e714d0b io_uring: improve send/recv error handling
- ccf06b5a981c io_uring: pass in EPOLL_URING_WAKE for eventfd signaling and wakeups
- 77baf39227c0 eventfd: provide a eventfd_signal_mask() helper
- a2d8ff00a7b0 eventpoll: add EPOLL_URING_WAKE poll wakeup flag
- a9aa4aa7a5b2 io_uring: don't gate task_work run on TIF_NOTIFY_SIGNAL
- bd9a23a4bb8a hugetlb: unshare some PMDs when splitting VMAs
- 393d9e3ed10c drm/amd: Delay removal of the firmware framebuffer
- 865e244e06c7 drm/amdgpu: disable runtime pm on several sienna cichlid cards(v2)
- 560373fb1e9a ALSA: hda/realtek: fix mute/micmute LEDs don't work for a HP platform
- 26264260a80b ALSA: hda/realtek: fix mute/micmute LEDs for a HP ProBook
- 1026756321bd efi: fix userspace infinite retry read efivars after EFI runtime services page fault
- 45627a1a6450 nilfs2: fix general protection fault in nilfs_btree_insert()
- 350d66d9e730 zonefs: Detect append writes at invalid locations
- 5054d001ffaf Add exception protection processing for vd in axi_chan_handle_err function
- a12fd43bd175 wifi: mac80211: sdata can be NULL during AMPDU start
- f96a6c009ed9 wifi: brcmfmac: fix regression for Broadcom PCIe wifi devices
- 908d1742b6e6 Bluetooth: hci_qca: Fix driver shutdown on closed serdev
- 7530fbc05ff5 fbdev: omapfb: avoid stack overflow warning
- e1df7f0b27c2 perf/x86/rapl: Treat Tigerlake like Icelake
- 2c129e868992 f2fs: let's avoid panic if extent_tree is not created
- 58bac7440251 x86/asm: Fix an assembler warning with current binutils
- fdb4a70bb768 btrfs: always report error in run_one_delayed_ref()
- f641067ea2af RDMA/srp: Move large values to a new enum for gcc13
- 793f8ac21874 r8169: move rtl_wol_enable_rx() and rtl_prepare_power_down()
- dc072762f900 net/ethtool/ioctl: return -EOPNOTSUPP if we have no phy stats
- 308d24d87599 vduse: Validate vq_num in vduse_validate_config()
- 8e1eb926a093 virtio_pci: modify ENOENT to EINVAL
- 64a6f3689d0d tools/virtio: initialize spinlocks in vring_test.c
- 95fc28a8e921 selftests/bpf: check null propagation only neither reg is PTR_TO_BTF_ID
- d4a9d2944f2e pNFS/filelayout: Fix coalescing test for single DS
- 6a3319af6b36 btrfs: fix trace event name typo for FLUSH_DELAYED_REFS
- 3bcc86eb3ed9 Linux 5.15.89
- 37c18ef49ec3 pinctrl: amd: Add dynamic debugging for active GPIOs
- a5841b81adfa Revert "usb: ulpi: defer ulpi_register on ulpi_read_id timeout"
- 7ec9a45fc4ee block: handle bio_split_to_limits() NULL return
- ba86db02d408 io_uring/io-wq: only free worker if it was allocated for creation
- bb135bcc9499 io_uring/io-wq: free worker if task_work creation is canceled
- 63c2fa09b856 scsi: mpt3sas: Remove scsi_dma_map() error messages
- e2ea55564229 efi: fix NULL-deref in init error path
- 94b6cf84db42 arm64: cmpxchg_double*: hazard against entire exchange variable
- 3891fa4982b9 arm64: atomics: remove LL/SC trampolines
- 61e86339af2a arm64: atomics: format whitespace consistently
- ed4629d1e968 io_uring: lock overflowing for IOPOLL
- fbf501514182 KVM: x86: Do not return host topology information from KVM_GET_SUPPORTED_CPUID
- ee16841134be Documentation: KVM: add API issues section
- b8f3b3cffb4a mm: Always release pages to the buddy allocator in memblock_free_late().
- d2dc110deabe platform/surface: aggregator: Add missing call to ssam_request_sync_free()
- cfd5978411ed igc: Fix PPS delta between two synchronized end-points
- 0bf52601ced1 perf build: Properly guard libbpf includes
- 205f35eee7be net/mlx5e: Don't support encap rules with gbp option
- 0526fc9330fe net/mlx5: Fix ptp max frequency adjustment range
- 9e2c38827cdc net/sched: act_mpls: Fix warning during failed attribute validation
- e3bb44beafde tools/nolibc: fix the O_* fcntl/open macro definitions for riscv
- 1e6ec75bb3b5 tools/nolibc: restore mips branch ordering in the _start block
- bd0431a66c39 tools/nolibc: Remove .global _start from the entry point code
- a77c54f5b50c tools/nolibc/arch: mark the _start symbol as weak
- da51e086d154 tools/nolibc/arch: split arch-specific code into individual files
- 8591e788bea3 tools/nolibc/types: split syscall-specific definitions into their own files
- 4fceecdeaa8a tools/nolibc/std: move the standard type definitions to std.h
- 1792136f228e tools/nolibc: use pselect6 on RISCV
- 487386a49e01 tools/nolibc: x86-64: Use `mov $60,%eax` instead of `mov $60,%rax`
- 27af4f2260cd tools/nolibc: x86: Remove `r8`, `r9` and `r10` from the clobber list
- a60b24192b1f af_unix: selftest: Fix the size of the parameter to connect()
- 39ae73e58111 nfc: pn533: Wait for out_urb's completion in pn533_usb_send_frame()
- f6003784b1f6 hvc/xen: lock console list traversal
- 79c58b74244d octeontx2-af: Fix LMAC config in cgx_lmac_rx_tx_enable
- 303d06288122 tipc: fix unexpected link reset due to discovery messages
- e79d0f97cc6e ALSA: usb-audio: Relax hw constraints for implicit fb sync
- c9557906bd3b ALSA: usb-audio: Make sure to stop endpoints before closing EPs
- 83e758105bc8 ASoC: wm8904: fix wrong outputs volume after power reactivation
- 7c26d218729b scsi: ufs: core: WLUN suspend SSU/enter hibern8 fail recovery
- 513fdf0b8e20 scsi: ufs: Stop using the clock scaling lock in the error handler
- 13259b60b71b scsi: mpi3mr: Refer CONFIG_SCSI_MPI3MR in Makefile
- 470f6a9175f1 regulator: da9211: Use irq handler when ready
- 24107ad469df x86/resctrl: Fix task CLOSID/RMID update race
- cd3da505fb35 EDAC/device: Fix period calculation in edac_device_reset_delay_period()
- ab0d02c53a60 x86/boot: Avoid using Intel mnemonics in AT&T syntax asm
- a90d339f1f66 powerpc/imc-pmu: Fix use of mutex in IRQs disabled section
- 511cf17b2447 netfilter: ipset: Fix overflow before widen in the bitmap_ip_create() function.
- b22faa21b623 sched/core: Fix use-after-free bug in dup_user_cpus_ptr()
- d766ccadbe85 iommu/mediatek-v1: Fix an error handling path in mtk_iommu_v1_probe()
- c929a230c844 iommu/iova: Fix alloc iova overflows issue
- 4b51aa263ae4 usb: ulpi: defer ulpi_register on ulpi_read_id timeout
- 9a8bf443f6a2 bus: mhi: host: Fix race between channel preparation and M0 event
- 456e3794e08a ipv6: raw: Deduct extension header length in rawv6_push_pending_frames
- 4c93422a54cd ixgbe: fix pci device refcount leak
- e97da5d97a97 platform/x86: sony-laptop: Don't turn off 0x153 keyboard backlight during probe
- f3b1e04daf86 dt-bindings: msm/dsi: Don't require vcca-supply on 14nm PHY
- 52a5f596c6cc dt-bindings: msm/dsi: Don't require vdds-supply on 10nm PHY
- 984ad875db80 drm/msm/dp: do not complete dp_aux_cmd_fifo_tx() if irq is not for aux transfer
- 92ae83665e9e platform/x86: ideapad-laptop: Add Legion 5 15ARH05 DMI id to set_fn_lock_led_list[]
- e38b5f81dfa8 dt-bindings: msm: dsi-phy-28nm: Add missing qcom, dsi-phy-regulator-ldo-mode
- bb32ab40cb7f dt-bindings: msm: dsi-controller-main: Fix description of core clock
- 3fb8d10beef9 dt-bindings: msm: dsi-controller-main: Fix power-domain constraint
- dc5b651cad66 drm/msm/adreno: Make adreno quirks not overwrite each other
- 757d665ee1fe dt-bindings: msm: dsi-controller-main: Fix operating-points-v2 constraint
- c90cf47d309a platform/x86: dell-privacy: Fix SW_CAMERA_LENS_COVER reporting
- 25b5f693bc2d platform/surface: aggregator: Ignore command messages not intended for us
- ee7b8ce2cc28 platform/x86: dell-privacy: Only register SW_CAMERA_LENS_COVER if present
- e0072068adaf cifs: Fix uninitialized memory read for smb311 posix symlink create
- f3495b5e9e68 net/mlx5e: Set action fwd flag when parsing tc action goto
- 1a8431cc202a drm/i915/gt: Reset twice
- 011ecdbcd520 drm/virtio: Fix GEM handle creation UAF
- 798dfeeae33d s390/percpu: add READ_ONCE() to arch_this_cpu_to_op_simple()
- a400593eb373 s390/cpum_sf: add READ_ONCE() semantics to compare and swap loops
- d4fa65960a9d ASoC: qcom: lpass-cpu: Fix fallback SD line index handling
- 8400b91c11db s390/kexec: fix ipl report address for kdump
- c07e0babd1df perf auxtrace: Fix address filter duplicate symbol selection
- e81d82da619a net: stmmac: add aux timestamps fifo clearance wait
- 44167b74a8a3 docs: Fix the docs build with Sphinx 6.0
- 24176bf2a145 efi: tpm: Avoid READ_ONCE() for accessing the event log
- 01b966b14c6e selftests: kvm: Fix a compile error in selftests/kvm/rseq_test.c
- c773ebe11c39 KVM: arm64: nvhe: Fix build with profile optimization
- c1d6a72fc810 KVM: arm64: Fix S1PTW handling on RO memslots
- e04e6cd8830f ALSA: hda/realtek: Enable mute/micmute LEDs on HP Spectre x360 13-aw0xxx
- b983c9a9714e ALSA: hda/realtek - Turn on power early
- 9ab3696881ca ALSA: control-led: use strscpy in set_led_id()
- a8acfe2c6fb9 netfilter: nft_payload: incorrect arithmetics when fetching VLAN header bits
- 90bb4f8f399f Linux 5.15.88
- cbd3e6d5e516 ALSA: hda - Enable headset mic on another Dell laptop with ALC3254
- b98dee474642 ALSA: hda/hdmi: Add a HP device 0x8715 to force connect list
- 26350c21bc5e ALSA: pcm: Move rwsem lock inside snd_ctl_elem_read to prevent UAF
- dadd0dcaa67d net/ulp: prevent ULP without clone op from entering the LISTEN status
- 04941c1d5bb5 net: sched: disallow noqueue for qdisc classes
- 068b51219362 serial: fixup backport of "serial: Deassert Transmit Enable on probe in driver-specific way"
- 46aa1557581f selftests/vm/pkeys: Add a regression test for setting PKRU through ptrace
- 3c1940c54922 x86/fpu: Emulate XRSTOR's behavior if the xfeatures PKRU bit is not set
- 3f1c81426a9f x86/fpu: Allow PKRU to be (once again) written by ptrace.
- b29773d6b0bb x86/fpu: Add a pkru argument to copy_uabi_to_xstate()
- 9813c5fc22bc x86/fpu: Add a pkru argument to copy_uabi_from_kernel_to_xstate().
- fea26e83a196 x86/fpu: Take task_struct* in copy_sigframe_from_user_to_xstate()
- d4d152017e1d parisc: Align parisc MADV_XXX constants with all other architectures
- d57287729e22 Linux 5.15.87
- 24186c682288 drm/mgag200: Fix PLL setup for G200_SE_A rev >=4
- e326ee018a24 io_uring: Fix unsigned 'res' comparison with zero in io_fixup_rw_res()
- b2b6eefab43d efi: random: combine bootloader provided RNG seed with RNG protocol output
- 99c0759495a0 mbcache: Avoid nesting of cache->c_list_lock under bit locks
- d50d6c193adb net: hns3: fix return value check bug of rx copybreak
- d4e6a13eb9a3 btrfs: make thaw time super block check to also verify checksum
- 70a1dccd0e58 selftests: set the BUILD variable to absolute path
- 58fef3ebc83c ext4: don't allow journal inode to have encrypt flag
- bd5dc96fea4e mptcp: use proper req destructor for IPv6
- 78bd6ab52c03 mptcp: dedicated request sock for subflow in v6
- 6e9c1aef3e32 Revert "ACPI: PM: Add support for upcoming AMD uPEP HID AMDI007"
- e32f867b37da ksmbd: check nt_len to be at least CIFS_ENCPWD_SIZE in ksmbd_decode_ntlmssp_auth_blob
- 4136f1ac1ecd ksmbd: fix infinite loop in ksmbd_conn_handler_loop()
- f10defb0be6a hfs/hfsplus: avoid WARN_ON() for sanity check, use proper error handling
- 48d9e2e6de01 hfs/hfsplus: use WARN_ON for sanity check
- f5a9bbf962e2 drm/i915/gvt: fix vgpu debugfs clean in remove
- ae9a61511736 drm/i915/gvt: fix gvt debugfs destroy
- eb3e943a3243 riscv, kprobes: Stricter c.jr/c.jalr decoding
- 620a229f576a riscv: uaccess: fix type of 0 variable on error in get_user()
- 8e05a993f8aa thermal: int340x: Add missing attribute for data rate base
- c3222fd28225 io_uring: fix CQ waiting timeout handling
- b7b9bc93055d block: don't allow splitting of a REQ_NOWAIT bio
- e1358c878711 fbdev: matroxfb: G200eW: Increase max memory from 1 MB to 16 MB
- 682a7d064f35 nfsd: fix handling of readdir in v4root vs. mount upcall timeout
- cb42aa7b5f72 x86/bugs: Flush IBP in ib_prctl_set()
- 554a880a1fff x86/kexec: Fix double-free of elf header buffer
- 264241a61045 btrfs: check superblock to ensure the fs was not modified at thaw time
- 69f4bda5f4e6 nvme: also return I/O command effects from nvme_command_effects
- a6a4b057cd47 nvmet: use NVME_CMD_EFFECTS_CSUPP instead of open coding it
- f9309dcaa9c0 io_uring: check for valid register opcode earlier
- 4df413d46960 nvme: fix multipath crash caused by flush request when blktrace is enabled
- 03ce7921285e ASoC: Intel: bytcr_rt5640: Add quirk for the Advantech MICA-071 tablet
- 0dca7375e2b9 udf: Fix extension of the last extent in the file
- dc1bc903970b caif: fix memory leak in cfctrl_linkup_request()
- bce3680b48d2 drm/i915: unpin on error in intel_vgpu_shadow_mm_pin()
- da6a3653b82c perf stat: Fix handling of --for-each-cgroup with --bpf-counters to match non BPF mode
- 11cd4ec6359d usb: rndis_host: Secure rndis_query check against int overflow
- 6ea5273c71dd octeontx2-pf: Fix lmtst ID used in aura free
- 4e5f2c74cbbf drivers/net/bonding/bond_3ad: return when there's no aggregator
- 8414983c2e64 fs/ntfs3: don't hold ni_lock when calling truncate_setsize()
- a23e8376e613 drm/imx: ipuv3-plane: Fix overlay plane width
- a8f7fd322f56 perf tools: Fix resources leak in perf_data__open_dir()
- a1e1521b4639 netfilter: ipset: Rework long task execution when adding/deleting entries
- 6f19a3848367 netfilter: ipset: fix hash:net,port,net hang with /0 subnet
- 774d259749d7 net: sparx5: Fix reading of the MAC address
- 04dc4003e5df net: sched: cbq: dont intepret cls results when asked to drop
- f02327a4877a net: sched: atm: dont intepret cls results when asked to drop
- 95da1882ce93 gpio: sifive: Fix refcount leak in sifive_gpio_probe
- da9c9883ec96 ceph: switch to vfs_inode_has_locks() to fix file lock bug
- 54e72ce5f1d7 filelock: new helper: vfs_inode_has_locks
- f34b03ce3a86 drm/meson: Reduce the FIFO lines held when AFBC is not used
- 05a8410b0fce RDMA/mlx5: Fix validation of max_rd_atomic caps for DC
- 8d89870d6375 RDMA/mlx5: Fix mlx5_ib_get_hw_stats when used for device
- 4d112f001612 net: phy: xgmiitorgmii: Fix refcount leak in xgmiitorgmii_probe
- e5fbeb3d16b4 net: ena: Update NUMA TPH hint register upon NUMA node update
- 7840b93cfd4c net: ena: Set default value for RX interrupt moderation
- d09b7a9d2f34 net: ena: Fix rx_copybreak value update
- 0e7ad9b006d7 net: ena: Use bitmask to indicate packet redirection
- 5d4964984b99 net: ena: Account for the number of processed bytes in XDP
- f17d9aec07de net: ena: Don't register memory info on XDP exchange
- a4aa727ad0b2 net: ena: Fix toeplitz initial hash value
- 0bec17f1ce31 net: amd-xgbe: add missed tasklet_kill
- cb2f74685f76 net/mlx5e: Fix hw mtu initializing at XDP SQ allocation
- 6c72abb78b01 net/mlx5e: Always clear dest encap in neigh-update-del
- b36783bc11d1 net/mlx5e: TC, Refactor mlx5e_tc_add_flow_mod_hdr() to get flow attr
- f8c10eeba31b net/mlx5e: IPoIB, Don't allow CQE compression to be turned on by default
- 7227bbb7c140 net/mlx5: Avoid recovery in probe flows
- 9369b9afa8b0 net/mlx5: Add forgotten cleanup calls into mlx5_init_once() error path
- d966f2ee4b8e net/mlx5: E-Switch, properly handle ingress tagged packets on VST
- 6a37a01aba5d vdpa_sim: fix vringh initialization in vdpasim_queue_ready()
- e3462410c36d vhost: fix range used in translate_desc()
- 13871f60ec2f vringh: fix range used in iotlb_translate()
- e05d4c8c287a vhost/vsock: Fix error handling in vhost_vsock_init()
- 586e6fd7d581 vdpa_sim: fix possible memory leak in vdpasim_net_init() and vdpasim_blk_init()
- b63bc2db244c nfc: Fix potential resource leaks
- 945e58bdaf6f net: dsa: mv88e6xxx: depend on PTP conditionally
- 95df720e64a6 qlcnic: prevent ->dcb use-after-free on qlcnic_dcb_enable() failure
- 6c55953e232e net: sched: fix memory leak in tcindex_set_parms
- d14a4b24d58e net: hns3: fix VF promisc mode not update when mac table full
- 7ed205b9478d net: hns3: fix miss L3E checking for rx packet
- 47868cb77f8f net: hns3: extract macro to simplify ring stats update code
- 7457c5a7761a net: hns3: refactor hns3_nic_reuse_page()
- 4a6e9fb534c5 net: hns3: add interrupts re-initialization while doing VF FLR
- 5e48ed805c4f nfsd: shut down the NFSv4 state objects before the filecache
- 7e2825f5fb84 veth: Fix race with AF_XDP exposing old or uninitialized descriptors
- ac95cdafaca8 netfilter: nf_tables: honor set timeout and garbage collection updates
- 49677ea1513e vmxnet3: correctly report csum_level for encapsulated packet
- 9d30cb442156 netfilter: nf_tables: perform type checking for existing sets
- c3bfb7784a09 netfilter: nf_tables: add function to create set stateful expressions
- 996cd779c2a4 netfilter: nf_tables: consolidate set description
- 4f1105ee72d8 drm/panfrost: Fix GEM handle creation ref-counting
- df493f676fb0 bpf: pull before calling skb_postpull_rcsum()
- d7e817e689b1 btrfs: fix an error handling path in btrfs_defrag_leaves()
- 4d69cdba2c27 SUNRPC: ensure the matching upcall is in-flight upon downcall
- af0265dfeffa drm/i915/migrate: fix length calculation
- 8b25a526a5e9 drm/i915/migrate: fix offset calculation
- a3d1e6f9b678 drm/i915/migrate: don't check the scratch page
- 5bc0b2fda4b4 ext4: fix deadlock due to mbcache entry corruption
- a6e4094faf3c mbcache: automatically delete entries from cache on freeing
- 187254912971 ext4: correct inconsistent error msg in nojournal mode
- 761f88f82e0f ext4: goto right label 'failed_mount3a'
- eb16602140f0 ravb: Fix "failed to switch device to config mode" message during unbind
- 4216995dbd93 perf probe: Fix to get the DW_AT_decl_file and DW_AT_call_file as unsinged data
- d8bbbf2b52b2 perf probe: Use dwarf_attr_integrate as generic DWARF attr accessor
- b131b5f1361e media: s5p-mfc: Fix in register read and write for H264
- ff27800c0a6d media: s5p-mfc: Clear workbit to handle error condition
- 4653ba32adcd media: s5p-mfc: Fix to handle reference queue during finishing
- 1bd7283dc0be x86/MCE/AMD: Clear DFR errors found in THR handler
- 5ddcd349d9af x86/mce: Get rid of msr_ops
- b8e7ed42bc3c btrfs: fix extent map use-after-free when handling missing device in read_one_chunk
- 9c3beebd21f3 btrfs: move missing device handling in a dedicate function
- 7528b21cebe0 btrfs: replace strncpy() with strscpy()
- 4cef44525f4f phy: qcom-qmp-combo: fix out-of-bounds clock access
- 855edc4ec64c ARM: renumber bits related to _TIF_WORK_MASK
- 18f28f13301d ext4: fix off-by-one errors in fast-commit block filling
- b205332b6b87 ext4: fix unaligned memory access in ext4_fc_reserve_space()
- 9c197dcbacc4 ext4: add missing validation of fast-commit record lengths
- 6220ec405571 ext4: don't set up encryption key during jbd2 transaction
- 6482d42baff5 ext4: disable fast-commit of encrypted dir operations
- 6969367c1500 ext4: fix potential out of bound read in ext4_fc_replay_scan()
- 818175ae3bd2 ext4: factor out ext4_fc_get_tl()
- ffd84d0bc5dc ext4: introduce EXT4_FC_TAG_BASE_LEN helper
- 37914e029bec ext4: use ext4_debug() instead of jbd_debug()
- b0ed9a032e52 ext4: remove unused enum EXT4_FC_COMMIT_FAILED
- 394514ddf90e tracing: Fix issue of missing one synthetic field
- 5234dd5d205b block: mq-deadline: Fix dd_finish_request() for zoned devices
- 78623b10fc9f drm/amdgpu: make display pinning more flexible (v2)
- 6363da2c854a drm/amdgpu: handle polaris10/11 overlap asics (v2)
- 2771c7a0eedc ext4: allocate extended attribute value in vmalloc area
- e995ff918e66 ext4: avoid unaccounted block allocation when expanding inode
- 877247222a0c ext4: initialize quota before expanding inode in setproject ioctl
- 322cf639b0b7 ext4: fix inode leak in ext4_xattr_inode_create() on an error path
- 6380a93b57db ext4: fix kernel BUG in 'ext4_write_inline_data_end()'
- dc3bbc9753f4 ext4: avoid BUG_ON when creating xattrs
- 844c40555297 ext4: fix error code return to user-space in ext4_get_branch()
- b870b28e29f6 ext4: fix corruption when online resizing a 1K bigalloc fs
- d440d6427a5e ext4: fix delayed allocation bug in ext4_clu_mapped for bigalloc + inline
- def7a39091e6 ext4: init quota for 'old.inode' in 'ext4_rename'
- 3c31d8d3ad95 ext4: fix uninititialized value in 'ext4_evict_inode'
- 871800770d7f ext4: fix leaking uninitialized memory in fast-commit journal
- d480a49c15c4 ext4: fix bug_on in __es_tree_search caused by bad boot loader inode
- 91009e361e8c ext4: check and assert if marking an no_delete evicting inode dirty
- 820eacbc4e4f ext4: fix reserved cluster accounting in __es_remove_extent()
- 0dcbf4dc3d54 ext4: fix bug_on in __es_tree_search caused by bad quota inode
- 06a20a68bb6d ext4: add helper to check quota inums
- f7e6b5548f91 ext4: add EXT4_IGET_BAD flag to prevent unexpected bad inode
- 205ac16628ac ext4: fix undefined behavior in bit shift for ext4_check_flag_values
- cf0e0817b0f9 ext4: fix use-after-free in ext4_orphan_cleanup
- 970bfd7a4188 fs: ext4: initialize fsdata in pagecache_write()
- 744bbde378a5 ext4: remove trailing newline from ext4_msg() message
- 7192afa5e4bf ext4: add inode table check in __ext4_get_inode_loc to aovid possible infinite loop
- 0d041b7251c1 ext4: silence the warning when evicting inode with dioread_nolock
- af4ceb00ebea drm/ingenic: Fix missing platform_driver_unregister() call in ingenic_drm_init()
- c919e1154b8c drm/i915/dsi: fix VBT send packet port selection for dual link DSI
- 6948e570f54f drm/vmwgfx: Validate the box size for the snooped cursor
- 5594fde1ef53 drm/connector: send hotplug uevent on connector cleanup
- 317ebe61a6d4 device_cgroup: Roll back to original exceptions after copy failure
- ac838c663ba1 parisc: led: Fix potential null-ptr-deref in start_task()
- 2c1881f0816a remoteproc: core: Do pm_relax when in RPROC_OFFLINE state
- 9b615f957ca7 iommu/amd: Fix ivrs_acpihid cmdline parsing code
- 35b792179b10 phy: qcom-qmp-combo: fix sc8180x reset
- dfd05a133556 driver core: Fix bus_type.match() error handling in __driver_attach()
- 44618a339741 crypto: ccp - Add support for TEE for PCI ID 0x14CA
- c55507a94bc6 crypto: n2 - add missing hash statesize
- 48307506964e riscv: mm: notify remote harts about mmu cache updates
- 16b6d9525da6 riscv: stacktrace: Fixup ftrace_graph_ret_addr retp argument
- 657b440a270c PCI/sysfs: Fix double free in error path
- 67fd41bbb0f5 PCI: Fix pci_device_is_present() for VFs by checking PF
- bfce073089cb ipmi: fix use after free in _ipmi_destroy_user()
- 3b4984035c40 ima: Fix a potential NULL pointer access in ima_restore_measurement_list
- a843699f1665 mtd: spi-nor: Check for zero erase size in spi_nor_find_best_erase_type()
- 24f4649cd8fc ipmi: fix long wait in unload when IPMI disconnect
- fa6bbb4894b9 ipu3-imgu: Fix NULL pointer dereference in imgu_subdev_set_selection()
- cdb208b090f3 ASoC: jz4740-i2s: Handle independent FIFO flush bits
- 2d0d083d8ae6 wifi: wilc1000: sdio: fix module autoloading
- 2e4a088804c1 efi: Add iMac Pro 2017 to uefi skip cert quirk
- c49fb9b760d3 md/bitmap: Fix bitmap chunk size overflow issues
- 94fe975d54ab block: mq-deadline: Do not break sequential write streams to zoned HDDs
- 8e91679f7bd2 rtc: ds1347: fix value written to century register
- 5eb8296d73da cifs: fix missing display of three mount options
- cfa9f66f9172 cifs: fix confusing debug message
- 8b45a3b19a2e media: dvb-core: Fix UAF due to refcount races at releasing
- acf984a3718c media: dvb-core: Fix double free in dvb_register_device()
- 5fac317bee18 ARM: 9256/1: NWFPE: avoid compiler-generated __aeabi_uldivmod
- ce50c6124580 staging: media: tegra-video: fix device_node use after free
- 6b16758215f6 staging: media: tegra-video: fix chan->mipi value on error
- 4f5de49d8c52 tracing: Fix infinite loop in tracing_read_pipe on overflowed print_trace_line
- 17becbc4dd67 tracing/probes: Handle system names with hyphens
- 2442e655a693 tracing/hist: Fix wrong return value in parse_action_params()
- 2a81ff5ce893 tracing: Fix complicated dependency of CONFIG_TRACER_MAX_TRACE
- fe8c35c6ffa2 tracing: Fix race where eprobes can be called before the event
- eb20f6ed3733 x86/kprobes: Fix optprobe optimization check with CONFIG_RETHUNK
- 3e0fbc06db12 x86/kprobes: Fix kprobes instruction boudary check with CONFIG_RETHUNK
- 6268a0704b97 ftrace/x86: Add back ftrace_expected for ftrace bug reports
- c95cf30dd447 x86/microcode/intel: Do not retry microcode reloading on the APs
- f8fe2f41784b KVM: nVMX: Properly expose ENABLE_USR_WAIT_PAUSE control to L1
- ca3483d71bd5 KVM: nVMX: Inject #GP, not #UD, if "generic" VMXON CR0/CR4 check fails
- 2c73b349fd78 KVM: VMX: Resume guest immediately when injecting #GP on ECREATE
- 4a19f48bee09 of/kexec: Fix reading 32-bit "linux,initrd-{start,end}" values
- 7eddcdb09f62 perf/core: Call LSM hook after copying perf_event_attr
- 15697f653399 tracing/hist: Fix out-of-bound write on 'action_data.var_ref_idx'
- fd52b86a7248 dm cache: set needs_check flag after aborting metadata
- d2a0b298ebf8 dm cache: Fix UAF in destroy()
- 856edd0e92f3 dm clone: Fix UAF in clone_dtr()
- 9215b25f2e10 dm integrity: Fix UAF in dm_integrity_dtr()
- 34cd15d83b72 dm thin: Fix UAF in run_timer_softirq()
- ac362c40e3e9 dm thin: resume even if in FAIL mode
- 4b710e8481ad dm thin: Use last transaction's pmd->root when commit failed
- f8c26c33fef5 dm thin: Fix ABBA deadlock between shrink_slab and dm_pool_abort_metadata
- 28d307f380df dm cache: Fix ABBA deadlock between shrink_slab and dm_cache_metadata_abort
- a9e89a567f48 mptcp: remove MPTCP 'ifdef' in TCP SYN cookies
- 13b9fd0dee93 mptcp: mark ops structures as ro_after_init
- b2120ed7fd75 fs: dlm: retry accept() until -EAGAIN or error returns
- 5b4478615f70 fs: dlm: fix sock release if listen fails
- b7ede8a63dd9 ALSA: hda/realtek: Apply dual codec fixup for Dell Latitude laptops
- dbd1f301915f ALSA: patch_realtek: Fix Dell Inspiron Plus 16
- 8fb4c98f20df cpufreq: Init completion before kobject_init_and_add()
- 876c6ab96782 PM/devfreq: governor: Add a private governor_data for governor
- 0e945ea733ea selftests: Use optional USERCFLAGS and USERLDFLAGS
- 31697c5953ff arm64: dts: qcom: sdm850-lenovo-yoga-c630: correct I2C12 pins drive strength
- 163049866030 ARM: ux500: do not directly dereference __iomem
- 99590f29b2b7 btrfs: fix resolving backrefs for inline extent followed by prealloc
- 1f9cf4daf2d3 mmc: sdhci-sprd: Disable CLK_AUTO when the clock is less than 400K
- 58d53ff30a00 arm64: dts: qcom: sdm845-db845c: correct SPI2 pins drive strength
- a777b90a0575 perf/x86/intel/uncore: Clear attr_update properly
- ca77ac238c1e perf/x86/intel/uncore: Disable I/O stacks to PMU mapping on ICX-D
- df06e7777cf9 jbd2: use the correct print format
- 8e75b1dd4b16 ktest.pl minconfig: Unset configs instead of just removing them
- 55e5e8b44561 kest.pl: Fix grub2 menu handling for rebooting
- 823fed7c400f soc: qcom: Select REMAP_MMIO for LLCC driver
- 8dabeeb1ff89 media: stv0288: use explicitly signed char
- d167ebea9086 net/af_packet: make sure to pull mac header
- 9ff46c36df2e net/af_packet: add VLAN support for AF_PACKET SOCK_RAW GSO
- cd0f597c8aa8 rcu-tasks: Simplify trc_read_check_handler() atomic operations
- 593ca696687c ASoC/SoundWire: dai: expand 'stream' concept beyond SoundWire
- a7874dac6ba6 ASoC: Intel/SOF: use set_stream() instead of set_tdm_slots() for HDAudio
- ae4f70b2fed4 kcsan: Instrument memcpy/memset/memmove with newer Clang
- d01fa993eb7f SUNRPC: Don't leak netobj memory when gss_read_proxy_verf() fails
- 43135fb09812 tpm: tpm_tis: Add the missed acpi_put_table() to fix memory leak
- 986cd9a9b954 tpm: tpm_crb: Add the missed acpi_put_table() to fix memory leak
- 638cd298dfeb tpm: acpi: Call acpi_put_table() to fix memory leak
- d58289fc77f8 mmc: vub300: fix warning - do not call blocking ops when !TASK_RUNNING
- 7eb57bc92f1b f2fs: allow to read node block after shutdown
- acc13987fdea f2fs: should put a page when checking the summary info
- 35d8a89862e6 mm, compaction: fix fast_isolate_around() to stay within boundaries
- 91bd504128a5 md: fix a crash in mempool_free
- 29328fbce56c mfd: mt6360: Add bounds checking in Regmap read/write call-backs
- c24cc476acd8 pnode: terminate at peers of source
- 0c9118e381ff ALSA: line6: fix stack overflow in line6_midi_transmit
- ac4b4fdf3262 ALSA: line6: correct midi status byte when receiving data from podxt
- 83c44f0ebfd0 ovl: Use ovl mounter's fsuid and fsgid in ovl_link()
- fcb94283e014 binfmt: Fix error return code in load_elf_fdpic_binary()
- ed9947277b2d hfsplus: fix bug causing custom uid and gid being unable to be assigned with mount
- 76d52b54127c pstore/zone: Use GFP_ATOMIC to allocate zone buffer
- 74b0a2fcc31a pstore: Properly assign mem_type property
- d25aac3489af HID: plantronics: Additional PIDs for double volume key presses quirk
- 9d4294545c1d HID: multitouch: fix Asus ExpertBook P2 P2451FA trackpoint
- 7280fdb80bf0 powerpc/rtas: avoid scheduling in rtas_os_term()
- d8939315b734 powerpc/rtas: avoid device tree lookups in rtas_os_term()
- 23a249b1185c objtool: Fix SEGFAULT
- ed686e7a26dd fs/ntfs3: Fix slab-out-of-bounds in r_page
- dd34665cb004 fs/ntfs3: Delete duplicate condition in ntfs_read_mft()
- a9847a11b683 fs/ntfs3: Use __GFP_NOWARN allocation at ntfs_fill_super()
- abd2ee2cf42f fs/ntfs3: Use __GFP_NOWARN allocation at wnd_init()
- d7ce7bb6881a fs/ntfs3: Validate index root when initialize NTFS security
- f29676cc3a46 soundwire: dmi-quirks: add quirk variant for LAPBC710 NUC15
- 9c8471a17f1f fs/ntfs3: Fix slab-out-of-bounds read in run_unpack
- 3a52f1786772 fs/ntfs3: Validate resident attribute name
- 3cd9e5b41b83 fs/ntfs3: Validate buffer length while parsing index
- c878a915bcb9 fs/ntfs3: Validate attribute name offset
- f62506f5e45a fs/ntfs3: Add null pointer check for inode operations
- 2dd9ccfb06bc fs/ntfs3: Fix memory leak on ntfs_fill_super() error path
- ea6b3598406c fs/ntfs3: Add null pointer check to attr_load_runs_vcn
- de5e0955248f fs/ntfs3: Validate data run offset
- d4489ba8fb80 fs/ntfs3: Add overflow check for attribute size
- af7a195deae3 fs/ntfs3: Validate BOOT record_size
- 8e228ac90c39 nvmet: don't defer passthrough commands with trivial effects to the workqueue
- f068a7315a9e nvme: fix the NVME_CMD_EFFECTS_CSE_MASK definition
- 576502f25f79 ata: ahci: Fix PCS quirk application for suspend
- 7949b0df3dd9 block, bfq: fix uaf for bfqq in bfq_exit_icq_bfqq
- ff3d9ab51cd5 ACPI: resource: do IRQ override on Lenovo 14ALC7
- 698a0813ce69 ACPI: resource: do IRQ override on XMG Core 15
- a9ac7633bbe5 ACPI: resource: do IRQ override on LENOVO IdeaPad
- 5fe31f29501c ACPI: resource: Skip IRQ override on Asus Vivobook K3402ZA/K3502ZA
- 4c5fee0d883a nvme-pci: fix page size checks
- 9141144b37f3 nvme-pci: fix mempool alloc size
- f17cf8fa2c9d nvme-pci: fix doorbell buffer value endianness
- ead99ec669b5 Revert "selftests/bpf: Add test for unstable CT lookup API"
- bf0543b93740 cifs: fix oops during encryption
- 56f6de394f0f usb: dwc3: qcom: Fix memory leak in dwc3_qcom_interconnect_init ...

Signed-off-by: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>