### PR TITLE
imx-sc-firmware: Remove -fcanon-prefix-map

### DIFF
--- a/recipes-bsp/imx-sc-firmware/imx-sc-firmware_1.15.0.bb
+++ b/recipes-bsp/imx-sc-firmware/imx-sc-firmware_1.15.0.bb
@@ -40,4 +40,6 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 LDFLAGS:remove = "-fuse-ld=lld"
 
+DEBUG_PREFIX_MAP:remove = "-fcanon-prefix-map"
+
 COMPATIBLE_MACHINE = "(mx8qm-generic-bsp|mx8qxp-generic-bsp|mx8dxl-generic-bsp|mx8dx-generic-bsp)"


### PR DESCRIPTION
Its not supported by gcc < 13 and this package uses a prebuilt toolchain based on gcc 8

Fixes
| arm-none-eabi-gcc: error: unrecognized command line option '-fcanon-prefix-map'; did you mean '-fmacro-prefix-map='?