### PR TITLE
linux: Add compatibility logic for 32-bit dtb move

### DIFF
--- a/recipes-kernel/linux/linux-fslc-imx_6.1.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_6.1.bb
@@ -52,6 +52,8 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 
 require linux-imx.inc
 
+KERNEL_DEVICETREE_32BIT_COMPATIBILITY_UPDATE = "1"
+
 KBRANCH = "6.1-2.1.x-imx"
 SRC_URI = "git://github.com/Freescale/linux-fslc.git;branch=${KBRANCH};protocol=https"
 SRCREV = "3f41fbe42851375d3d5996e4bf9e9809e6c79517"

--- a/recipes-kernel/linux/linux-fslc-lts_6.1.bb
+++ b/recipes-kernel/linux/linux-fslc-lts_6.1.bb
@@ -12,6 +12,8 @@ upstreaming in any form."
 
 require linux-imx.inc
 
+KERNEL_DEVICETREE_32BIT_COMPATIBILITY_UPDATE = "1"
+
 SRC_URI = "git://github.com/Freescale/linux-fslc.git;branch=${KBRANCH};protocol=https"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition

--- a/recipes-kernel/linux/linux-imx.inc
+++ b/recipes-kernel/linux/linux-imx.inc
@@ -38,3 +38,29 @@ KCONFIG_MODE="--alldefconfig"
 # We need to pass it as param since kernel might support more then one
 # machine, with different entry points
 KERNEL_EXTRA_ARGS += "LOADADDR=${UBOOT_ENTRYPOINT}"
+
+# A function to strip the new 32-bit dtb sub-folders in KERNEL_DEVICETREE
+# for older kernel builds.
+# Set KERNEL_DEVICETREE_32BIT_COMPATIBILITY_UPDATE = "1" to enable.
+KERNEL_DEVICETREE_32BIT_COMPATIBILITY_UPDATE ?= "0"
+python kernel_devicetree_32bit_compatibility_update() {
+    import os.path
+    import re
+    if d.getVar('KERNEL_DEVICETREE_32BIT_COMPATIBILITY_UPDATE') != "1" or d.getVar('TUNE_ARCH') != "arm":
+        return
+    input = d.getVar('KERNEL_DEVICETREE').split()
+    output = ""
+    stripped = ""
+    for original in input:
+        if re.match("^.*/", original):
+            stripped = os.path.basename(original)
+            output += stripped + " "
+            bb.debug(1, "Devicetrees are moved to sub-folder, stripping the sub-folder for older kernel: %s -> %s" % (original, stripped))
+        else:
+            output += original + " "
+    if stripped:
+        bb.warn("Updating KERNEL_DEVICETREE, removing sub-folders for older kernel. Use -D for more details. Set KERNEL_DEVICETREE_32BIT_COMPATIBILITY_UPDATE = \"0\" to disable.")
+        d.setVar('KERNEL_DEVICETREE', output)
+}
+addhandler kernel_devicetree_32bit_compatibility_update
+kernel_devicetree_32bit_compatibility_update[eventmask] = "bb.event.RecipeParsed"

--- a/recipes-kernel/linux/linux-imx_6.1.bb
+++ b/recipes-kernel/linux/linux-imx_6.1.bb
@@ -12,6 +12,8 @@ i.MX Family Reference Boards. It includes support for many IPs such as GPU, VPU 
 
 require recipes-kernel/linux/linux-imx.inc
 
+KERNEL_DEVICETREE_32BIT_COMPATIBILITY_UPDATE = "1"
+
 SRCBRANCH = "lf-6.1.y"
 LOCALVERSION = "-6.1.36-2.1.0"
 SRCREV = "04b05c5527e9af8d81254638c307df07dc9a5dd3"


### PR DESCRIPTION
Newer kernels have moved the dtbs to a vendor sub-folder, including the ones for i.MX 32-bit, which now reside in nxp/imx. In order to maintain one KERNEL_DEVICETREE for both new and old kernels, provide logic that can be enabled in older kernels to strip the new sub-folder.

Fixes: 0d838c68