### PR TITLE
Update imx[-fslc] linux kernel, u-boot and related recipes to 6.1.22-2.0.0

### DIFF
--- a/conf/machine/imx6ullevk.conf
+++ b/conf/machine/imx6ullevk.conf
@@ -17,7 +17,6 @@ KERNEL_DEVICETREE = " \
 
 KERNEL_DEVICETREE:append:use-nxp-bsp = " \
     imx6ull-14x14-evk-btwifi.dtb \
-    imx6ull-14x14-evk-btwifi-sdio3_0.dtb \
     imx6ull-14x14-evk-emmc.dtb \
     imx6ull-14x14-evk-gpmi-weim.dtb \
 "

--- a/conf/machine/imx6ulz-14x14-evk.conf
+++ b/conf/machine/imx6ulz-14x14-evk.conf
@@ -16,7 +16,6 @@ KERNEL_DEVICETREE = " \
 "
 KERNEL_DEVICETREE:append:use-nxp-bsp = " \
     imx6ulz-14x14-evk-btwifi.dtb \
-    imx6ull-14x14-evk-btwifi-sdio3_0.dtb \
     imx6ulz-14x14-evk-emmc.dtb \
     imx6ulz-14x14-evk-gpmi-weim.dtb \
 "

--- a/recipes-bsp/imx-lib/imx-lib_git.bb
+++ b/recipes-bsp/imx-lib/imx-lib_git.bb
@@ -13,8 +13,8 @@ PE = "1"
 PV = "5.9+${SRCPV}"
 
 SRC_URI = "git://github.com/nxp-imx/imx-lib.git;protocol=https;branch=${SRCBRANCH}"
-SRCBRANCH = "lf-6.1.1_1.0.0"
-SRCREV = "43e5ee7dc4f88d883f8ce2bea309f8708be88a3e"
+SRCBRANCH = "lf-6.1.22_2.0.0"
+SRCREV = "8f124c3914d82019849fb697baeb730e4cb1b547"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-bsp/imx-mkimage/files/0001-iMX8M-soc.mak-use-native-mkimage-from-sysroot.patch
+++ b/recipes-bsp/imx-mkimage/files/0001-iMX8M-soc.mak-use-native-mkimage-from-sysroot.patch
@@ -1,6 +1,6 @@
-From 70b7d067ca0f6659e4f842f8d841714a26bf9d8c Mon Sep 17 00:00:00 2001
-From: Andrey Zhizhikin <andrey.z@gmail.com>
-Date: Thu, 21 Oct 2021 08:53:38 +0000
+From 3e0f78a4efeac4ea0651ac763099d780447a18b4 Mon Sep 17 00:00:00 2001
+From: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>
+Date: Wed, 19 Jul 2023 18:34:32 +0300
 Subject: [PATCH] iMX8M: soc.mak: use native mkimage from sysroot
 
 mkimage tool is provided as a part of sysroot from Yocto build. Current
@@ -13,63 +13,65 @@ build.
 
 Use it from the build sysroot, and do not pull the local version of it.
 
-Upstream-Status: Inappropriate [OE-specific]
+Reinjected the original patch from Andrey Zhizhikin <andrey.z@gmail.com>
 
-Signed-off-by: Andrey Zhizhikin <andrey.z@gmail.com>
+Upstream-Status: Inappropriate [OE-specific]
+Signed-off-by: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>
 ---
+
  iMX8M/soc.mak | 11 +++++------
  1 file changed, 5 insertions(+), 6 deletions(-)
 
-Index: git/iMX8M/soc.mak
-===================================================================
---- git.orig/iMX8M/soc.mak
-+++ git/iMX8M/soc.mak
-@@ -149,7 +149,7 @@ u-boot.itb: $(dtb)
+diff --git a/iMX8M/soc.mak b/iMX8M/soc.mak
+index 3486079..855c1e5 100644
+--- a/iMX8M/soc.mak
++++ b/iMX8M/soc.mak
+@@ -155,7 +155,7 @@ u-boot.itb: $(dtb) $(supp_dtbs)
  	./$(PAD_IMAGE) bl31.bin
