### PR TITLE
wayland: sync wayland, wayland-native and nativesdk-wayland versions

### DIFF
--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -527,8 +527,9 @@ PREFERRED_VERSION_wayland-protocols:mx7-nxp-bsp  ??= "1.31.imx"
 PREFERRED_VERSION_wayland-protocols:mx8-nxp-bsp  ??= "1.31.imx"
 PREFERRED_VERSION_wayland-protocols:mx9-nxp-bsp  ??= "1.31.imx"
 
-PREFERRED_VERSION_wayland:imx-nxp-bsp ??= "1.22.0.imx"
-PREFERRED_VERSION_wayland-native:imx-nxp-bsp ??= "1.22.0.imx"
+PREFERRED_VERSION_wayland-native       ??= "1.22.0.imx"
+PREFERRED_VERSION_nativesdk-wayland    ??= "1.22.0.imx"
+PREFERRED_VERSION_wayland:imx-nxp-bsp  ??= "1.22.0.imx"
 PREFERRED_VERSION_xwayland:imx-nxp-bsp ??= "23.1.1.imx"
 
 # Use i.MX libdrm Version


### PR DESCRIPTION
When using wayland and an i.MX SoC the recipes ought to be in sync. This
fixes a build error in nativesdk-wayland when running in mickledore:

,----
| ../wayland-1.21.0/src/meson.build:81:1: ERROR: Dependency lookup for
|   wayland-scanner with method 'pkgconfig' failed: Invalid version, need
|   'wayland-scanner' ['1.21.0'] found '1.22.0'.
`----

Fixes: 60510fbb ("wayland: make local copy of the 1.22.0 recipe")
Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>