### PR TITLE
imx8mnul-ddr3l-evk.conf: allow switch between `u-boot-imx` and `u-boo…

### DIFF
--- a/conf/machine/imx8mnul-ddr3l-evk.conf
+++ b/conf/machine/imx8mnul-ddr3l-evk.conf
@@ -4,7 +4,11 @@
 #@DESCRIPTION: Machine configuration for NXP i.MX 8M Nano UltraLite Evaluation Kit with DDR3L
 #@MAINTAINER: Jun Zhu <junzhu@nxp.com>
 
-MACHINEOVERRIDES =. "imx-boot-container:mx8mnul:"
+MACHINEOVERRIDES =. "mx8mnul:"
+
+# FIXME: u-boot-imx should be converted to `binman` and then we can
+# avoid this specific overrides and handle it in a generic way.
+MACHINEOVERRIDES =. "${@bb.utils.contains('IMX_DEFAULT_BOOTLOADER', 'u-boot-imx', '', 'imx-boot-container:', d)}"
 
 require conf/machine/include/imx-base.inc
 require conf/machine/include/arm/armv8a/tune-cortexa53.inc


### PR DESCRIPTION
…t-fslc`

We ought to add `imx-boot-container` `MACHINEOVERRIDES` only if not building for `u-boot-imx`. This can be removed once it uses `binman` as `u-boot-imx` and u-boot-fslc would use same mechanism to build the container.