### PR TITLE
Add screen machine feature to all machine configurations

### DIFF
--- a/conf/machine/imx23evk.conf
+++ b/conf/machine/imx23evk.conf
@@ -19,5 +19,3 @@ UBOOT_SUFFIX = "sb"
 UBOOT_MACHINE = "mx23evk_config"
 
 KERNEL_DEVICETREE = "imx23-evk.dtb"
-
-MACHINE_FEATURES = "usbgadget usbhost vfat touchscreen"

--- a/conf/machine/imx28evk.conf
+++ b/conf/machine/imx28evk.conf
@@ -25,8 +25,6 @@ KERNEL_DEVICETREE = "imx28-evk.dtb"
 
 SERIAL_CONSOLES = "115200;ttyAMA0"
 
-MACHINE_FEATURES = "usbgadget usbhost vfat alsa touchscreen"
-
 ## Parameters for NAND IC part-# K9LBG08U0D-PCB0
 
 MKUBIFS_ARGS = "--min-io-size 4096 --leb-size 516096 --max-leb-cnt 8139"

--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -600,7 +600,7 @@ SERIAL_CONSOLES:mxs-generic-bsp = "115200;ttyAMA0"
 KERNEL_IMAGETYPE = "zImage"
 KERNEL_IMAGETYPE:aarch64 = "Image"
 
-MACHINE_FEATURES = "usbgadget usbhost vfat alsa touchscreen"
+MACHINE_FEATURES = "usbgadget usbhost vfat alsa touchscreen screen"
 
 HOSTTOOLS_NONFATAL:append:mx8-nxp-bsp = " sha384sum"
 


### PR DESCRIPTION
Backport of #1540 to kirkstone. Dunfell is not affected by change in poky.