### PR TITLE
 imx-mcore-demos: Fix install for multilib  Replace  `base_libdir` with `nonarch_base_libdir`

### DIFF
--- a/recipes-fsl/mcore-demos/imx-mcore-demos.inc
+++ b/recipes-fsl/mcore-demos/imx-mcore-demos.inc
@@ -40,9 +40,8 @@ S = "${WORKDIR}/${SOC}-${MCORE_TYPE}-demo-${PV}"
 SCR = "SCR-${SOC}-${MCORE_TYPE}-demo.txt"
 
 do_install () {
-    # install elf format binary to /lib/firmware
-    install -d ${D}${base_libdir}/firmware
-    install -m 0644 ${S}/*.elf ${D}${base_libdir}/firmware
+    install -d ${D}${nonarch_base_libdir}/firmware
+    install -m 0644 ${S}/*.elf ${D}${nonarch_base_libdir}/firmware
 }
 
 DEPLOY_FILE_EXT       ?= "bin"


### PR DESCRIPTION
When using multilib configuration there is a build break at packaging step