### PR TITLE
uuu: Add missing zstd dependency

### DIFF
--- a/recipes-devtools/uuu/uuu_git.bb
+++ b/recipes-devtools/uuu/uuu_git.bb
@@ -13,6 +13,6 @@ inherit cmake pkgconfig
 
 S = "${WORKDIR}/git"
 
-DEPENDS = "libusb zlib bzip2 openssl"
+DEPENDS = "libusb zlib bzip2 openssl zstd"
 
 BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
Since 1.4.243, uuu includes zstd support. Currently, this dependency is not specified, and thus if nativesdk-uuu is built, cmake will err during do_configure reporting that the package is missing.

To fix this, add zstd to DEPENDS.