### PR TITLE
imx93-evk: use correct name for the iw612 machine feature

### DIFF
--- a/conf/machine/include/imx93-evk.inc
+++ b/conf/machine/include/imx93-evk.inc
@@ -2,7 +2,7 @@ require conf/machine/include/imx-base.inc
 require conf/machine/include/arm/armv8-2a/tune-cortexa55.inc
 
 MACHINE_FEATURES += "pci wifi bluetooth"
-MACHINE_FEATURES:append:use-nxp-bsp = " optee jailhouse iw612"
+MACHINE_FEATURES:append:use-nxp-bsp = " optee jailhouse nxpiw612-sdio"
 
 KERNEL_DEVICETREE = " \
     freescale/${KERNEL_DEVICETREE_BASENAME}.dtb \


### PR DESCRIPTION
imx-base.inc uses nxpiw612-sdio instead of iw612 when adding the relevant firmware packages.