### PR TITLE
linux-fslc: update to v6.1.38

### DIFF
--- a/recipes-kernel/linux/linux-fslc_6.1.bb
+++ b/recipes-kernel/linux/linux-fslc_6.1.bb
@@ -19,10 +19,10 @@ SRC_URI = "git://github.com/Freescale/linux-fslc.git;branch=${KBRANCH};protocol=
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "6.1.31"
+LINUX_VERSION = "6.1.38"
 
 KBRANCH = "6.1.x+fslc"
-SRCREV = "58cb4aeaeec012a2d36b29531a5e48093f7183ef"
+SRCREV = "085682f3fc7ed71fdafa987c96d76805086336a9"
 
 KBUILD_DEFCONFIG:mx27-generic-bsp = "imx_v4_v5_defconfig"
 KBUILD_DEFCONFIG:mx5-generic-bsp = "imx_v6_v7_defconfig"


### PR DESCRIPTION
Tested building with:
- **aarch64**: defconfig
- **arm**: mxs_defconfig imx_v4_v5_defconfig imx_v6_v7_defconfig

The kernel repository has been upgraded up to v6.1.38 from a stable release.

Following commits are added on top of stable tree:
- 085682f3fc7e ("kbuild: filter only valid dtb files to construct complex dtb")