### PR TITLE
gstreamer1.0-libav,gstreamer1.0-plugins-ugly,gstreamer1.0-rtsp-server…

### DIFF
--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -479,6 +479,7 @@ PREFERRED_VERSION_gstreamer1.0-plugins-bad:mx8-nxp-bsp  ??= "1.20.3.imx"
 PREFERRED_VERSION_gstreamer1.0-plugins-ugly:mx8-nxp-bsp ??= "1.20.3.imx"
 PREFERRED_VERSION_gstreamer1.0-libav:mx8-nxp-bsp        ??= "1.20.3.imx"
 PREFERRED_VERSION_gstreamer1.0-rtsp-server:mx8-nxp-bsp  ??= "1.20.3.imx"
+PREFERRED_VERSION_gstreamer1.0-python:mx8-nxp-bsp  ??= "1.20.3.imx"
 PREFERRED_VERSION_ffmpeg:mx8-nxp-bsp                    ??= "4.4.1"
 
 # Determines if the SoC has support for Vivante kernel driver

--- a/recipes-multimedia/gstreamer/gstreamer1.0-libav_1.20.3.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-libav_1.20.3.imx.bb
@@ -11,12 +11,12 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=69333daa044cb77e486cc36129f7a770 \
                     file://ext/libav/gstav.h;beginline=1;endline=18;md5=a752c35267d8276fd9ca3db6994fca9c \
                     "
 
-SRC_URI = "https://gstreamer.freedesktop.org/src/gst-libav/gst-libav-${PV}.tar.xz \
+SRC_URI = "https://gstreamer.freedesktop.org/src/gst-libav/gst-libav-${@get_gst_ver('${PV}')}.tar.xz \
            file://0001-libav-Fix-for-APNG-encoder-property-registration.patch \
            "
 SRC_URI[sha256sum] = "3fedd10560fcdfaa1b6462cbf79a38c4e7b57d7f390359393fc0cef6dbf27dfe"
 
-S = "${WORKDIR}/gst-libav-${PV}"
+S = "${WORKDIR}/gst-libav-${@get_gst_ver('${PV}')}"
 
 DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base ffmpeg"
 
@@ -25,6 +25,10 @@ inherit meson pkgconfig upstream-version-is-even
 EXTRA_OEMESON += " \
     -Dtests=disabled \
 "
+
+# Drop .imx from PV
+def get_gst_ver(v):
+    return oe.utils.trim_version(v, 3)
 
 FILES:${PN} += "${libdir}/gstreamer-1.0/*.so"
 FILES:${PN}-staticdev += "${libdir}/gstreamer-1.0/*.a"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly_1.20.3.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly_1.20.3.imx.bb
@@ -12,11 +12,11 @@ LICENSE = "LGPL-2.1-or-later & GPL-2.0-or-later"
 LICENSE_FLAGS = "commercial"
 
 SRC_URI = " \
-            https://gstreamer.freedesktop.org/src/gst-plugins-ugly/gst-plugins-ugly-${PV}.tar.xz \
+            https://gstreamer.freedesktop.org/src/gst-plugins-ugly/gst-plugins-ugly-${@get_gst_ver("${PV}")}.tar.xz \
             "
 SRC_URI[sha256sum] = "8caa20789a09c304b49cf563d33cca9421b1875b84fcc187e4a385fa01d6aefd"
 
-S = "${WORKDIR}/gst-plugins-ugly-${PV}"
+S = "${WORKDIR}/gst-plugins-ugly-${@get_gst_ver("${PV}")}"
 
 DEPENDS += "gstreamer1.0-plugins-base"
 
@@ -41,6 +41,10 @@ EXTRA_OEMESON += " \
     -Ddoc=disabled \
     -Dsidplay=disabled \
 "
+
+# Drop .imx from PV
+def get_gst_ver(v):
+    return oe.utils.trim_version(v, 3)
 
 FILES:${PN}-amrnb += "${datadir}/gstreamer-1.0/presets/GstAmrnbEnc.prs"
 FILES:${PN}-x264 += "${datadir}/gstreamer-1.0/presets/GstX264Enc.prs"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-python_1.20.3.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-python_1.20.3.imx.bb
@@ -1,0 +1,30 @@
+SUMMARY = "Python bindings for GStreamer 1.0"
+DESCRIPTION = "GStreamer Python binding overrides (complementing the bindings \
+provided by python-gi) "
+HOMEPAGE = "http://cgit.freedesktop.org/gstreamer/gst-python/"
+SECTION = "multimedia"
+
+LICENSE = "LGPL-2.1-or-later"
+LIC_FILES_CHKSUM = "file://COPYING;md5=c34deae4e395ca07e725ab0076a5f740"
+
+SRC_URI = "https://gstreamer.freedesktop.org/src/${PNREAL}/${PNREAL}-${@get_gst_ver('${PV}')}.tar.xz"
+SRC_URI[sha256sum] = "db348120eae955b8cc4de3560a7ea06e36d6e1ddbaa99a7ad96b59846601cfdc"
+
+DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base python3-pygobject"
+RDEPENDS:${PN} += "gstreamer1.0 gstreamer1.0-plugins-base python3-pygobject"
+
+PNREAL = "gst-python"
+
+S = "${WORKDIR}/${PNREAL}-${@get_gst_ver('${PV}')}"
+
+EXTRA_OEMESON += "\
+    -Dtests=disabled \
+    -Dplugin=enabled \
+    -Dlibpython-dir=${libdir} \
+"
+
+# Drop .imx from PV
+def get_gst_ver(v):
+    return oe.utils.trim_version(v, 3)
+
+inherit meson pkgconfig setuptools3-base upstream-version-is-even

--- a/recipes-multimedia/gstreamer/gstreamer1.0-rtsp-server_1.20.3.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-rtsp-server_1.20.3.imx.bb
@@ -8,11 +8,11 @@ DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base"
 
 PNREAL = "gst-rtsp-server"
 
-SRC_URI = "https://gstreamer.freedesktop.org/src/${PNREAL}/${PNREAL}-${PV}.tar.xz"
+SRC_URI = "https://gstreamer.freedesktop.org/src/${PNREAL}/${PNREAL}-${@get_gst_ver("${PV}")}.tar.xz"
 
 SRC_URI[sha256sum] = "ee402718be9b127f0e5e66ca4c1b4f42e4926ec93ba307b7ccca5dc6cc9794ca"
 
-S = "${WORKDIR}/${PNREAL}-${PV}"
+S = "${WORKDIR}/${PNREAL}-${@get_gst_ver("${PV}")}"
 
 inherit meson pkgconfig upstream-version-is-even gobject-introspection
 
@@ -24,6 +24,10 @@ EXTRA_OEMESON += " \
 
 GIR_MESON_ENABLE_FLAG = "enabled"
 GIR_MESON_DISABLE_FLAG = "disabled"
+
+# Drop .imx from PV
+def get_gst_ver(v):
+    return oe.utils.trim_version(v, 3)
 
 # Starting with 1.8.0 gst-rtsp-server includes dependency-less plugins as well
 require recipes-multimedia/gstreamer/gstreamer1.0-plugins-packaging.inc


### PR DESCRIPTION
…: Drop .imx when needing gstreamer version

Fixes fetching errors otherwise, since it can not file source tarballs on gstreamer download servers with 1.20.3.imx suffix


Cc: Jose Quaresma <jose.quaresma@foundries.io>