- 	./$(PAD_IMAGE) u-boot-nodtb.bin $(dtb)
- 	BL32=$(TEE) DEK_BLOB_LOAD_ADDR=$(DEK_BLOB_LOAD_ADDR) TEE_LOAD_ADDR=$(TEE_LOAD_ADDR) ATF_LOAD_ADDR=$(ATF_LOAD_ADDR) ../$(SOC_DIR)/mkimage_fit_atf.sh $(dtb) > u-boot.its
+ 	./$(PAD_IMAGE) u-boot-nodtb.bin $(dtb) $(supp_dtbs)
+ 	BL32=$(TEE) DEK_BLOB_LOAD_ADDR=$(DEK_BLOB_LOAD_ADDR) TEE_LOAD_ADDR=$(TEE_LOAD_ADDR) ATF_LOAD_ADDR=$(ATF_LOAD_ADDR) ../$(SOC_DIR)/mkimage_fit_atf.sh $(dtb) $(supp_dtbs) > u-boot.its
 -	./mkimage_uboot -E -p 0x3000 -f u-boot.its u-boot.itb
 +	mkimage -E -p 0x3000 -f u-boot.its u-boot.itb
  	@rm -f u-boot.its $(dtb)
  
  dtb_ddr3l = valddr3l.dtb
-@@ -161,7 +161,7 @@ u-boot-ddr3l.itb: $(dtb_ddr3l)
+@@ -167,7 +167,7 @@ u-boot-ddr3l.itb: $(dtb_ddr3l) $(supp_dtbs)
  	./$(PAD_IMAGE) bl31.bin
- 	./$(PAD_IMAGE) u-boot-nodtb.bin $(dtb_ddr3l)
- 	DEK_BLOB_LOAD_ADDR=$(DEK_BLOB_LOAD_ADDR) TEE_LOAD_ADDR=$(TEE_LOAD_ADDR) ATF_LOAD_ADDR=$(ATF_LOAD_ADDR) ../$(SOC_DIR)/mkimage_fit_atf.sh $(dtb_ddr3l) > u-boot-ddr3l.its
+ 	./$(PAD_IMAGE) u-boot-nodtb.bin $(dtb_ddr3l) $(supp_dtbs)
+ 	DEK_BLOB_LOAD_ADDR=$(DEK_BLOB_LOAD_ADDR) TEE_LOAD_ADDR=$(TEE_LOAD_ADDR) ATF_LOAD_ADDR=$(ATF_LOAD_ADDR) ../$(SOC_DIR)/mkimage_fit_atf.sh $(dtb_ddr3l) $(supp_dtbs) > u-boot-ddr3l.its
 -	./mkimage_uboot -E -p 0x3000 -f u-boot-ddr3l.its u-boot-ddr3l.itb
 +	mkimage -E -p 0x3000 -f u-boot-ddr3l.its u-boot-ddr3l.itb
  	@rm -f u-boot.its $(dtb_ddr3l)
  
  dtb_ddr3l_evk = evkddr3l.dtb
-@@ -173,7 +173,7 @@ u-boot-ddr3l-evk.itb: $(dtb_ddr3l_evk)
+@@ -179,7 +179,7 @@ u-boot-ddr3l-evk.itb: $(dtb_ddr3l_evk) $(supp_dtbs)
  	./$(PAD_IMAGE) bl31.bin
