### PR TITLE
imx: fw: allow to build for mainline bsp too

### DIFF
--- a/classes/use-imx-security-controller-firmware.bbclass
+++ b/classes/use-imx-security-controller-firmware.bbclass
@@ -17,14 +17,14 @@
 # present in the image file have it properly defined.
 
 SECO_FIRMWARE_NAME                ?= ""
-SECO_FIRMWARE_NAME:mx8qm-nxp-bsp  ?= "mx8qmb0-ahab-container.img"
-SECO_FIRMWARE_NAME:mx8qxp-nxp-bsp ?= \
+SECO_FIRMWARE_NAME:mx8qm-generic-bsp  ?= "mx8qmb0-ahab-container.img"
+SECO_FIRMWARE_NAME:mx8qxp-generic-bsp ?= \
     "${@bb.utils.contains('MACHINE_FEATURES', 'soc-revb0', 'mx8qxb0-ahab-container.img', \
                                                            'mx8qxc0-ahab-container.img', d)}"
-SECO_FIRMWARE_NAME:mx8dx-nxp-bsp  ?= "mx8qxc0-ahab-container.img"
-SECO_FIRMWARE_NAME:mx8dxl-nxp-bsp ?= "mx8dxla1-ahab-container.img"
-SECO_FIRMWARE_NAME:mx8ulp-nxp-bsp ?= "mx8ulpa1-ahab-container.img"
-SECO_FIRMWARE_NAME:mx93-nxp-bsp   ?= "mx93a0-ahab-container.img"
+SECO_FIRMWARE_NAME:mx8dx-generic-bsp  ?= "mx8qxc0-ahab-container.img"
+SECO_FIRMWARE_NAME:mx8dxl-generic-bsp ?= "mx8dxla1-ahab-container.img"
+SECO_FIRMWARE_NAME:mx8ulp-generic-bsp ?= "mx8ulpa1-ahab-container.img"
+SECO_FIRMWARE_NAME:mx93-generic-bsp   ?= "mx93a0-ahab-container.img"
 
 python () {
     if "mx8m-generic-bsp" in d.getVar('MACHINEOVERRIDES').split(":"):

--- a/recipes-bsp/firmware-imx/firmware-imx-8_8.18.bb
+++ b/recipes-bsp/firmware-imx/firmware-imx-8_8.18.bb
@@ -34,6 +34,6 @@ addtask deploy after do_install before do_build
 
 PACKAGE_ARCH = "${MACHINE_SOCARCH}"
 
-COMPATIBLE_MACHINE      = "(mx8-nxp-bsp|mx9-nxp-bsp)"
-COMPATIBLE_MACHINE:mx8m-nxp-bsp = "(^$)"
-COMPATIBLE_MACHINE:mx8x-nxp-bsp = "(^$)"
+COMPATIBLE_MACHINE      = "(mx8-generic-bsp|mx9-generic-bsp)"
+COMPATIBLE_MACHINE:mx8m-generic-bsp = "(^$)"
+COMPATIBLE_MACHINE:mx8x-generic-bsp = "(^$)"

--- a/recipes-bsp/imx-sc-firmware/imx-sc-firmware_1.15.0.bb
+++ b/recipes-bsp/imx-sc-firmware/imx-sc-firmware_1.15.0.bb
@@ -15,10 +15,10 @@ SRC_URI[sha256sum] = "1272ac5c31a88017ef548721f3acf930a7eda6ac73aa9f41b5f0cade9d
 
 BOARD_TYPE ?= "mek"
 SC_FIRMWARE_NAME ?= "INVALID"
-SC_FIRMWARE_NAME:mx8qm-nxp-bsp = "mx8qm-${BOARD_TYPE}-scfw-tcm.bin"
-SC_FIRMWARE_NAME:mx8qxp-nxp-bsp = "mx8qx-${BOARD_TYPE}-scfw-tcm.bin"
-SC_FIRMWARE_NAME:mx8dxl-nxp-bsp = "mx8dxl-${BOARD_TYPE}-scfw-tcm.bin"
-SC_FIRMWARE_NAME:mx8dx-nxp-bsp = "mx8dx-${BOARD_TYPE}-scfw-tcm.bin"
+SC_FIRMWARE_NAME:mx8qm-generic-bsp = "mx8qm-${BOARD_TYPE}-scfw-tcm.bin"
+SC_FIRMWARE_NAME:mx8qxp-generic-bsp = "mx8qx-${BOARD_TYPE}-scfw-tcm.bin"
+SC_FIRMWARE_NAME:mx8dxl-generic-bsp = "mx8dxl-${BOARD_TYPE}-scfw-tcm.bin"
+SC_FIRMWARE_NAME:mx8dx-generic-bsp = "mx8dx-${BOARD_TYPE}-scfw-tcm.bin"
 
 symlink_name = "scfw_tcm.bin"
 
@@ -38,4 +38,4 @@ INHIBIT_PACKAGE_STRIP = "1"
 INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
-COMPATIBLE_MACHINE = "(mx8qm-nxp-bsp|mx8qxp-nxp-bsp|mx8dxl-nxp-bsp|mx8dx-nxp-bsp)"
+COMPATIBLE_MACHINE = "(mx8qm-generic-bsp|mx8qxp-generic-bsp|mx8dxl-generic-bsp|mx8dx-generic-bsp)"

--- a/recipes-bsp/imx-seco/imx-seco_5.9.0.bb
+++ b/recipes-bsp/imx-seco/imx-seco_5.9.0.bb
@@ -24,4 +24,4 @@ do_deploy () {
     install -m 0644 ${S}/firmware/seco/${SECO_FIRMWARE_NAME} ${DEPLOYDIR}
 }
 
-COMPATIBLE_MACHINE = "(mx8qm-nxp-bsp|mx8qxp-nxp-bsp|mx8dxl-nxp-bsp|mx8dx-nxp-bsp)"
+COMPATIBLE_MACHINE = "(mx8qm-generic-bsp|mx8qxp-generic-bsp|mx8dxl-generic-bsp|mx8dx-generic-bsp)"


### PR DESCRIPTION
SECO/SC FW/HDMI FW and friends should not be restricted to imx-nxp-bsp. If one wants to build machines for a mainline kernel / user space these would be required to build the boot container too.