### PR TITLE
Multiple uboot

### DIFF
--- a/classes/imx-boot-container.bbclass
+++ b/classes/imx-boot-container.bbclass
@@ -92,14 +92,14 @@ do_deploy:append() {
                 then
                     install -m 0644 ${B}/${config}/flash.bin  ${DEPLOYDIR}/flash.bin-${MACHINE}-${type}
                     # When there's more than one word in UBOOT_CONFIG,
-                    # this will overwrite the links created in
-                    # previous loop iterations, effectively making
-                    # u-boot.itb and flash.bin correspond to the _last_
-                    # word in UBOOT_CONFIG. This is also how all other
-                    # artifacts handled by oe-core's u-boot.inc are
-                    # treated.
-                    ln -sf flash.bin-${MACHINE}-${type} flash.bin
-                    ln -sf flash.bin-${MACHINE}-${type} imx-boot
+                    # the first UBOOT_CONFIG listed will be the imx-boot binary
+                    if [ ! -f "${DEPLOYDIR}/imx-boot" ]; then
+                        ln -sf flash.bin-${MACHINE}-${type} flash.bin
+                        ln -sf flash.bin-${MACHINE}-${type} imx-boot
+
+                    else
+                        bbwarn "Use custom wks.in for $UBOOT_CONFIG = $type"
+                    fi
                 fi
             done
             unset  j

--- a/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
+++ b/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
@@ -43,9 +43,6 @@ SC_FIRMWARE_NAME ?= "scfw_tcm.bin"
 ATF_MACHINE_NAME ?= "bl31-${ATF_PLATFORM}.bin"
 ATF_MACHINE_NAME:append = "${@bb.utils.contains('MACHINE_FEATURES', 'optee', '-optee', '', d)}"
 
-UBOOT_NAME = "u-boot-${MACHINE}.bin-${UBOOT_CONFIG}"
-BOOT_CONFIG_MACHINE = "${BOOT_NAME}-${MACHINE}-${UBOOT_CONFIG}.bin"
-
 TOOLS_NAME ?= "mkimage_imx8"
 
 IMX_BOOT_SOC_TARGET       ?= "INVALID"
@@ -82,28 +79,35 @@ compile_mx8m() {
         bbnote "Copy ddr_firmware: ${ddr_firmware} from ${DEPLOY_DIR_IMAGE} -> ${BOOT_STAGING} "
         cp ${DEPLOY_DIR_IMAGE}/${ddr_firmware}               ${BOOT_STAGING}
     done
+
     cp ${DEPLOY_DIR_IMAGE}/signed_dp_imx8m.bin               ${BOOT_STAGING}
     cp ${DEPLOY_DIR_IMAGE}/signed_hdmi_imx8m.bin             ${BOOT_STAGING}
-    cp ${DEPLOY_DIR_IMAGE}/u-boot-spl.bin-${MACHINE}-${UBOOT_CONFIG} \
+    cp ${DEPLOY_DIR_IMAGE}/u-boot-spl.bin-${MACHINE}-${UBOOT_CONFIG_EXTRA} \
                                                              ${BOOT_STAGING}/u-boot-spl.bin
+
     cp ${DEPLOY_DIR_IMAGE}/${BOOT_TOOLS}/${UBOOT_DTB_NAME}   ${BOOT_STAGING}
+
     if [ "x${UBOOT_SIGN_ENABLE}" = "x1" ] ; then
         # Use DTB binary patched with signature node
         cp ${DEPLOY_DIR_IMAGE}/${UBOOT_DTB_BINARY} ${BOOT_STAGING}/${UBOOT_DTB_NAME}
     fi
-    cp ${DEPLOY_DIR_IMAGE}/${BOOT_TOOLS}/u-boot-nodtb.bin-${MACHINE}-${UBOOT_CONFIG} \
+
+    cp ${DEPLOY_DIR_IMAGE}/${BOOT_TOOLS}/u-boot-nodtb.bin-${MACHINE}-${UBOOT_CONFIG_EXTRA} \
                                                              ${BOOT_STAGING}/u-boot-nodtb.bin
+
     cp ${DEPLOY_DIR_IMAGE}/${ATF_MACHINE_NAME}               ${BOOT_STAGING}/bl31.bin
-    cp ${DEPLOY_DIR_IMAGE}/${UBOOT_NAME}                     ${BOOT_STAGING}/u-boot.bin
+
+    cp ${DEPLOY_DIR_IMAGE}/${UBOOT_NAME_EXTRA}                     ${BOOT_STAGING}/u-boot.bin
+
 }
 compile_mx8() {
     bbnote 8QM boot binary build
     cp ${DEPLOY_DIR_IMAGE}/${BOOT_TOOLS}/${SC_FIRMWARE_NAME} ${BOOT_STAGING}/scfw_tcm.bin
     cp ${DEPLOY_DIR_IMAGE}/${ATF_MACHINE_NAME}               ${BOOT_STAGING}/bl31.bin
-    cp ${DEPLOY_DIR_IMAGE}/${UBOOT_NAME}                     ${BOOT_STAGING}/u-boot.bin
+    cp ${DEPLOY_DIR_IMAGE}/${UBOOT_NAME_EXTRA}                     ${BOOT_STAGING}/u-boot.bin
     cp ${DEPLOY_DIR_IMAGE}/${SECO_FIRMWARE_NAME}             ${BOOT_STAGING}
-    if [ -e ${DEPLOY_DIR_IMAGE}/u-boot-spl.bin-${MACHINE}-${UBOOT_CONFIG} ] ; then
-        cp ${DEPLOY_DIR_IMAGE}/u-boot-spl.bin-${MACHINE}-${UBOOT_CONFIG} \
+    if [ -e ${DEPLOY_DIR_IMAGE}/u-boot-spl.bin-${MACHINE}-${UBOOT_CONFIG_EXTRA} ] ; then
+        cp ${DEPLOY_DIR_IMAGE}/u-boot-spl.bin-${MACHINE}-${UBOOT_CONFIG_EXTRA} \
                                                              ${BOOT_STAGING}/u-boot-spl.bin
     fi
 }
@@ -113,9 +117,9 @@ compile_mx8x() {
     cp ${DEPLOY_DIR_IMAGE}/${SECO_FIRMWARE_NAME}             ${BOOT_STAGING}
     cp ${DEPLOY_DIR_IMAGE}/${BOOT_TOOLS}/${SC_FIRMWARE_NAME} ${BOOT_STAGING}/scfw_tcm.bin
     cp ${DEPLOY_DIR_IMAGE}/${ATF_MACHINE_NAME}               ${BOOT_STAGING}/bl31.bin
-    cp ${DEPLOY_DIR_IMAGE}/${UBOOT_NAME}                     ${BOOT_STAGING}/u-boot.bin
-    if [ -e ${DEPLOY_DIR_IMAGE}/u-boot-spl.bin-${MACHINE}-${UBOOT_CONFIG} ] ; then
-        cp ${DEPLOY_DIR_IMAGE}/u-boot-spl.bin-${MACHINE}-${UBOOT_CONFIG} \
+    cp ${DEPLOY_DIR_IMAGE}/${UBOOT_NAME_EXTRA}                     ${BOOT_STAGING}/u-boot.bin
+    if [ -e ${DEPLOY_DIR_IMAGE}/u-boot-spl.bin-${MACHINE}-${UBOOT_CONFIG_EXTRA} ] ; then
+        cp ${DEPLOY_DIR_IMAGE}/u-boot-spl.bin-${MACHINE}-${UBOOT_CONFIG_EXTRA} \
                                                              ${BOOT_STAGING}/u-boot-spl.bin
     fi
 }
@@ -125,9 +129,9 @@ compile_mx8ulp() {
     cp ${DEPLOY_DIR_IMAGE}/${SECO_FIRMWARE_NAME}             ${BOOT_STAGING}/
     cp ${DEPLOY_DIR_IMAGE}/${ATF_MACHINE_NAME} ${BOOT_STAGING}/bl31.bin
     cp ${DEPLOY_DIR_IMAGE}/${BOOT_TOOLS}/upower.bin          ${BOOT_STAGING}/upower.bin
-    cp ${DEPLOY_DIR_IMAGE}/${UBOOT_NAME}                     ${BOOT_STAGING}/u-boot.bin
-    if [ -e ${DEPLOY_DIR_IMAGE}/u-boot-spl.bin-${MACHINE}-${UBOOT_CONFIG} ] ; then
-        cp ${DEPLOY_DIR_IMAGE}/u-boot-spl.bin-${MACHINE}-${UBOOT_CONFIG} \
+    cp ${DEPLOY_DIR_IMAGE}/${UBOOT_NAME_EXTRA}                     ${BOOT_STAGING}/u-boot.bin
+    if [ -e ${DEPLOY_DIR_IMAGE}/u-boot-spl.bin-${MACHINE}-${UBOOT_CONFIG_EXTRA} ] ; then
+        cp ${DEPLOY_DIR_IMAGE}/u-boot-spl.bin-${MACHINE}-${UBOOT_CONFIG_EXTRA} \
                                                              ${BOOT_STAGING}/u-boot-spl.bin
     fi
 }
@@ -141,9 +145,9 @@ compile_mx93() {
 
     cp ${DEPLOY_DIR_IMAGE}/${SECO_FIRMWARE_NAME}             ${BOOT_STAGING}/
     cp ${DEPLOY_DIR_IMAGE}/${ATF_MACHINE_NAME} ${BOOT_STAGING}/bl31.bin
-    cp ${DEPLOY_DIR_IMAGE}/${UBOOT_NAME}                     ${BOOT_STAGING}/u-boot.bin
-    if [ -e ${DEPLOY_DIR_IMAGE}/u-boot-spl.bin-${MACHINE}-${UBOOT_CONFIG} ] ; then
-        cp ${DEPLOY_DIR_IMAGE}/u-boot-spl.bin-${MACHINE}-${UBOOT_CONFIG} \
+    cp ${DEPLOY_DIR_IMAGE}/${UBOOT_NAME_EXTRA}                     ${BOOT_STAGING}/u-boot.bin
+    if [ -e ${DEPLOY_DIR_IMAGE}/u-boot-spl.bin-${MACHINE}-${UBOOT_CONFIG_EXTRA} ] ; then
+        cp ${DEPLOY_DIR_IMAGE}/u-boot-spl.bin-${MACHINE}-${UBOOT_CONFIG_EXTRA} \
                                                              ${BOOT_STAGING}/u-boot-spl.bin
     fi
 }
@@ -154,50 +158,103 @@ do_compile() {
     if ${DEPLOY_OPTEE}; then
         cp ${DEPLOY_DIR_IMAGE}/tee.bin ${BOOT_STAGING}
     fi
-    for target in ${IMXBOOT_TARGETS}; do
-        compile_${SOC_FAMILY}
-        if [ "$target" = "flash_linux_m4_no_v2x" ]; then
-           # Special target build for i.MX 8DXL with V2X off
-           bbnote "building ${IMX_BOOT_SOC_TARGET} - ${REV_OPTION} V2X=NO ${target}"
-           make SOC=${IMX_BOOT_SOC_TARGET} ${REV_OPTION} V2X=NO dtbs=${UBOOT_DTB_NAME} flash_linux_m4
+   for type in ${UBOOT_CONFIG}; do
+        if [ "${@d.getVarFlags('UBOOT_DTB_NAME')}" = "None" ]; then
+            UBOOT_DTB_NAME_FLAGS="${type}:${UBOOT_DTB_NAME}"
         else
-           bbnote "building ${IMX_BOOT_SOC_TARGET} - ${REV_OPTION} ${target}"
-           make SOC=${IMX_BOOT_SOC_TARGET} ${REV_OPTION} dtbs=${UBOOT_DTB_NAME} ${target}
+            UBOOT_DTB_NAME_FLAGS="${@' '.join(flag + ':' + dtb for flag, dtb in (d.getVarFlags('UBOOT_DTB_NAME')).items()) if d.getVarFlags('UBOOT_DTB_NAME') is not None else '' }"
         fi
-        if [ -e "${BOOT_STAGING}/flash.bin" ]; then
-            cp ${BOOT_STAGING}/flash.bin ${S}/${BOOT_CONFIG_MACHINE}-${target}
-        fi
+
+        for key_value in ${UBOOT_DTB_NAME_FLAGS}; do
+            type_key="${key_value%%:*}"
+            dtb_name="${key_value#*:}"
+
+            if [ "$type_key" = "$type" ]
+            then
+                bbnote "UBOOT_CONFIG = $type, UBOOT_DTB_NAME = $dtb_name"
+
+                UBOOT_CONFIG_EXTRA="$type_key"
+                if [ -e ${DEPLOY_DIR_IMAGE}/${BOOT_TOOLS}/${dtb_name}-${type} ] ; then
+                    UBOOT_DTB_NAME_EXTRA="${dtb_name}-${type}"
+                else
+                    # backward compatibility
+                    UBOOT_DTB_NAME_EXTRA="${dtb_name}"
+                fi
+                UBOOT_NAME_EXTRA="u-boot-${MACHINE}.bin-${UBOOT_CONFIG_EXTRA}"
+                BOOT_CONFIG_MACHINE_EXTRA="${BOOT_NAME}-${MACHINE}-${UBOOT_CONFIG_EXTRA}.bin"
+
+                for target in ${IMXBOOT_TARGETS}; do
+                    compile_${SOC_FAMILY}
+                    if [ "$target" = "flash_linux_m4_no_v2x" ]; then
+                        # Special target build for i.MX 8DXL with V2X off
+                        bbnote "building ${IMX_BOOT_SOC_TARGET} - ${REV_OPTION} V2X=NO ${target}"
+                        make SOC=${IMX_BOOT_SOC_TARGET} ${REV_OPTION} V2X=NO dtbs=${UBOOT_DTB_NAME_EXTRA} flash_linux_m4
+                    else
+                        bbnote "building ${IMX_BOOT_SOC_TARGET} - ${REV_OPTION} ${target}"
+                        make SOC=${IMX_BOOT_SOC_TARGET} ${REV_OPTION} dtbs=${UBOOT_DTB_NAME_EXTRA} ${target}
+                    fi
+                    if [ -e "${BOOT_STAGING}/flash.bin" ]; then
+                        cp ${BOOT_STAGING}/flash.bin ${S}/${BOOT_CONFIG_MACHINE_EXTRA}-${target}
+                    fi
+                done
+
+                unset UBOOT_CONFIG_EXTRA
+                unset UBOOT_DTB_NAME_EXTRA
+                unset UBOOT_NAME_EXTRA
+                unset BOOT_CONFIG_MACHINE_EXTRA
+            fi
+
+            unset type_key
+            unset dtb_name
+        done
+
+        unset UBOOT_DTB_NAME_FLAGS
     done
+    unset type
 }
 
 do_install () {
     install -d ${D}/boot
-    for target in ${IMXBOOT_TARGETS}; do
-        install -m 0644 ${S}/${BOOT_CONFIG_MACHINE}-${target} ${D}/boot/
+    for type in ${UBOOT_CONFIG}; do
+
+        bbnote "UBOOT_CONFIG = $type"
+
+        UBOOT_CONFIG_EXTRA="$type"
+        BOOT_CONFIG_MACHINE_EXTRA="${BOOT_NAME}-${MACHINE}-${UBOOT_CONFIG_EXTRA}.bin"
+
+        for target in ${IMXBOOT_TARGETS}; do
+            install -m 0644 ${S}/${BOOT_CONFIG_MACHINE_EXTRA}-${target} ${D}/boot/
+        done
+
+        unset UBOOT_CONFIG_EXTRA
+        unset BOOT_CONFIG_MACHINE_EXTRA
     done
+
+    unset type
 }
 
 deploy_mx8m() {
     install -d ${DEPLOYDIR}/${BOOT_TOOLS}
-    install -m 0644 ${DEPLOY_DIR_IMAGE}/u-boot-spl.bin-${MACHINE}-${UBOOT_CONFIG} \
-                                                             ${DEPLOYDIR}/${BOOT_TOOLS}
     for ddr_firmware in ${DDR_FIRMWARE_NAME}; do
         install -m 0644 ${DEPLOY_DIR_IMAGE}/${ddr_firmware}  ${DEPLOYDIR}/${BOOT_TOOLS}
     done
+
     install -m 0644 ${BOOT_STAGING}/signed_dp_imx8m.bin      ${DEPLOYDIR}/${BOOT_TOOLS}
     install -m 0644 ${BOOT_STAGING}/signed_hdmi_imx8m.bin    ${DEPLOYDIR}/${BOOT_TOOLS}
     install -m 0755 ${BOOT_STAGING}/${TOOLS_NAME}            ${DEPLOYDIR}/${BOOT_TOOLS}
     install -m 0755 ${BOOT_STAGING}/mkimage_fit_atf.sh       ${DEPLOYDIR}/${BOOT_TOOLS}
 }
+
 deploy_mx8() {
     install -d ${DEPLOYDIR}/${BOOT_TOOLS}
     install -m 0644 ${BOOT_STAGING}/${SECO_FIRMWARE_NAME}    ${DEPLOYDIR}/${BOOT_TOOLS}
     install -m 0755 ${S}/${TOOLS_NAME}                       ${DEPLOYDIR}/${BOOT_TOOLS}
-    if [ -e ${DEPLOY_DIR_IMAGE}/u-boot-spl.bin-${MACHINE}-${UBOOT_CONFIG} ] ; then
-        install -m 0644 ${DEPLOY_DIR_IMAGE}/u-boot-spl.bin-${MACHINE}-${UBOOT_CONFIG} \
+    if [ -e ${DEPLOY_DIR_IMAGE}/u-boot-spl.bin-${MACHINE}-${UBOOT_CONFIG_EXTRA} ] ; then
+        install -m 0644 ${DEPLOY_DIR_IMAGE}/u-boot-spl.bin-${MACHINE}-${UBOOT_CONFIG_EXTRA} \
                                                              ${DEPLOYDIR}/${BOOT_TOOLS}
     fi
 }
+
 deploy_mx8x() {
     install -d ${DEPLOYDIR}/${BOOT_TOOLS}
     install -m 0644 ${BOOT_STAGING}/${SECO_FIRMWARE_NAME}    ${DEPLOYDIR}/${BOOT_TOOLS}
@@ -212,7 +269,7 @@ deploy_mx8ulp() {
     install -d ${DEPLOYDIR}/${BOOT_TOOLS}
     install -m 0644 ${BOOT_STAGING}/${SECO_FIRMWARE_NAME}    ${DEPLOYDIR}/${BOOT_TOOLS}
     install -m 0755 ${S}/${TOOLS_NAME}                       ${DEPLOYDIR}/${BOOT_TOOLS}
-    if [ -e ${DEPLOY_DIR_IMAGE}/u-boot-spl.bin-${MACHINE}-${UBOOT_CONFIG} ] ; then
+    if [ -e ${DEPLOY_DIR_IMAGE}/u-boot-spl.bin-${MACHINE}-${UBOOT_CONFIG_EXTRA} ] ; then
         install -m 0644 ${DEPLOY_DIR_IMAGE}/u-boot-spl.bin-${MACHINE}-${UBOOT_CONFIG} \
                                                              ${DEPLOYDIR}/${BOOT_TOOLS}
     fi
@@ -235,27 +292,48 @@ deploy_mx93() {
 
 do_deploy() {
     deploy_${SOC_FAMILY}
-    # copy the sc fw, dcd and uboot to deploy path
-    install -m 0644 ${DEPLOY_DIR_IMAGE}/${UBOOT_NAME}        ${DEPLOYDIR}/${BOOT_TOOLS}
 
     # copy tee.bin to deploy path
     if ${DEPLOY_OPTEE}; then
        install -m 0644 ${DEPLOY_DIR_IMAGE}/tee.bin ${DEPLOYDIR}/${BOOT_TOOLS}
     fi
-
     # copy makefile (soc.mak) for reference
     install -m 0644 ${BOOT_STAGING}/soc.mak                  ${DEPLOYDIR}/${BOOT_TOOLS}
-    # copy the generated boot image to deploy path
-    for target in ${IMXBOOT_TARGETS}; do
-        # Use first "target" as IMAGE_IMXBOOT_TARGET
-        if [ "$IMAGE_IMXBOOT_TARGET" = "" ]; then
-            IMAGE_IMXBOOT_TARGET="$target"
-            echo "Set boot target as $IMAGE_IMXBOOT_TARGET"
-        fi
-        install -m 0644 ${S}/${BOOT_CONFIG_MACHINE}-${target} ${DEPLOYDIR}
-    done
 
-    ln -sf ${BOOT_CONFIG_MACHINE}-${IMAGE_IMXBOOT_TARGET}    ${DEPLOYDIR}/${BOOT_NAME}
+    for type in ${UBOOT_CONFIG}; do
+        UBOOT_CONFIG_EXTRA="$type"
+        UBOOT_NAME_EXTRA="u-boot-${MACHINE}.bin-${UBOOT_CONFIG_EXTRA}"
+        BOOT_CONFIG_MACHINE_EXTRA="${BOOT_NAME}-${MACHINE}-${UBOOT_CONFIG_EXTRA}.bin"
+
+        if [ -e ${DEPLOY_DIR_IMAGE}/u-boot-spl.bin-${MACHINE}-${UBOOT_CONFIG_EXTRA} ] ; then
+            install -m 0644 ${DEPLOY_DIR_IMAGE}/u-boot-spl.bin-${MACHINE}-${UBOOT_CONFIG_EXTRA} \
+                                                             ${DEPLOYDIR}/${BOOT_TOOLS}
+        fi
+        # copy the tool mkimage to deploy path and sc fw, dcd and uboot
+        install -m 0644 ${DEPLOY_DIR_IMAGE}/${UBOOT_NAME_EXTRA}  ${DEPLOYDIR}/${BOOT_TOOLS}
+
+        # copy the generated boot image to deploy path
+        for target in ${IMXBOOT_TARGETS}; do
+            # Use first "target" as IMAGE_IMXBOOT_TARGET
+            if [ "$IMAGE_IMXBOOT_TARGET" = "" ]; then
+                IMAGE_IMXBOOT_TARGET="$target"
+                echo "Set boot target as $IMAGE_IMXBOOT_TARGET"
+            fi
+            install -m 0644 ${S}/${BOOT_CONFIG_MACHINE_EXTRA}-${target} ${DEPLOYDIR}
+        done
+
+        # The first UBOOT_CONFIG listed will be the ${BOOT_NAME} binary
+        if [ ! -f "${DEPLOYDIR}/${UUU_BOOTLOADER}" ]; then
+            ln -sf ${BOOT_CONFIG_MACHINE_EXTRA}-${IMAGE_IMXBOOT_TARGET} ${DEPLOYDIR}/${BOOT_NAME}
+        else
+            bbwarn "Use custom wks.in for $UBOOT_CONFIG = $type"
+        fi
+
+        unset UBOOT_CONFIG_EXTRA
+        unset UBOOT_NAME_EXTRA
+        unset BOOT_CONFIG_MACHINE_EXTRA
+    done
+    unset type
 }
 addtask deploy before do_build after do_compile
 

--- a/recipes-bsp/u-boot/u-boot-imx_2023.04.bb
+++ b/recipes-bsp/u-boot/u-boot-imx_2023.04.bb
@@ -27,8 +27,27 @@ do_deploy:append:mx8m-generic-bsp() {
                 if [ $j -eq $i ]
                 then
                     install -d ${DEPLOYDIR}/${BOOT_TOOLS}
-                    install -m 0644 ${B}/${config}/arch/arm/dts/${UBOOT_DTB_NAME}  ${DEPLOYDIR}/${BOOT_TOOLS}
-                    install -m 0644 ${B}/${config}/u-boot-nodtb.bin  ${DEPLOYDIR}/${BOOT_TOOLS}/u-boot-nodtb.bin-${MACHINE}-${type}
+                    install -m 0644 ${B}/${config}/u-boot-nodtb.bin ${DEPLOYDIR}/${BOOT_TOOLS}/u-boot-nodtb.bin-${MACHINE}-${type}
+                    UBOOT_DTB_NAME_FLAGS="${type}:${UBOOT_DTB_NAME}"
+                    for key_value in ${UBOOT_DTB_NAME_FLAGS}; do
+                        local type_key="${key_value%%:*}"
+                        local dtb_name="${key_value#*:}"
+                        if [ "$type_key" = "$type" ]
+                        then
+                            bbnote "UBOOT_CONFIG = $type, UBOOT_DTB_NAME = $dtb_name"
+                            # There is only one ${dtb_name}, the first one. All the other are with the type appended
+                            if [ ! -f "${DEPLOYDIR}/${BOOT_TOOLS}/${dtb_name}" ]; then
+                                install -m 0644 ${B}/${config}/arch/arm/dts/${dtb_name}  ${DEPLOYDIR}/${BOOT_TOOLS}/${dtb_name}
+                            else
+                                bbwarn "Use custom wks.in for $dtb_name = $type"
+                            fi
+                            install -m 0644 ${B}/${config}/arch/arm/dts/${dtb_name}  ${DEPLOYDIR}/${BOOT_TOOLS}/${dtb_name}-${type}
+                        fi
+                        unset type_key
+                        unset dtb_name
+                    done
+
+                    unset UBOOT_DTB_NAME_FLAGS
                 fi
             done
             unset  j


### PR DESCRIPTION
This is a rebase for https://github.com/Freescale/meta-freescale/pull/1439

It creates the `imx-boot` binary only for the first `UBOOT_CONFIG`, so UUU class is satisfied.

It also supports imx93 and imx8ulp (missing in the first PR)

----
**From the original PR:**
A long time ago I implemented a workaround to support multiple u-boot builds for the same machine.
This saved our project several hours every day on builds (16 different U-boots) because the image was common to all machines, only U-boot had a few changes per machine configuration. All wic-images are generated at once, separate tasks are not needed.

It still supports the original way of configuration, but for multiple u-boot I added flags for the same env vars.

For example, original machine configs for boards M1 and M2 :

```
# MACHINE M1
KERNEL_DEVICETREE = "freescale/imx8mp_m1.dtb"
IMXBOOT_TARGETS = "flash_evk"
UBOOT_CONFIG ??= "sd"
UBOOT_CONFIG[sd] = "imx8mp_m1_defconfig,sdcard"
UBOOT_DTB_NAME = "imx8mp_m1.dtb"
```

```
# MACHINE M2
KERNEL_DEVICETREE = "freescale/imx8mp_m2.dtb"
IMXBOOT_TARGETS = "flash_evk"
UBOOT_CONFIG ??= "sd"
UBOOT_CONFIG[sd] = "imx8mp_m2_defconfig,sdcard"
UBOOT_DTB_NAME = "imx8mp_m2.dtb"
```

New unified machine config for both boards M1 and M2

```
# MACHINE M1 and M2
KERNEL_DEVICETREE = "\
    freescale/imx8mp_m1.dtb \
    freescale/imx8mp_m2.dtb \
"
IMXBOOT_TARGETS = "flash_evk"
UBOOT_CONFIG = "m1 m2"

UBOOT_CONFIG[m1] = "imx8mp_m1_defconfig,sdcard"
UBOOT_CONFIG[m2] = "imx8mp_m2_defconfig,sdcard"

UBOOT_DTB_NAME[m1] = "imx8mp_m1.dtb"
UBOOT_DTB_NAME[m2] = "imx8mp_m2.dtb"

WKS_FILE = "${IMAGE_BASENAME}.wks.in"
```

And instead of using common wks.in like
```
part u-boot --source rawcopy --sourceparams="file=imx-boot" ...
```

I need to create 2 extra wks.in differing only by imx-boot

**my-image-m1.wks.in**
```
part u-boot --source rawcopy --sourceparams="file=imx-boot-imx8mp-m1.bin-flash_evk" ...
```

**my-image-m2.wks.in**
```
part u-boot --source rawcopy --sourceparams="file=imx-boot-imx8mp-m2.bin-flash_evk" ...
```

It would also be nice to have **IMXBOOT_TARGETS** separated by configurations, but this was not necessary in my project, so I left it just "flash_evk"

There is also one trick I forgot to mention how to generate multiple wic-images at once. For example your build is using **my-image.bb** and machine's configuration includes U-boot configs **m1** and **m2**, and `WKS_FILE = "${IMAGE_BASENAME}.wks.in"`

You should create wks.in in wic folder for each u-boot configs with required image prefix (ex, "my-image"):

- meta-mylayer/wic/my-image-common.wks.in
- meta-mylayer/wic/my-image-m1.wks.in
- meta-mylayer/wic/my-image-m2.wks.in

Suppose you have a main image recipe located at
- recipes-images/images/my-image.bb

To cheat "do_image_wic" you should rename `my-image.bb` into `my-image-common.bb`

Then you should create common and dummy image recipes with the same suffixes for every U-boot configs:
- recipes-images/images/my-image-m1.bb
- recipes-images/images/my-image-m2.bb

content of dummy image recipes:
```
require my-image-common.bb
```

and then you should create a new fake recipe `my-image.bb` with content
 ```
SUMMARY = "Recipe to build multiple BLABLA images"

LICENSE = "MIT"

inherit image

do_rootfs[noexec] = "1"
do_rootfs_wicenv[noexec] = "1"
do_image[noexec] = "1"
do_image_wic[noexec] = "1"
do_image_complete[noexec] = "1"

do_clean[depends] = "\
	my-image-common:do_clean \
	my-image-m1:do_clean \
	my-image-m2:do_clean \
"

do_cleanall[depends] = "\
	my-image-common:do_cleanall \
	my-image-m1:do_cleanall \
	my-image-m2:do_cleanall \
"

do_cleansstate[depends] = "\
	my-image-common:do_cleanall \
	my-image-m1:do_cleansstate \
	my-image-m2:do_cleansstate \
"

IMAGE_NAMES = "my-image-common"
DEPENDS = "my-image-common"

IMAGE_NAMES_remove_unified8mp = "my-image-common"
IMAGE_NAMES_append_unified8mp = "\
	my-image-m1 \
	my-image-m2 \
"

DEPENDS_remove_unified8mp = "my-image-common"
DEPENDS_append_unified8mp = "\
	my-image-m1 \
	my-image-m2 \
"

# Set target image variables
TARGET_IMAGES = "${IMAGE_NAMES}"
TARGET_MACHINES = "${MACHINE_${IMAGE_NAMES}}"
```

> NOTE: replace unified8mp on your unified machine

In that case, **my-image** will create `my-image-common` for the original machine config (each machine has its own U-boot config) or multiple my-image-XXX for each U-boot configs which are defined in unified machine's config.

