### PR TITLE
weston: add xwayland to DEPENDS for PACKAGECONFIG xwayland

### DIFF
--- a/recipes-graphics/wayland/weston_10.0.1.imx.bb
+++ b/recipes-graphics/wayland/weston_10.0.1.imx.bb
@@ -189,7 +189,7 @@ PACKAGECONFIG:append:imxgpu2d = " imxg2d"
 SIMPLECLIENTS:imxfbdev = "damage,im,egl,shm,touch,dmabuf-v4l"
 
 # Override
-PACKAGECONFIG[xwayland] = "-Dxwayland=true,-Dxwayland=false,libxcursor"
+PACKAGECONFIG[xwayland] = "-Dxwayland=true,-Dxwayland=false,libxcursor xwayland"
 # Weston with i.MX GPU support
 PACKAGECONFIG[imxgpu] = "-Dimxgpu=true,-Dimxgpu=false,virtual/egl"
 # Weston with i.MX G2D renderer


### PR DESCRIPTION
Otherwise xwayland.pc would not be present in sysroot, this leads to some xwayland configs missing like have_listenfd, have_glamor.