### PR TITLE
imx-uboot-mxs-bootpart.wks.in: drop extra 'rootfs'

### DIFF
--- a/wic/imx-uboot-mxs-bootpart.wks.in
+++ b/wic/imx-uboot-mxs-bootpart.wks.in
@@ -12,7 +12,7 @@
 # | |         |              |
 # 0 1kiB    4MiB          16MiB + rootfs + IMAGE_EXTRA_SPACE (default 10MiB)
 #
-part u-boot --source rawcopy --sourceparams="file=${IMAGE_LINK_NAME}.rootfs.uboot-mxsboot-sdcard" --ondisk mmcblk --align 1024
+part u-boot --source rawcopy --sourceparams="file=${IMAGE_LINK_NAME}.uboot-mxsboot-sdcard" --ondisk mmcblk --align 1024
 part /boot --source bootimg-partition --ondisk mmcblk --fstype=vfat --label boot --active --align 4096 --size 16
 part / --source rootfs --ondisk mmcblk --fstype=ext4 --label root --align 4096
 


### PR DESCRIPTION
${IMAGE_LINK_NAME} already contains "rootfs" at the end, therefore it does not need to be added explicitly. Otherwise the wic creation fails with:

	wic.filemap.Error: cannot open image file '.../build/tmp-glibc/deploy/images/imx233-olinuxino-maxi/core-image-minimal-imx233-olinuxino-maxi.rootfs.rootfs.uboot-mxsboot-sdcard'