### PR TITLE
vulkan-loader: Do not limit to x11 or wayland

### DIFF
--- a/recipes-downgrade/vulkan/vulkan-loader_1.2.182.0.imx.bb
+++ b/recipes-downgrade/vulkan/vulkan-loader_1.2.182.0.imx.bb
@@ -18,7 +18,6 @@ S = "${WORKDIR}/git"
 REQUIRED_DISTRO_FEATURES = "vulkan"
 
 inherit cmake features_check pkgconfig
-ANY_OF_DISTRO_FEATURES = "x11 wayland"
 
 DEPENDS += "vulkan-headers"
 


### PR DESCRIPTION
as long as vulkan is part of distro features this should work. this also ensures that build works when using eglfs with opengl instead