### PR TITLE
imx-gpu-viv: fix libclc-imx packaging

### DIFF
--- a/recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc
+++ b/recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc
@@ -327,7 +327,8 @@ do_install:append:libc-musl() {
 
 ALLOW_EMPTY:${PN} = "1"
 
-FILES:libclc-imx = "${libdir}/libCLC${SOLIBS} ${includedir}/CL/cl_viv_vx_ext.h"
+FILES:libclc-imx = "${libdir}/libCLC${SOLIBS}"
+FILES:libclc-imx-dev = "${includedir}/CL/cl_viv_vx_ext.h"
 
 # libEGL.so is used by some demo apps from Freescale
 INSANE_SKIP:libegl-imx += "dev-so"


### PR DESCRIPTION
Amend 6e41d851e71505183ff021b07c317e5290571916 and move cl_viv_vx_ext.h header to the libclc-imx-dev package. Missing value for ${FILES:libclc-imx-dev} caused Bad substitution error for imx8mm builds.