### PR TITLE
linux: fix building linux 6.1 for 32-bit arm machines

### DIFF
--- a/recipes-kernel/linux/linux-fslc-imx_6.1.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_6.1.bb
@@ -52,6 +52,8 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 
 require linux-imx.inc
 
+include linux-legacy-arm-dts.inc
+
 KBRANCH = "6.1-2.1.x-imx"
 SRC_URI = "git://github.com/Freescale/linux-fslc.git;branch=${KBRANCH};protocol=https"
 SRCREV = "3f41fbe42851375d3d5996e4bf9e9809e6c79517"

--- a/recipes-kernel/linux/linux-fslc-lts_6.1.bb
+++ b/recipes-kernel/linux/linux-fslc-lts_6.1.bb
@@ -12,6 +12,8 @@ upstreaming in any form."
 
 require linux-imx.inc
 
+include linux-legacy-arm-dts.inc
+
 SRC_URI = "git://github.com/Freescale/linux-fslc.git;branch=${KBRANCH};protocol=https"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition

--- a/recipes-kernel/linux/linux-imx_6.1.bb
+++ b/recipes-kernel/linux/linux-imx_6.1.bb
@@ -12,6 +12,8 @@ i.MX Family Reference Boards. It includes support for many IPs such as GPU, VPU 
 
 require recipes-kernel/linux/linux-imx.inc
 
+include linux-legacy-arm-dts.inc
+
 SRCBRANCH = "lf-6.1.y"
 LOCALVERSION = "-6.1.36-2.1.0"
 SRCREV = "04b05c5527e9af8d81254638c307df07dc9a5dd3"

--- a/recipes-kernel/linux/linux-legacy-arm-dts.inc
+++ b/recipes-kernel/linux/linux-legacy-arm-dts.inc
@@ -1,0 +1,7 @@
+# In linux kernels < 6.6 dts files for arm arch are collected in the
+# common dts directory arch/arm/boot/dts
+
+KERNEL_DEVICETREE:imx23evk = "imx23-evk.dtb"
+KERNEL_DEVICETREE:imx28evk = "imx28-evk.dtb"
+KERNEL_DEVICETREE:imx51evk = "imx51-babbage.dtb"
+KERNEL_DEVICETREE:imx53qsb = "imx53-qsb.dtb imx53-qsrb.dtb"


### PR DESCRIPTION
Tested bulding linux-fslc-lts 6.1 and linux-fslc 6.6:
- imx23evk
- imx28evk
- imx51evk
- imx53qsb

Only kernels >= 6.6 have dts files for 32-bit ARM devices
reorganized by placing them in vendor+family subdirectories.
previous kernels keep all arm arch dts files in a single default
directory.
Correctly reassign KERNEL_DEVICETREE for 32-bit ARM devices for all
supported kernels 6.1 to fix building.

Fixes: 0d838c68 ("ARM 32-bit device-tree reorganization")

The fix for other arm32 machines for 6.6 is coming.