### PR TITLE
conf: set the list of required layers

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,6 +9,7 @@ BBFILE_COLLECTIONS += "freescale-layer"
 BBFILE_PATTERN_freescale-layer := "^${LAYERDIR}/"
 BBFILE_PRIORITY_freescale-layer = "5"
 LAYERSERIES_COMPAT_freescale-layer = "langdale mickledore"
+LAYERDEPENDS_freescale-layer = "core"
 
 # Add the Freescale-specific licenses into the metadata
 LICENSE_PATH += "${LAYERDIR}/custom-licenses"


### PR DESCRIPTION
LAYERDEPENDS Lists the layers on which this recipe depends.

meta-oe is required by the linux-fscl recipe because it depends of lzop-native.