### PR TITLE
imx-gpu-viv: Fix i.MX GPU driver version for Vulkan loader

### DIFF
--- a/recipes-graphics/imx-gpu-viv/imx-gpu-viv/imx_icd.json
+++ b/recipes-graphics/imx-gpu-viv/imx-gpu-viv/imx_icd.json
@@ -1,7 +1,7 @@
 {
     "file_format_version": "1.0.0",
     "ICD": {
-        "library_path": "%libdir%/libvulkan_VSI.so",
+        "library_path": "%libdir%/libvulkan_VSI.so.1",
         "api_version": "%api_version%"
     }
 }


### PR DESCRIPTION
Vulkan loader reads driver path from imx_icd.json so update it to use a driver version installed on target.