### PR TITLE
gstreamer1.0-plugins-base: set default videosink for IMXQM/IMXQXP

### DIFF
--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base/0001-meson-introduce-default-videosink-autosink-options.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base/0001-meson-introduce-default-videosink-autosink-options.patch
@@ -1,0 +1,110 @@
+From 7f44fc14f83f8ff03783f1a97df8cbabab1eada4 Mon Sep 17 00:00:00 2001
+From: Ming Liu <liu.ming50@gmail.com>
+Date: Wed, 15 Mar 2023 10:54:48 +0100
+Subject: [PATCH] meson: introduce default videosink and autosink options
+
+So the end users can choose the default videosink/autosink at build
+time. It now also supports pipelines as default videosink/autosink,
+if no options chosen by meson, the default values go to autoaudiosink
+and autovideosink, no functional changes in that case.
+
+Upstream-Status: Submitted [https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/4168]
+
+Signed-off-by: Ming Liu <liu.ming50@gmail.com>
+---
+ gst/playback/gstplaysink.c      | 12 ++++++++++--
+ meson.build                     |  5 ++---
+ meson_options.txt               |  5 +++++
+ tools/gst-play.c                |  7 +++++++
+ 4 files changed, 24 insertions(+), 5 deletions(-)
+
+diff --git a/gst/playback/gstplaysink.c b/gst/playback/gstplaysink.c
+index a5619e9464..62b508f88e 100644
+--- a/gst/playback/gstplaysink.c
++++ b/gst/playback/gstplaysink.c
+@@ -1780,7 +1780,11 @@ gen_video_chain (GstPlaySink * playsink, gboolean raw, gboolean async)
+       /* if default sink from config.h is different then try it too */
+       if (strcmp (DEFAULT_VIDEOSINK, "autovideosink")) {
+         GST_DEBUG_OBJECT (playsink, "trying " DEFAULT_VIDEOSINK);
+-        elem = gst_element_factory_make (DEFAULT_VIDEOSINK, "videosink");
++        /* Check if it's a pipeline description */
++        if (strchr (DEFAULT_VIDEOSINK, ' ') != NULL)
++          elem = gst_parse_bin_from_description (DEFAULT_VIDEOSINK, TRUE, NULL);
++        else
++          elem = gst_element_factory_make (DEFAULT_VIDEOSINK, "videosink");
+         chain->sink = try_element (playsink, elem, TRUE);
+       }
+     }
+@@ -2723,7 +2727,11 @@ gen_audio_chain (GstPlaySink * playsink, gboolean raw)
+       /* if default sink from config.h is different then try it too */
+       if (strcmp (DEFAULT_AUDIOSINK, "autoaudiosink")) {
+         GST_DEBUG_OBJECT (playsink, "trying " DEFAULT_AUDIOSINK);
+-        elem = gst_element_factory_make (DEFAULT_AUDIOSINK, "audiosink");
++        /* Check if it's a pipeline description */
++        if (strchr (DEFAULT_AUDIOSINK, ' ') != NULL)
++          elem = gst_parse_bin_from_description (DEFAULT_AUDIOSINK, TRUE, NULL);
++        else
++          elem = gst_element_factory_make (DEFAULT_AUDIOSINK, "audiosink");
+         chain->sink = try_element (playsink, elem, TRUE);
+       }
+     }
+diff --git a/meson.build b/meson.build
+index a390dfd69b..f9703aed49 100644
+--- a/meson.build
++++ b/meson.build
+@@ -293,9 +293,8 @@ endif
+ core_conf.set_quoted('GST_PACKAGE_NAME', gst_package_name)
+ core_conf.set_quoted('GST_PACKAGE_ORIGIN', get_option('package-origin'))
+ 
+-# FIXME: These should be configure options
+-core_conf.set_quoted('DEFAULT_VIDEOSINK', 'autovideosink')
+-core_conf.set_quoted('DEFAULT_AUDIOSINK', 'autoaudiosink')
++core_conf.set_quoted('DEFAULT_VIDEOSINK', get_option('default_videosink'))
++core_conf.set_quoted('DEFAULT_AUDIOSINK', get_option('default_audiosink'))
+ 
+ # Set whether the audioresampling method should be detected at runtime
+ core_conf.set('AUDIORESAMPLE_FORMAT_' + get_option('audioresample_format').to_upper(), true)
+diff --git a/meson_options.txt b/meson_options.txt
+index 50ec6aae1f..865f6a84ec 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -21,6 +21,11 @@ option('opengl_module_name', type : 'string', value : '',
+ option('gles2_module_name', type : 'string', value : '',
+        description : 'The file to pass to g_module_open to open the libGLESv2 library (default: libGLESv2)')
+ 
++option('default_audiosink', type : 'string', value : 'autoaudiosink',
++       description : 'The default audiosink')
++option('default_videosink', type : 'string', value : 'autovideosink',
++       description : 'The default videosink')
++
+ # Feature option for opengl plugin and integration library
+ option('gl', type : 'feature', value : 'auto', description : 'OpenGL integration library and OpenGL plugin')
+ option('gl-graphene', type : 'feature', value : 'auto', description : 'Use Graphene in OpenGL plugin')
+diff --git a/tools/gst-play.c b/tools/gst-play.c
+index ee8847d2f1..4fa36299cb 100644
+--- a/tools/gst-play.c
++++ b/tools/gst-play.c
+@@ -219,6 +219,7 @@ play_new (gchar ** uris, const gchar * audio_sink, const gchar * video_sink,
+     else
+       g_warning ("Couldn't create specified audio sink '%s'", audio_sink);
+   }
++
+   if (video_sink != NULL) {
+     if (strchr (video_sink, ' ') != NULL)
+       sink = gst_parse_bin_from_description (video_sink, TRUE, NULL);
+@@ -1758,6 +1759,12 @@ real_main (int argc, char **argv)
+     playlist_file = NULL;
+   }
+ 
++  if (audio_sink == NULL)
++    audio_sink = g_strdup (DEFAULT_AUDIOSINK);
++
++  if (video_sink == NULL)
++    video_sink = g_strdup (DEFAULT_VIDEOSINK);
++
+   if (playlist->len == 0 && (filenames == NULL || *filenames == NULL)) {
+     gst_printerr (_("Usage: %s FILE1|URI1 [FILE2|URI2] [FILE3|URI3] ..."),
+         "gst-play-" GST_API_VERSION);
+-- 
+2.25.1
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.20.3.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.20.3.imx.bb
@@ -121,7 +121,9 @@ SRC_URI:remove = " \
     file://0003-viv-fb-Make-sure-config.h-is-included.patch \
     file://0002-ssaparse-enhance-SSA-text-lines-parsing.patch"
 SRC_URI:prepend = "${GST1.0-PLUGINS-BASE_SRC};branch=${SRCBRANCH} "
-SRC_URI += "file://0001-gstallocatorphymem.c-Typecast-result-of-gst_phymem_g.patch"
+SRC_URI:append = " \
+    file://0001-gstallocatorphymem.c-Typecast-result-of-gst_phymem_g.patch \
+    file://0001-meson-introduce-default-videosink-autosink-options.patch"
 GST1.0-PLUGINS-BASE_SRC ?= "gitsm://github.com/nxp-imx/gst-plugins-base.git;protocol=https"
 SRCBRANCH = "MM_04.07.02_2210_L5.15.y"
 SRCREV = "cbf542ce3e0bad1009d5ecf72707e870c375c3f0"
@@ -144,7 +146,12 @@ PACKAGECONFIG:append:imxgpu2d = " g2d"
 PACKAGECONFIG[g2d] = ",,virtual/libg2d"
 PACKAGECONFIG[viv-fb] = ",,virtual/libgles2"
 
-EXTRA_OEMESON += "-Dc_args="${CFLAGS} -I${STAGING_INCDIR_IMX}""
+DEFAULT_AUDIOSINK ?= "autoaudiosink"
+DEFAULT_VIDEOSINK ?= "autovideosink"
+DEFAULT_VIDEOSINK:mx8qm-nxp-bsp = "imxvideoconvert_g2d ! autovideosink"
+DEFAULT_VIDEOSINK:mx8qxp-nxp-bsp = "imxvideoconvert_g2d ! autovideosink"
+
+EXTRA_OEMESON += "-Ddefault_audiosink="${DEFAULT_AUDIOSINK}" -Ddefault_videosink="${DEFAULT_VIDEOSINK}" -Dc_args="${CFLAGS} -I${STAGING_INCDIR_IMX}""
 
 # links with imx-gpu libs which are pre-built for glibc
 # gcompat will address it during runtime


### PR DESCRIPTION
The default 'autovideosink' gives very bad performance when playing H264/H265 videos on IMXQM/IMXQXP machines. Let's choose 'imxvideoconvert_g2d ! autovideosink' as the default videosink, so the end users dont need manually pass 'imxvideoconvert_g2d' pipeline to gst-play-1.0.