### PR TITLE
conf/machine: remove unsupported dtb for imx8mp-lpddr4-evk machine

### DIFF
--- a/conf/machine/imx8mp-lpddr4-evk.conf
+++ b/conf/machine/imx8mp-lpddr4-evk.conf
@@ -42,7 +42,6 @@ KERNEL_DEVICETREE:append:use-nxp-bsp = " \
     freescale/imx8mp-evk-rpmsg.dtb \
     freescale/imx8mp-evk-rpmsg-lpv.dtb \
     freescale/imx8mp-evk-sof-wm8960.dtb \
-    freescale/imx8mp-evk-sof-pdm.dtb \
     freescale/imx8mp-evk-spdif-lb.dtb \
     freescale/imx8mp-evk-usdhc1-m2.dtb \
     freescale/imx8mp-evk-8mic-swpdm.dtb \


### PR DESCRIPTION
This PR removes a device-tree from `im8mp-lpddr4-evk` machine which doesn't exist on `linux-fslc-imx` (which is the default kernel on `imx8mp-lpddr4-evk` board)
Otherwise `linux-fslc-imx` recipe failed to build for this target.

Fixes #1704 