### PR TITLE
imx-atf: Update 6.1.1-1.0.0 to 6.1.22-2.0.0

### DIFF
--- a/recipes-bsp/imx-atf/imx-atf_2.8.bb
+++ b/recipes-bsp/imx-atf/imx-atf_2.8.bb
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2022 NXP
+# Copyright (C) 2017-2023 NXP
 
 DESCRIPTION = "i.MX ARM Trusted Firmware"
 SECTION = "BSP"
@@ -8,8 +8,8 @@ LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/BSD-3-Clause;m
 PV .= "+git${SRCPV}"
 
 SRC_URI = "git://github.com/nxp-imx/imx-atf.git;protocol=https;branch=${SRCBRANCH}"
-SRCBRANCH = "lf_v2.6"
-SRCREV = "616a4588f333522d50a55bedd2b9a90a51474a75"
+SRCBRANCH = "lf_v2.8"
+SRCREV = "99195a23d3aef485fb8f10939583b1bdef18881c"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Update to the 2.8 version aligned with NXP BSP release L6.1.22-2.0.0.

Relevant changes:
- 99195a23d MA-21286 imx8m: habv4: support dram dynamic mapping
- 57e74c226 MA-21277 imx93: fix boot failure on opteed
- 8c5bfc946 MA-21257 imx93: enable trusty support
- 5ce0b6827 MA-21254 remove static declaration for rank_setting_update()
- 8ab375a81 LF-9014 imx8ulp: pd: Fix EPDC update issue
- 70db244d4 MA-21229 android: imx8mq: fix build break
- 4dfe57384 MA-21228 trusty: sync spmd ffa handler function
- a78eb7c37 LF-8090 imx93: TRDC: Fix wrong fuse bits for USB1 and eQOS disable
- d25473f6f LF-8893 feat(imx8ulp): add some delay before cmc1 access
- 64de3dc30 LF-8890 feat(imx8ulp): update the upower pmic_cfg setting
- 856a80e65 LF-8838 feat(imx93): skip system level power config when m33 active
- cf678144d LF-8817 feat(imx93): update the swffc/retention flow for i.mx93
- 36de99cac LF-8614 fix(imx8m): disable auto self refresh before swffc
- f27b39ecd LF-8453 imx8ulp: Update XRDC for ELE to access DDR with CA35 DID
- e1577f8d7 LF-8648 feat(imx93): add get ddr fsp info for imx93
- b8bfb4b4b LF-8459-02: fix(imx): add the missing copyright
- 57eff4fb6 LF-8459-01 refine(imx8ulp): remove the unused header file