### PR TITLE
fsl-kernel-localversion: fix SRCREV_machine and AUTOREV use cases

### DIFF
--- a/classes/fsl-kernel-localversion.bbclass
+++ b/classes/fsl-kernel-localversion.bbclass
@@ -25,8 +25,18 @@ do_kernel_localversion() {
 
 	if [ "${SCMVERSION}" = "y" ]; then
 		# Add GIT revision to the local version
-		head=`git --git-dir=${S}/.git rev-parse --verify --short ${SRCREV} 2> /dev/null`
-		patches=`git --git-dir=${S}/.git rev-list --count ${SRCREV}..HEAD 2> /dev/null`
+		if [ "${SRCREV}" = "INVALID" ]; then
+			hash=${SRCREV_machine}
+		else
+			hash=${SRCREV}
+		fi
+		if [ "$hash" = "AUTOINC" ]; then
+			branch=`git --git-dir=${S}/.git  symbolic-ref --short -q HEAD`
+			head=`git --git-dir=${S}/.git rev-parse --verify --short origin/${branch} 2> /dev/null`
+		else
+			head=`git --git-dir=${S}/.git rev-parse --verify --short $hash 2> /dev/null`
+		fi
+		patches=`git --git-dir=${S}/.git rev-list --count $head..HEAD 2> /dev/null`
 		printf "%s%s%s%s" +g $head +p $patches > ${S}/.scmversion
 
 		sed -i -e "/CONFIG_LOCALVERSION_AUTO[ =]/d" ${B}/.config


### PR DESCRIPTION
This would need backport to kirkstone too. The commit it fixes is currently a backport pull request for kirkstone: https://github.com/Freescale/meta-freescale/pull/1694