### PR TITLE
imx-boot-firmware-files: Avoid Cadence firmware for in mx8m

### DIFF
--- a/recipes-bsp/firmware-imx/imx-boot-firmware-files_8.18.bb
+++ b/recipes-bsp/firmware-imx/imx-boot-firmware-files_8.18.bb
@@ -10,7 +10,7 @@ do_install[noexec] = "1"
 
 DEPLOY_FOR                  = ""
 DEPLOY_FOR:mx8-generic-bsp  = "mx8"
-DEPLOY_FOR:mx8m-generic-bsp = "mx8 mx8m"
+DEPLOY_FOR:mx8m-generic-bsp = "mx8m"
 DEPLOY_FOR:mx9-generic-bsp  = "mx9"
 
 deploy_for_mx8() {


### PR DESCRIPTION
Fixes: 90df14f9 ("imx-boot-firmware-files: consolidate deploy firmware files across SoCs")
Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>