### PR TITLE
linux-imx: remove SoC-specific defconfig to use in-tree defconfig

### DIFF
--- a/recipes-kernel/linux/linux-imx.inc
+++ b/recipes-kernel/linux/linux-imx.inc
@@ -17,9 +17,7 @@ PROVIDES += "linux-mfgtool"
 # Set the PV to the correct kernel version to satisfy the kernel version sanity check
 PV = "${LINUX_VERSION}+git${SRCPV}"
 
-SRC_URI = "git://github.com/nxp-imx/linux-imx;protocol=https;branch=${SRCBRANCH} \
-    file://defconfig \
-"
+SRC_URI = "git://github.com/nxp-imx/linux-imx;protocol=https;branch=${SRCBRANCH}"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Fixes: dca02c80 ("linux-imx: remove SoC-specific defconfig to use in-tree defconfig")