### PR TITLE
recipe-multimedia: Upgrade to 6.1.22-2.0.0 release

### DIFF
--- a/recipes-multimedia/alsa/imx-alsa-plugins_git.bb
+++ b/recipes-multimedia/alsa/imx-alsa-plugins_git.bb
@@ -1,5 +1,5 @@
 # Copyright 2013-2016 Freescale Semiconductor
-# Copyright 2017-2022 NXP
+# Copyright 2017-2023 NXP
 # Released under the MIT license (see COPYING.MIT for the terms)
 
 DESCRIPTION = "Freescale alsa-lib plugins"
@@ -20,8 +20,8 @@ inherit autotools pkgconfig use-imx-headers
 PV = "1.0.26+${SRCPV}"
 
 SRC_URI = "git://github.com/nxp-imx/imx-alsa-plugins.git;protocol=https;branch=${SRCBRANCH}"
-SRCBRANCH = "MM_04.07.03_2301_L6.1.y"
-SRCREV = "8ed567b446d49abe0498278b4da90ecc4db3e37d"
+SRCBRANCH = "MM_04.08.00_2305_L6.1.y"
+SRCREV = "b2ba082e70333f187972ee4e85f63f9d2f608331"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-multimedia/imx-codec/imx-codec_4.8.0.bb
+++ b/recipes-multimedia/imx-codec/imx-codec_4.8.0.bb
@@ -1,18 +1,18 @@
 # Copyright (C) 2012-2016 Freescale Semiconductor
-# Copyright 2017 NXP
+# Copyright 2017 NXP-2023
 # Copyright 2018 (C) O.S. Systems Software LTDA.
 # Released under the MIT license (see COPYING.MIT for the terms)
 DESCRIPTION = "Freescale Multimedia codec libs"
 LICENSE = "Proprietary"
 SECTION = "multimedia"
-LIC_FILES_CHKSUM = "file://COPYING;md5=5a0bf11f745e68024f37b4724a5364fe"
+LIC_FILES_CHKSUM = "file://COPYING;md5=63a38e9f392d8813d6f1f4d0d6fbe657"
 
 # Backward compatibility
 PROVIDES += "libfslcodec"
 
 SRC_URI = "${FSL_MIRROR}/${BPN}-${PV}.bin;fsl-eula=true"
-SRC_URI[md5sum] = "ef8b76bbe907539e62b5bd30c0c08f75"
-SRC_URI[sha256sum] = "90e541b82b6849ec8b00bdf70b89b2af3a36cebde8b9b067341243ea46bc786a"
+SRC_URI[md5sum] = "e33477360b20f1338cf3899c2bd7813e"
+SRC_URI[sha256sum] = "ad767de5c50f8d64f9583b52fb42e8b94c5c17f9e75e426b9e4d3053b483b486"
 
 inherit fsl-eula-unpack autotools pkgconfig
 

--- a/recipes-multimedia/imx-dsp/imx-dsp-codec-ext_2.0.5.bb
+++ b/recipes-multimedia/imx-dsp/imx-dsp-codec-ext_2.0.5.bb
@@ -1,15 +1,21 @@
-# Copyright 2018-2021 NXP
+# Copyright 2018-2023 NXP
 
 DESCRIPTION = "i.MX DSP Codec Wrapper and Lib owned by NXP"
 LICENSE = "Proprietary"
-LIC_FILES_CHKSUM = "file://COPYING;md5=5a0bf11f745e68024f37b4724a5364fe"
+LIC_FILES_CHKSUM = "file://COPYING;md5=63a38e9f392d8813d6f1f4d0d6fbe657"
 
 inherit fsl-eula-unpack autotools pkgconfig
 
 SRC_URI = "${FSL_MIRROR}/${BP}.bin;fsl-eula=true"
 
-SRC_URI[md5sum] = "80f1ea02e8af55f08efcc1014b51565b"
-SRC_URI[sha256sum] = "3575152bb1372842b07794e7daafb8282827ce301c1c944bd1c2b5fc12120671"
+SRC_URI[md5sum] = "2f79f786604ef4d12d1682610353555a"
+SRC_URI[sha256sum] = "b138fcda29be9ed7939d05365af3ac94b0fa6e35e56593168a9d4eed58498a8f"
+
+EXTRA_OECONF:append:mx8qm-nxp-bsp = " --enable-imx8qmqxp"
+EXTRA_OECONF:append:mx8qxp-nxp-bsp = " --enable-imx8qmqxp"
+EXTRA_OECONF:append:mx8dx-nxp-bsp = " --enable-imx8qmqxp"
+EXTRA_OECONF:append:mx8mp-nxp-bsp = " --enable-imx8m"
+EXTRA_OECONF:append:mx8ulp-nxp-bsp = " --enable-imx8ulp"
 
 # Fix strip command failed: 'Unable to recognise the format of the input file'
 INHIBIT_PACKAGE_STRIP = "1"

--- a/recipes-multimedia/imx-dsp/imx-dsp_2.0.5.bb
+++ b/recipes-multimedia/imx-dsp/imx-dsp_2.0.5.bb
@@ -1,15 +1,15 @@
-# Copyright 2017-2022 NXP
+# Copyright 2017-2023 NXP
 
 DESCRIPTION = "i.MX DSP Wrapper, Firmware Binary, Codec Libraries"
 LICENSE = "Proprietary"
