### PR TITLE
jailhouse-imx: Add MODLIB to build option to set right module install…

### DIFF
--- a/recipes-extended/jailhouse/jailhouse-imx_git.bb
+++ b/recipes-extended/jailhouse/jailhouse-imx_git.bb
@@ -64,6 +64,7 @@ do_install:prepend() {
         ARCH=${JH_ARCH} \
         CROSS_COMPILE=${TARGET_PREFIX} \
         KDIR=${STAGING_KERNEL_BUILDDIR} \
+        MODLIB="${D}${nonarch_base_libdir}/modules/${KERNEL_VERSION}" \
         INSTALL_MOD_PATH=${D}${root_prefix} \
         firmwaredir=${nonarch_base_libdir}/firmware \
         DESTDIR=${D} install


### PR DESCRIPTION
… path

Must overrides module install path to algin with module_do_install in module.bbclass
-  MODLIB="${D}${nonarch_base_libdir}/modules/${KERNEL_VERSION}"