### PR TITLE
mx93

### DIFF
--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -180,6 +180,7 @@ IMX_SOC_REV:mx8dx-generic-bsp  ??= "C0"
 IMX_SOC_REV:mx8ulp-generic-bsp ??= \
     "${@bb.utils.contains('MACHINE_FEATURES', 'soc-reva0', 'A0', \
                                                            'A2', d)}"
+IMX_SOC_REV:mx93-generic-bsp   ??= "A1"
 
 IMX_SOC_REV_LOWER   = "${@d.getVar('IMX_SOC_REV').lower()}"
 IMX_SOC_REV_UPPER   = "${@d.getVar('IMX_SOC_REV').upper()}"

--- a/recipes-bsp/firmware-sentinel/firmware-sentinel_0.11.bb
+++ b/recipes-bsp/firmware-sentinel/firmware-sentinel_0.11.bb
@@ -3,13 +3,13 @@ SUMMARY = "NXP i.MX Sentinel firmware"
 DESCRIPTION = "Firmware for i.MX Sentinel Security Controller"
 SECTION = "base"
 LICENSE = "Proprietary"
-LIC_FILES_CHKSUM = "file://COPYING;md5=63a38e9f392d8813d6f1f4d0d6fbe657"
+LIC_FILES_CHKSUM = "file://COPYING;md5=db4762b09b6bda63da103963e6e081de"
 
 inherit fsl-eula-unpack use-imx-security-controller-firmware deploy
 
 SRC_URI = "${FSL_MIRROR}/${BP}.bin;fsl-eula=true"
-SRC_URI[md5sum] = "a92e272d665a3b3bb9281253d5eca69f"
-SRC_URI[sha256sum] = "be862b62c849510cce08ec24c1ddf53d826458e326e5a7f09c4b35092d6f9950"
+SRC_URI[md5sum] = "339011b6b199151d835c03089a3c2221"
+SRC_URI[sha256sum] = "269480417a8ae9aa4cc4101ab947287fc33455a931021dbdc4d9badb5212bceb"
 
 do_compile[noexec] = "1"
 

--- a/recipes-bsp/imx-mkimage/files/0001-iMX8M-soc.mak-use-native-mkimage-from-sysroot.patch
+++ b/recipes-bsp/imx-mkimage/files/0001-iMX8M-soc.mak-use-native-mkimage-from-sysroot.patch
@@ -22,56 +22,56 @@ Signed-off-by: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>
  iMX8M/soc.mak | 11 +++++------
  1 file changed, 5 insertions(+), 6 deletions(-)
 
-diff --git a/iMX8M/soc.mak b/iMX8M/soc.mak
-index 3486079..855c1e5 100644
---- a/iMX8M/soc.mak
-+++ b/iMX8M/soc.mak
-@@ -155,7 +155,7 @@ u-boot.itb: $(dtb) $(supp_dtbs)
+Index: git/iMX8M/soc.mak
+===================================================================
+--- git.orig/iMX8M/soc.mak
++++ git/iMX8M/soc.mak
+@@ -160,7 +160,7 @@ u-boot.itb: $(dtb) $(supp_dtbs)
  	./$(PAD_IMAGE) bl31.bin
  	./$(PAD_IMAGE) u-boot-nodtb.bin $(dtb) $(supp_dtbs)
  	BL32=$(TEE) DEK_BLOB_LOAD_ADDR=$(DEK_BLOB_LOAD_ADDR) TEE_LOAD_ADDR=$(TEE_LOAD_ADDR) ATF_LOAD_ADDR=$(ATF_LOAD_ADDR) ../$(SOC_DIR)/mkimage_fit_atf.sh $(dtb) $(supp_dtbs) > u-boot.its
--	./mkimage_uboot -E -p 0x3000 -f u-boot.its u-boot.itb
-+	mkimage -E -p 0x3000 -f u-boot.its u-boot.itb
+-	./mkimage_uboot -E -p $(FIT_EXTERNAL_POSITION) -f u-boot.its u-boot.itb
++	mkimage -E -p $(FIT_EXTERNAL_POSITION) -f u-boot.its u-boot.itb
  	@rm -f u-boot.its $(dtb)
  
  dtb_ddr3l = valddr3l.dtb
