### PR TITLE
imx*.conf: Drop unused UBOOT_CONFIG[mfgtool]

### DIFF
--- a/conf/machine/imx6qdlsabreauto.conf
+++ b/conf/machine/imx6qdlsabreauto.conf
@@ -54,7 +54,6 @@ UBOOT_CONFIG[eimnor]   = "${UBOOT_CONFIG_MACHINE_NAME}_eimnor_defconfig"
 UBOOT_CONFIG[nand]     = "${UBOOT_CONFIG_MACHINE_NAME}_nand_defconfig,ubifs"
 UBOOT_CONFIG[spinor]   = "${UBOOT_CONFIG_MACHINE_NAME}_spinor_defconfig"
 UBOOT_CONFIG[sata]     = "${UBOOT_CONFIG_MACHINE_NAME}_sata_defconfig"
-UBOOT_CONFIG[mfgtool]  = "${UBOOT_CONFIG_MACHINE_NAME}_defconfig"
 
 # The u-boot-imx does not provide unified functionality for DL/Q/QP SoC
 # variants. Change the defconfig to the targeted SoC variant.

--- a/conf/machine/imx6qdlsabresd.conf
+++ b/conf/machine/imx6qdlsabresd.conf
@@ -60,7 +60,6 @@ UBOOT_SUFFIX:pn-u-boot-imx-mfgtool = "imx"
 UBOOT_CONFIG[sd]       = "${UBOOT_CONFIG_MACHINE_NAME}_defconfig,sdcard"
 UBOOT_CONFIG[sd-optee] = "${UBOOT_CONFIG_MACHINE_NAME}_optee_defconfig,sdcard"
 UBOOT_CONFIG[sata]     = "${UBOOT_CONFIG_MACHINE_NAME}_sata_defconfig"
-UBOOT_CONFIG[mfgtool]  = "${UBOOT_CONFIG_MACHINE_NAME}_defconfig"
 
 # The u-boot-imx does not provide unified functionality for DL/Q/QP SoC
 # variants. Change the defconfig to the targeted SoC variant.

--- a/conf/machine/imx6slevk.conf
+++ b/conf/machine/imx6slevk.conf
@@ -28,7 +28,6 @@ UBOOT_CONFIG[sd]       = "mx6slevk_config,sdcard"
 UBOOT_CONFIG[sd-optee] = "mx6slevk_optee_config,sdcard"
 UBOOT_CONFIG[epdc]     = "mx6slevk_epdc_config"
 UBOOT_CONFIG[spinor]   = "mx6slevk_spinor_config"
-UBOOT_CONFIG[mfgtool]  = "mx6slevk_config"
 
 OPTEE_BIN_EXT = "6slevk"
 

--- a/conf/machine/imx6sllevk.conf
+++ b/conf/machine/imx6sllevk.conf
@@ -24,7 +24,6 @@ UBOOT_CONFIG ??= " \
 UBOOT_CONFIG[sd]       = "mx6sllevk_config,sdcard"
 UBOOT_CONFIG[sd-optee] = "mx6sllevk_optee_config,sdcard"
 UBOOT_CONFIG[epdc]     = "mx6sllevk_epdc_config"
-UBOOT_CONFIG[mfgtool]  = "mx6sllevk_config"
 
 OPTEE_BIN_EXT:imx6sllevk = "6sllevk"
 

--- a/conf/machine/imx6sxsabreauto.conf
+++ b/conf/machine/imx6sxsabreauto.conf
@@ -23,7 +23,6 @@ UBOOT_CONFIG[sd]       = "mx6sxsabreauto_config,sdcard"
 UBOOT_CONFIG[sd-optee] = "mx6sxsabreauto_optee_config,sdcard"
 UBOOT_CONFIG[qspi1]    = "mx6sxsabreauto_qspi1_config"
 UBOOT_CONFIG[nand]     = "mx6sxsabreauto_nand_config,ubifs"
-UBOOT_CONFIG[mfgtool]  = "mx6sxsabreauto_config"
 
 OPTEE_BIN_EXT = "6sxauto"
 

--- a/conf/machine/imx6sxsabresd.conf
+++ b/conf/machine/imx6sxsabresd.conf
@@ -37,7 +37,6 @@ UBOOT_CONFIG[sd-optee] = "mx6sxsabresd_optee_config,sdcard"
 UBOOT_CONFIG[emmc]     = "mx6sxsabresd_emmc_config,sdcard"
 UBOOT_CONFIG[qspi2]    = "mx6sxsabresd_qspi2_config"
 UBOOT_CONFIG[m4fastup] = "mx6sxsabresd_m4fastup_config"
-UBOOT_CONFIG[mfgtool]  = "mx6sxsabresd_config"
 
 OPTEE_BIN_EXT = "6sxsdb"
 

--- a/conf/machine/imx6ulevk.conf
+++ b/conf/machine/imx6ulevk.conf
@@ -50,6 +50,5 @@ UBOOT_CONFIG[sd]       = "mx6ul_14x14_evk_config,sdcard"
 UBOOT_CONFIG[sd-optee] = "mx6ul_14x14_evk_optee_config,sdcard"
 UBOOT_CONFIG[emmc]     = "mx6ul_14x14_evk_emmc_config,sdcard"
 UBOOT_CONFIG[qspi1]    = "mx6ul_14x14_evk_qspi1_config"
-UBOOT_CONFIG[mfgtool]  = "mx6ul_14x14_evk_config"
 
 OPTEE_BIN_EXT = "6ulevk"

