### PR TITLE
Update u-boot-imx to lf-6.1.36-2.1.0

### DIFF
--- a/recipes-bsp/u-boot/u-boot-imx-common_2023.04.inc
+++ b/recipes-bsp/u-boot/u-boot-imx-common_2023.04.inc
@@ -5,8 +5,8 @@ LIC_FILES_CHKSUM = "file://Licenses/gpl-2.0.txt;md5=b234ee4d69f5fce4486a80fdaf4a
 
 SRC_URI = "git://github.com/nxp-imx/uboot-imx.git;protocol=https;branch=${SRCBRANCH}"
 SRCBRANCH = "lf_v2023.04"
-LOCALVERSION ?= "-imx_v2023.04_6.1.22-2.0.0"
-SRCREV = "af7d004eaf18437c7db76f7962652b924099405b"
+LOCALVERSION ?= "-imx_v2023.04_6.1.36-2.1.0"
+SRCREV = "1e5b6c6bf246a38654d07e7e23f333ad0e7d42d0"
 
 DEPENDS += " \
     bc-native \

--- a/recipes-bsp/u-boot/u-boot-imx_2023.04.bb
+++ b/recipes-bsp/u-boot/u-boot-imx_2023.04.bb
@@ -3,7 +3,7 @@
 # Copyright (C) 2017-2023 NXP
 
 require recipes-bsp/u-boot/u-boot.inc
-require recipes-bsp/u-boot/u-boot-imx-common_${PV}.inc
+require u-boot-imx-common_${PV}.inc
 
 PROVIDES += "u-boot u-boot-mfgtool"
 


### PR DESCRIPTION
Tested building all imx* machines with `IMX_DEFAULT_BOOTLOADER="u-boot-imx" bitbake u-boot`

For `U-Boot (i.MX variants)` in  https://github.com/Freescale/meta-freescale/issues/1655