### PR TITLE
Allow generation of mfgtool bundle

### DIFF
--- a/classes/image_populate_mfgtool.bbclass
+++ b/classes/image_populate_mfgtool.bbclass
@@ -1,0 +1,139 @@
+# Allow generation of mfgtool bundle
+#
+# The class provides the infrastructure for MFGTOOL generation and is tied to images. To generate
+# the bundle, the task populate_mfgtool must be called. For example:
+#
+# ,----[ Running populate_mfgtool for core-image-minimal image ]
+# | $: bitbake core-image-minimal -c populate_mfgtool
+# `----
+#
+# The class behavior is controlled through the MFGTOOLCONFIG (analogous to PACKAGECONFIG)
+# variable. The MFGTOOLCONFIG variable itself specifies a space-separated list of the script to
+# enable. Following the script, you can determine the behavior of each script by providing up to two
+# order-dependent arguments, which are separated by commas. You can omit any argument you like but
+# must retain the separating commas. The order is important and specifies the following:
+#
+#   1. Extra dependencies that should be added to the do_populate_mfgtool task, if the script is
+#      enabled.
+#   2. Extra binaries that should be added to the bundle, if the script is enabled.
+#
+# For example:
+#
+# ,----[ Defining foo.uuu.in and bar.uuu script ]
+# | MFGTOOLCONFIG = "foo.uuu.in bar.uuu"
+# | MFGTOOLCONFIG[foo.uuu.in] = "dep-foo1:do_deploy dep-foo2:do_deploy,file-foo1"
+# | MFGTOOLCONFIG[bar.uuu] = "dep-bar1:do_deploy,file-bar1 file-bar2"
+# `----
+#
+# The dep-foo1:do_deploy, dep-foo2:do_deploy, and dep-bar1:do_deploy are added to
+# do_populate_mfgtool dependencies. In addition, file-foo1, file-bar1, and file-bar2 are copied to
+# the bundle, only if the script is enabled.
+#
+# During the mfgtool bundle generation, the uuu.in files are processed and some variables
+# replaced. The variables are:
+#
+#   - MACHINE
+#   - UBOOT_BINARY
+#   - SPL_BINARY
+#   - IMAGE_BASENAME
+#
+# Copyright 2022-2023 (C) O.S. Systems Software LTDA.
+#
+# SPDX-License-Identifier: MIT
+
+MFGTOOL_FILESPATH ??= " \
+    ${@base_set_filespath(["%s/mfgtool" % p for p in "${BBPATH}".split(":")] \
+                             + ["${FILE_DIRNAME}/${BP}/mfgtool", \
+                                "${FILE_DIRNAME}/${BPN}/mfgtool", \
+                                "${FILE_DIRNAME}/files/mfgtool"] \
+                          , d)} \
+"
+
+MFGTOOLDIR = "${WORKDIR}/mfgtool-${PN}"
+do_populate_mfgtool[dirs] = "${MFGTOOLDIR}"
+do_populate_mfgtool[cleandirs] = "${MFGTOOLDIR}"
+
+addtask populate_mfgtool after do_image_complete do_unpack before do_deploy
+do_populate_mfgtool[dirs] ?= "${DEPLOY_DIR_IMAGE} ${WORKDIR}"
+do_populate_mfgtool[nostamp] = "1"
+do_populate_mfgtool[recrdeptask] += "do_deploy"
+do_populate_mfgtool[depends] += "uuu-bin:do_populate_sysroot"
+
+python () {
+    depends = []
+    deploy_files = []
+    scripts = (d.getVar('MFGTOOLCONFIG') or "").split()
+    scripts_and_flags = d.getVarFlags('MFGTOOLCONFIG') or {}
+    for flag, flagval in sorted(scripts_and_flags.items()):
+        items = flagval.split(",")
+        num = len(items)
+        if num > 2:
+            bb.error("%s: MFGTOOLCONFIG[%s] Only \"depends,deploy files\" can be specified!" % (d.getVar("PN"), flag))
+
+        if flag in scripts:
+            if num >= 2 and items[1]:
+                deploy_files.append(items[1])
+            if num >= 1 and items[0]:
+                depends.append(items[0])
+
+    d.appendVarFlag('do_populate_mfgtool', 'depends', ' ' + ' '.join(depends))
+    d.setVar('_SCRIPT_DEPLOY_FILES', ' '.join(deploy_files))
+}
+
+python do_populate_mfgtool() {
+    # For MFGTOOLCONFIG items we use BitBake's fetcher module allowing a consistent behavior.
+    scripts = (d.getVar('MFGTOOLCONFIG') or "").split()
+    src_uri = ["file://%s" % f for f in scripts]
+    if not src_uri:
+        bb.fatal("MFGTOOLCONFIG is empty so populate_mfgtool cannot be run.")
+        return
+    bb.debug(1, "following scripts are used: %s" % ', '.join(scripts))
+
+    localdata = bb.data.createCopy(d)
+    filespath = (d.getVar('MFGTOOL_FILESPATH') or "")
+    localdata.setVar('FILESPATH', filespath)
+
+    try:
+        fetcher = bb.fetch2.Fetch(src_uri, localdata)
+        fetcher.unpack(localdata.getVar('WORKDIR'))
+    except bb.fetch2.BBFetchException as e:
+        bb.fatal("BitBake Fetcher Error: " + repr(e))
+
+    # Generate MFGTOOL bundle.
+    bb.build.exec_func('generate_mfgtool_bundle', d)
+}
+
+generate_mfgtool_bundle() {
+    bbnote "Processing uuu files ..."
+    for src in $(ls -1 ${WORKDIR}/*.uuu.in); do
+        dest=$(echo $src | sed 's,.in$,,g')
+        bbnote " - $src -> $dest"
+        sed -e 's/@@MACHINE@@/${MACHINE}/g' \
+            -e "s,@@UBOOT_BINARY@@,${UBOOT_BINARY},g" \
+            -e "s,@@SPL_BINARY@@,${SPL_BINARY},g" \
+            -e "s,@@IMAGE_BASENAME@@,${IMAGE_BASENAME},g" \
+            $src > $dest
+    done
+
+    bbnote "Deploying uuu files ..."
+    for src in $(ls -1 ${WORKDIR}/*.uuu); do
+        dest=$(basename $src)
+        bbnote " - $src -> ${MFGTOOLDIR}/${PN}-${MACHINE}/$dest"
+        install -D -m 0644 $src ${MFGTOOLDIR}/${PN}-${MACHINE}/$dest
+    done
+
+    bbnote "Copying uuu binaries..."
+    cp -v -s ${STAGING_LIBDIR}/uuu/* ${MFGTOOLDIR}/${PN}-${MACHINE}/
+
+    bbnote "Copying MFGTOOL extra deploy files..."
+    for f in ${_SCRIPT_DEPLOY_FILES}; do
+        mkdir -p ${MFGTOOLDIR}/${PN}-${MACHINE}/binaries
+        cp -v -s ${DEPLOY_DIR_IMAGE}/$f ${MFGTOOLDIR}/${PN}-${MACHINE}/binaries/
+    done
+
+    tar -czf ${DEPLOY_DIR_IMAGE}/mfgtool-bundle-${PN}-${MACHINE}.tar.gz \
+        --dereference -C ${MFGTOOLDIR} ${PN}-${MACHINE}
+
+    ln -fs mfgtool-bundle-${PN}-${MACHINE}.tar.gz \
+          ${DEPLOY_DIR_IMAGE}/mfgtool-bundle-${PN}.tar.gz
+}

--- a/classes/mfgtool-initramfs-image.bbclass
+++ b/classes/mfgtool-initramfs-image.bbclass
@@ -6,7 +6,7 @@
 #
 # Copyright 2014-2017 (C) O.S. Systems Software LTDA.
 
-DEPENDS += "u-boot-mfgtool linux-mfgtool"
+DEPENDS += "linux-mfgtool"
 
 FEATURE_PACKAGES_mtd = "packagegroup-fsl-mfgtool-mtd"
 FEATURE_PACKAGES_extfs = "packagegroup-fsl-mfgtool-extfs"

--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -614,5 +614,8 @@ MACHINE_FEATURES = "usbgadget usbhost vfat alsa touchscreen"
 
 HOSTTOOLS_NONFATAL:append:mx8-nxp-bsp = " sha384sum"
 
+# Add task to generate the mfgtool bundle for the image.
+IMAGE_CLASSES:append:imx-generic-bsp = " image_populate_mfgtool"
+
 # Allow meta-imx to add NIP devices information until upstreamed.
 include conf/machine/include/imx-base-extend.inc

--- a/recipes-devtools/uuu/uuu-bin_1.4.243.bb
+++ b/recipes-devtools/uuu/uuu-bin_1.4.243.bb
@@ -1,0 +1,35 @@
+# Copyright (C) 2022-2023 O.S. Systems Software LTDA.
+# Released under the MIT License (see COPYING.MIT for the terms)
+
+SUMMARY = "Universal Update Utility - Binaries"
+DESCRIPTION = "Image deploy tool for i.MX chips"
+HOMEPAGE = "https://github.com/NXPmicro/mfgtools"
+
+LICENSE = "BSD-3-Clause & LGPL-2.1-or-later"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/BSD-3-Clause;md5=550794465ba0ec5312d6919e203a55f9 \
+                    file://${COMMON_LICENSE_DIR}/LGPL-2.1-or-later;md5=2a4f4fd2128ea2f65047ee63fbca9f68"
+
+SRC_URI = " \
+    https://github.com/NXPmicro/mfgtools/releases/download/uuu_${PV}/uuu;downloadfilename=uuu-${PV};name=Linux \
+    https://github.com/NXPmicro/mfgtools/releases/download/uuu_${PV}/uuu_mac;downloadfilename=uuu-${PV}_mac;name=Mac \
+    https://github.com/NXPmicro/mfgtools/releases/download/uuu_${PV}/uuu.exe;downloadfilename=uuu-${PV}.exe;name=Windows \
+"
+
+SRC_URI[Linux.sha256sum] = "dfb2a6dca337ebd59675ea5ce7f1bce6724e3b901bcb455126d4bf9bdfa2e585"
+SRC_URI[Mac.sha256sum] = "399efa4bc7e3eb452fefe89ef5e2e453b516ea716658a963a890c430ad81a471"
+SRC_URI[Windows.sha256sum] = "f3f178e7be161c7dc058dbcd35c8cfa1516981e7c4f915fe0256ae4cda7f101e"
+
+S = "${WORKDIR}"
+
+inherit allarch
+
+do_install() {
+    install -D -m 0755 ${WORKDIR}/uuu-${PV}     ${D}${libdir}/uuu/uuu
+    install -D -m 0755 ${WORKDIR}/uuu-${PV}_mac ${D}${libdir}/uuu/uuu_mac
+    install -D -m 0644 ${WORKDIR}/uuu-${PV}.exe ${D}${libdir}/uuu/uuu.exe
+}
+
+# HACK! We are not aiming to run those binaries during the build but copy then for MFGTOOL bundle.
+INSANE_SKIP:${PN} += "arch file-rdeps"
+FILES:${PN} = "${libdir}/uuu"
+SYSROOT_DIRS = "${libdir}/uuu"


### PR DESCRIPTION
The class provides the infrastructure for MFGTOOL generation and is tied
to images. To generate the bundle, the task populate_mfgtool must be
called. For example:

,----[ Running populate_mfgtool for core-image-minimal image ]
| $: bitbake core-image-minimal -c populate_mfgtool
`----

The class behavior is controlled through the MFGTOOL_SCRIPT variable. The
MFGTOOL_SCRIPT variable itself specifies a space-separated list of the
scripts to enable. Following the scripts, you can determine the behavior
of each script by providing up to two order-dependent arguments, which
are separated by commas. You can omit any argument you like but must
retain the separating commas. The order is important and specifies the
following:

  1. Extra dependencies that should be added to the do_populate_mfgtool
     task, if the script is enabled.
  2. Extra binaries that should be added to the bundle, if the script is
     enabled.

For example:

,----[ Defining bootloader.uuu.in script ]
| MFGTOOL_SCRIPT = "bootloader.uuu.in"
| MFGTOOL_SCRIPT[bootloader.uuu.in] = "virtual/bootloader:do_deploy,${UBOOT_BINARY}"
`----

The virtual/bootloader:do_deploy is added to do_populate_mfgtool
dependencies and ${UBOOT_BINARY} copied to the bundle, only if the
script is enabled.

During the mfgtool bundle generation, the uuu.in files are processed and
some variables replaced. The variables are:

  - MACHINE
  - UBOOT_BINARY
  - SPL_BINARY
  - IMAGE_BASENAME

---

TODO Items before merging:
- [ ] add an i.MX8MM uuu script set
- [ ] add an i.MX6QDL uuu script set