### PR TITLE
jailhouse: Update to lf-6.1.22_2.0.0

### DIFF
--- a/recipes-extended/jailhouse/jailhouse_git.bb
+++ b/recipes-extended/jailhouse/jailhouse_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/siemens/jailhouse"
 SECTION = "jailhouse"
 LICENSE = "GPL-2.0-only"
 
-LIC_FILES_CHKSUM = "file://LICENSE;md5=9fa7f895f96bde2d47fd5b7d95b6ba4d \
+LIC_FILES_CHKSUM = "file://COPYING;md5=9fa7f895f96bde2d47fd5b7d95b6ba4d \
                  file://tools/root-cell-config.c.tmpl;beginline=6;endline=33;md5=2825581c1666c44a17955dc574cfbfb3 \
                  file://include/jailhouse/hypercall.h;beginline=9;endline=36;md5=2825581c1666c44a17955dc574cfbfb3 \
                  file://include/jailhouse/cell-config.h;beginline=9;endline=36;md5=2825581c1666c44a17955dc574cfbfb3 \
@@ -13,8 +13,8 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=9fa7f895f96bde2d47fd5b7d95b6ba4d \
                  file://driver/jailhouse.h;beginline=9;endline=36;md5=2825581c1666c44a17955dc574cfbfb3 \
 "
 
-SRCBRANCH = "lf-6.1.1_1.0.0"
-SRCREV = "8faaeb45b989f6f74f0d56e6ae9aaddbf5ebfb06"
+SRCBRANCH = "lf-6.1.22_2.0.0"
+SRCREV = "e090abc70bb395f705f85659ad92bdafbe407628"
 
 SRC_URI = "git://github.com/nxp-imx/imx-jailhouse.git;protocol=https;branch=${SRCBRANCH}"
 


### PR DESCRIPTION
Switch a branch to lf-6.1.22_2.0.0 to align the recipe with NXP BSP LF6.1.22_2.0.0, and update relevant parts of the recipe.