-LIC_FILES_CHKSUM = "file://COPYING;md5=5a0bf11f745e68024f37b4724a5364fe"
+LIC_FILES_CHKSUM = "file://COPYING;md5=63a38e9f392d8813d6f1f4d0d6fbe657"
 
 inherit fsl-eula-unpack autotools pkgconfig
 
 SRC_URI = "${FSL_MIRROR}/${BP}.bin;fsl-eula=true"
 
-SRC_URI[md5sum] = "1ba2634775bf9b7a66fe25ce72195aca"
-SRC_URI[sha256sum] = "f3fb2f61dc3d9a5ae4e42474d309d891f6ac710540b47adb147df33560629aa8"
+SRC_URI[md5sum] = "536180f4d50982a6a3df9cdb0bf9e28b"
+SRC_URI[sha256sum] = "c16f077411f3af412b2b58312b041eea5eb0fadc0271d7d2322860cc40089445"
 
 EXTRA_OECONF = " \
     -datadir=${base_libdir}/firmware \

--- a/recipes-multimedia/imx-parser/imx-parser_4.8.0.bb
+++ b/recipes-multimedia/imx-parser/imx-parser_4.8.0.bb
@@ -1,11 +1,11 @@
 # Copyright (C) 2012-2018 O.S. Systems Software LTDA.
 # Copyright (C) 2012-2016 Freescale Semiconductor
-# Copyright (C) 2017-2021 NXP
+# Copyright (C) 2017-2023 NXP
 # Released under the MIT license (see COPYING.MIT for the terms)
 DESCRIPTION = "Freescale Multimedia parser libs"
 LICENSE = "Proprietary"
 SECTION = "multimedia"
-LIC_FILES_CHKSUM = "file://COPYING;md5=5a0bf11f745e68024f37b4724a5364fe"
+LIC_FILES_CHKSUM = "file://COPYING;md5=63a38e9f392d8813d6f1f4d0d6fbe657"
 
 # For backwards compatibility
 PROVIDES += "libfslparser"
@@ -14,8 +14,8 @@ RPROVIDES:${PN} = "libfslparser"
 RCONFLICTS:${PN} = "libfslparser"
 
 SRC_URI = "${FSL_MIRROR}/${BP}.bin;fsl-eula=true"
-SRC_URI[md5sum] = "b4fee8f21ecef727af00f7106620f44b"
-SRC_URI[sha256sum] = "745dbc6c9d28bf380b707f0aeb6dfde02a3bcbb34522640510f8756e945c7320"
+SRC_URI[md5sum] = "46c0636293e387a8b3e4c7d08bd35e02"
+SRC_URI[sha256sum] = "804414bfa016461687d4f077feb29deb6e4bdcd018e1da9691ae55284bb65b7f"
 
 inherit fsl-eula-unpack autotools pkgconfig
 

--- a/recipes-multimedia/imx-sw-pdm/imx-sw-pdm_1.0.3.bb
+++ b/recipes-multimedia/imx-sw-pdm/imx-sw-pdm_1.0.3.bb
@@ -1,13 +1,13 @@
-# Copyright 2020 NXP Semiconductors
+# Copyright 2020,2023 NXP
 
 DESCRIPTION = "NXP PDM to PCM Software Decimation SIMD Library"
 LICENSE = "Proprietary"
 SECTION = "multimedia"
-LIC_FILES_CHKSUM = "file://COPYING;md5=03bcadc8dc0a788f66ca9e2b89f56c6f"
+LIC_FILES_CHKSUM = "file://COPYING;md5=63a38e9f392d8813d6f1f4d0d6fbe657"
 
 SRC_URI = "${FSL_MIRROR}/${BP}.bin;fsl-eula=true"
-SRC_URI[md5sum] = "af01428c2971af339d0308f4aca1dac0"
-SRC_URI[sha256sum] = "d310ef581f9e6e6d726c5dc8998178b7993680b5552c45561e56ac0e927b6d9c"
+SRC_URI[md5sum] = "cbd5af6e9019db789c03c2d05a8bb444"
+SRC_URI[sha256sum] = "f778a7b785fc500df5573f5b810a190ddc561267b47ca54b9ddf4ae12571cfe3"
 
 inherit fsl-eula-unpack autotools pkgconfig
 

--- a/recipes-multimedia/imx-vpuwrap/imx-vpuwrap_git.bb
+++ b/recipes-multimedia/imx-vpuwrap/imx-vpuwrap_git.bb
@@ -1,5 +1,5 @@
 # Copyright (C) 2013-2016 Freescale Semiconductor
-# Copyright 2017-2022 NXP
+# Copyright 2017-2023 NXP
 # Released under the MIT license (see COPYING.MIT for the terms)
 
 DESCRIPTION = "Freescale Multimedia VPU wrapper"
@@ -11,8 +11,8 @@ DEPENDS = "virtual/imxvpu"
 DEPENDS:append:mx8mp-nxp-bsp = " imx-vpu-hantro-vc"
 
 SRC_URI = "git://github.com/NXP/imx-vpuwrap.git;protocol=https;branch=${SRCBRANCH}"
-SRCBRANCH = "MM_04.07.03_2301_L6.1.y"
-SRCREV = "12a78274b3bc4f3105aabe16df03edd5e0c3b84a"
+SRCBRANCH = "MM_04.08.00_2305_L6.1.y"
+SRCREV = "a9cd0835da0ecce55d94510d028371b473090fcc"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
The updated recipes are:
- imx-codec/imx-parser: Upgrade to 4.8.0.
- imx-dsp/imx-dsp-codec-ext: Upgrade to 2.0.5.
- imx-sw-pdm: Upgrade to 1.0.3.
- imx-vpuwrap/imx-alsa-plugins: Upgrade to new revision.