### PR TITLE
imx-atf: Explicitly demand BFD linker

### DIFF
--- a/recipes-bsp/imx-atf/imx-atf_2.8.bb
+++ b/recipes-bsp/imx-atf/imx-atf_2.8.bb
@@ -48,7 +48,7 @@ def remove_options_tail (in_string):
     from itertools import takewhile
     return ' '.join(takewhile(lambda x: not x.startswith('-'), in_string.split(' ')))
 
-EXTRA_OEMAKE += 'LD="${@remove_options_tail(d.getVar('LD'))}"'
+EXTRA_OEMAKE += 'LD="${@remove_options_tail(d.getVar('LD'))}.bfd"'
 
 EXTRA_OEMAKE += 'CC="${@remove_options_tail(d.getVar('CC'))}"'
 


### PR DESCRIPTION
This component uses BFD linker specific options which may not be available when default ld is not GNU BFD LD

Fixes

| aarch64-yoe-linux-ld: error: unknown argument '--fix-cortex-a53-835769'