### PR TITLE
imx93-14x14-lpddr4x-evk: Add i.MX 93 14x14 EVK machine

### DIFF
--- a/conf/machine/imx93-14x14-lpddr4x-evk.conf
+++ b/conf/machine/imx93-14x14-lpddr4x-evk.conf
@@ -1,0 +1,33 @@
+#@TYPE: Machine
+#@NAME: NXP i.MX 93 14x14 Evaluation Kit with LPDDR4X
+#@SOC: i.MX93
+#@DESCRIPTION: Machine configuration for NXP i.MX 93 14x14 EVK with LPDDR4X
+#@MAINTAINER: Jun Zhu <junzhu@nxp.com>
+
+MACHINEOVERRIDES =. "mx93:"
+
+require conf/machine/include/imx93-evk.inc
+
+KERNEL_DEVICETREE_BASENAME = "imx93-14x14-evk"
+
+KERNEL_DEVICETREE:append:use-nxp-bsp = " \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-aud-hat.dtb \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-tja1103.dtb \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-mqs.dtb \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-rm67199.dtb \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-lvds-it6263.dtb \
+"
+
+UBOOT_CONFIG_BASENAME = "imx93_14x14_evk"
+IMXBOOT_TARGETS_BASENAME = "flash_singleboot"
+
+DDR_FIRMWARE_NAME = " \
+    lpddr4_dmem_1d_v202201.bin \
+    lpddr4_dmem_2d_v202201.bin \
+    lpddr4_imem_1d_v202201.bin \
+    lpddr4_imem_2d_v202201.bin \
+"
+
+UBOOT_CONFIG[fspi]   = "${UBOOT_CONFIG_BASENAME}_defconfig"
+
+IMXBOOT_TARGETS = "${@bb.utils.contains('UBOOT_CONFIG', 'fspi', '${IMXBOOT_TARGETS_BASENAME}_flexspi', '${IMXBOOT_TARGETS_BASENAME}', d)}"


### PR DESCRIPTION
It is based on 6.1.22_2.0.0 NXP BSP release.