### PR TITLE
imx6qdlsabre*: ensure UBOOT_CONFIG setting is always available

### DIFF
--- a/conf/machine/imx6qdlsabreauto.conf
+++ b/conf/machine/imx6qdlsabreauto.conf
@@ -32,17 +32,17 @@ KERNEL_DEVICETREE:use-mainline-bsp = " \
     imx6dl-sabreauto.dtb \
 "
 
+UBOOT_CONFIG ??= " \
+    sd \
+    ${@oe.utils.ifelse(d.getVar('IMX_DEFAULT_BOOTLOADER') == 'u-boot-imx', \
+           bb.utils.contains('MACHINE_FEATURES', 'optee', 'sd-optee', '', d), '')}"
+
 ### u-boot-fslc settings ###
 SPL_BINARY:pn-u-boot-fslc = "SPL"
-UBOOT_CONFIG:pn-u-boot-fslc ??= "sd"
 UBOOT_SUFFIX:pn-u-boot-fslc = "img"
 
 ### u-boot-imx settings ###
 SPL_BINARY:pn-u-boot-imx = ""
-UBOOT_CONFIG:pn-u-boot-imx ??= " \
-    sd \
-    ${@bb.utils.contains('MACHINE_FEATURES', 'optee', 'sd-optee', '', d)} \
-"
 UBOOT_MAKE_TARGET:pn-u-boot-imx = "u-boot.imx"
 UBOOT_SUFFIX:pn-u-boot-imx = "imx"
 UBOOT_MAKE_TARGET:pn-u-boot-imx-mfgtool = "u-boot.imx"

--- a/conf/machine/imx6qdlsabresd.conf
+++ b/conf/machine/imx6qdlsabresd.conf
@@ -41,17 +41,17 @@ KERNEL_DEVICETREE:use-mainline-bsp = " \
     imx6dl-sabresd.dtb \
 "
 
+UBOOT_CONFIG ??= " \
+    sd \
+    ${@oe.utils.ifelse(d.getVar('IMX_DEFAULT_BOOTLOADER') == 'u-boot-imx', \
+           bb.utils.contains('MACHINE_FEATURES', 'optee', 'sd-optee', '', d), '')}"
+
 ### u-boot-fslc settings ###
 SPL_BINARY:pn-u-boot-fslc = "SPL"
-UBOOT_CONFIG:pn-u-boot-fslc ??= "sd"
 UBOOT_SUFFIX:pn-u-boot-fslc = "img"
 
 ### u-boot-imx settings ###
 SPL_BINARY:pn-u-boot-imx = ""
-UBOOT_CONFIG:pn-u-boot-imx ??= " \
-    sd \
-    ${@bb.utils.contains('MACHINE_FEATURES', 'optee', 'sd-optee', '', d)} \
-"
 UBOOT_MAKE_TARGET:pn-u-boot-imx = "u-boot.imx"
 UBOOT_SUFFIX:pn-u-boot-imx = "imx"
 UBOOT_MAKE_TARGET:pn-u-boot-imx-mfgtool = "u-boot.imx"


### PR DESCRIPTION
We cannot tie the UBOOT_CONFIG setting to the U-Boot recipe otherwise if
kernel-fitimage is added in KERNEL_CLASSES, the following build errors
is raised:

,----
| Nothing PROVIDES ‘virtual/kernel’
| ...
| Either UBOOT_MACHINE or UBOOT_CONFIG must be set in the imx6qdlsabresd machine configuration.
`----

kernel-fitimage class inherits uboot-sign which inherits
uboot-config. uboot-config class checks UBOOT_CONFIG and it is not
defined.

The fix is essentially to move the conditional for the variable
assignment instead of using the recipe override.

Fixes: #1290
Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>