### PR TITLE
linux-fslc-imx: Update to lf-6.1.36-2.1.0

### DIFF
--- a/recipes-kernel/linux/linux-fslc-imx_6.1.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_6.1.bb
@@ -52,16 +52,16 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 
 require linux-imx.inc
 
-KBRANCH = "6.1-2.0.x-imx"
+KBRANCH = "6.1-2.1.x-imx"
 SRC_URI = "git://github.com/Freescale/linux-fslc.git;branch=${KBRANCH};protocol=https"
-SRCREV = "b872b1170fc8843b55e9f8838dd373ff43bb7552"
+SRCREV = "3f41fbe42851375d3d5996e4bf9e9809e6c79517"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "6.1.38"
+LINUX_VERSION = "6.1.57"
 
 KBUILD_DEFCONFIG:mx6-generic-bsp = "imx_v7_defconfig"
 KBUILD_DEFCONFIG:mx7-generic-bsp = "imx_v7_defconfig"


### PR DESCRIPTION
    Upgrade the kernel to 6.1-2.1.x-imx based on the NXP kernel sources
    with the tag lf-6.1.36-2.1.0 and the mainline stable linux-6.1.y.
    
    Stable version: 6.1.57
    
    Relevant internal commits:
    $ git log --oneline  --no-merges v6.1.22.. ^mainline/linux-6.1.y ^nxp/lf-6.1.y
    3f1f2ea72955 mxc: gpu-viv: change _QuerySignal() return type to gceSTATUS
    b73c6797ee42 ARM: imx_v7_defconfig: Remove KERNEL_LZO config
    ec33c7fc43be touchscreen: Kconfig: add I2C dependency for CT36X
    6c41233a2cfb pwm: pwm-adp5585: fix get_state callback prototype
    9c7540ecb891 pwm: pwm-rpmsg-imx: fix get_state callback prototype
