### PR TITLE
wayland: make local copy of the 1.22.0 recipe

### DIFF
--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -527,6 +527,8 @@ PREFERRED_VERSION_wayland-protocols:mx7-nxp-bsp  ??= "1.31.imx"
 PREFERRED_VERSION_wayland-protocols:mx8-nxp-bsp  ??= "1.31.imx"
 PREFERRED_VERSION_wayland-protocols:mx9-nxp-bsp  ??= "1.31.imx"
 
+PREFERRED_VERSION_wayland:imx-nxp-bsp ??= "1.22.0.imx"
+PREFERRED_VERSION_wayland-native:imx-nxp-bsp ??= "1.22.0.imx"
 PREFERRED_VERSION_xwayland:imx-nxp-bsp ??= "23.1.1.imx"
 
 # Use i.MX libdrm Version

--- a/recipes-graphics/wayland/wayland/0001-build-Fix-strndup-detection-on-MinGW.patch
+++ b/recipes-graphics/wayland/wayland/0001-build-Fix-strndup-detection-on-MinGW.patch
@@ -1,0 +1,41 @@
+From b4c64b6f07743e3fb63ce52359bc664ab7d60df0 Mon Sep 17 00:00:00 2001
+From: Joshua Watt <JPEWhacker@gmail.com>
+Date: Thu, 20 Feb 2020 15:20:45 -0600
+Subject: [PATCH] build: Fix strndup detection on MinGW
+
+GCC and meson conspire together to incorrectly detect that strndup()
+exists on MinGW as __builtin_strndup, when no such function exists. As a
+work around, meson will skip looking for __builtin functions if an
+'#include' is in the prefix, so add '#include <string.h>' when looking
+for strndup().
+
+See: https://github.com/mesonbuild/meson/issues/3672
+
+Upstream-Status: Submitted [https://gitlab.freedesktop.org/wayland/wayland/merge_requests/63]
+
+Signed-off-by: Joshua Watt <JPEWhacker@gmail.com>
+Signed-off-by: Denys Dmytriyenko <denis@denix.org>
+---
+ meson.build | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/meson.build b/meson.build
+index 3bc25c9..adde7b9 100644
+--- a/meson.build
++++ b/meson.build
+@@ -38,11 +38,11 @@ have_funcs = [
+ 	'prctl',
+ 	'memfd_create',
+ 	'mremap',
+-	'strndup',
+ ]
+ foreach f: have_funcs
+ 	config_h.set('HAVE_' + f.underscorify().to_upper(), cc.has_function(f))
+ endforeach
++config_h.set('HAVE_STRNDUP', cc.has_function('strndup') and cc.has_header_symbol('string.h', 'strndup'))
+ config_h.set10('HAVE_XUCRED_CR_PID', cc.has_member('struct xucred', 'cr_pid', prefix : '#include <sys/ucred.h>'))
+ have_broken_msg_cmsg_cloexec = false
+ if host_machine.system() == 'freebsd'
+-- 
+2.7.4
+

--- a/recipes-graphics/wayland/wayland/run-ptest
+++ b/recipes-graphics/wayland/wayland/run-ptest
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+export WAYLAND_SCANNER=wayland-scanner
+export TEST_DATA_DIR=tests/data
+export TEST_OUTPUT_DIR=tests/output
+export SED=sed
+export WAYLAND_EGL_LIB=/usr/lib/libwayland-egl.so.1
+export NM=nm
+
+for i in `ls tests/*-test tests/wayland-egl-symbols-check tests/scanner-test.sh`; do
+    $i
+    if [ $? -eq 0 ]; then
+        echo "PASS: $i"
+    else
+        echo "FAIL: $i"
+    fi
+done

--- a/recipes-graphics/wayland/wayland_1.22.0.imx.bb
+++ b/recipes-graphics/wayland/wayland_1.22.0.imx.bb
@@ -1,0 +1,67 @@
+SUMMARY = "Wayland, a protocol between a compositor and clients"
+DESCRIPTION = "Wayland is a protocol for a compositor to talk to its clients \
+as well as a C library implementation of that protocol. The compositor can be \
+a standalone display server running on Linux kernel modesetting and evdev \
+input devices, an X application, or a wayland client itself. The clients can \
+be traditional applications, X servers (rootless or fullscreen) or other \
+display servers."
+HOMEPAGE = "http://wayland.freedesktop.org"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://COPYING;md5=b31d8f53b6aaf2b4985d7dd7810a70d1 \
+                    file://src/wayland-server.c;endline=24;md5=b8e046164a766bb1ede8ba38e9dcd7ce"
+
+DEPENDS = "expat libffi wayland-native"
+
+SRC_URI = "https://gitlab.freedesktop.org/wayland/wayland/-/releases/1.22.0/downloads/${BP_ORIGINAL}.tar.xz \
+           file://run-ptest \
+           file://0001-build-Fix-strndup-detection-on-MinGW.patch \
+           "
+SRC_URI[sha256sum] = "1540af1ea698a471c2d8e9d288332c7e0fd360c8f1d12936ebb7e7cbc2425842"
+BP_ORIGINAL = "${BPN}-1.22.0"
+S = "${WORKDIR}/${BP_ORIGINAL}"
+
+UPSTREAM_CHECK_URI = "https://wayland.freedesktop.org/releases.html"
+UPSTREAM_CHECK_REGEX = "wayland-(?P<pver>\d+\.\d+\.(?!9\d+)\d+)"
+
+inherit meson pkgconfig ptest
+
+PACKAGECONFIG ??= "dtd-validation"
+PACKAGECONFIG[dtd-validation] = "-Ddtd_validation=true,-Ddtd_validation=false,libxml2,,"
+
+EXTRA_OEMESON = "-Ddocumentation=false"
+EXTRA_OEMESON:class-native = "-Ddocumentation=false"
+
+# Wayland installs a M4 macro for other projects to use, which uses the target
+# pkg-config to find files.  Replace pkg-config with pkg-config-native.
+do_install:append:class-native() {
+  sed -e 's,PKG_CHECK_MODULES(.*),,g' \
+      -e 's,$PKG_CONFIG,pkg-config-native,g' \
+      -i ${D}/${datadir}/aclocal/wayland-scanner.m4
+}
+
+do_install_ptest() {
+    mkdir -p ${D}${PTEST_PATH}/tests/data
+    cp -rf ${B}/tests/*-test ${B}/tests/*-checker ${D}${PTEST_PATH}/tests
+    cp -rf ${B}/tests/*-checker ${D}${PTEST_PATH}
+    cp -rf ${S}/tests/scanner-test.sh ${D}${PTEST_PATH}/tests
+    cp -rf ${S}/tests/data/* ${D}${PTEST_PATH}/tests/data/
+    cp -rf ${S}/egl/wayland-egl-symbols-check ${D}${PTEST_PATH}/tests/
+}
+
+sysroot_stage_all:append:class-target () {
+	rm ${SYSROOT_DESTDIR}/${datadir}/aclocal/wayland-scanner.m4
+	cp ${STAGING_DATADIR_NATIVE}/aclocal/wayland-scanner.m4 ${SYSROOT_DESTDIR}/${datadir}/aclocal/
+}
+
+PACKAGES =+ "${PN}-tools"
+
+FILES:${PN}-tools = "${bindir}/wayland-scanner"
+FILES:${PN}-dev += "${datadir}/${BPN}/wayland-scanner.mk"
+
+BBCLASSEXTEND = "native nativesdk"
+
+RDEPENDS:${PN}-ptest += "binutils sed ${PN}-tools"
+
+PACKAGE_ARCH = "${MACHINE_SOCARCH}"
+
+DEFAULT_PREFERENCE = "-1"


### PR DESCRIPTION
Current xwayland 23.1.1 release is not compatible with the wayland version available in kirkstone (1.20.0).

Make a local copy of the 1.22.0 recipe from oe-core master b73784851 but for imx, with default preference set as -1, following how xwayland was also imported from oe-core.

This change is mostly relevant for uses wanting to use meta-freescale master with oe-core kirkstone. In case it is not desired to fork yet another recipe due kirkstone compatibility I can have a similar change on my distro layer instead (but opening the pull request anyway).