### PR TITLE
linux-fslc: update to v6.1.57

### DIFF
--- a/recipes-kernel/linux/linux-fslc_6.1.bb
+++ b/recipes-kernel/linux/linux-fslc_6.1.bb
@@ -19,10 +19,10 @@ SRC_URI = "git://github.com/Freescale/linux-fslc.git;branch=${KBRANCH};protocol=
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "6.1.38"
+LINUX_VERSION = "6.1.57"
 
 KBRANCH = "6.1.x+fslc"
-SRCREV = "085682f3fc7ed71fdafa987c96d76805086336a9"
+SRCREV = "2c0a3c104b3104e0244b32ac25151f699ac960c3"
 
 KBUILD_DEFCONFIG:mx5-generic-bsp = "imx_v6_v7_defconfig"
 KBUILD_DEFCONFIG:mx5-generic-bsp = "imx_v6_v7_defconfig"


### PR DESCRIPTION
Kernel repository has been upgraded up to v6.1.57 from stable release.

Build test: imx8mm-lpddr4-evk only