### PR TITLE
gstreamer: rename the version to be imx specific

### DIFF
--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -476,9 +476,9 @@ PREFERRED_VERSION_gstreamer1.0:mx8-nxp-bsp              ??= "1.20.3.imx"
 PREFERRED_VERSION_gstreamer1.0-plugins-base:mx8-nxp-bsp ??= "1.20.3.imx"
 PREFERRED_VERSION_gstreamer1.0-plugins-good:mx8-nxp-bsp ??= "1.20.3.imx"
 PREFERRED_VERSION_gstreamer1.0-plugins-bad:mx8-nxp-bsp  ??= "1.20.3.imx"
-PREFERRED_VERSION_gstreamer1.0-plugins-ugly:mx8-nxp-bsp ??= "1.20.3"
-PREFERRED_VERSION_gstreamer1.0-libav:mx8-nxp-bsp        ??= "1.20.3"
-PREFERRED_VERSION_gstreamer1.0-rtsp-server:mx8-nxp-bsp  ??= "1.20.3"
+PREFERRED_VERSION_gstreamer1.0-plugins-ugly:mx8-nxp-bsp ??= "1.20.3.imx"
+PREFERRED_VERSION_gstreamer1.0-libav:mx8-nxp-bsp        ??= "1.20.3.imx"
+PREFERRED_VERSION_gstreamer1.0-rtsp-server:mx8-nxp-bsp  ??= "1.20.3.imx"
 PREFERRED_VERSION_ffmpeg:mx8-nxp-bsp                    ??= "4.4.1"
 
 # Determines if the SoC has support for Vivante kernel driver

--- a/recipes-multimedia/gstreamer/gstreamer1.0-libav_1.20.3.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-libav_1.20.3.imx.bb
@@ -29,4 +29,9 @@ EXTRA_OEMESON += " \
 FILES:${PN} += "${libdir}/gstreamer-1.0/*.so"
 FILES:${PN}-staticdev += "${libdir}/gstreamer-1.0/*.a"
 
+# These recipes are copies of oe-core 1.20.3 that are not available
+# anymore upstream on the master branch.
+# The requirement to have them is because they are dependencies of
+# the other ones imx specific gstreamer forks on the layer.
+# So make their names maching the exisng ones will make it more safe.
 COMPATIBLE_MACHINE = "(imx-nxp-bsp)"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly_1.20.3.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly_1.20.3.imx.bb
@@ -45,4 +45,9 @@ EXTRA_OEMESON += " \
 FILES:${PN}-amrnb += "${datadir}/gstreamer-1.0/presets/GstAmrnbEnc.prs"
 FILES:${PN}-x264 += "${datadir}/gstreamer-1.0/presets/GstX264Enc.prs"
 
+# These recipes are copies of oe-core 1.20.3 that are not available
+# anymore upstream on the master branch.
+# The requirement to have them is because they are dependencies of
+# the other ones imx specific gstreamer forks on the layer.
+# So make their names maching the exisng ones will make it more safe.
 COMPATIBLE_MACHINE = "(imx-nxp-bsp)"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-rtsp-server_1.20.3.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-rtsp-server_1.20.3.imx.bb
@@ -30,4 +30,9 @@ require recipes-multimedia/gstreamer/gstreamer1.0-plugins-packaging.inc
 
 CVE_PRODUCT += "gst-rtsp-server"
 
+# These recipes are copies of oe-core 1.20.3 that are not available
+# anymore upstream on the master branch.
+# The requirement to have them is because they are dependencies of
+# the other ones imx specific gstreamer forks on the layer.
+# So make their names maching the exisng ones will make it more safe.
 COMPATIBLE_MACHINE = "(imx-nxp-bsp)"


### PR DESCRIPTION
These recipes are copies of oe-core 1.20.3 that are not available anymore upstream on the master branch.
The requirement to have them is because they are dependencies of the other ones imx specific gstreamer forks on the layer. So make their names maching the exisng ones will make it more safe.