### PR TITLE
image_types_fsl: IMAGE_NAME_SUFFIX is now directly included

### DIFF
--- a/classes/image_types_fsl.bbclass
+++ b/classes/image_types_fsl.bbclass
@@ -40,5 +40,5 @@ do_image_wic[depends] += " \
 IMAGE_CMD:wic:append:mxs-generic-bsp() {
 	# Change partition type for mxs processor family
 	bbnote "Setting partition type to 0x53 as required for mxs' SoC family."
-	echo -n S | dd of=$out${IMAGE_NAME_SUFFIX}.wic bs=1 count=1 seek=450 conv=notrunc
+	echo -n S | dd of=${out}.wic bs=1 count=1 seek=450 conv=notrunc
 }


### PR DESCRIPTION
The IMAGE_NAME_SUFFIX is now directly included in both IMAGE_NAME and IMAGE_LINK_NAME.

https://git.yoctoproject.org/poky/commit/?id=6f6c79029bc2020907295858449c725952d560a1