### PR TITLE
uuu: drop bogus COMPATIBLE_MACHINE

### DIFF
--- a/recipes-devtools/uuu/uuu_git.bb
+++ b/recipes-devtools/uuu/uuu_git.bb
@@ -15,6 +15,4 @@ S = "${WORKDIR}/git"
 
 DEPENDS = "libusb zlib bzip2 openssl"
 
-COMPATIBLE_MACHINE   = "(imx-generic-bsp)"
-
 BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
This apparently prevents the recipe from actually building for the most useful variants, native and nativesdk - it's really rare that one would actually want to run uuu itself _on_ an imx target.

Moreover, we have a test setup where we use Raspberry Pis for power cycling, exposing the serial console etc. from various boards, so we do want to build uuu for the BSPs we put on those RPis in order to automatically test bootstrapping of imx boards.