### PR TITLE
recipes: Update github.com urls to use https

### DIFF
--- a/recipes-kernel/kernel-modules/kernel-module-ar_git.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-ar_git.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=b5881ecf398da8a03a3f4c501e29d287"
 
 inherit module
 
-SRC_URI = "git://github.com/nxp-qoriq-yocto-sdk/auto-resp;branch=nxp/sdk-v2.0.x"
+SRC_URI = "git://github.com/nxp-qoriq-yocto-sdk/auto-resp;branch=nxp/sdk-v2.0.x;protocol=https"
 SRCREV =  "9a74743167dcfcfbca5056eedbff9a52337c9712"
 
 S = "${WORKDIR}/git"

--- a/recipes-kernel/kernel-modules/kernel-module-ls-debug_git.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-ls-debug_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=94263f12f9416f9fd0493c8f9e8085a3"
 
 inherit module autotools-brokensep
 
-SRC_URI = "git://github.com/nxp-qoriq-yocto-sdk/ls-dbg;branch=nxp/master"
+SRC_URI = "git://github.com/nxp-qoriq-yocto-sdk/ls-dbg;branch=nxp/master;protocol=https"
 SRCREV = "40501f6659e880d38508cdd34a4df2d348d1c68e"
 
 S = "${WORKDIR}/git"

--- a/recipes-kernel/kernel-modules/kernel-module-scatter-gather_git.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-scatter-gather_git.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=e9605a22ea50467bd2bfe4cdd66e69ae"
 
 inherit module
 
-SRC_URI = "git://github.com/nxp-qoriq-yocto-sdk/scatter-gather;branch=nxp/master"
+SRC_URI = "git://github.com/nxp-qoriq-yocto-sdk/scatter-gather;branch=nxp/master;protocol=https"
 SRCREV = "97db173d08a70abe2b9a6fa928299a117f3febc2"
 
 S = "${WORKDIR}/git"

--- a/recipes-kernel/kernel-modules/kernel-module-uio-seville_0.1.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-uio-seville_0.1.bb
@@ -2,7 +2,7 @@ DESCRIPTION = "UIO driver for T1040 L2 Switch"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e"
 
-SRC_URI = "git://github.com/nxp-qoriq-yocto-sdk/l2switch-uio;branch=nxp/sdk-v2.0.x"
+SRC_URI = "git://github.com/nxp-qoriq-yocto-sdk/l2switch-uio;branch=nxp/sdk-v2.0.x;protocol=https"
 SRCREV = "0f31fbcbe9ab1ab9c424da34f70c82314b16f8de"
 
 inherit module


### PR DESCRIPTION
Disclaimer: As I don't use any layerscape based machine I didn't build test at all.
Due to COMPATIBLE_MACHINE the bitbake parser will not even parse the recipe.

These (together with one recipe in meta-freescale-distro) seem to be the last instances of a github fetch using the git protocol in the layers I use.