### PR TITLE
qoriq-atf: Remove mbedtls from DEPENDS

### DIFF
--- a/recipes-bsp/atf/qoriq-atf_2.6.bb
+++ b/recipes-bsp/atf/qoriq-atf_2.6.bb
@@ -2,7 +2,7 @@ require qoriq-atf-${PV}.inc
 
 inherit deploy
 
-DEPENDS += "u-boot-mkimage-native u-boot openssl openssl-native mbedtls rcw qoriq-cst-native bc-native"
+DEPENDS += "u-boot-mkimage-native u-boot openssl openssl-native rcw qoriq-cst-native bc-native"
 do_compile[depends] += "u-boot:do_deploy rcw:do_deploy uefi:do_deploy"
 
 PV:append = "+${SRCPV}"


### PR DESCRIPTION
mbedtls is included in SCR_URI into fetched source code tree.