### PR TITLE
basler-camera: delete files also provided by isp-imx

### DIFF
--- a/recipes-bsp/isp-imx/basler-camera_4.2.2.21.0.bb
+++ b/recipes-bsp/isp-imx/basler-camera_4.2.2.21.0.bb
@@ -12,6 +12,10 @@ SRC_URI[md5sum] = "4e33adeb8a43f5bd06703368721085f5"
 SRC_URI[sha256sum] = "c44fc890902d9d8ef22186d56af035c9cac182817525e64575e3b79015383790"
 
 do_install() {
+    # provided by the isp-imx package, do not install them here additionally
+    rm -f ${S}/opt/imx8-isp/bin/dewarp_config/sensor_dwe_os08a20_1080P_config.json
+    rm -f ${S}/opt/imx8-isp/bin/dewarp_config/sensor_dwe_os08a20_4K_config.json    
+
     dest_dir=${D}/opt/imx8-isp/bin
     install -d ${D}/${libdir}
     install -d $dest_dir


### PR DESCRIPTION
The binary blob providing basler-camera files now (4.2.2.21) contains configuration files for the Omnivion OS08A20 as used on NXP's camera module [1].
Those files have been and still are provided by isp-imx. The content is identical.
Delete them to prevent the following error during do_rootfs if the basler-camera package is installed into a image:

| * check_data_file_clashes: Package libdaa3840-30mc1 wants to install file
|        .../rootfs/opt/imx8-isp/bin/dewarp_config/sensor_dwe_os08a20_1080P_config.json
|        But that file is already provided by package  * isp-imx
| * check_data_file_clashes: Package libdaa3840-30mc1 wants to install file
|        .../rootfs/opt/imx8-isp/bin/dewarp_config/sensor_dwe_os08a20_4K_config.json
|        But that file is already provided by package  * isp-imx

[1] https://www.nxp.com/part/IMX-OS08A20#/