### PR TITLE
kernel-module-nxp89xx: upgrade to lf-6.1.1_1.0.0

### DIFF
--- a/recipes-kernel/kernel-modules/kernel-module-nxp89xx_git.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-nxp89xx_git.bb
@@ -1,11 +1,11 @@
 SUMMARY = "NXP Wi-Fi driver for module 88w8997/8987"
 LICENSE = "GPL-2.0-only"
-LIC_FILES_CHKSUM = "file://gpl-2.0.txt;md5=ab04ac0f249af12befccb94447c08b77"
+LIC_FILES_CHKSUM = "file://../../LICENSE;md5=ab04ac0f249af12befccb94447c08b77"
 
-SRCBRANCH = "lf-5.15.52_2.1.0"
+SRCBRANCH = "lf-6.1.1_1.0.0"
 MRVL_SRC ?= "git://github.com/nxp-imx/mwifiex.git;protocol=https"
 SRC_URI = "${MRVL_SRC};branch=${SRCBRANCH}"
-SRCREV = "5cda905576fd26eca6b49d0f0fb5e2bb3c0bf441"
+SRCREV = "98e5b28b1a7afea9dbded4067e93bfd584531a79"
 
 S = "${WORKDIR}/git/mxm_wifiex/wlan_src"
 


### PR DESCRIPTION
Update to the version used in NXP BSP release L6.1.1-1.0.0.