-@@ -167,7 +167,7 @@ u-boot-ddr3l.itb: $(dtb_ddr3l) $(supp_dtbs)
+@@ -172,7 +172,7 @@ u-boot-ddr3l.itb: $(dtb_ddr3l) $(supp_dt
  	./$(PAD_IMAGE) bl31.bin
  	./$(PAD_IMAGE) u-boot-nodtb.bin $(dtb_ddr3l) $(supp_dtbs)
  	DEK_BLOB_LOAD_ADDR=$(DEK_BLOB_LOAD_ADDR) TEE_LOAD_ADDR=$(TEE_LOAD_ADDR) ATF_LOAD_ADDR=$(ATF_LOAD_ADDR) ../$(SOC_DIR)/mkimage_fit_atf.sh $(dtb_ddr3l) $(supp_dtbs) > u-boot-ddr3l.its
--	./mkimage_uboot -E -p 0x3000 -f u-boot-ddr3l.its u-boot-ddr3l.itb
-+	mkimage -E -p 0x3000 -f u-boot-ddr3l.its u-boot-ddr3l.itb
+-	./mkimage_uboot -E -p $(FIT_EXTERNAL_POSITION) -f u-boot-ddr3l.its u-boot-ddr3l.itb
++	mkimage -E -p $(FIT_EXTERNAL_POSITION) -f u-boot-ddr3l.its u-boot-ddr3l.itb
  	@rm -f u-boot.its $(dtb_ddr3l)
  
  dtb_ddr3l_evk = evkddr3l.dtb
-@@ -179,7 +179,7 @@ u-boot-ddr3l-evk.itb: $(dtb_ddr3l_evk) $(supp_dtbs)
+@@ -184,7 +184,7 @@ u-boot-ddr3l-evk.itb: $(dtb_ddr3l_evk) $
  	./$(PAD_IMAGE) bl31.bin
  	./$(PAD_IMAGE) u-boot-nodtb.bin $(dtb_ddr3l_evk) $(supp_dtbs)
  	DEK_BLOB_LOAD_ADDR=$(DEK_BLOB_LOAD_ADDR) TEE_LOAD_ADDR=$(TEE_LOAD_ADDR) ATF_LOAD_ADDR=$(ATF_LOAD_ADDR) ../$(SOC_DIR)/mkimage_fit_atf.sh $(dtb_ddr3l_evk) $(supp_dtbs) > u-boot-ddr3l-evk.its
--	./mkimage_uboot -E -p 0x3000 -f u-boot-ddr3l-evk.its u-boot-ddr3l-evk.itb
-+	mkimage -E -p 0x3000 -f u-boot-ddr3l-evk.its u-boot-ddr3l-evk.itb
+-	./mkimage_uboot -E -p $(FIT_EXTERNAL_POSITION) -f u-boot-ddr3l-evk.its u-boot-ddr3l-evk.itb
++	mkimage -E -p $(FIT_EXTERNAL_POSITION) -f u-boot-ddr3l-evk.its u-boot-ddr3l-evk.itb
  	@rm -f u-boot.its $(dtb_ddr3l_evk)
  
  dtb_ddr4 = valddr4.dtb
-@@ -191,7 +191,7 @@ u-boot-ddr4.itb: $(dtb_ddr4) $(supp_dtbs)
+@@ -196,7 +196,7 @@ u-boot-ddr4.itb: $(dtb_ddr4) $(supp_dtbs
  	./$(PAD_IMAGE) bl31.bin
  	./$(PAD_IMAGE) u-boot-nodtb.bin $(dtb_ddr4) $(supp_dtbs)
  	DEK_BLOB_LOAD_ADDR=$(DEK_BLOB_LOAD_ADDR) TEE_LOAD_ADDR=$(TEE_LOAD_ADDR) ATF_LOAD_ADDR=$(ATF_LOAD_ADDR) ../$(SOC_DIR)/mkimage_fit_atf.sh $(dtb_ddr4) $(supp_dtbs) > u-boot-ddr4.its
--	./mkimage_uboot -E -p 0x3000 -f u-boot-ddr4.its u-boot-ddr4.itb
-+	mkimage -E -p 0x3000 -f u-boot-ddr4.its u-boot-ddr4.itb
+-	./mkimage_uboot -E -p $(FIT_EXTERNAL_POSITION) -f u-boot-ddr4.its u-boot-ddr4.itb
++	mkimage -E -p $(FIT_EXTERNAL_POSITION) -f u-boot-ddr4.its u-boot-ddr4.itb
  	@rm -f u-boot.its $(dtb_ddr4)
  
  dtb_ddr4_evk = evkddr4.dtb
-@@ -203,7 +203,7 @@ u-boot-ddr4-evk.itb: $(dtb_ddr4_evk) $(supp_dtbs)
+@@ -208,7 +208,7 @@ u-boot-ddr4-evk.itb: $(dtb_ddr4_evk) $(s
  	./$(PAD_IMAGE) bl31.bin
  	./$(PAD_IMAGE) u-boot-nodtb.bin $(dtb_ddr4_evk) $(supp_dtbs)
  	DEK_BLOB_LOAD_ADDR=$(DEK_BLOB_LOAD_ADDR) TEE_LOAD_ADDR=$(TEE_LOAD_ADDR) ATF_LOAD_ADDR=$(ATF_LOAD_ADDR) ../$(SOC_DIR)/mkimage_fit_atf.sh $(dtb_ddr4_evk) $(supp_dtbs) > u-boot-ddr4-evk.its
--	./mkimage_uboot -E -p 0x3000 -f u-boot-ddr4-evk.its u-boot-ddr4-evk.itb
-+	mkimage -E -p 0x3000 -f u-boot-ddr4-evk.its u-boot-ddr4-evk.itb
+-	./mkimage_uboot -E -p $(FIT_EXTERNAL_POSITION) -f u-boot-ddr4-evk.its u-boot-ddr4-evk.itb
++	mkimage -E -p $(FIT_EXTERNAL_POSITION) -f u-boot-ddr4-evk.its u-boot-ddr4-evk.itb
  	@rm -f u-boot.its $(dtb_ddr4_evk)
  
  ifeq ($(HDMI),yes)
-@@ -353,7 +353,6 @@ nightly :
+@@ -358,7 +358,6 @@ nightly :
  	@$(WGET) -q $(SERVER)/$(DIR)/$(FW_DIR)/fsl-$(PLAT)-evk.dtb -O fsl-$(PLAT)-evk.dtb
  	@$(WGET) -q $(SERVER)/$(DIR)/$(FW_DIR)/signed_hdmi_imx8m.bin -O signed_hdmi_imx8m.bin
  	@$(WGET) -q $(SERVER)/$(DIR)/$(FW_DIR)/signed_dp_imx8m.bin -O signed_dp_imx8m.bin
@@ -79,6 +79,3 @@ index 3486079..855c1e5 100644
  
  archive :
  	git ls-files --others --exclude-standard -z | xargs -0 tar rvf $(ARCHIVE_PATH)/$(ARCHIVE_NAME)
--- 
-2.40.1
-

--- a/recipes-bsp/imx-mkimage/imx-mkimage_git.inc
+++ b/recipes-bsp/imx-mkimage/imx-mkimage_git.inc
@@ -5,8 +5,8 @@ DEPENDS = "zlib-native openssl-native"
 SRC_URI = "git://github.com/nxp-imx/imx-mkimage.git;protocol=https;branch=${SRCBRANCH} \
            file://0001-iMX8M-soc.mak-use-native-mkimage-from-sysroot.patch \
 "
-SRCBRANCH = "lf-6.1.22_2.0.0"
-SRCREV = "5cfd218012e080fb907d9cc301fbb4ece9bc17a9"
+SRCBRANCH = "lf-6.1.36_2.1.0"
+SRCREV = "5a0faefc223e51e088433663b6e7d6fbce89bf59"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Fix the mx93 build with missing updates to firmware-sentinel and mkimage and a default Rev update to A1.