### PR TITLE
webkitgtk: Remove x11 from packageconfigs

### DIFF
--- a/recipes-sato/webkit/webkitgtk_%.bbappend
+++ b/recipes-sato/webkit/webkitgtk_%.bbappend
@@ -1,4 +1,4 @@
 # Fixes compile errors like
 # Source/WebCore/platform/graphics/egl/GLContextEGL.cpp:198:59: error: invalid 'static_cast' from type 'GLNativeWindowType' {aka 'long unsigned int'} to type 'EGLNativeWindowType' {aka 'wl_egl_window*'}
-PACKAGECONFIG:remove:imxgpu3d = "opengl opengl-or-es"
+PACKAGECONFIG:remove:imxgpu3d = "opengl x11"
 PACKAGECONFIG:append:imxgpu3d = " gles2"


### PR DESCRIPTION
opengl-or-es can be kept now

This ends up configure errors with newly updated 2.40 webkit in core Fixes issues like

| CMake Error at Source/cmake/WebKitMacros.cmake:154 (target_link_libraries):
|   Target "WebCore" links to:
|
|     WPE::libwpe
|
|   but the target was not found.  Possible reasons include:
|
|     * There is a typo in the target name.
|     * A find_package call is missing for an IMPORTED target.
|     * An ALIAS target is missing.