### PR TITLE
imx-boot: Copy UBOOT_DTB_NAME_EXTRA instead of UBOOT_DTB_NAME to BOOT…

### DIFF
--- a/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
+++ b/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
@@ -85,7 +85,7 @@ compile_mx8m() {
     cp ${DEPLOY_DIR_IMAGE}/u-boot-spl.bin-${MACHINE}-${UBOOT_CONFIG_EXTRA} \
                                                              ${BOOT_STAGING}/u-boot-spl.bin
 
-    cp ${DEPLOY_DIR_IMAGE}/${BOOT_TOOLS}/${UBOOT_DTB_NAME}   ${BOOT_STAGING}
+    cp ${DEPLOY_DIR_IMAGE}/${BOOT_TOOLS}/${UBOOT_DTB_NAME_EXTRA}   ${BOOT_STAGING}
 
     if [ "x${UBOOT_SIGN_ENABLE}" = "x1" ] ; then
         # Use DTB binary patched with signature node

--- a/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
+++ b/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
@@ -85,11 +85,11 @@ compile_mx8m() {
     cp ${DEPLOY_DIR_IMAGE}/u-boot-spl.bin-${MACHINE}-${UBOOT_CONFIG_EXTRA} \
                                                              ${BOOT_STAGING}/u-boot-spl.bin
 
-    cp ${DEPLOY_DIR_IMAGE}/${BOOT_TOOLS}/${UBOOT_DTB_NAME_EXTRA}   ${BOOT_STAGING}
-
     if [ "x${UBOOT_SIGN_ENABLE}" = "x1" ] ; then
         # Use DTB binary patched with signature node
-        cp ${DEPLOY_DIR_IMAGE}/${UBOOT_DTB_BINARY} ${BOOT_STAGING}/${UBOOT_DTB_NAME}
+        cp ${DEPLOY_DIR_IMAGE}/${UBOOT_DTB_BINARY} ${BOOT_STAGING}/${UBOOT_DTB_NAME_EXTRA}
+    else
+        cp ${DEPLOY_DIR_IMAGE}/${BOOT_TOOLS}/${UBOOT_DTB_NAME_EXTRA}   ${BOOT_STAGING}
     fi
 
     cp ${DEPLOY_DIR_IMAGE}/${BOOT_TOOLS}/u-boot-nodtb.bin-${MACHINE}-${UBOOT_CONFIG_EXTRA} \


### PR DESCRIPTION
Variables set in machine configuration:
UBOOT_CONFIG ??= "sd"
UBOOT_CONFIG[sd] = "msc_sm2s_imx8mp_defconfig,sdcard"
UBOOT_DTB_NAME = "msc-sm2s-imx8mp.dtb"

imx-boot:do_compile:

| NOTE: building iMX8MP - REV=A0 flash_evk
| 39860+1 records in
| 39861+0 records out
| 159444 bytes (159 kB, 156 KiB) copied, 0.284542 s, 560 kB/s
| ./../scripts/dtb_check.sh imx8mp-evk.dtb evk.dtb msc-sm2s-imx8mp.dtb-sd
|  Can't find u-boot DTB file, please copy from u-boot
| make[1]: *** [soc.mak:151: evk.dtb] Error 254
| make: *** [Makefile:23: flash_evk] Error 2
| WARNING: exit code 2 from a shell command.

In imx-boot compilation, dtb_chek.sh fails, as UBOOT_DTB_NAME (msc-sm2s-imx8mp.dtb) is copied instead of the new UBOOT_DTB_NAME_EXTRA (msc-sm2s-imx8mp.dtb-sd) variable in compile_mx8
