### PR TITLE
imx-mkimage: use mkimage tool from sysroot

### DIFF
--- a/recipes-bsp/imx-mkimage/files/0001-iMX8M-soc.mak-use-native-mkimage-from-sysroot.patch
+++ b/recipes-bsp/imx-mkimage/files/0001-iMX8M-soc.mak-use-native-mkimage-from-sysroot.patch
@@ -1,0 +1,70 @@
+From fe3d11ae2886f00ff57e2a3d20cdae02cca28234 Mon Sep 17 00:00:00 2001
+From: Andrey Zhizhikin <andrey.z@gmail.com>
+Date: Thu, 21 Oct 2021 08:53:38 +0000
+Subject: [PATCH] iMX8M: soc.mak: use native mkimage from sysroot
+
+mkimage tool is provided as a part of sysroot from Yocto build. Current
+implementation on the imx-mkimge on the other hand copies it locally in
+order to invoke it from within the build folder.
+
+Since recent updates, mkimage requires openssl.so to be installed, which
+when local copy is used causes the tool not to operate and fails the
+build.
+
+Use it from the build sysroot, and do not pull the local version of it.
+
+Upstream-Status: Inappropriate [OE-specific]
+
+Signed-off-by: Andrey Zhizhikin <andrey.z@gmail.com>
+---
+ iMX8M/soc.mak | 9 ++++-----
+ 1 file changed, 4 insertions(+), 5 deletions(-)
+
+diff --git a/iMX8M/soc.mak b/iMX8M/soc.mak
+index b7b3986..ca00411 100644
+--- a/iMX8M/soc.mak
++++ b/iMX8M/soc.mak
+@@ -142,7 +142,7 @@ u-boot.itb: $(dtbs)
+ 	./$(PAD_IMAGE) bl31.bin
+ 	./$(PAD_IMAGE) u-boot-nodtb.bin $(dtbs)
+ 	DEK_BLOB_LOAD_ADDR=$(DEK_BLOB_LOAD_ADDR) TEE_LOAD_ADDR=$(TEE_LOAD_ADDR) ATF_LOAD_ADDR=$(ATF_LOAD_ADDR) ./mkimage_fit_atf.sh $(dtbs) > u-boot.its
+-	./mkimage_uboot -E -p 0x3000 -f u-boot.its u-boot.itb
++	mkimage -E -p 0x3000 -f u-boot.its u-boot.itb
+ 	@rm -f u-boot.its $(dtbs)
+ 
+ dtbs_ddr3l = valddr3l.dtb
+@@ -154,7 +154,7 @@ u-boot-ddr3l.itb: $(dtbs_ddr3l)
+ 	./$(PAD_IMAGE) bl31.bin
+ 	./$(PAD_IMAGE) u-boot-nodtb.bin $(dtbs_ddr3l)
+ 	DEK_BLOB_LOAD_ADDR=$(DEK_BLOB_LOAD_ADDR) TEE_LOAD_ADDR=$(TEE_LOAD_ADDR) ATF_LOAD_ADDR=$(ATF_LOAD_ADDR) ./mkimage_fit_atf.sh $(dtbs_ddr3l) > u-boot-ddr3l.its
+-	./mkimage_uboot -E -p 0x3000 -f u-boot-ddr3l.its u-boot-ddr3l.itb
++	mkimage -E -p 0x3000 -f u-boot-ddr3l.its u-boot-ddr3l.itb
+ 	@rm -f u-boot.its $(dtbs_ddr3l)
+ 
+ dtbs_ddr4 = valddr4.dtb
+@@ -166,7 +166,7 @@ u-boot-ddr4.itb: $(dtbs_ddr4)
+ 	./$(PAD_IMAGE) bl31.bin
+ 	./$(PAD_IMAGE) u-boot-nodtb.bin $(dtbs_ddr4)
+ 	DEK_BLOB_LOAD_ADDR=$(DEK_BLOB_LOAD_ADDR) TEE_LOAD_ADDR=$(TEE_LOAD_ADDR) ATF_LOAD_ADDR=$(ATF_LOAD_ADDR) ./mkimage_fit_atf.sh $(dtbs_ddr4) > u-boot-ddr4.its
+-	./mkimage_uboot -E -p 0x3000 -f u-boot-ddr4.its u-boot-ddr4.itb
++	mkimage -E -p 0x3000 -f u-boot-ddr4.its u-boot-ddr4.itb
+ 	@rm -f u-boot.its $(dtbs_ddr4)
+ 
+ dtbs_ddr4_evk = evkddr4.dtb
+@@ -178,7 +178,7 @@ u-boot-ddr4-evk.itb: $(dtbs_ddr4_evk)
+ 	./$(PAD_IMAGE) bl31.bin
+ 	./$(PAD_IMAGE) u-boot-nodtb.bin $(dtbs_ddr4_evk)
+ 	DEK_BLOB_LOAD_ADDR=$(DEK_BLOB_LOAD_ADDR) TEE_LOAD_ADDR=$(TEE_LOAD_ADDR) ATF_LOAD_ADDR=$(ATF_LOAD_ADDR) ./mkimage_fit_atf.sh $(dtbs_ddr4_evk) > u-boot-ddr4-evk.its
+-	./mkimage_uboot -E -p 0x3000 -f u-boot-ddr4-evk.its u-boot-ddr4-evk.itb
++	mkimage -E -p 0x3000 -f u-boot-ddr4-evk.its u-boot-ddr4-evk.itb
+ 	@rm -f u-boot.its $(dtbs_ddr4_evk)
+ 
+ ifeq ($(HDMI),yes)
+@@ -285,7 +285,6 @@ nightly :
+ 	@$(WGET) -q $(SERVER)/$(DIR)/$(FW_DIR)/fsl-$(PLAT)-evk.dtb -O fsl-$(PLAT)-evk.dtb
+ 	@$(WGET) -q $(SERVER)/$(DIR)/$(FW_DIR)/signed_hdmi_imx8m.bin -O signed_hdmi_imx8m.bin
+ 	@$(WGET) -q $(SERVER)/$(DIR)/$(FW_DIR)/signed_dp_imx8m.bin -O signed_dp_imx8m.bin
+-	@$(WGET) -q $(SERVER)/$(DIR)/$(FW_DIR)/mkimage_uboot -O mkimage_uboot
+ 
+ archive :
+ 	git ls-files --others --exclude-standard -z | xargs -0 tar rvf $(ARCHIVE_PATH)/$(ARCHIVE_NAME)

