### PR TITLE
multiple uboot for single machine

### DIFF
--- a/recipes-bsp/u-boot/u-boot-imx_2020.04.bb
+++ b/recipes-bsp/u-boot/u-boot-imx_2020.04.bb
@@ -18,8 +18,27 @@ do_deploy_append_mx8m() {
                 if [ $j -eq $i ]
                 then
                     install -d ${DEPLOYDIR}/${BOOT_TOOLS}
-                    install -m 0777 ${B}/${config}/arch/arm/dts/${UBOOT_DTB_NAME}  ${DEPLOYDIR}/${BOOT_TOOLS}
-                    install -m 0777 ${B}/${config}/u-boot-nodtb.bin  ${DEPLOYDIR}/${BOOT_TOOLS}/u-boot-nodtb.bin-${MACHINE}-${UBOOT_CONFIG}
+                    install -m 0777 ${B}/${config}/u-boot-nodtb.bin  ${DEPLOYDIR}/${BOOT_TOOLS}/u-boot-nodtb.bin-${MACHINE}-${type}
+
+                    if [ "${@d.getVarFlags('UBOOT_DTB_NAME')}" = "None" ]; then
+                        UBOOT_DTB_NAME_FLAGS="${type}:${UBOOT_DTB_NAME}"
+                    else
+                        UBOOT_DTB_NAME_FLAGS="${@' '.join(flag + ':' + dtb for flag, dtb in (d.getVarFlags('UBOOT_DTB_NAME')).items()) if d.getVarFlags('UBOOT_DTB_NAME') is not None else '' }"
+                    fi
+
+                    for key_value in ${UBOOT_DTB_NAME_FLAGS}; do
+                        local type_key="${key_value%%:*}"
+                        local dtb_name="${key_value#*:}"
+                        if [ "$type_key" = "$type" ]
+                        then
+                            bbnote "UBOOT_CONFIG = $type, UBOOT_DTB_NAME = $dtb_name"
+                            install -m 0777 ${B}/${config}/arch/arm/dts/${dtb_name}  ${DEPLOYDIR}/${BOOT_TOOLS}/${dtb_name}-${type}
+                        fi
+                        unset type_key
+                        unset dtb_name
+                    done
+
+                    unset UBOOT_DTB_NAME_FLAGS
                 fi
             done
             unset  j


### PR DESCRIPTION
A long time ago I implemented a workaround to support multiple u-boot builds for the same machine.
This saved our project several hours every day on builds (16 different U-boots) because the image was common to all machines, only U-boot had a few changes per machine configuration. All wic-images are generated at once, separate tasks are not needed.

It still supports the original way of configuration, but for multiple u-boot I added flags for the same env vars.

For example, original machine configs for boards M1 and M2 :

```
# MACHINE M1
KERNEL_DEVICETREE = "freescale/imx8mp_m1.dtb"
IMXBOOT_TARGETS = "flash_evk"
UBOOT_CONFIG ??= "sd"
UBOOT_CONFIG[sd] = "imx8mp_m1_defconfig,sdcard"
UBOOT_DTB_NAME = "imx8mp_m1.dtb"
```

```
# MACHINE M2
KERNEL_DEVICETREE = "freescale/imx8mp_m2.dtb"
IMXBOOT_TARGETS = "flash_evk"
UBOOT_CONFIG ??= "sd"
UBOOT_CONFIG[sd] = "imx8mp_m2_defconfig,sdcard"
UBOOT_DTB_NAME = "imx8mp_m2.dtb"
```

New unified machine config for both boards M1 and M2

```
# MACHINE M1 and M2
KERNEL_DEVICETREE = "\
    freescale/imx8mp_m1.dtb \
    freescale/imx8mp_m2.dtb \
"
IMXBOOT_TARGETS = "flash_evk"
UBOOT_CONFIG = "m1 m2"

UBOOT_CONFIG[m1] = "imx8mp_m1_defconfig,sdcard"
UBOOT_CONFIG[m2] = "imx8mp_m2_defconfig,sdcard"

UBOOT_DTB_NAME[m1] = "imx8mp_m1.dtb"
UBOOT_DTB_NAME[m2] = "imx8mp_m2.dtb"

WKS_FILE = "${IMAGE_BASENAME}.wks.in"
```

And instead of using common wks.in like
```
part u-boot --source rawcopy --sourceparams="file=imx-boot" ...
```

I need to create 2 extra wks.in differing only by imx-boot

**my-image-m1.wks.in**
```
part u-boot --source rawcopy --sourceparams="file=imx-boot-imx8mp-m1.bin-flash_evk" ...
```

**my-image-m2.wks.in**
```
part u-boot --source rawcopy --sourceparams="file=imx-boot-imx8mp-m2.bin-flash_evk" ...
```

It would also be nice to have **IMXBOOT_TARGETS** separated by configurations, but this was not necessary in my project, so I left it just "flash_evk"

I will left it here as draft PR, maybe someone will refactor it and implement better design.