### PR TITLE
meta-freescale: fmlib: map kernel source path to target path

### DIFF
--- a/recipes-dpaa/fmlib/fmlib_git.bb
+++ b/recipes-dpaa/fmlib/fmlib_git.bb
@@ -10,6 +10,9 @@ SRCREV = "69a70474cd8411d5a099c34f40760b6567d781d6"
 
 S = "${WORKDIR}/git"
 
+CFLAGS += "-fmacro-prefix-map=${STAGING_KERNEL_DIR}=/usr/src/debug/fmlib/git-r1 \
+		-fdebug-prefix-map=${STAGING_KERNEL_DIR}=/usr/src/debug/fmlib/git-r1"
+
 EXTRA_OEMAKE = "DESTDIR=${D} PREFIX=${prefix} LIB_DEST_DIR=${libdir} \
         CROSS_COMPILE=${TARGET_PREFIX} KERNEL_SRC=${STAGING_KERNEL_DIR}"
 


### PR DESCRIPTION
When building package fmlib based on Yocto version mickledore, there is below warning reported:
WARNING: fmlib-git-r1 do_package_qa: QA Issue: File /usr/lib64/libfm-arm.a in package fmlib-staticdev contains reference to TMPDIR [buildpaths] Because the KERNEL_SRC is passed into Makefile, and not mapped to a target path like the source of this package. To void this warning, it also needs to add the path map in CFLAGS  for kernel source.