### PR TITLE
boot-format: Use https protocol with github

### DIFF
--- a/recipes-bsp/boot-format/boot-format_git.bb
+++ b/recipes-bsp/boot-format/boot-format_git.bb
@@ -3,7 +3,7 @@ LICENSE = "GPL-2.0-only"
 PR = "r6"
 LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
-SRC_URI = "git://github.com/nxp-qoriq-yocto-sdk/boot-format;nobranch=1 \
+SRC_URI = "git://github.com/nxp-qoriq-yocto-sdk/boot-format;protocol=https;nobranch=1 \
            file://flags.patch"
 SRCREV = "4eb81a6797ef4e58bf7d9b2d58afb37a21c1f550"
 


### PR DESCRIPTION
https is the preferred protocol especially with github

Fixes
WARNING: boot-format-git-r6 do_fetch: URL: git://github.com/nxp-qoriq-yocto-sdk/boot-format;nobranch=1 uses git protocol which is no longer supported by github. Please change to ;protocol=https in the url.