### PR TITLE
kernel-module-nxp-wlan: Fix REGULATORY_IGNORE_STALE_KICKOFF build break

### DIFF
--- a/recipes-kernel/kernel-modules/kernel-module-nxp-wlan/0001-moal_cfg80211-remove-dropped-REGULATORY_IGNORE_STALE.patch
+++ b/recipes-kernel/kernel-modules/kernel-module-nxp-wlan/0001-moal_cfg80211-remove-dropped-REGULATORY_IGNORE_STALE.patch
@@ -1,0 +1,34 @@
+From 223ec51667cfdc6339b5c74a65c87e0e8ad970b5 Mon Sep 17 00:00:00 2001
+From: Andrey Zhizhikin <andrey.zhizhikin@leica-geosystems.com>
+Date: Tue, 31 Oct 2023 14:49:12 -0700
+Subject: [PATCH] moal_cfg80211: remove dropped REGULATORY_IGNORE_STALE_KICKOFF
+
+Upstream commit e8c2af660ba0 ("wifi: cfg80211: fix regulatory disconnect with
+OCB/NAN") removed the definition of REGULATORY_IGNORE_STALE_KICKOFF. Fix the
+driver code to indicate Kernel version where it is no longer available.
+
+Link: https://lore.kernel.org/r/20230616222844.2794d1625a26.I8e78a3789a29e6149447b3139df724a6f1b46fc3@changeid
+
+Upstream-Status: Pending
+Signed-off-by: Andrey Zhizhikin <andrey.zhizhikin@leica-geosystems.com>
+Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>
+---
+ mxm_wifiex/wlan_src/mlinux/moal_sta_cfg80211.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/mxm_wifiex/wlan_src/mlinux/moal_sta_cfg80211.c b/mxm_wifiex/wlan_src/mlinux/moal_sta_cfg80211.c
+index bf39f0e..8a69d32 100644
+--- a/mxm_wifiex/wlan_src/mlinux/moal_sta_cfg80211.c
++++ b/mxm_wifiex/wlan_src/mlinux/moal_sta_cfg80211.c
+@@ -10357,7 +10357,7 @@ mlan_status woal_register_cfg80211(moal_private *priv)
+ 		PRINTM(MIOCTL, "Follow countryIE provided by AP.\n");
+ 	}
+ #endif
+-#if CFG80211_VERSION_CODE >= KERNEL_VERSION(3, 19, 0)
++#if (CFG80211_VERSION_CODE >= KERNEL_VERSION(3, 19, 0)) && (CFG80211_VERSION_CODE < KERNEL_VERSION(6, 1, 39))
+ 	/*REGULATORY_IGNORE_STALE_KICKOFF: the regulatory core will _not_ make
+ 	 * sure all interfaces on this wiphy reside on allowed channels. If this
+ 	 * flag is not set, upon a regdomain change, the interfaces are given a
+-- 
+2.25.1
+

--- a/recipes-kernel/kernel-modules/kernel-module-nxp-wlan_git.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-nxp-wlan_git.bb
@@ -10,7 +10,8 @@ RCONFLICTS:${PN} = "kernel-module-nxp89xx"
 
 SRCBRANCH = "lf-6.1.22_2.0.0"
 MRVL_SRC ?= "git://github.com/nxp-imx/mwifiex.git;protocol=https"
-SRC_URI = "${MRVL_SRC};branch=${SRCBRANCH}"
+SRC_URI = "${MRVL_SRC};branch=${SRCBRANCH} \
+           file://0001-moal_cfg80211-remove-dropped-REGULATORY_IGNORE_STALE.patch;patchdir=${WORKDIR}/git"
 SRCREV = "f1382ccbd34fc22daf504e798745f6cddb702b82"
 
 S = "${WORKDIR}/git/mxm_wifiex/wlan_src"


### PR DESCRIPTION
Apply patch to fix build for kernels 6.1.39 and greater.

Fixes: #1676