- 	./$(PAD_IMAGE) u-boot-nodtb.bin $(dtb_ddr3l_evk)
- 	DEK_BLOB_LOAD_ADDR=$(DEK_BLOB_LOAD_ADDR) TEE_LOAD_ADDR=$(TEE_LOAD_ADDR) ATF_LOAD_ADDR=$(ATF_LOAD_ADDR) ../$(SOC_DIR)/mkimage_fit_atf.sh $(dtb_ddr3l_evk) > u-boot-ddr3l-evk.its
+ 	./$(PAD_IMAGE) u-boot-nodtb.bin $(dtb_ddr3l_evk) $(supp_dtbs)
+ 	DEK_BLOB_LOAD_ADDR=$(DEK_BLOB_LOAD_ADDR) TEE_LOAD_ADDR=$(TEE_LOAD_ADDR) ATF_LOAD_ADDR=$(ATF_LOAD_ADDR) ../$(SOC_DIR)/mkimage_fit_atf.sh $(dtb_ddr3l_evk) $(supp_dtbs) > u-boot-ddr3l-evk.its
 -	./mkimage_uboot -E -p 0x3000 -f u-boot-ddr3l-evk.its u-boot-ddr3l-evk.itb
 +	mkimage -E -p 0x3000 -f u-boot-ddr3l-evk.its u-boot-ddr3l-evk.itb
  	@rm -f u-boot.its $(dtb_ddr3l_evk)
  
  dtb_ddr4 = valddr4.dtb
-@@ -185,7 +185,7 @@ u-boot-ddr4.itb: $(dtb_ddr4)
+@@ -191,7 +191,7 @@ u-boot-ddr4.itb: $(dtb_ddr4) $(supp_dtbs)
  	./$(PAD_IMAGE) bl31.bin
- 	./$(PAD_IMAGE) u-boot-nodtb.bin $(dtb_ddr4)
- 	DEK_BLOB_LOAD_ADDR=$(DEK_BLOB_LOAD_ADDR) TEE_LOAD_ADDR=$(TEE_LOAD_ADDR) ATF_LOAD_ADDR=$(ATF_LOAD_ADDR) ../$(SOC_DIR)/mkimage_fit_atf.sh $(dtb_ddr4) > u-boot-ddr4.its
+ 	./$(PAD_IMAGE) u-boot-nodtb.bin $(dtb_ddr4) $(supp_dtbs)
+ 	DEK_BLOB_LOAD_ADDR=$(DEK_BLOB_LOAD_ADDR) TEE_LOAD_ADDR=$(TEE_LOAD_ADDR) ATF_LOAD_ADDR=$(ATF_LOAD_ADDR) ../$(SOC_DIR)/mkimage_fit_atf.sh $(dtb_ddr4) $(supp_dtbs) > u-boot-ddr4.its
 -	./mkimage_uboot -E -p 0x3000 -f u-boot-ddr4.its u-boot-ddr4.itb
 +	mkimage -E -p 0x3000 -f u-boot-ddr4.its u-boot-ddr4.itb
  	@rm -f u-boot.its $(dtb_ddr4)
  
  dtb_ddr4_evk = evkddr4.dtb
-@@ -197,7 +197,7 @@ u-boot-ddr4-evk.itb: $(dtb_ddr4_evk)
+@@ -203,7 +203,7 @@ u-boot-ddr4-evk.itb: $(dtb_ddr4_evk) $(supp_dtbs)
  	./$(PAD_IMAGE) bl31.bin
- 	./$(PAD_IMAGE) u-boot-nodtb.bin $(dtb_ddr4_evk)
- 	DEK_BLOB_LOAD_ADDR=$(DEK_BLOB_LOAD_ADDR) TEE_LOAD_ADDR=$(TEE_LOAD_ADDR) ATF_LOAD_ADDR=$(ATF_LOAD_ADDR) ../$(SOC_DIR)/mkimage_fit_atf.sh $(dtb_ddr4_evk) > u-boot-ddr4-evk.its
+ 	./$(PAD_IMAGE) u-boot-nodtb.bin $(dtb_ddr4_evk) $(supp_dtbs)
+ 	DEK_BLOB_LOAD_ADDR=$(DEK_BLOB_LOAD_ADDR) TEE_LOAD_ADDR=$(TEE_LOAD_ADDR) ATF_LOAD_ADDR=$(ATF_LOAD_ADDR) ../$(SOC_DIR)/mkimage_fit_atf.sh $(dtb_ddr4_evk) $(supp_dtbs) > u-boot-ddr4-evk.its
 -	./mkimage_uboot -E -p 0x3000 -f u-boot-ddr4-evk.its u-boot-ddr4-evk.itb
 +	mkimage -E -p 0x3000 -f u-boot-ddr4-evk.its u-boot-ddr4-evk.itb
  	@rm -f u-boot.its $(dtb_ddr4_evk)
  
  ifeq ($(HDMI),yes)
