### PR TITLE
Remove the need of lzop-native from layer

### DIFF
--- a/recipes-kernel/linux/linux-fslc-imx_6.1.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_6.1.bb
@@ -38,6 +38,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 3. Critical patches (SHA(s))
 # ------------------------------------------------------------------------------
+# - ad9ab3b3c553c ARM: imx_v7_defconfig: Remove KERNEL_LZO config
 #
 # NOTE to upgraders:
 # This recipe should NOT collect individual patches, they should be applied to
@@ -47,11 +48,9 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 
 require linux-imx.inc
 
-DEPENDS += "lzop-native bc-native"
-
 KBRANCH = "6.1-1.0.x-imx"
 SRC_URI = "git://github.com/Freescale/linux-fslc.git;branch=${KBRANCH};protocol=https"
-SRCREV = "897d73a656fe33d0c4549c5de1d07797f99d6871"
+SRCREV = "ad9ab3b3c553cbc3c61f233b6e2cd5abdd2a624b"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.

--- a/recipes-kernel/linux/linux-fslc_6.1.bb
+++ b/recipes-kernel/linux/linux-fslc_6.1.bb
@@ -10,8 +10,6 @@ provide support for some backported features and fixes, or because it was applie
 and takes some time to become part of a stable version, or because it is not applicable for \
 upstreaming."
 
-DEPENDS += "lzop-native bc-native"
-
 require linux-imx.inc
 
 SRC_URI = "git://github.com/Freescale/linux-fslc.git;branch=${KBRANCH};protocol=https"
@@ -21,10 +19,10 @@ SRC_URI = "git://github.com/Freescale/linux-fslc.git;branch=${KBRANCH};protocol=
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "6.1.27"
+LINUX_VERSION = "6.1.29"
 
 KBRANCH = "6.1.x+fslc"
-SRCREV = "ddc32335b72f78943045b242eb6e0b069ef4cdae"
+SRCREV = "9dd7c6bd8a02e7c5b745b18cfec8bce73feb6de7"
 
 KBUILD_DEFCONFIG:mx27-generic-bsp = "imx_v4_v5_defconfig"
 KBUILD_DEFCONFIG:mx5-generic-bsp = "imx_v6_v7_defconfig"

--- a/recipes-kernel/linux/linux-imx/ARM-imx_v7_defconfig-Remove-KERNEL_LZO-config.patch
+++ b/recipes-kernel/linux/linux-imx/ARM-imx_v7_defconfig-Remove-KERNEL_LZO-config.patch
@@ -1,0 +1,27 @@
+From ad9ab3b3c553cbc3c61f233b6e2cd5abdd2a624b Mon Sep 17 00:00:00 2001
+From: Otavio Salvador <otavio@ossystems.com.br>
+Date: Tue, 23 May 2023 13:16:05 -0300
+Subject: [PATCH] ARM: imx_v7_defconfig: Remove KERNEL_LZO config
+
+The KERNEL_GZIP is used in most config and is the default, there is no
+clear reason to diverge so let default be used.
+
+Upstream-Status: Pending
+
+Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>
+---
+ arch/arm/configs/imx_v7_defconfig | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/arch/arm/configs/imx_v7_defconfig b/arch/arm/configs/imx_v7_defconfig
+index 6de3049689191..94e9457e2bab1 100644
+--- a/arch/arm/configs/imx_v7_defconfig
++++ b/arch/arm/configs/imx_v7_defconfig
+@@ -1,4 +1,3 @@
+-CONFIG_KERNEL_LZO=y
+ CONFIG_SYSVIPC=y
+ CONFIG_POSIX_MQUEUE=y
+ CONFIG_NO_HZ=y
+-- 
+2.40.1
+

--- a/recipes-kernel/linux/linux-imx_6.1.bb
+++ b/recipes-kernel/linux/linux-imx_6.1.bb
@@ -12,7 +12,7 @@ i.MX Family Reference Boards. It includes support for many IPs such as GPU, VPU 
 
 require recipes-kernel/linux/linux-imx.inc
 
-DEPENDS += "lzop-native bc-native"
+SRC_URI += "file://ARM-imx_v7_defconfig-Remove-KERNEL_LZO-config.patch"
 
 SRCBRANCH = "lf-6.1.y"
 LOCALVERSION = "-6.1.1-1.0.0"


### PR DESCRIPTION
There are three commits related to the Linux kernel configuration in the imx platform. This changes
remove the KERNEL_LZO configuration Linux kernel configuration and uses the KERNEL_GZIP, which is
the default. This is enough to remove the lzop-native dependency.