--- a/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
+++ b/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
@@ -104,7 +104,6 @@ compile_mx8m() {
     fi
     cp ${DEPLOY_DIR_IMAGE}/${BOOT_TOOLS}/u-boot-nodtb.bin-${MACHINE}-${UBOOT_CONFIG} \
                                                              ${BOOT_STAGING}/u-boot-nodtb.bin
-    cp ${STAGING_DIR_NATIVE}/${bindir}/mkimage               ${BOOT_STAGING}/mkimage_uboot
     cp ${DEPLOY_DIR_IMAGE}/${BOOT_TOOLS}/${ATF_MACHINE_NAME} ${BOOT_STAGING}/bl31.bin
     cp ${DEPLOY_DIR_IMAGE}/${UBOOT_NAME}                     ${BOOT_STAGING}/u-boot.bin
 }
@@ -171,7 +170,6 @@ deploy_mx8m() {
     install -m 0644 ${BOOT_STAGING}/signed_hdmi_imx8m.bin    ${DEPLOYDIR}/${BOOT_TOOLS}
     install -m 0755 ${BOOT_STAGING}/${TOOLS_NAME}            ${DEPLOYDIR}/${BOOT_TOOLS}
     install -m 0755 ${BOOT_STAGING}/mkimage_fit_atf.sh       ${DEPLOYDIR}/${BOOT_TOOLS}
-    install -m 0755 ${BOOT_STAGING}/mkimage_uboot            ${DEPLOYDIR}/${BOOT_TOOLS}
 }
 deploy_mx8() {
     install -d ${DEPLOYDIR}/${BOOT_TOOLS}
@@ -193,7 +191,7 @@ deploy_mx8x() {
 }
 do_deploy() {
     deploy_${SOC_FAMILY}
-    # copy the tool mkimage to deploy path and sc fw, dcd and uboot
+    # copy the sc fw, dcd and uboot to deploy path
     install -m 0644 ${DEPLOY_DIR_IMAGE}/${UBOOT_NAME}        ${DEPLOYDIR}/${BOOT_TOOLS}
 
     # copy tee.bin to deploy path

--- a/recipes-bsp/imx-mkimage/imx-mkimage_git.inc
+++ b/recipes-bsp/imx-mkimage/imx-mkimage_git.inc
@@ -3,7 +3,9 @@
 DEPENDS = "zlib-native openssl-native"
 
 SRCBRANCH = "imx_5.4.24_2.1.0"
-SRC_URI = "git://source.codeaurora.org/external/imx/imx-mkimage.git;protocol=https;branch=${SRCBRANCH}"
+SRC_URI = "git://source.codeaurora.org/external/imx/imx-mkimage.git;protocol=https;branch=${SRCBRANCH} \
+           file://0001-iMX8M-soc.mak-use-native-mkimage-from-sysroot.patch \
+"
 SRCREV = "6745ccdcf15384891639b7ced3aa6ce938682365"
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
mkimage tool is provided as a part of sysroot and should not be used as a local copy, since it contains runtime dependencies which local copy does not account for.

Drop the local copy on mkimage, introduce the patch that fixes mkimage invocations in build system.


(cherry picked from commit c59f817b0d1ee70ef224405ff8acd31e0743ed91)