### PR TITLE
Fixes with latest oe-core master changes and clang16

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-multimedia/mpv/mpv_%.bbappend
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/mpv/mpv_%.bbappend
@@ -1,0 +1,2 @@
+# testbuild/../test.c:10: undefined reference to `glXCreateContext' 
+PACKAGECONFIG:remove:imxgpu = "x11"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good/0001-v4l2-Include-gst-allocators-gstdmabuf.h-for-gst_is_d.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good/0001-v4l2-Include-gst-allocators-gstdmabuf.h-for-gst_is_d.patch
@@ -1,0 +1,32 @@
+From dc5d752ec3fbec10402aa60fa8245e384e0c7206 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Wed, 7 Jun 2023 22:53:47 -0700
+Subject: [PATCH] v4l2: Include gst/allocators/gstdmabuf.h for
+ gst_is_dmabuf_memory()
+
+This is flagged by clang-16
+../git/sys/v4l2/gstv4l2videoenc.c:756:9: error: call to undeclared function 'gst_is_dmabuf_memory'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
+    if (gst_is_dmabuf_memory (gst_buffer_peek_memory (frame->input_buffer, 0))
+        ^
+
+Upstream-Status: Submitted [https://github.com/nxp-imx/gst-plugins-good/pull/2]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ sys/v4l2/gstv4l2videoenc.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/sys/v4l2/gstv4l2videoenc.c b/sys/v4l2/gstv4l2videoenc.c
+index a505a228f..f24d5a795 100644
+--- a/sys/v4l2/gstv4l2videoenc.c
++++ b/sys/v4l2/gstv4l2videoenc.c
+@@ -36,6 +36,7 @@
+ 
+ #include <string.h>
+ #include <gst/gst-i18n-plugin.h>
++#include <gst/allocators/gstdmabuf.h>
+ 
+ GST_DEBUG_CATEGORY_STATIC (gst_v4l2_video_enc_debug);
+ #define GST_CAT_DEFAULT gst_v4l2_video_enc_debug
+-- 
+2.41.0
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.20.3.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.20.3.imx.bb
@@ -13,6 +13,7 @@ BUGTRACKER = "https://gitlab.freedesktop.org/gstreamer/gst-plugins-good/-/issues
 
 SRC_URI = "https://gstreamer.freedesktop.org/src/gst-plugins-good/gst-plugins-good-${PV}.tar.xz \
            file://0001-qt-include-ext-qt-gstqtgl.h-instead-of-gst-gl-gstglf.patch \
+           file://0001-v4l2-Include-gst-allocators-gstdmabuf.h-for-gst_is_d.patch \
            "
 
 SRC_URI[sha256sum] = "f8f3c206bf5cdabc00953920b47b3575af0ef15e9f871c0b6966f6d0aa5868b7"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-python_1.20.3.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-python_1.20.3.imx.bb
@@ -28,3 +28,5 @@ def get_gst_ver(v):
     return oe.utils.trim_version(v, 3)
 
 inherit meson pkgconfig setuptools3-base upstream-version-is-even
+
+FILES:${PN} += "${libdir}/gstreamer-1.0"


### PR DESCRIPTION
setuptools3-base FILES assignments have been simplified, therefore the internal libraries should be now packaged explicitly.

Fixes
ERROR: QA Issue: gstreamer1.0-python: Files/directories were installed but not shipped in any package:
  /usr/lib/gstreamer-1.0/libgstpython.so