### PR TITLE
firmware-nxp-wifi: install NXP wlan and bt only firmware blobs

### DIFF
--- a/recipes-bsp/firmware-imx/firmware-nxp-wifi_1.0.bb
+++ b/recipes-bsp/firmware-imx/firmware-nxp-wifi_1.0.bb
@@ -45,25 +45,33 @@ do_install() {
 
     # Install NXP Connectivity SDIO8987 firmware
     install -m 0644 nxp/FwImage_8987/ed_mac_ctrl_V3_8987.conf  ${D}${nonarch_base_libdir}/firmware/nxp
+    install -m 0644 nxp/FwImage_8987/sd8987_wlan.bin           ${D}${nonarch_base_libdir}/firmware/nxp
     install -m 0644 nxp/FwImage_8987/sdiouart8987_combo_v0.bin ${D}${nonarch_base_libdir}/firmware/nxp
     install -m 0644 nxp/FwImage_8987/txpwrlimit_cfg_8987.conf  ${D}${nonarch_base_libdir}/firmware/nxp
+    install -m 0644 nxp/FwImage_8987/uartuart8987_bt.bin       ${D}${nonarch_base_libdir}/firmware/nxp
 
     # Install NXP Connectivity PCIE8997 firmware
     install -m 0644 nxp/FwImage_8997/ed_mac_ctrl_V3_8997.conf  ${D}${nonarch_base_libdir}/firmware/nxp
+    install -m 0644 nxp/FwImage_8997/pcie8997_wlan_v4.bin      ${D}${nonarch_base_libdir}/firmware/nxp
     install -m 0644 nxp/FwImage_8997/pcieuart8997_combo_v4.bin ${D}${nonarch_base_libdir}/firmware/nxp
     install -m 0644 nxp/FwImage_8997/txpwrlimit_cfg_8997.conf  ${D}${nonarch_base_libdir}/firmware/nxp
+    install -m 0644 nxp/FwImage_8997/uartuart8997_bt_v4.bin    ${D}${nonarch_base_libdir}/firmware/nxp
 
     # Install NXP Connectivity SDIO8997 firmware
     install -m 0644 nxp/FwImage_8997_SD/ed_mac_ctrl_V3_8997.conf  ${D}${nonarch_base_libdir}/firmware/nxp
+    install -m 0644 nxp/FwImage_8997_SD/sdio8997_wlan_v4.bin      ${D}${nonarch_base_libdir}/firmware/nxp
     install -m 0644 nxp/FwImage_8997_SD/sdiouart8997_combo_v4.bin ${D}${nonarch_base_libdir}/firmware/nxp
     install -m 0644 nxp/FwImage_8997_SD/txpwrlimit_cfg_8997.conf  ${D}${nonarch_base_libdir}/firmware/nxp
 
     # Install NXP Connectivity PCIE9098 firmware
     install -m 0644 nxp/FwImage_9098_PCIE/ed_mac_ctrl_V3_909x.conf  ${D}${nonarch_base_libdir}/firmware/nxp
+    install -m 0644 nxp/FwImage_9098_PCIE/pcie9098_wlan_v1.bin      ${D}${nonarch_base_libdir}/firmware/nxp
     install -m 0644 nxp/FwImage_9098_PCIE/pcieuart9098_combo_v1.bin ${D}${nonarch_base_libdir}/firmware/nxp
     install -m 0644 nxp/FwImage_9098_PCIE/txpwrlimit_cfg_9098.conf  ${D}${nonarch_base_libdir}/firmware/nxp
+    install -m 0644 nxp/FwImage_9098_PCIE/uartuart9098_bt_v1.bin    ${D}${nonarch_base_libdir}/firmware/nxp
 
     # Install NXP Connectivity SDIO9098 firmware
+    install -m 0644 nxp/FwImage_9098_SD/sdio9098_wlan_v1.bin      ${D}${nonarch_base_libdir}/firmware/nxp
     install -m 0644 nxp/FwImage_9098_SD/sdiouart9098_combo_v1.bin ${D}${nonarch_base_libdir}/firmware/nxp
 
     # Install NXP Connectivity IW416 firmware
@@ -89,6 +97,7 @@ PACKAGES =+ " \
     ${PN}-nxp8997-pcie \
     ${PN}-nxp8997-sdio \
     ${PN}-nxp9098-pcie \
+    ${PN}-nxp9098-common \
     ${PN}-nxp9098-sdio \
     ${PN}-nxpiw416-sdio \
     ${PN}-nxpiw612-sdio \
@@ -116,30 +125,36 @@ RDEPENDS:${PN}-nxp8987-sdio += "${PN}-nxp-common"
 FILES:${PN}-nxp8997-common = " \
     ${nonarch_base_libdir}/firmware/nxp/ed_mac_ctrl_V3_8997.conf \
     ${nonarch_base_libdir}/firmware/nxp/txpwrlimit_cfg_8997.conf \
+    ${nonarch_base_libdir}/firmware/nxp/uartuart8997_bt_v4.bin \
 "
 RDEPENDS:${PN}-nxp8997-common += "${PN}-nxp-common"
 
 FILES:${PN}-nxp8997-pcie = " \
-    ${nonarch_base_libdir}/firmware/nxp/pcieuart8997* \
+    ${nonarch_base_libdir}/firmware/nxp/pci*8997* \
 "
 RDEPENDS:${PN}-nxp8997-pcie += "${PN}-nxp8997-common"
 
 FILES:${PN}-nxp8997-sdio = " \
-    ${nonarch_base_libdir}/firmware/nxp/sdiouart8997* \
+    ${nonarch_base_libdir}/firmware/nxp/sdio*8997* \
 "
 RDEPENDS:${PN}-nxp8997-sdio += "${PN}-nxp8997-common"
 
-FILES:${PN}-nxp9098-pcie = " \
+FILES:${PN}-nxp9098-common = " \
     ${nonarch_base_libdir}/firmware/nxp/ed_mac_ctrl_V3_909x.conf \
-    ${nonarch_base_libdir}/firmware/nxp/pcieuart9098* \
     ${nonarch_base_libdir}/firmware/nxp/txpwrlimit_cfg_9098.conf \
+    ${nonarch_base_libdir}/firmware/nxp/uartuart9098_bt_v1.bin \
 "
-RDEPENDS:${PN}-nxp9098-pcie += "${PN}-nxp-common"
+RDEPENDS:${PN}-nxp9098-common += "${PN}-nxp-common"
+
+FILES:${PN}-nxp9098-pcie = " \
+    ${nonarch_base_libdir}/firmware/nxp/pcie*9098* \
+"
+RDEPENDS:${PN}-nxp9098-pcie += "${PN}-nxp9098-common"
 
 FILES:${PN}-nxp9098-sdio = " \
-    ${nonarch_base_libdir}/firmware/nxp/sdiouart9098* \
+    ${nonarch_base_libdir}/firmware/nxp/sdio*9098* \
 "
-RDEPENDS:${PN}-nxp9098-sdio += "${PN}-nxp-common"
+RDEPENDS:${PN}-nxp9098-sdio += "${PN}-nxp9098-common"
 
 FILES:${PN}-nxpiw416-sdio = " \
     ${nonarch_base_libdir}/firmware/nxp/*iw416* \


### PR DESCRIPTION
Also install the standalone NXP firmware for wlan and bt, available as part of lf-6.1.22_2.0.0.