-@@ -343,7 +343,6 @@ nightly :
+@@ -353,7 +353,6 @@ nightly :
  	@$(WGET) -q $(SERVER)/$(DIR)/$(FW_DIR)/fsl-$(PLAT)-evk.dtb -O fsl-$(PLAT)-evk.dtb
  	@$(WGET) -q $(SERVER)/$(DIR)/$(FW_DIR)/signed_hdmi_imx8m.bin -O signed_hdmi_imx8m.bin
  	@$(WGET) -q $(SERVER)/$(DIR)/$(FW_DIR)/signed_dp_imx8m.bin -O signed_dp_imx8m.bin
@@ -77,3 +79,6 @@ Index: git/iMX8M/soc.mak
  
  archive :
  	git ls-files --others --exclude-standard -z | xargs -0 tar rvf $(ARCHIVE_PATH)/$(ARCHIVE_NAME)
+-- 
+2.40.1
+

--- a/recipes-bsp/imx-mkimage/imx-mkimage_git.inc
+++ b/recipes-bsp/imx-mkimage/imx-mkimage_git.inc
@@ -5,8 +5,8 @@ DEPENDS = "zlib-native openssl-native"
 SRC_URI = "git://github.com/nxp-imx/imx-mkimage.git;protocol=https;branch=${SRCBRANCH} \
            file://0001-iMX8M-soc.mak-use-native-mkimage-from-sysroot.patch \
 "
-SRCBRANCH = "lf-6.1.1_1.0.0"
-SRCREV = "d489494622585a47b4be88988595b0e4f9598f39"
+SRCBRANCH = "lf-6.1.22_2.0.0"
+SRCREV = "5cfd218012e080fb907d9cc301fbb4ece9bc17a9"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-bsp/imx-test/imx-test_git.bb
+++ b/recipes-bsp/imx-test/imx-test_git.bb
@@ -19,8 +19,8 @@ PV = "7.0+${SRCPV}"
 
 SRC_URI = "git://github.com/nxp-imx/imx-test.git;protocol=https;branch=${SRCBRANCH} \
            file://memtool_profile"
-SRCBRANCH = "lf-6.1.1_1.0.0"
-SRCREV = "75cb486d616e6561f803073b250a1d26e03a0d92"
+SRCBRANCH = "lf-6.1.22_2.0.0"
+SRCREV = "9fe083c29439b71292df9a8e4d40c73f25828a69"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-bsp/u-boot/u-boot-imx-common_2023.04.inc
+++ b/recipes-bsp/u-boot/u-boot-imx-common_2023.04.inc
@@ -4,9 +4,9 @@ LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://Licenses/gpl-2.0.txt;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 SRC_URI = "git://github.com/nxp-imx/uboot-imx.git;protocol=https;branch=${SRCBRANCH}"
-SRCBRANCH = "lf_v2022.04"
-LOCALVERSION ?= "-imx_v2022.04_5.15.71-2.2.0"
-SRCREV = "7376547b9e424b2d0f42dfe96394168c781ca297"
+SRCBRANCH = "lf_v2023.04"
+LOCALVERSION ?= "-imx_v2023.04_6.1.22-2.0.0"
+SRCREV = "af7d004eaf18437c7db76f7962652b924099405b"
 
 DEPENDS += " \
     bc-native \

--- a/recipes-bsp/u-boot/u-boot-imx_2023.04.bb
+++ b/recipes-bsp/u-boot/u-boot-imx_2023.04.bb
@@ -1,9 +1,9 @@
 # Copyright (C) 2013-2016 Freescale Semiconductor
 # Copyright 2018 (C) O.S. Systems Software LTDA.
-# Copyright (C) 2017-2021 NXP
+# Copyright (C) 2017-2023 NXP
 
 require recipes-bsp/u-boot/u-boot.inc
