### PR TITLE
imx-gst1.0-plugin: Fix build with clang

### DIFF
--- a/recipes-extended/dpdk/dpdk.inc
+++ b/recipes-extended/dpdk/dpdk.inc
@@ -24,7 +24,7 @@ DPDK_RTE_TARGET ?= "${ARCH}-dpaa-linuxapp-gcc"
 
 export RTE_TARGET = "${DPDK_RTE_TARGET}"
 export RTE_OUTPUT = "${S}/${RTE_TARGET}"
-export  MODULE_DIR = "/lib/modules/${KERNEL_VERSION}/kernel/drivers/net"
+export  MODULE_DIR = "${nonarch_base_libdir}/modules/${KERNEL_VERSION}/kernel/drivers/net"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-extended/dpdk/dpdk/0001-examples-fix-Arm-build-with-GCC-12.patch
+++ b/recipes-extended/dpdk/dpdk/0001-examples-fix-Arm-build-with-GCC-12.patch
@@ -1,0 +1,49 @@
+From 229fc129be85a4d2d2c4efddae7bb97c3d87d416 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Mon, 13 Mar 2023 22:02:01 -0700
+Subject: [PATCH] examples: fix Arm build with GCC 12
+
+GCC-12 warns when a pointer of type union points to an array of same
+defined size, as union internally gets paded with pad bytes.
+
+    ../examples/common/neon/port_group.h:42:21: error: array subscript
+            'union <anonymous>[0]' is partly outside array bounds of
+            'uint16_t[5]' {aka 'short unsigned int[5]'}
+            [-Werror=array-bounds]
+       42 |                 pnum->u64 = gptbl[v].pnum;
+          |                     ^~
+    ../examples/common/neon/port_group.h:21:23: note: object 'pn' of
+            size [0, 10]
+       21 | port_groupx4(uint16_t pn[FWDSTEP + 1], uint16_t *lp, uint16x8_t dp1
+          |              ~~~~~~~~~^~~~~~~~~~~~~~~
+    ../examples/common/neon/port_group.h:43:21: error: array subscript
+            'union <anonymous>[0]' is partly outside array bounds of
+            'uint16_t[5]' {aka 'short unsigned int[5]'} [-Werror=array-bounds]
+       43 |                 pnum->u16[FWDSTEP] = 1;
+          |                     ^~
+
+Fixes: 732115ce38c6 ("examples/l3fwd: move packet group function in common")
+
+Upstream-Status: Backport [https://github.com/DPDK/dpdk/commit/b269bd630e96b276a69d698e13ad9ebfbbb67512]
+Signed-off-by: Amit Prakash Shukla <amitprakashs@marvell.com>
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ examples/l3fwd/l3fwd_neon.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/examples/l3fwd/l3fwd_neon.h b/examples/l3fwd/l3fwd_neon.h
+index 86ac5971d7..dc73e9fef7 100644
+--- a/examples/l3fwd/l3fwd_neon.h
++++ b/examples/l3fwd/l3fwd_neon.h
+@@ -77,7 +77,7 @@ port_groupx4(uint16_t pn[FWDSTEP + 1], uint16_t *lp, uint16x8_t dp1,
+ 	union {
+ 		uint16_t u16[FWDSTEP + 1];
+ 		uint64_t u64;
+-	} *pnum = (void *)pn;
++	} __rte_packed *pnum = (void *)pn;
+ 
+ 	int32_t v;
+ 	uint16x8_t mask = {1, 2, 4, 8, 0, 0, 0, 0};
+-- 
+2.39.2
+

--- a/recipes-extended/dpdk/dpdk_19.11-20.12.bb
+++ b/recipes-extended/dpdk/dpdk_19.11-20.12.bb
@@ -8,6 +8,7 @@ SRC_URI = "git://github.com/nxp-qoriq/dpdk;protocol=https;nobranch=1 \
            file://0001-add-Wno-cast-function-type.patch \
            file://0001-Add-RTE_KERNELDIR_OUT.patch \
            file://0005-use-python3-instead-of-python.patch \
+           file://0001-examples-fix-Arm-build-with-GCC-12.patch \
 "
 SRCREV = "7071c27f6f5aefb57de1cffab3484707b1e82e2b"
 

--- a/recipes-multimedia/gstreamer/imx-gst1.0-plugin/0001-aiurdemux-Fix-type-of-USER_DATA_LOCATION.patch
+++ b/recipes-multimedia/gstreamer/imx-gst1.0-plugin/0001-aiurdemux-Fix-type-of-USER_DATA_LOCATION.patch
@@ -1,0 +1,33 @@
+From 090fb758a63b7d362d9bee8b8a665d1346c83f83 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Mon, 13 Mar 2023 20:15:22 -0700
+Subject: [PATCH 01/10] aiurdemux: Fix type of USER_DATA_LOCATION
+
+It should be char pointer not integer
+Fixe
+plugins/aiurdemux/aiurdemux.c:198:47: error: incompatible integer to pointer conversion initializin
+g 'const gchar *' (aka 'const char *') with an expression of type 'int' [-Wint-conversion]
+  {USER_DATA_LOCATION, USER_DATA_FORMAT_UTF8, -1,
+                                              ^~
+Upstream-Status: Submitted [https://github.com/nxp-imx/imx-gst1.0-plugin/pull/4]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ plugins/aiurdemux/aiurdemux.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/plugins/aiurdemux/aiurdemux.c b/plugins/aiurdemux/aiurdemux.c
+index 532b439..39c50ea 100755
+--- a/plugins/aiurdemux/aiurdemux.c
++++ b/plugins/aiurdemux/aiurdemux.c
+@@ -195,7 +195,7 @@ static AiurDemuxTagEntry g_user_data_entry[] = {
+       "Track Number : %s\n"},
+   {USER_DATA_TOTALTRACKNUMBER, USER_DATA_FORMAT_UTF8, GST_TAG_TRACK_COUNT,
+       "Track Count : %s\n"},
+-  {USER_DATA_LOCATION, USER_DATA_FORMAT_UTF8, -1,
++  {USER_DATA_LOCATION, USER_DATA_FORMAT_UTF8, (const gchar*)-1,
+       "Location : %s\n"},
+   {USER_DATA_KEYWORDS, USER_DATA_FORMAT_UTF8, GST_TAG_KEYWORDS,
+       "Keywords : %s\n"},
+-- 
+2.39.2
+

--- a/recipes-multimedia/gstreamer/imx-gst1.0-plugin/0002-aiurdemux.h-Include-glib-gprintf.h-for-g_printf-prot.patch
+++ b/recipes-multimedia/gstreamer/imx-gst1.0-plugin/0002-aiurdemux.h-Include-glib-gprintf.h-for-g_printf-prot.patch
@@ -1,0 +1,28 @@
+From f8b8322cd4c3a69e5cb47b5cb33abe860e89d6ed Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sun, 12 Mar 2023 20:33:54 -0700
+Subject: [PATCH 02/10] aiurdemux.h: Include glib/gprintf.h for g_printf
+ prototype
+
+Upstream-Status: Submitted [https://github.com/nxp-imx/imx-gst1.0-plugin/pull/4]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ plugins/aiurdemux/aiurdemux.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/plugins/aiurdemux/aiurdemux.h b/plugins/aiurdemux/aiurdemux.h
+index 1d7d0a0..f7fcb2e 100755
+--- a/plugins/aiurdemux/aiurdemux.h
++++ b/plugins/aiurdemux/aiurdemux.h
+@@ -39,7 +39,7 @@
+ #include <gst/gst.h>
+ #include <gst/base/gstadapter.h>
+ #include <gst/tag/tag.h>
+-
++#include <glib/gprintf.h>
+ //#include "mfw_gst_utils.h"
+ 
+ #include "fsl_parser.h"
+-- 
+2.39.2
+

--- a/recipes-multimedia/gstreamer/imx-gst1.0-plugin/0003-grecorder-Fix-build-with-clang.patch
+++ b/recipes-multimedia/gstreamer/imx-gst1.0-plugin/0003-grecorder-Fix-build-with-clang.patch
@@ -1,0 +1,44 @@
+From 19e6a541d2026386c9cfdeca0eebd269fef2536c Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Mon, 13 Mar 2023 20:29:01 -0700
+Subject: [PATCH 03/10] grecorder: Fix build with clang
+
+Add missing includes for APIs from libc and glib
+Add prototype declaration for post_message before
+using it in macros later in the same source file
+
+Upstream-Status: Submitted [https://github.com/nxp-imx/imx-gst1.0-plugin/pull/4]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ tools/grecorder/grecorder.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/tools/grecorder/grecorder.c b/tools/grecorder/grecorder.c
+index c8eff2f..89aa801 100644
+--- a/tools/grecorder/grecorder.c
++++ b/tools/grecorder/grecorder.c
+@@ -23,10 +23,11 @@
+ #include <semaphore.h>
+ #include <pthread.h>
+ #include <signal.h>
++#include <unistd.h> /* sleep */
+ #include <getopt.h>
+ #define __USE_LARGEFILE64
+ #include <sys/statvfs.h>
+-
++#include <glib/gprintf.h> /* g_print */
+ #include "recorder_engine.h"
+ 
+ #define LOG_ERROR printf
+@@ -168,6 +169,8 @@ static RecorderMessage latest_message = MESSAGE_NULL;
+ 
+ static volatile sig_atomic_t quit_flag = 0;
+ 
++static void post_message (RecorderMessage message);
++
+ static void signal_handler(int signum)
+ {
+   quit_flag = 1;
+-- 
+2.39.2
+

--- a/recipes-multimedia/gstreamer/imx-gst1.0-plugin/0004-gstimxcommon-Return-0-instead-of-NULL-for-a-function.patch
+++ b/recipes-multimedia/gstreamer/imx-gst1.0-plugin/0004-gstimxcommon-Return-0-instead-of-NULL-for-a-function.patch
@@ -1,0 +1,87 @@
+From 141f8f692ae2c7e6d41a2d78113c806602122ad5 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sun, 12 Mar 2023 19:51:27 -0700
+Subject: [PATCH 04/10] gstimxcommon: Return 0 instead of NULL for a functions
+ returning unsigned long
+
+Fixes
+gstimxcommon.c:113:10: error: incompatible pointer to integer conversion returning 'void *' from a function with result type 'unsigned long' [-Wint-conversion]
+  return NULL;
+
+Upstream-Status: Submitted [https://github.com/nxp-imx/imx-gst1.0-plugin/pull/4]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ libs/gstimxcommon.c | 18 +++++++++---------
+ 1 file changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/libs/gstimxcommon.c b/libs/gstimxcommon.c
+index 27fd913..803c6e5 100644
+--- a/libs/gstimxcommon.c
++++ b/libs/gstimxcommon.c
+@@ -35,13 +35,13 @@ unsigned long phy_addr_from_fd(int dmafd)
+   int ret, fd;
+ 
+   if (dmafd < 0)
+-    return NULL;
++    return 0;
+   
+ #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 0)
+ #ifdef USE_ION
+   fd = open(dev_ion, O_RDWR);
+   if(fd < 0) {
+-    return NULL;
++    return 0;
+   }
+ 
+   struct ion_phys_dma_data data = {
+@@ -58,18 +58,18 @@ unsigned long phy_addr_from_fd(int dmafd)
+   ret = ioctl(fd, ION_IOC_CUSTOM, &custom);
+   close(fd);
+   if (ret < 0)
+-    return NULL;
++    return 0;
+ 
+   return data.phys;
+ #else
+-  return NULL;
++  return 0;
+ #endif /* USE_ION */
+ #else
+   struct dma_buf_phys dma_phys;
+ 
+   ret = ioctl(dmafd, DMA_BUF_IOCTL_PHYS, &dma_phys);
+   if (ret < 0)
+-    return NULL;
++    return 0;
+ 
+   return dma_phys.phys;
+ #endif
+@@ -86,7 +86,7 @@ unsigned long phy_addr_from_vaddr(void *vaddr, int size)
+ #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 0)
+   fd = open(dev_ion, O_RDWR);
+   if(fd < 0) {
+-    return NULL;
++    return 0;
+   }
+ 
+   struct ion_phys_virt_data data = {
+@@ -103,13 +103,13 @@ unsigned long phy_addr_from_vaddr(void *vaddr, int size)
+   ret = ioctl(fd, ION_IOC_CUSTOM, &custom);
+   close(fd);
+   if (ret < 0)
+-    return NULL;
++    return 0;
+ 
+   return data.phys;
+ #else
+-  return NULL;
++  return 0;
+ #endif
+ #else
+-  return NULL;
++  return 0;
+ #endif
+ }
+-- 
+2.39.2
+

--- a/recipes-multimedia/gstreamer/imx-gst1.0-plugin/0005-aiurstreamcache-Include-gst-gstinfo.h.patch
+++ b/recipes-multimedia/gstreamer/imx-gst1.0-plugin/0005-aiurstreamcache-Include-gst-gstinfo.h.patch
@@ -1,0 +1,28 @@
+From 379b0492a4b53fd8fd42c734d04fd62df2e0465f Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Mon, 13 Mar 2023 20:16:48 -0700
+Subject: [PATCH 05/10] aiurstreamcache: Include gst/gstinfo.h
+
+Its needed for various GST_* defines
+
+Upstream-Status: Submitted [https://github.com/nxp-imx/imx-gst1.0-plugin/pull/4]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ plugins/aiurdemux/aiurstreamcache.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/plugins/aiurdemux/aiurstreamcache.c b/plugins/aiurdemux/aiurstreamcache.c
+index d566268..e114a9d 100755
+--- a/plugins/aiurdemux/aiurstreamcache.c
++++ b/plugins/aiurdemux/aiurstreamcache.c
+@@ -33,6 +33,7 @@
+  * Changelog:
+  *
+  */
++ #include <gst/gstinfo.h>
+ 
+ GST_DEBUG_CATEGORY_EXTERN (aiurdemux_debug);
+ #define GST_CAT_DEFAULT aiurdemux_debug
+-- 
+2.39.2
+

--- a/recipes-multimedia/gstreamer/imx-gst1.0-plugin/0006-Fix-typecast-warnings-found-with-clang.patch
+++ b/recipes-multimedia/gstreamer/imx-gst1.0-plugin/0006-Fix-typecast-warnings-found-with-clang.patch
@@ -1,0 +1,61 @@
+From 02e16c4de3f138f0ebabf699e840bb86c98be599 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sun, 12 Mar 2023 20:45:23 -0700
+Subject: [PATCH 06/10] Fix typecast warnings found with clang
+
+Upstream-Status: Submitted [https://github.com/nxp-imx/imx-gst1.0-plugin/pull/4]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ libs/device-2d/imx_2d_device_g2d.c | 15 ++++++++-------
+ 1 file changed, 8 insertions(+), 7 deletions(-)
+
+diff --git a/libs/device-2d/imx_2d_device_g2d.c b/libs/device-2d/imx_2d_device_g2d.c
+index 2672e0b..6a36f6a 100755
+--- a/libs/device-2d/imx_2d_device_g2d.c
++++ b/libs/device-2d/imx_2d_device_g2d.c
+@@ -425,7 +425,7 @@ static gint imx_g2d_blit(Imx2DDevice *device,
+       goto err;
+     }
+     if (paddr) {
+-      src->mem->paddr = paddr;
++      src->mem->paddr = (guint8*)paddr;
+     } else {
+       GST_ERROR ("Can't get physical address.");
+       ret = -1;
+@@ -435,7 +435,7 @@ static gint imx_g2d_blit(Imx2DDevice *device,
+   if (!dst->mem->paddr) {
+     paddr = phy_addr_from_fd (dst->fd[0]);
+     if (paddr) {
+-      dst->mem->paddr = paddr;
++      dst->mem->paddr = (guint8*)paddr;
+     } else {
+       GST_ERROR ("Can't get physical address.");
+       ret = -1;
+@@ -474,10 +474,11 @@ static gint imx_g2d_blit(Imx2DDevice *device,
+ 
+   if (src->fd[1] >= 0)
+   {
+-    if (!src->mem->user_data)
+-      src->mem->user_data = g2d->src.base.planes[1] = phy_addr_from_fd (src->fd[1]);
+-    else
+-      g2d->src.base.planes[1] = src->mem->user_data;
++    if (!src->mem->user_data) {
++      g2d->src.base.planes[1] = (gint)phy_addr_from_fd (src->fd[1]);
++      src->mem->user_data = (gpointer *)g2d->src.base.planes[1];
++    } else
++      g2d->src.base.planes[1] = (unsigned long)src->mem->user_data;
+   }
+   switch (src->interlace_type) {
+     case IMX_2D_INTERLACE_INTERLEAVED:
+@@ -693,7 +694,7 @@ static gint imx_g2d_fill_color(Imx2DDevice *device, Imx2DFrame *dst,
+   if (!dst->mem->paddr) {
+     paddr = phy_addr_from_fd (dst->fd[0]);
+     if (paddr) {
+-      dst->mem->paddr = paddr;
++      dst->mem->paddr = (guint8*)paddr;
+     } else {
+       GST_ERROR ("Can't get physical address.");
+       return -1;
+-- 
+2.39.2
+

--- a/recipes-multimedia/gstreamer/imx-gst1.0-plugin/0007-gstimxv4l2-Fix-typecasting-errors.patch
+++ b/recipes-multimedia/gstreamer/imx-gst1.0-plugin/0007-gstimxv4l2-Fix-typecasting-errors.patch
@@ -1,0 +1,30 @@
+From a1a2069403e227d4d40fc99257d1be077f65bdc8 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sun, 12 Mar 2023 19:54:18 -0700
+Subject: [PATCH 07/10] gstimxv4l2: Fix typecasting errors
+
+Fixes
+gstimxv4l2.c:1702:22: error: incompatible pointer to integer conversion assigning to 'unsigned long' from 'guint8 *' (aka 'unsigned char *') [-Wint-conversion]
+
+Upstream-Status: Submitted [https://github.com/nxp-imx/imx-gst1.0-plugin/pull/4]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ libs/v4l2_core/gstimxv4l2.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libs/v4l2_core/gstimxv4l2.c b/libs/v4l2_core/gstimxv4l2.c
+index 1dc826b..bf2620a 100755
+--- a/libs/v4l2_core/gstimxv4l2.c
++++ b/libs/v4l2_core/gstimxv4l2.c
+@@ -1699,7 +1699,7 @@ gint gst_imx_v4l2_register_buffer (gpointer v4l2handle, PhyMemBlock *memblk)
+   v4l2buf->type = handle->type;
+   v4l2buf->memory = handle->memory_mode;
+   v4l2buf->index = handle->allocated;
+-  v4l2buf->m.userptr = memblk->paddr;
++  v4l2buf->m.userptr = (unsigned long)memblk->paddr;
+   v4l2buf->length = memblk->size;
+   handle->buffer_pair[handle->allocated].vaddr = memblk->vaddr;
+ 
+-- 
+2.39.2
+

--- a/recipes-multimedia/gstreamer/imx-gst1.0-plugin/0008-beepdec-Declare-beep_register_external_typefinders.patch
+++ b/recipes-multimedia/gstreamer/imx-gst1.0-plugin/0008-beepdec-Declare-beep_register_external_typefinders.patch
@@ -1,0 +1,32 @@
+From e86c20fee52f79a270a1913c5f0be98fb3f5cb77 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Mon, 13 Mar 2023 20:18:18 -0700
+Subject: [PATCH 08/10] beepdec: Declare beep_register_external_typefinders
+
+Fixes
+plugins/beepdec/beep.c:45:3: error: call to undeclared function 'beep_register_external_typefinders'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
+  beep_register_external_typefinders (plugin);
+  ^
+
+Upstream-Status: Submitted [https://github.com/nxp-imx/imx-gst1.0-plugin/pull/4]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ plugins/beepdec/beep.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/plugins/beepdec/beep.c b/plugins/beepdec/beep.c
+index 3543352..e174bb3 100755
+--- a/plugins/beepdec/beep.c
++++ b/plugins/beepdec/beep.c
+@@ -37,7 +37,7 @@
+ #endif
+ #include "beepdec.h"
+ #include "gstimxcommon.h"
+-
++extern gboolean beep_register_external_typefinders (GstPlugin * plugin);
+ static gboolean
+ plugin_init (GstPlugin * plugin)
+ {
+-- 
+2.39.2
+

--- a/recipes-multimedia/gstreamer/imx-gst1.0-plugin/0009-gstimxv4l2.c-Fix-incompatible-integer-to-pointer-con.patch
+++ b/recipes-multimedia/gstreamer/imx-gst1.0-plugin/0009-gstimxv4l2.c-Fix-incompatible-integer-to-pointer-con.patch
@@ -1,0 +1,41 @@
+From 8a3d7f26c73bdfe050d3331b30ae2f5917dc6723 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sun, 12 Mar 2023 19:59:22 -0700
+Subject: [PATCH 09/10] gstimxv4l2.c: Fix incompatible integer to pointer
+ conversion returning
+
+Fixes
+gstimxv4l2.c:1587:24: error: incompatible pointer to integer conversion assigning to 'unsigned long' from 'guint8 *' (aka 'unsigned char *') [-Wint-c
+onversion]
+
+Upstream-Status: Submitted [https://github.com/nxp-imx/imx-gst1.0-plugin/pull/4]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ libs/v4l2_core/gstimxv4l2.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/libs/v4l2_core/gstimxv4l2.c b/libs/v4l2_core/gstimxv4l2.c
+index bf2620a..0fd7452 100755
+--- a/libs/v4l2_core/gstimxv4l2.c
++++ b/libs/v4l2_core/gstimxv4l2.c
+@@ -1576,7 +1576,7 @@ static void * gst_imx_v4l2_find_buffer(gpointer v4l2handle, PhyMemBlock *memblk)
+ 
+     if (handle->allocated >= MAX_BUFFER) {
+       GST_ERROR ("No more v4l2 buffer for allocating.\n");
+-      return -1;
++      return NULL;
+     }
+ 
+     v4l2buf = &handle->buffer_pair[handle->allocated].v4l2buffer;
+@@ -1584,7 +1584,7 @@ static void * gst_imx_v4l2_find_buffer(gpointer v4l2handle, PhyMemBlock *memblk)
+     v4l2buf->type = handle->type;
+     v4l2buf->memory = handle->memory_mode;
+     v4l2buf->index = handle->allocated;
+-    v4l2buf->m.userptr = memblk->paddr;
++    v4l2buf->m.userptr = (unsigned long)memblk->paddr;
+     v4l2buf->length = memblk->size;
+     handle->buffer_pair[handle->allocated].vaddr = memblk->vaddr;
+ 
+-- 
+2.39.2
+

--- a/recipes-multimedia/gstreamer/imx-gst1.0-plugin/0010-provide-declaration-for-aiur_register_external_typef.patch
+++ b/recipes-multimedia/gstreamer/imx-gst1.0-plugin/0010-provide-declaration-for-aiur_register_external_typef.patch
@@ -1,0 +1,28 @@
+From c2144da90e64547d9e346f8e721a0d2155ed610b Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sun, 12 Mar 2023 21:09:49 -0700
+Subject: [PATCH 10/10] provide declaration for
+ aiur_register_external_typefinders
+
+Upstream-Status: Submitted [https://github.com/nxp-imx/imx-gst1.0-plugin/pull/4]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ plugins/aiurdemux/aiur.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/plugins/aiurdemux/aiur.c b/plugins/aiurdemux/aiur.c
+index 2a52465..681ae2e 100755
+--- a/plugins/aiurdemux/aiur.c
++++ b/plugins/aiurdemux/aiur.c
+@@ -41,6 +41,8 @@
+ #include "aiurdemux.h"
+ #include "gstimxcommon.h"
+ 
++extern gboolean aiur_register_external_typefinders (GstPlugin * plugin);
++
+ static gboolean
+ plugin_init (GstPlugin * plugin)
+ {
+-- 
+2.39.2
+

--- a/recipes-multimedia/gstreamer/imx-gst1.0-plugin_git.bb
+++ b/recipes-multimedia/gstreamer/imx-gst1.0-plugin_git.bb
@@ -25,7 +25,18 @@ LIC_FILES_CHKSUM = "file://COPYING-LGPL-2;md5=5f30f0716dfdd0d91eb439ebec522ec2 \
 
 PV = "4.7.2+git${SRCPV}"
 
-SRC_URI = "git://github.com/nxp-imx/imx-gst1.0-plugin.git;protocol=https;branch=${SRCBRANCH}"
+SRC_URI = "git://github.com/nxp-imx/imx-gst1.0-plugin.git;protocol=https;branch=${SRCBRANCH} \
+           file://0001-aiurdemux-Fix-type-of-USER_DATA_LOCATION.patch \
+           file://0002-aiurdemux.h-Include-glib-gprintf.h-for-g_printf-prot.patch \
+           file://0003-grecorder-Fix-build-with-clang.patch \
+           file://0004-gstimxcommon-Return-0-instead-of-NULL-for-a-function.patch \
+           file://0005-aiurstreamcache-Include-gst-gstinfo.h.patch \
+           file://0006-Fix-typecast-warnings-found-with-clang.patch \
+           file://0007-gstimxv4l2-Fix-typecasting-errors.patch \
+           file://0008-beepdec-Declare-beep_register_external_typefinders.patch \
+           file://0009-gstimxv4l2.c-Fix-incompatible-integer-to-pointer-con.patch \
+           file://0010-provide-declaration-for-aiur_register_external_typef.patch \
+           "
 SRCBRANCH = "MM_04.07.02_2210_L5.15.y"
 SRCREV = "3a0250b983f2610e6936d10c63b45e2d39eadd7e"
 
@@ -42,6 +53,8 @@ PLATFORM:mx7-nxp-bsp= "MX7D"
 PLATFORM:mx7ulp-nxp-bsp= "MX7ULP"
 PLATFORM:mx8-nxp-bsp = "MX8"
 PLATFORM:mx9-nxp-bsp = "MX9"
+
+CFLAGS:append:toolchain-clang = " -Wno-implicit-int -Wno-int-conversion -Wno-incompatible-function-pointer-types"
 
 # Todo add a mechanism to map possible build targets
 EXTRA_OEMESON = "-Dplatform=${PLATFORM} \


### PR DESCRIPTION
These warnings are already there, gcc just does not error on them yet but clang does. Therefore clean them up a bit