### PR TITLE
uuu: Update nxp repository links

### DIFF
--- a/recipes-devtools/uuu/uuu-bin_1.4.243.bb
+++ b/recipes-devtools/uuu/uuu-bin_1.4.243.bb
@@ -3,16 +3,16 @@
 
 SUMMARY = "Universal Update Utility - Binaries"
 DESCRIPTION = "Image deploy tool for i.MX chips"
-HOMEPAGE = "https://github.com/NXPmicro/mfgtools"
+HOMEPAGE = "https://github.com/nxp-imx/mfgtools"
 
 LICENSE = "BSD-3-Clause & LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/BSD-3-Clause;md5=550794465ba0ec5312d6919e203a55f9 \
                     file://${COMMON_LICENSE_DIR}/LGPL-2.1-or-later;md5=2a4f4fd2128ea2f65047ee63fbca9f68"
 
 SRC_URI = " \
-    https://github.com/NXPmicro/mfgtools/releases/download/uuu_${PV}/uuu;downloadfilename=uuu-${PV};name=Linux \
-    https://github.com/NXPmicro/mfgtools/releases/download/uuu_${PV}/uuu_mac;downloadfilename=uuu-${PV}_mac;name=Mac \
-    https://github.com/NXPmicro/mfgtools/releases/download/uuu_${PV}/uuu.exe;downloadfilename=uuu-${PV}.exe;name=Windows \
+    https://github.com/nxp-imx/mfgtools/releases/download/uuu_${PV}/uuu;downloadfilename=uuu-${PV};name=Linux \
+    https://github.com/nxp-imx/mfgtools/releases/download/uuu_${PV}/uuu_mac;downloadfilename=uuu-${PV}_mac;name=Mac \
+    https://github.com/nxp-imx/mfgtools/releases/download/uuu_${PV}/uuu.exe;downloadfilename=uuu-${PV}.exe;name=Windows \
 "
 
 SRC_URI[Linux.sha256sum] = "dfb2a6dca337ebd59675ea5ce7f1bce6724e3b901bcb455126d4bf9bdfa2e585"

--- a/recipes-devtools/uuu/uuu_git.bb
+++ b/recipes-devtools/uuu/uuu_git.bb
@@ -1,8 +1,8 @@
 SUMMARY = "Universal Update Utility"
 DESCRIPTION = "Image deploy tool for i.MX chips"
-HOMEPAGE = "https://github.com/NXPmicro/mfgtools"
+HOMEPAGE = "https://github.com/nxp-imx/mfgtools"
 
-SRC_URI = "git://github.com/NXPmicro/mfgtools.git;protocol=https;branch=master"
+SRC_URI = "git://github.com/nxp-imx/mfgtools.git;protocol=https;branch=master"
 SRCREV = "ed48c514ee4c1ea4562c875877b180a87474f895"
 PV = "1.4.243"
 


### PR DESCRIPTION
Due to the transition of github.com/NXPMicro/mfgtools to github.com/nxp-imx/mfgtools, this commit updates the repository links to ensure future fetches will not break.

The recipe still works because NXPMicro repository became an alias to nxp-imx.