-require u-boot-imx-common_${PV}.inc
+require recipes-bsp/u-boot/u-boot-imx-common_${PV}.inc
 
 PROVIDES += "u-boot u-boot-mfgtool"
 

--- a/recipes-kernel/linux/linux-fslc-imx_6.1.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_6.1.bb
@@ -28,17 +28,21 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v6.1.24
+#    tag: v6.1.38
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: lf-6.1.1-1.0.0
+#    tag: lf-6.1.22-2.0.0
 #
 # ------------------------------------------------------------------------------
 # 3. Critical patches (SHA(s))
 # ------------------------------------------------------------------------------
-# - ad9ab3b3c553c ARM: imx_v7_defconfig: Remove KERNEL_LZO config
+# - 3f1f2ea729550 mxc: gpu-viv: change _QuerySignal() return type to gceSTATUS
+# - b73c6797ee427 ARM: imx_v7_defconfig: Remove KERNEL_LZO config
+# - ec33c7fc43bef touchscreen: Kconfig: add I2C dependency for CT36X
+# - 6c41233a2cfbe pwm: pwm-adp5585: fix get_state callback prototype
+# - 9c7540ecb891f pwm: pwm-rpmsg-imx: fix get_state callback prototype
 #
 # NOTE to upgraders:
 # This recipe should NOT collect individual patches, they should be applied to
@@ -48,16 +52,16 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 
 require linux-imx.inc
 
-KBRANCH = "6.1-1.0.x-imx"
+KBRANCH = "6.1-2.0.x-imx"
 SRC_URI = "git://github.com/Freescale/linux-fslc.git;branch=${KBRANCH};protocol=https"
-SRCREV = "ad9ab3b3c553cbc3c61f233b6e2cd5abdd2a624b"
+SRCREV = "b872b1170fc8843b55e9f8838dd373ff43bb7552"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "6.1.24"
+LINUX_VERSION = "6.1.38"
 
 KBUILD_DEFCONFIG:mx6-generic-bsp = "imx_v7_defconfig"
 KBUILD_DEFCONFIG:mx7-generic-bsp = "imx_v7_defconfig"

--- a/recipes-kernel/linux/linux-imx-headers_6.1.bb
+++ b/recipes-kernel/linux/linux-imx-headers_6.1.bb
@@ -9,8 +9,8 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
 SRC_URI = "git://github.com/nxp-imx/linux-imx.git;protocol=https;branch=${SRCBRANCH}"
 SRCBRANCH = "lf-6.1.y"
-LOCALVERSION = "-6.1.1-1.0.0"
-SRCREV = "29549c7073bf72cfb2c4614d37de45ec36b60475"
+LOCALVERSION = "-6.1.22-2.0.0"
+SRCREV = "66e442bc7fdcc935e6faa94c743f653263d4ed67"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-kernel/linux/linux-imx_6.1.bb
+++ b/recipes-kernel/linux/linux-imx_6.1.bb
@@ -15,15 +15,15 @@ require recipes-kernel/linux/linux-imx.inc
 SRC_URI += "file://ARM-imx_v7_defconfig-Remove-KERNEL_LZO-config.patch"
 
 SRCBRANCH = "lf-6.1.y"
-LOCALVERSION = "-6.1.1-1.0.0"
-SRCREV = "29549c7073bf72cfb2c4614d37de45ec36b60475"
+LOCALVERSION = "-6.1.22-2.0.0"
+SRCREV = "66e442bc7fdcc935e6faa94c743f653263d4ed67"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "6.1.1"
+LINUX_VERSION = "6.1.22"
 
 KBUILD_DEFCONFIG:mx6-generic-bsp = "imx_v7_defconfig"
 KBUILD_DEFCONFIG:mx7-generic-bsp = "imx_v7_defconfig"


### PR DESCRIPTION
For https://github.com/Freescale/meta-freescale/issues/1588:

- Upgrade Linux kernel and U-Boot (i.MX variants)

Tested building, flashing, and booting on:
- imx6ullevk
- imx8mm-lpddr4-evk
- imx7ulpevk