### PR TITLE
imx-gpu-viv: Simplify using imx-gpu-viv-6.inc from another layer

### DIFF
--- a/recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc
+++ b/recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc
@@ -76,6 +76,7 @@ inherit fsl-eula-unpack
 
 SRC_URI = "${FSL_MIRROR}/${BPN}-${PV}.bin;fsl-eula=true \
            file://imx_icd.json"
+FILESEXTRAPATHS:append := "${THISDIR}/imx-gpu-viv:"
 
 PACKAGECONFIG ?= ""
 


### PR DESCRIPTION
When the recipe include file imx-gpu-viv-6.inc is used from another layer, the included SRC_URI file imx_icd.json is not found.