### PR TITLE
weston-init: disable xwayland for mainline BSPs

### DIFF
--- a/recipes-graphics/wayland/weston-init.bbappend
+++ b/recipes-graphics/wayland/weston-init.bbappend
@@ -10,11 +10,15 @@ SRC_URI:append:mx6sl-nxp-bsp = " file://weston.config"
 
 PACKAGECONFIG ??= " \
     no-idle-timeout \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'xwayland', '', d)} \
     ${PACKAGECONFIG_GBM_FORMAT} \
     ${PACKAGECONFIG_REPAINT_WINDOW} \
     ${PACKAGECONFIG_SIZE} \
     ${PACKAGECONFIG_USE_G2D} \
 "
+
+# Mainline BSPs dont support xwayland
+PACKAGECONFIG:remove:use-mainline-bsp = "xwayland"
 
 PACKAGECONFIG_GBM_FORMAT               ?= ""
 PACKAGECONFIG_GBM_FORMAT:mx8mq-nxp-bsp ?= "gbm-format"
@@ -46,6 +50,7 @@ PACKAGECONFIG[rdp] = ",,"
 PACKAGECONFIG[repaint-window] = ",,"
 PACKAGECONFIG[size] = ",,"
 PACKAGECONFIG[use-g2d] = ",,"
+PACKAGECONFIG[xwayland] = ",,"
 
 do_install:append() {
     if [ -f "${WORKDIR}/weston.config" ]; then
@@ -73,6 +78,10 @@ do_install:append() {
         sed -i -e "/^\[core\]/a use-g2d=${USE_G2D_VALUE}" ${D}${sysconfdir}/xdg/weston/weston.ini
     else
         sed -i -e "/^\[core\]/a #use-g2d=${USE_G2D_VALUE}" ${D}${sysconfdir}/xdg/weston/weston.ini
+    fi
+
+    if [ "${@bb.utils.contains('PACKAGECONFIG', 'xwayland', 'yes', 'no', d)}" = "no" ]; then
+        sed -i -e "s/^xwayland=true/#xwayland=true/g" ${D}${sysconfdir}/xdg/weston/weston.ini
     fi
 
     sed -i -e 's,@bindir@,${bindir},g' ${D}${sysconfdir}/xdg/weston/weston.ini


### PR DESCRIPTION
A regression was introduced by commit 47f0410be1:
[ weston-init: Rework weston.ini configuration ]

xwayland had been dropped from weston.ini for mainline BSPs before that commit, since it's not supported by mainline BSPs, but after that, it's added back again.

Introduce a xwayland PACKAGECONFIG to control that, drop it from weston.ini from mainline BSPs.