--- a/conf/machine/imx6ullevk.conf
+++ b/conf/machine/imx6ullevk.conf
@@ -34,6 +34,5 @@ UBOOT_CONFIG[sd-optee] = "mx6ull_14x14_evk_optee_config,sdcard"
 UBOOT_CONFIG[emmc]     = "mx6ull_14x14_evk_emmc_config,sdcard"
 UBOOT_CONFIG[nand]     = "mx6ull_14x14_evk_nand_config,ubifs"
 UBOOT_CONFIG[qspi1]    = "mx6ull_14x14_evk_qspi1_config"
-UBOOT_CONFIG[mfgtool]  = "mx6ull_14x14_evk_config"
 
 OPTEE_BIN_EXT = "6ullevk"

--- a/conf/machine/imx7dsabresd.conf
+++ b/conf/machine/imx7dsabresd.conf
@@ -38,7 +38,6 @@ UBOOT_CONFIG[nonsec]   = "mx7dsabresd_nonsec_config,sdcard"
 UBOOT_CONFIG[qspi1]    = "mx7dsabresd_qspi1_config"
 UBOOT_CONFIG[nand]     = "mx7dsabresd_nand_config,ubifs"
 UBOOT_CONFIG[epdc]     = "mx7dsabresd_epdc_config"
-UBOOT_CONFIG[mfgtool]  = "mx7dsabresd_config"
 
 OPTEE_BIN_EXT = "7dsdb"
 

--- a/conf/machine/imx7ulpevk.conf
+++ b/conf/machine/imx7ulpevk.conf
@@ -38,7 +38,6 @@ UBOOT_CONFIG ??= " \
 UBOOT_CONFIG[sd]       = "mx7ulp_evk_config,sdcard"
 UBOOT_CONFIG[sd-optee] = "mx7ulp_evk_optee_config,sdcard"
 UBOOT_CONFIG[emmc]     = "mx7ulp_evk_emmc_config,sdcard"
-UBOOT_CONFIG[mfgtool]  = "mx7ulp_evk_config"
 
 OPTEE_BIN_EXT = "7ulp"
 

--- a/conf/machine/imx8mq-evk.conf
+++ b/conf/machine/imx8mq-evk.conf
@@ -50,7 +50,6 @@ UBOOT_SUFFIX = "bin"
 
 UBOOT_CONFIG ??= "sd"
 UBOOT_CONFIG[sd]       = "imx8mq_evk_config,sdcard"
-UBOOT_CONFIG[mfgtool]  = "imx8mq_evk_config"
 
 SPL_BINARY = "spl/u-boot-spl.bin"
 

--- a/conf/machine/imx8qm-mek.conf
+++ b/conf/machine/imx8qm-mek.conf
@@ -63,7 +63,6 @@ UBOOT_SUFFIX = "bin"
 UBOOT_CONFIG ??= "sd"
 UBOOT_CONFIG[sd]      = "imx8qm_mek_defconfig,sdcard"
 UBOOT_CONFIG[fspi]    = "imx8qm_mek_fspi_defconfig"
-UBOOT_CONFIG[mfgtool] = "imx8qm_mek_defconfig"
 
 IMX_BOOT_SEEK = "32"
 

--- a/conf/machine/include/imx8mm-evk.inc
+++ b/conf/machine/include/imx8mm-evk.inc
@@ -34,7 +34,6 @@ UBOOT_SUFFIX = "bin"
 
 UBOOT_CONFIG ??= "sd"
 UBOOT_CONFIG[sd]       = "${UBOOT_CONFIG_BASENAME}_defconfig,sdcard"
-UBOOT_CONFIG[mfgtool]  = "${UBOOT_CONFIG_BASENAME}_defconfig"
 
 SPL_BINARY = "spl/u-boot-spl.bin"
 

--- a/conf/machine/include/imx8mn-evk.inc
+++ b/conf/machine/include/imx8mn-evk.inc
@@ -38,7 +38,6 @@ UBOOT_CONFIG ??= "sd"
 UBOOT_CONFIG[sd]      = "${UBOOT_CONFIG_BASENAME}_defconfig,sdcard"
 UBOOT_CONFIG[fspi]    = "${UBOOT_CONFIG_BASENAME}_defconfig"
 UBOOT_CONFIG[ld]      = "${UBOOT_CONFIG_BASENAME}_ld_defconfig"
-UBOOT_CONFIG[mfgtool] = "${UBOOT_CONFIG_BASENAME}_defconfig"
 
 SPL_BINARY = "spl/u-boot-spl.bin"
 

--- a/conf/machine/include/imx8mp-evk.inc
+++ b/conf/machine/include/imx8mp-evk.inc
@@ -31,7 +31,6 @@ UBOOT_SUFFIX = "bin"
 UBOOT_CONFIG ??= "sd"
 UBOOT_CONFIG[sd]      = "${UBOOT_CONFIG_BASENAME}_defconfig,sdcard"
 UBOOT_CONFIG[ecc]     = "${UBOOT_CONFIG_BASENAME}_inline_ecc_defconfig"
-UBOOT_CONFIG[mfgtool] = "${UBOOT_CONFIG_BASENAME}_defconfig"
 
 SPL_BINARY = "spl/u-boot-spl.bin"
 


### PR DESCRIPTION
UBOOT_CONFIG[mfgtool] is no longer used since the following:

88399694 linux-*-mfgtool, u-boot-*-mfgtool: Remove specific recipes