### PR TITLE
image_types_fsl.bbclass: Drop use of IMAGE_NAME_SUFFIX

### DIFF
--- a/classes/image_types_fsl.bbclass
+++ b/classes/image_types_fsl.bbclass
@@ -13,9 +13,9 @@ do_image_uboot_mxsboot_sdcard[depends] += "u-boot-mxsboot-native:do_populate_sys
                                            u-boot:do_deploy"
 IMAGE_CMD:uboot-mxsboot-sdcard() {
     mxsboot sd ${DEPLOY_DIR_IMAGE}/u-boot-${MACHINE}.${UBOOT_SUFFIX} \
-               ${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.rootfs.uboot-mxsboot-sdcard
-    ln -sf ${IMAGE_NAME}.rootfs.uboot-mxsboot-sdcard \
-           ${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}.rootfs.uboot-mxsboot-sdcard
+               ${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.uboot-mxsboot-sdcard
+    ln -sf ${IMAGE_NAME}.uboot-mxsboot-sdcard \
+           ${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}.uboot-mxsboot-sdcard
 }
 
 # U-Boot mxsboot generation for NAND
@@ -24,9 +24,9 @@ do_image_uboot_mxsboot_nand[depends] += "u-boot-mxsboot-native:do_populate_sysro
 IMAGE_CMD:uboot-mxsboot-nand() {
     mxsboot ${MXSBOOT_NAND_ARGS} nand \
             ${DEPLOY_DIR_IMAGE}/u-boot-${MACHINE}.${UBOOT_SUFFIX} \
-            ${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.rootfs.uboot-mxsboot-nand
-    ln -sf ${IMAGE_NAME}.rootfs.uboot-mxsboot-nand \
-           ${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}.rootfs.uboot-mxsboot-nand
+            ${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.uboot-mxsboot-nand
+    ln -sf ${IMAGE_NAME}.uboot-mxsboot-nand \
+           ${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}.uboot-mxsboot-nand
 }
 
 # In case we are building for i.MX23 or i.MX28 we need to have the
@@ -40,5 +40,5 @@ do_image_wic[depends] += " \
 IMAGE_CMD:wic:append:mxs-generic-bsp() {
 	# Change partition type for mxs processor family
 	bbnote "Setting partition type to 0x53 as required for mxs' SoC family."
-	echo -n S | dd of=$out${IMAGE_NAME_SUFFIX}.wic bs=1 count=1 seek=450 conv=notrunc
+	echo -n S | dd of=$out.wic bs=1 count=1 seek=450 conv=notrunc
 }


### PR DESCRIPTION
This is no longer required since its already merged into IMAGE_NAME and IMAGE_LINK_NAME via [1] in OE-Core. Infact it causes problems now if we add .rootfs explicitly, this created non-existent filenames and resulting images are wrong.

[1] https://git.openembedded.org/openembedded-core/commit/meta/classes-recipe/image-artifact-names.bbclass?id=26d97acc71379ab6702fa54a23b6542a3f51779c