### PR TITLE
dynamic-layers: meta-arm: don't force build nor install target in TF-A

### DIFF
--- a/dynamic-layers/meta-arm/recipes-bsp/trusted-firmware-a/trusted-firmware-a_%.bbappend
+++ b/dynamic-layers/meta-arm/recipes-bsp/trusted-firmware-a/trusted-firmware-a_%.bbappend
@@ -1,16 +1,20 @@
-# Common Build targets
-TFA_BUILD_TARGET = "all"
-TFA_INSTALL_TARGET = "bl31"
-
 # List of supported machines from this layer
 COMPATIBLE_MACHINE:imx8mm-lpddr4-evk = "imx8mm-lpddr4-evk"
+TFA_BUILD_TARGET:imx8mm-lpddr4-evk = "all"
+TFA_INSTALL_TARGET:imx8mm-lpddr4-evk = "bl31"
 TFA_PLATFORM:imx8mm-lpddr4-evk = "imx8mm"
 
 COMPATIBLE_MACHINE:imx8mn-ddr4-evk = "imx8mn-ddr4-evk"
+TFA_BUILD_TARGET:imx8mn-ddr4-evk = "all"
+TFA_INSTALL_TARGET:imx8mn-ddr4-evk = "bl31"
 TFA_PLATFORM:imx8mn-ddr4-evk = "imx8mn"
 
 COMPATIBLE_MACHINE:imx8mp-lpddr4-evk = "imx8mp-lpddr4-evk"
+TFA_BUILD_TARGET:imx8mp-lpddr4-evk = "all"
+TFA_INSTALL_TARGET:imx8mp-lpddr4-evk = "bl31"
 TFA_PLATFORM:imx8mp-lpddr4-evk = "imx8mp"
 
 COMPATIBLE_MACHINE:imx8mq-evk = "imx8mq-evk"
+TFA_BUILD_TARGET:imx8mq-evk = "all"
+TFA_INSTALL_TARGET:imx8mq-evk = "bl31"
 TFA_PLATFORM:imx8mq-evk = "imx8mq"


### PR DESCRIPTION
Some board or user could like to change the build or install target of the ARM trusted firmware.

Only set those variables if they are empty.