### PR TITLE
gstreamer1.0-plugins-base: Fix GL packageconfig and Vivante GPU details

### DIFF
--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.22.%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.22.%.bbappend
@@ -1,0 +1,16 @@
+PACKAGECONFIG_GL:imxgpu2d = \
+    "${@bb.utils.contains('DISTRO_FEATURES', 'opengl x11', 'opengl', '', d)}"
+PACKAGECONFIG_GL:imxgpu3d = \
+    "${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'gles2 egl', '', d)}"
+PACKAGECONFIG_GL:use-mainline-bsp = \
+    "${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'gles2 egl gbm', '', d)}"
+
+# The i.MX8 uses KMS instead of the Vivante specific framebuffer API.
+# The i.MX7 does not have a GPU.
+# This leaves the i.MX6 - with the vendor BSP - as the remaining use case for viv-fb.
+#
+# (Note that viv-fb is about the _windowing system_. Vivante direct texture support
+# does not depend on the viv-fb feature. It used to, but that was actually a bug
+# which was fixed in GStreamer 1.22.5. Since then, the direct texture support is
+# detected by Meson by checking for direct texture symbols like "glTexDirectVIV".)
+PACKAGECONFIG_GL:append:mx6-nxp-bsp = " viv-fb "

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.22.0.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.22.0.imx.bb
@@ -123,12 +123,11 @@ S = "${WORKDIR}/git"
 
 inherit use-imx-headers
 
-PACKAGECONFIG_GL:imxgpu2d = \
-    "${@bb.utils.contains('DISTRO_FEATURES', 'opengl x11', 'opengl viv-fb', '', d)}"
-PACKAGECONFIG_GL:imxgpu3d = \
-    "${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'gles2 egl viv-fb', '', d)}"
-PACKAGECONFIG_GL:use-mainline-bsp = \
-    "${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'gles2 egl gbm', '', d)}"
+# Prior to version 1.22.5, viv-fb is coupled with the Vivante direct texture feature.
+# For this reason, in these older versions, viv-fb must be enabled always, even when
+# building for SoCs like the i.MX8 that do not support the viv-fb windowing system.
+# TODO: Once this .imx recipe is upgraded to 1.22.5 or newer, drop this line.
+PACKAGECONFIG_GL:append = " viv-fb "
 
 PACKAGECONFIG_REMOVE ?= "jpeg"
 PACKAGECONFIG:remove = "${PACKAGECONFIG_REMOVE}"


### PR DESCRIPTION
* Extract PACKAGECONFIG_GL settings into a common .bappend file that is used for both the imx GStreamer fork and upstream GStreamer.
* Backport fix for being able to use the viv-fb display support in upstream GStreamer (relevant for i.MX6).
* Backport fix for decoupling Vivante direct textures from the viv-fb display support, since direct textures can also be used with other systems like Wayland for example. This obviates the need to enable the viv-fb package just to get "fast paths" in GStreamer pipelines; if direct textures are supported, they are enabled automatically.