### PR TITLE
vulkan-loader: Fix renamed master branch in source repository

### DIFF
--- a/recipes-downgrade/vulkan/vulkan-loader_1.2.182.0.bb
+++ b/recipes-downgrade/vulkan/vulkan-loader_1.2.182.0.bb
@@ -9,7 +9,7 @@ SECTION = "libs"
 
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=7dbefed23242760aa3475ee42801c5ac"
-SRC_URI = "git://github.com/KhronosGroup/Vulkan-Loader.git;protocol=https;branch=master \
+SRC_URI = "git://github.com/KhronosGroup/Vulkan-Loader.git;protocol=https;branch=main \
            "
 SRCREV = "1896143df69d439b0933c1bb485f5a4587bdf2dc"
 


### PR DESCRIPTION
	WARNING: vulkan-headers-1.2.182.0-r0 do_fetch: Failed to fetch URL git://github.com/KhronosGroup/Vulkan-Headers.git;branch=master;protocol=https, attempting MIRRORS if available
	WARNING: vulkan-loader-1.2.182.0-r0 do_fetch: Failed to fetch URL git://github.com/KhronosGroup/Vulkan-Loader.git;protocol=https;branch=master, attempting MIRRORS if available
	WARNING: libwebp-1.2.4-r0 do_fetch: Failed to fetch URL http://downloads.webmproject.org/releases/webp/libwebp-1.2.4.tar.gz, attempting MIRRORS if available
	ERROR: vulkan-loader-1.2.182.0-r0 do_fetch: Fetcher failure: Unable to find revision 1896143df69d439b0933c1bb485f5a4587bdf2dc in branch master even from upstream