### PR TITLE
Upgrade OP-TEE to LF3.1.66-2.1.0 NXP BSP

### DIFF
--- a/recipes-security/optee-imx/optee-client_3.21.0.imx.bb
+++ b/recipes-security/optee-imx/optee-client_3.21.0.imx.bb
@@ -1,6 +1,6 @@
 require optee-client-fslc-imx.inc
 
-SRCBRANCH = "lf-6.1.22_2.0.0"
+SRCBRANCH = "lf-6.1.36_2.1.0"
 SRCREV = "8533e0e6329840ee96cf81b6453f257204227e6c"
 
 DEPENDS += "util-linux"

--- a/recipes-security/optee-imx/optee-os-fslc.inc
+++ b/recipes-security/optee-imx/optee-os-fslc.inc
@@ -27,6 +27,13 @@ EXTRA_OEMAKE += " \
     CFG_TEE_CORE_LOG_LEVEL=0 \
 "
 
+EXTRA_OEMAKE:append:imx8mq-lpddr4-wevk = " \
+    CFG_CORE_LARGE_PHYS_ADDR=y \
+    CFG_CORE_ARM64_PA_BITS=36 \
+    CFG_DDR_SIZE=0x100000000 \
+    CFG_TZDRAM_START=0xfe000000 \
+"
+
 LDFLAGS[unexport] = "1"
 CPPFLAGS[unexport] = "1"
 AS[unexport] = "1"

--- a/recipes-security/optee-imx/optee-os_3.21.0.imx.bb
+++ b/recipes-security/optee-imx/optee-os_3.21.0.imx.bb
@@ -8,5 +8,5 @@ SRC_URI += " \
     file://0003-arm32-libutils-libutee-ta-add-.note.GNU-stack-sectio.patch \
     file://0004-core-link-add-no-warn-rwx-segments.patch \
 "
-SRCBRANCH = "lf-6.1.22_2.0.0"
-SRCREV = "1962aec9581760803b1485d455cd62cb11c14870"
+SRCBRANCH = "lf-6.1.36_2.1.0"
+SRCREV = "4e32281904b15af9ddbdf00f73e1c08eae21c695"

--- a/recipes-security/optee-imx/optee-test_3.21.0.imx.bb
+++ b/recipes-security/optee-imx/optee-test_3.21.0.imx.bb
@@ -4,7 +4,7 @@ require optee-test-fslc.inc
 
 SRC_URI = "git://github.com/nxp-imx/imx-optee-test.git;protocol=https;branch=${SRCBRANCH}"
 
-SRCBRANCH = "lf-6.1.22_2.0.0"
-SRCREV = "c2c9f922044d2c8a7ab384812bb124c6da2b7888"
+SRCBRANCH = "lf-6.1.36_2.1.0"
+SRCREV = "e0ebd5193070e0215b5389da191bc33f4f478222"
 
 COMPATIBLE_MACHINE = "(imx-nxp-bsp)"


### PR DESCRIPTION
It needs https://github.com/Freescale/meta-freescale/pull/1702 to be merged.

It closes "Upgrade OP-TEE" task of https://github.com/Freescale/meta-freescale/issues/1655