### PR TITLE
alsa-state: Add FILESEXTREAPATHS for NXP specific and Mainline BSP

### DIFF
--- a/recipes-bsp/alsa-state/alsa-state.bbappend
+++ b/recipes-bsp/alsa-state/alsa-state.bbappend
@@ -1,4 +1,4 @@
 # Prepend path to override files from upstream recipe
-FILESEXTRAPATHS:prepend:imx-generic-bsp := "${THISDIR}/${PN}/imx-generic-bsp:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 PACKAGE_ARCH:imx-generic-bsp = "${MACHINE_ARCH}"


### PR DESCRIPTION
Current implement can only apply the setting under folder imx-generic-bsp. Add paths for the NXP and mainline specific setting.