### PR TITLE
fsl-kernel-localversion: fix regression setting LOCALVERSION

### DIFF
--- a/classes/fsl-kernel-localversion.bbclass
+++ b/classes/fsl-kernel-localversion.bbclass
@@ -20,7 +20,7 @@ do_kernel_localversion() {
 
 	# Fallback for recipes not able to use LINUX_VERSION_EXTENSION
 	if [ "${@bb.data.inherits_class('kernel-yocto', d)}" = "False" ]; then
-		echo "CONFIG_LOCALVERSION=${LOCALVERSION}" >> ${B}/.config
+		echo 'CONFIG_LOCALVERSION="${LOCALVERSION}"' >> ${B}/.config
 	fi
 
 	if [ "${SCMVERSION}" = "y" ]; then


### PR DESCRIPTION
CONFIG_LOCALVERSION is a string setting. It needs to go between quotes in the .config file.

$ grep CONFIG_LOCALVERSION= .config
CONFIG_LOCALVERSION="-dey"