### PR TITLE
imx-atf: Explicitly demand BFD linker

### DIFF
--- a/recipes-bsp/imx-atf/imx-atf_2.6.bb
+++ b/recipes-bsp/imx-atf/imx-atf_2.6.bb
@@ -48,7 +48,7 @@ def remove_options_tail (in_string):
     from itertools import takewhile
     return ' '.join(takewhile(lambda x: not x.startswith('-'), in_string.split(' ')))
 
-EXTRA_OEMAKE += 'LD="${@remove_options_tail(d.getVar('LD'))}"'
+EXTRA_OEMAKE += 'LD="${@remove_options_tail(d.getVar('LD'))}.bfd"'
 
 EXTRA_OEMAKE += 'CC="${@remove_options_tail(d.getVar('CC'))}"'
 

--- a/recipes-bsp/imx-sc-firmware/imx-sc-firmware_1.15.0.bb
+++ b/recipes-bsp/imx-sc-firmware/imx-sc-firmware_1.15.0.bb
@@ -38,4 +38,6 @@ INHIBIT_PACKAGE_STRIP = "1"
 INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
+LDFLAGS:remove = "-fuse-ld=lld"
+
 COMPATIBLE_MACHINE = "(mx8qm-generic-bsp|mx8qxp-generic-bsp|mx8dxl-generic-bsp|mx8dx-generic-bsp)"

--- a/recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc
+++ b/recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc
@@ -373,6 +373,7 @@ RDEPENDS:libopenvx-imx = "libnn-imx ${OPENCL_VX_INTRINSIC_EXTENSION_PACKAGES}"
 OPENCL_VX_INTRINSIC_EXTENSION_PACKAGES               = ""
 OPENCL_VX_INTRINSIC_EXTENSION_PACKAGES:mx8qm-nxp-bsp = "libclc-imx libopencl-imx-dev"
 OPENCL_VX_INTRINSIC_EXTENSION_PACKAGES:mx8mp-nxp-bsp = "libclc-imx libopencl-imx-dev"
+INSANE_SKIP:libopenvx-imx += "dev-deps"
 
 # libGL is only targeting X11 backend, and in case if Wayland-only is used -
 # package QA complains on missing RDEPENDS, which are only available for X11.


### PR DESCRIPTION
This component uses BFD linker specific options which may not be available when default ld is not GNU BFD LD

Fixes

| aarch64-yoe-linux-ld: error: unknown argument '--fix-cortex-a53-835769'