### PR TITLE
ARM 32-bit device-tree reorganization

### DIFF
--- a/conf/machine/imx23evk.conf
+++ b/conf/machine/imx23evk.conf
@@ -18,4 +18,4 @@ UBOOT_SUFFIX = "sb"
 
 UBOOT_MACHINE = "mx23evk_config"
 
-KERNEL_DEVICETREE = "imx23-evk.dtb"
+KERNEL_DEVICETREE = "nxp/mxs/imx23-evk.dtb"

--- a/conf/machine/imx28evk.conf
+++ b/conf/machine/imx28evk.conf
@@ -21,7 +21,7 @@ UBOOT_CONFIG[sd] = "mx28evk_config,sdcard"
 UBOOT_CONFIG[nand] = "mx28evk_nand_config,ubifs"
 UBOOT_CONFIG[sd-auart-console] = "mx28evk_auart_console_config,sdcard"
 
-KERNEL_DEVICETREE = "imx28-evk.dtb"
+KERNEL_DEVICETREE = "nxp/mxs/imx28-evk.dtb"
 
 SERIAL_CONSOLES = "115200;ttyAMA0"
 

--- a/conf/machine/imx51evk.conf
+++ b/conf/machine/imx51evk.conf
@@ -9,7 +9,7 @@ MACHINEOVERRIDES =. "mx5:mx51:"
 include conf/machine/include/imx-base.inc
 include conf/machine/include/arm/armv7a/tune-cortexa8.inc
 
-KERNEL_DEVICETREE = "imx51-babbage.dtb"
+KERNEL_DEVICETREE = "nxp/imx/imx51-babbage.dtb"
 
 # This machine is not supported by u-boot-imx as it is not tested by NXP on this
 # board. So we force it to use u-boot-fslc which is based on mainline here.

--- a/conf/machine/imx53qsb.conf
+++ b/conf/machine/imx53qsb.conf
@@ -9,7 +9,7 @@ MACHINEOVERRIDES =. "mx5:mx53:"
 include conf/machine/include/imx-base.inc
 include conf/machine/include/arm/armv7a/tune-cortexa8.inc
 
-KERNEL_DEVICETREE = "imx53-qsb.dtb imx53-qsrb.dtb"
+KERNEL_DEVICETREE = "nxp/imx/imx53-qsb.dtb nxp/imx/imx53-qsrb.dtb"
 
 # This machine is not supported by u-boot-imx as it is not tested by NXP on this
 # board. So we force it to use u-boot-fslc which is based on mainline here.


### PR DESCRIPTION
The 32-bit ARM device trees in the Linux kernel were reorganized in a manner similar to how the 64-bit ARM device trees have always been organized: by placing them in vendor+family subdirectories. Therefore update the KERNEL_DEVICETREE definitions to match.