### PR TITLE
u-boot-imx: Change the imx bsp override to generic bsp

### DIFF
--- a/recipes-bsp/u-boot/u-boot-imx_2022.04.bb
+++ b/recipes-bsp/u-boot/u-boot-imx_2022.04.bb
@@ -10,13 +10,13 @@ PROVIDES += "u-boot"
 inherit uuu_bootloader_tag
 
 UUU_BOOTLOADER            = ""
-UUU_BOOTLOADER:mx6-nxp-bsp        = "${UBOOT_BINARY}"
-UUU_BOOTLOADER:mx7-nxp-bsp        = "${UBOOT_BINARY}"
+UUU_BOOTLOADER:mx6-generic-bsp        = "${UBOOT_BINARY}"
+UUU_BOOTLOADER:mx7-generic-bsp        = "${UBOOT_BINARY}"
 UUU_BOOTLOADER_TAGGED     = ""
-UUU_BOOTLOADER_TAGGED:mx6-nxp-bsp = "u-boot-tagged.${UBOOT_SUFFIX}"
-UUU_BOOTLOADER_TAGGED:mx7-nxp-bsp = "u-boot-tagged.${UBOOT_SUFFIX}"
+UUU_BOOTLOADER_TAGGED:mx6-generic-bsp = "u-boot-tagged.${UBOOT_SUFFIX}"
+UUU_BOOTLOADER_TAGGED:mx7-generic-bsp = "u-boot-tagged.${UBOOT_SUFFIX}"
 
-do_deploy:append:mx8m-nxp-bsp() {
+do_deploy:append:mx8m-generic-bsp() {
     # Deploy u-boot-nodtb.bin and fsl-imx8m*-XX.dtb for mkimage to generate boot binary
     if [ -n "${UBOOT_CONFIG}" ]
     then


### PR DESCRIPTION
With the imx bsp override the u-boot-imx does
not compile imx-boot-tools. This causes an error
in imx-boot because it does not find imx-boot-tools.

Signed-off-by: Rodrigo M. Duarte <rodrigo.duarte@ossystems.com.br>