### PR TITLE
classes: make localversion classes deterministic

### DIFF
--- a/classes/fsl-kernel-localversion.bbclass
+++ b/classes/fsl-kernel-localversion.bbclass
@@ -25,8 +25,9 @@ do_kernel_localversion() {
 
 	if [ "${SCMVERSION}" = "y" ]; then
 		# Add GIT revision to the local version
-		head=`git --git-dir=${S}/.git rev-parse --verify --short HEAD 2> /dev/null`
-		printf "%s%s" +g $head > ${S}/.scmversion
+		head=`git --git-dir=${S}/.git rev-parse --verify --short ${SRCREV} 2> /dev/null`
+		patches=`git --git-dir=${S}/.git rev-list --count ${SRCREV}..HEAD 2> /dev/null`
+		printf "%s%s%s%s" +g $head +p $patches > ${S}/.scmversion
 
 		sed -i -e "/CONFIG_LOCALVERSION_AUTO[ =]/d" ${B}/.config
 		echo "CONFIG_LOCALVERSION_AUTO=y" >> ${B}/.config

--- a/classes/fsl-u-boot-localversion.bbclass
+++ b/classes/fsl-u-boot-localversion.bbclass
@@ -17,9 +17,10 @@ UBOOT_LOCALVERSION = "${LOCALVERSION}"
 do_compile:prepend() {
 	if [ "${SCMVERSION}" = "y" ]; then
 		# Add GIT revision to the local version
-		head=`cd ${S} ; git rev-parse --verify --short HEAD 2> /dev/null`
-		printf "%s%s%s" "${UBOOT_LOCALVERSION}" +g $head > ${S}/.scmversion
-		printf "%s%s%s" "${UBOOT_LOCALVERSION}" +g $head > ${B}/.scmversion
+		head=`cd ${S} ; git rev-parse --verify --short ${SRCREV} 2> /dev/null`
+		patches=`cd ${S} ; git rev-list --count ${SRCREV}..HEAD 2> /dev/null`
+		printf "%s%s%s%s%s" "${UBOOT_LOCALVERSION}" +g $head +p $patches > ${S}/.scmversion
+		printf "%s%s%s%s%s" "${UBOOT_LOCALVERSION}" +g $head +p $patches > ${B}/.scmversion
     else
 		printf "%s" "${UBOOT_LOCALVERSION}" > ${S}/.scmversion
 		printf "%s" "${UBOOT_LOCALVERSION}" > ${B}/.scmversion


### PR DESCRIPTION
The localversion string built into the kernel and u-boot should be deterministic. With OpenEmbedded it is common practice to apply patches to the sources. The commit id of HEAD will differ each time the patching step is rerun. With the previous implementation of the fsl-{kernel,u- boot}-localversion classes this produced non-deterministic commit ids to be used. This is undesireable, because the commit-id read from the version string during runtime is not present in the sources. It also caused problems when building out-of-tree kernel-modules if the kernel itself was taken from sstate cache but the kernel-module needed to be rebuild and retriggered the kernels do_patch task (see #961).

Rework to produce a deterministic string that will use the commit id given as SRCREV and count the number of patches applied on top.

With e.g. commit id 11aabbcc and 5 patches this will result in a version string
  +g11aabbcc+p5

Fixes: https://github.com/Freescale/meta-freescale/issues/961