### PR TITLE
NXP WiFi firmware

### DIFF
--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -444,24 +444,33 @@ MACHINE_EXTRA_RRECOMMENDS:append = " ${@bb.utils.contains('MACHINE_FEATURES', 'n
 
 MACHINE_FIRMWARE:append = " ${@bb.utils.contains('MACHINE_FEATURES', 'nxp8987-sdio', 'firmware-nxp-wifi-nxp8987-sdio', '', d)}"
 MACHINE_EXTRA_RRECOMMENDS:append = " ${@bb.utils.contains('MACHINE_FEATURES', 'nxp8987-sdio', 'kernel-module-nxp-wlan', '', d)}"
+PREFERRED_RPROVIDER_linux-firmware-nxp8987-sdio = "firmware-nxp-wifi"
 
 MACHINE_FIRMWARE:append = " ${@bb.utils.contains('MACHINE_FEATURES', 'nxp8997-pcie', 'firmware-nxp-wifi-nxp8997-pcie', '', d)}"
 MACHINE_EXTRA_RRECOMMENDS:append = " ${@bb.utils.contains('MACHINE_FEATURES', 'nxp8997-pcie', 'kernel-module-nxp-wlan', '', d)}"
+PREFERRED_RPROVIDER_linux-firmware-nxp8997-common = "firmware-nxp-wifi"
+PREFERRED_RPROVIDER_linux-firmware-nxp8997-pcie = "firmware-nxp-wifi"
 
 MACHINE_FIRMWARE:append = " ${@bb.utils.contains('MACHINE_FEATURES', 'nxp8997-sdio', 'firmware-nxp-wifi-nxp8997-sdio', '', d)}"
 MACHINE_EXTRA_RRECOMMENDS:append = " ${@bb.utils.contains('MACHINE_FEATURES', 'nxp8997-sdio', 'kernel-module-nxp-wlan', '', d)}"
+PREFERRED_RPROVIDER_linux-firmware-nxp8997-sdio = "firmware-nxp-wifi"
 
 MACHINE_FIRMWARE:append = " ${@bb.utils.contains('MACHINE_FEATURES', 'nxp9098-pcie', 'firmware-nxp-wifi-nxp9098-pcie', '', d)}"
 MACHINE_EXTRA_RRECOMMENDS:append = " ${@bb.utils.contains('MACHINE_FEATURES', 'nxp9098-pcie', 'kernel-module-nxp-wlan', '', d)}"
+PREFERRED_RPROVIDER_linux-firmware-nxp9098-common = "firmware-nxp-wifi"
+PREFERRED_RPROVIDER_linux-firmware-nxp9098-pcie = "firmware-nxp-wifi"
 
 MACHINE_FIRMWARE:append = " ${@bb.utils.contains('MACHINE_FEATURES', 'nxp9098-sdio', 'firmware-nxp-wifi-nxp9098-sdio', '', d)}"
 MACHINE_EXTRA_RRECOMMENDS:append = " ${@bb.utils.contains('MACHINE_FEATURES', 'nxp9098-sdio', 'kernel-module-nxp-wlan', '', d)}"
+PREFERRED_RPROVIDER_linux-firmware-nxp9098-sdio = "firmware-nxp-wifi"
 
 MACHINE_FIRMWARE:append = " ${@bb.utils.contains('MACHINE_FEATURES', 'nxpiw416-sdio', 'firmware-nxp-wifi-nxpiw416-sdio', '', d)}"
 MACHINE_EXTRA_RRECOMMENDS:append = " ${@bb.utils.contains('MACHINE_FEATURES', 'nxpiw416-sdio', 'kernel-module-nxp-wlan', '', d)}"
+PREFERRED_RPROVIDER_linux-firmware-nxpiw416-sdio = "firmware-nxp-wifi"
 
 MACHINE_FIRMWARE:append = " ${@bb.utils.contains('MACHINE_FEATURES', 'nxpiw612-sdio', 'firmware-nxp-wifi-nxpiw612-sdio', '', d)}"
 MACHINE_EXTRA_RRECOMMENDS:append = " ${@bb.utils.contains('MACHINE_FEATURES', 'nxpiw612-sdio', 'kernel-module-nxp-wlan', '', d)}"
+PREFERRED_RPROVIDER_linux-firmware-nxpiw612-sdio = "firmware-nxp-wifi"
 
 # Extra QCA Wi-Fi & BTE driver and firmware
 MACHINE_EXTRA_RRECOMMENDS:append = " ${@bb.utils.contains('MACHINE_FEATURES', 'qca6174', 'packagegroup-fsl-qca6174', '', d)}"

