### PR TITLE
mfgtool-initramfs-image: IMAGE_NAME_SUFFIX should by empty for initramfs

### DIFF
--- a/classes/mfgtool-initramfs-image.bbclass
+++ b/classes/mfgtool-initramfs-image.bbclass
@@ -16,6 +16,7 @@ ZSTD_COMPRESSION_LEVEL ?= "-10"
 SOC_DEFAULT_IMAGE_FSTYPES = "cpio.zst.u-boot"
 SOC_DEFAULT_IMAGE_FSTYPES:mxs-generic-bsp = "cpio.gz.u-boot"
 IMAGE_ROOTFS_SIZE ?= "8192"
+IMAGE_NAME_SUFFIX = ""
 
 # Filesystems enabled by default
 DEFAULT_FS_SUPPORT = " \


### PR DESCRIPTION
INITRAMFS_IMAGE_NAME stay as before but it assumes that all images used as initramfs will set IMAGE_NAME_SUFFIX to empty.

https://git.yoctoproject.org/poky/commit/?id=6f6c79029bc2020907295858449c725952d560a1