--- a/recipes-bsp/firmware-imx/firmware-nxp-wifi_1.0.bb
+++ b/recipes-bsp/firmware-imx/firmware-nxp-wifi_1.0.bb
@@ -1,9 +1,10 @@
 # Copyright 2020-2023 NXP
 
 SUMMARY = "Wi-Fi firmware redistributed by NXP"
-DESCRIPTION = "Additional Wi-Fi firmware redistributed by NXP \
-and not available in linux-firmware. Once a package becomes \
-available in linux-firmware, it can be dropped from this recipe."
+DESCRIPTION = "Additional Wi-Fi firmware redistributed by NXP, \
+which is not covered by linux-firmware package. Once package becomes \
+available as a part of linux-firmware - it can be dropped from this \
+recipe in favor of upstream."
 
 SECTION = "kernel"
 LICENSE = "Proprietary"
@@ -47,12 +48,14 @@ do_install() {
     install -m 0644 nxp/FwImage_8987/sd8987_wlan.bin           ${D}${nonarch_base_libdir}/firmware/nxp
     install -m 0644 nxp/FwImage_8987/sdiouart8987_combo_v0.bin ${D}${nonarch_base_libdir}/firmware/nxp
     install -m 0644 nxp/FwImage_8987/txpwrlimit_cfg_8987.conf  ${D}${nonarch_base_libdir}/firmware/nxp
+    install -m 0644 nxp/FwImage_8987/uartuart8987_bt.bin       ${D}${nonarch_base_libdir}/firmware/nxp
 
     # Install NXP Connectivity PCIE8997 firmware
     install -m 0644 nxp/FwImage_8997/ed_mac_ctrl_V3_8997.conf  ${D}${nonarch_base_libdir}/firmware/nxp
     install -m 0644 nxp/FwImage_8997/pcie8997_wlan_v4.bin      ${D}${nonarch_base_libdir}/firmware/nxp
     install -m 0644 nxp/FwImage_8997/pcieuart8997_combo_v4.bin ${D}${nonarch_base_libdir}/firmware/nxp
     install -m 0644 nxp/FwImage_8997/txpwrlimit_cfg_8997.conf  ${D}${nonarch_base_libdir}/firmware/nxp
+    install -m 0644 nxp/FwImage_8997/uartuart8997_bt_v4.bin    ${D}${nonarch_base_libdir}/firmware/nxp
 
     # Install NXP Connectivity SDIO8997 firmware
     install -m 0644 nxp/FwImage_8997_SD/ed_mac_ctrl_V3_8997.conf  ${D}${nonarch_base_libdir}/firmware/nxp
@@ -65,6 +68,7 @@ do_install() {
     install -m 0644 nxp/FwImage_9098_PCIE/pcie9098_wlan_v1.bin      ${D}${nonarch_base_libdir}/firmware/nxp
     install -m 0644 nxp/FwImage_9098_PCIE/pcieuart9098_combo_v1.bin ${D}${nonarch_base_libdir}/firmware/nxp
     install -m 0644 nxp/FwImage_9098_PCIE/txpwrlimit_cfg_9098.conf  ${D}${nonarch_base_libdir}/firmware/nxp
+    install -m 0644 nxp/FwImage_9098_PCIE/uartuart9098_bt_v1.bin    ${D}${nonarch_base_libdir}/firmware/nxp
 
     # Install NXP Connectivity SDIO9098 firmware
     install -m 0644 nxp/FwImage_9098_SD/sdio9098_wlan_v1.bin      ${D}${nonarch_base_libdir}/firmware/nxp
@@ -73,10 +77,12 @@ do_install() {
     # Install NXP Connectivity IW416 firmware
     install -m 0644 nxp/FwImage_IW416_SD/sdioiw416_wlan_v0.bin      ${D}${nonarch_base_libdir}/firmware/nxp
     install -m 0644 nxp/FwImage_IW416_SD/sdiouartiw416_combo_v0.bin ${D}${nonarch_base_libdir}/firmware/nxp
+    install -m 0644 nxp/FwImage_IW416_SD/uartiw416_bt_v0.bin        ${D}${nonarch_base_libdir}/firmware/nxp
 
     # Install NXP Connectivity IW612 firmware
     install -m 0644 nxp/FwImage_IW612_SD/sduart_nw61x_v1.bin.se ${D}${nonarch_base_libdir}/firmware/nxp
     install -m 0644 nxp/FwImage_IW612_SD/sd_w61x_v1.bin.se      ${D}${nonarch_base_libdir}/firmware/nxp
+    install -m 0644 nxp/FwImage_IW612_SD/uartspi_n61x_v1.bin.se ${D}${nonarch_base_libdir}/firmware/nxp
     for f in nxp/FwImage_IW612_SD/IW612_SD_RFTest/*; do
         install -D -m 0644 $f ${D}${nonarch_base_libdir}/firmware/nxp/IW612_SD_RFTest/$(basename $f)
     done
@@ -119,6 +125,7 @@ RDEPENDS:${PN}-nxp8987-sdio += "${PN}-nxp-common"
 FILES:${PN}-nxp8997-common = " \
     ${nonarch_base_libdir}/firmware/nxp/ed_mac_ctrl_V3_8997.conf \
     ${nonarch_base_libdir}/firmware/nxp/txpwrlimit_cfg_8997.conf \
+    ${nonarch_base_libdir}/firmware/nxp/uartuart8997_bt_v4.bin \
 "
 RDEPENDS:${PN}-nxp8997-common += "${PN}-nxp-common"
 
@@ -135,6 +142,7 @@ RDEPENDS:${PN}-nxp8997-sdio += "${PN}-nxp8997-common"
 FILES:${PN}-nxp9098-common = " \
     ${nonarch_base_libdir}/firmware/nxp/ed_mac_ctrl_V3_909x.conf \
     ${nonarch_base_libdir}/firmware/nxp/txpwrlimit_cfg_9098.conf \
+    ${nonarch_base_libdir}/firmware/nxp/uartuart9098_bt_v1.bin \
 "
 RDEPENDS:${PN}-nxp9098-common += "${PN}-nxp-common"
 
@@ -156,6 +164,7 @@ RDEPENDS:${PN}-nxpiw416-sdio += "${PN}-nxp-common"
 FILES:${PN}-nxpiw612-sdio = " \
     ${nonarch_base_libdir}/firmware/nxp/sduart_nw61x_v1.bin.se \
     ${nonarch_base_libdir}/firmware/nxp/sd_w61x_v1.bin.se \
+    ${nonarch_base_libdir}/firmware/nxp/uartspi_n61x_v1.bin.se \
     ${nonarch_base_libdir}/firmware/nxp/IW612_SD_RFTest/ \
 "
 RDEPENDS:${PN}-nxpiw612-sdio += "${PN}-nxp-common"

--- a/recipes-bsp/firmware-imx/firmware-nxp-wifi_1.0.bb
+++ b/recipes-bsp/firmware-imx/firmware-nxp-wifi_1.0.bb
@@ -1,10 +1,9 @@
 # Copyright 2020-2023 NXP
 
 SUMMARY = "Wi-Fi firmware redistributed by NXP"
-DESCRIPTION = "Additional Wi-Fi firmware redistributed by NXP, \
-which is not covered by linux-firmware package. Once package becomes \
-available as a part of linux-firmware - it can be dropped from this \
-recipe in favor of upstream."
+DESCRIPTION = "Additional Wi-Fi firmware redistributed by NXP. Some \
+is available in linux-firmware, but what is here is the latest and \
+should be preferred."
 
 SECTION = "kernel"
 LICENSE = "Proprietary"
@@ -121,6 +120,9 @@ FILES:${PN}-nxp8987-sdio = " \
     ${nonarch_base_libdir}/firmware/nxp/*8987* \
 "
 RDEPENDS:${PN}-nxp8987-sdio += "${PN}-nxp-common"
+RPROVIDES:${PN}-nxp8987-sdio = "linux-firmware-nxp8987-sdio"
+RREPLACES:${PN}-nxp8987-sdio = "linux-firmware-nxp8987-sdio"
+RCONFLICTS:${PN}-nxp8987-sdio = "linux-firmware-nxp8987-sdio"
 
 FILES:${PN}-nxp8997-common = " \
     ${nonarch_base_libdir}/firmware/nxp/ed_mac_ctrl_V3_8997.conf \
@@ -128,16 +130,25 @@ FILES:${PN}-nxp8997-common = " \
     ${nonarch_base_libdir}/firmware/nxp/uartuart8997_bt_v4.bin \
 "
 RDEPENDS:${PN}-nxp8997-common += "${PN}-nxp-common"
+RPROVIDES:${PN}-nxp8997-common = "linux-firmware-nxp8997-common"
+RREPLACES:${PN}-nxp8997-common = "linux-firmware-nxp8997-common"
+RCONFLICTS:${PN}-nxp8997-common = "linux-firmware-nxp8997-common"
 
 FILES:${PN}-nxp8997-pcie = " \
     ${nonarch_base_libdir}/firmware/nxp/pci*8997* \
 "
 RDEPENDS:${PN}-nxp8997-pcie += "${PN}-nxp8997-common"
+RPROVIDES:${PN}-nxp8997-pcie = "linux-firmware-nxp8997-pcie"
+RREPLACES:${PN}-nxp8997-pcie = "linux-firmware-nxp8997-pcie"
+RCONFLICTS:${PN}-nxp8997-pcie = "linux-firmware-nxp8997-pcie"
 
 FILES:${PN}-nxp8997-sdio = " \
     ${nonarch_base_libdir}/firmware/nxp/sdio*8997* \
 "
 RDEPENDS:${PN}-nxp8997-sdio += "${PN}-nxp8997-common"
+RPROVIDES:${PN}-nxp8997-sdio = "linux-firmware-nxp8997-sdio"
+RREPLACES:${PN}-nxp8997-sdio = "linux-firmware-nxp8997-sdio"
+RCONFLICTS:${PN}-nxp8997-sdio = "linux-firmware-nxp8997-sdio"
 
 FILES:${PN}-nxp9098-common = " \
     ${nonarch_base_libdir}/firmware/nxp/ed_mac_ctrl_V3_909x.conf \
@@ -145,21 +156,33 @@ FILES:${PN}-nxp9098-common = " \
     ${nonarch_base_libdir}/firmware/nxp/uartuart9098_bt_v1.bin \
 "
 RDEPENDS:${PN}-nxp9098-common += "${PN}-nxp-common"
+RPROVIDES:${PN}-nxp9098-common = "linux-firmware-nxp9098-common"
+RREPLACES:${PN}-nxp9098-common = "linux-firmware-nxp9098-common"
+RCONFLICTS:${PN}-nxp9098-common = "linux-firmware-nxp9098-common"
 
 FILES:${PN}-nxp9098-pcie = " \
     ${nonarch_base_libdir}/firmware/nxp/pcie*9098* \
 "
 RDEPENDS:${PN}-nxp9098-pcie += "${PN}-nxp9098-common"
+RPROVIDES:${PN}-nxp9098-pcie = "linux-firmware-nxp9098-pcie"
+RREPLACES:${PN}-nxp9098-pcie = "linux-firmware-nxp9098-pcie"
+RCONFLICTS:${PN}-nxp9098-pcie = "linux-firmware-nxp9098-pcie"
 
 FILES:${PN}-nxp9098-sdio = " \
     ${nonarch_base_libdir}/firmware/nxp/sdio*9098* \
 "
 RDEPENDS:${PN}-nxp9098-sdio += "${PN}-nxp9098-common"
+RPROVIDES:${PN}-nxp9098-sdio = "linux-firmware-nxp9098-sdio"
+RREPLACES:${PN}-nxp9098-sdio = "linux-firmware-nxp9098-sdio"
+RCONFLICTS:${PN}-nxp9098-sdio = "linux-firmware-nxp9098-sdio"
 
 FILES:${PN}-nxpiw416-sdio = " \
     ${nonarch_base_libdir}/firmware/nxp/*iw416* \
 "
 RDEPENDS:${PN}-nxpiw416-sdio += "${PN}-nxp-common"
+RPROVIDES:${PN}-nxpiw416-sdio = "linux-firmware-nxpiw416-sdio"
+RREPLACES:${PN}-nxpiw416-sdio = "linux-firmware-nxpiw416-sdio"
+RCONFLICTS:${PN}-nxpiw416-sdio = "linux-firmware-nxpiw416-sdio"
 
 FILES:${PN}-nxpiw612-sdio = " \
     ${nonarch_base_libdir}/firmware/nxp/sduart_nw61x_v1.bin.se \
@@ -168,3 +191,6 @@ FILES:${PN}-nxpiw612-sdio = " \
     ${nonarch_base_libdir}/firmware/nxp/IW612_SD_RFTest/ \
 "
 RDEPENDS:${PN}-nxpiw612-sdio += "${PN}-nxp-common"
+RPROVIDES:${PN}-nxpiw612-sdio = "linux-firmware-nxpiw612-sdio"
+RREPLACES:${PN}-nxpiw612-sdio = "linux-firmware-nxpiw612-sdio"
+RCONFLICTS:${PN}-nxpiw612-sdio = "linux-firmware-nxpiw612-sdio"


### PR DESCRIPTION
Revised fix for #1639. Depends on OE-Core update to `linux-firmware`. That is currently pending a final internal review before I submit the change to OE-Core.
