### PR TITLE
linux-fslc-imx: Merge NXP changes from lf-6.1.36-2.1.0

### DIFF
--- a/recipes-kernel/linux/linux-fslc-imx_6.1.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_6.1.bb
@@ -28,16 +28,17 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v6.1.38
+#    tag: v6.1.57
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: lf-6.1.22-2.0.0
+#    tag: lf-6.1.36-2.1.0
 #
 # ------------------------------------------------------------------------------
 # 3. Critical patches (SHA(s))
 # ------------------------------------------------------------------------------
+# - d9e9cb8ce9bc7 hx280enc_vc8000e: fix misplaced #endif
 # - 3f1f2ea729550 mxc: gpu-viv: change _QuerySignal() return type to gceSTATUS
 # - b73c6797ee427 ARM: imx_v7_defconfig: Remove KERNEL_LZO config
 # - ec33c7fc43bef touchscreen: Kconfig: add I2C dependency for CT36X
@@ -56,7 +57,7 @@ KERNEL_DEVICETREE_32BIT_COMPATIBILITY_UPDATE = "1"
 
 KBRANCH = "6.1-2.1.x-imx"
 SRC_URI = "git://github.com/Freescale/linux-fslc.git;branch=${KBRANCH};protocol=https"
-SRCREV = "3f41fbe42851375d3d5996e4bf9e9809e6c79517"
+SRCREV = "241e2f51bd87beb652196d1db92f0387c1209bfb"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.


### PR DESCRIPTION
Merge changes from the tag lf-6.1.36-2.1.0 into 6.1-2.1.x-imx.

Tested building:
- imx8mm-lpddr4-evk
- imx8mq-lpddr4-wevk
- imx8mp-lpddr4-evk

Relevant changes:
- 688f1f419b08a Merge branch 'lf-6.1.36_2.1.0' into 6.1-2.1.x-imx-6.1.36-2.1.0
- d9e9cb8ce9bc7 hx280enc_vc8000e: fix misplaced #endif
- 04b05c5527e9a LF-9952 clocksource: imx-tpm: Wait for CnV write to take effect
- 5a6b16bf87543 LF-9849-3: dts: arm64: imx8dxl: add PHY reset gpio and drop refclk-in
- a11213e8e518d LF-9849-2: dts: arm64: imx8qxp: add PHY reset gpio
- b675c820b30b2 LF-9849-1: dts: arm64: imx8qm: correct clock setting
- 8c65de4996afd fec_uio: support deferred probing
- 9e1862c64d629 LF-9794: spi: nxp-fspi: reset the flashx control1 registers
- 2655f9cbd0d56 net: sdk_fman: cleanup resources if HashTableSet fails
- d9c3942e39428 net: sdk_fman: cleanup SP memory on FM_Config errors
- 2603338f061e4 net: sdk_fman: initialize variables before use
- 5c056d9160814 net: sdk_fman: cleanup memory on fm_probe error paths
- 322deb5aa68be net: sdk_fman: cleanup memory on fm_port_probe error paths
- 80561a7c394cc fsl_qbman: check qman_ccsrmempeek's return value
- 006068aa6e645 net: sdk_fman: wrapper: check the return value of FM_CtrlMonGetCounters
- 824200f73ea13 net: sdk_fman: fm_manip: release the p_Manip spinlock on error
- 23539acb9f011 net: sdk_fman: fm_manip: initialize prsArrayOffset
- 8ab2c0a1d1639 net: sdk_fman: fm_cc: free resources on MatchTableSet error path
- 1087a570f8e81 net: sdk_fman: macsec: free locks on error paths
- d317b04a0443f net: sdk_fman: macsec: check the return value of FM_MAC_GetId
- 026afc966524b LF-9736: arch: arm64: dts: imx8dxl: Fix gpio conflict for LCDIF
- dde879f98b827 Revert "LF-9333: ASoC: fsl_rpmsg: Move MCLK control to runtime suspend/resume phase"
- cc2ac4ee7121c LF-8359 soc: imx: imx93-blk-ctrl: fix power up domain fail during early noriq resume
- b8af24ccc1cf9 LF-9720: arm64:dts:freescale:imx8mn: Fix typo on imx8mn-pinfunc.h for SAI3_RXD_PDM_BIT_STREAM1
- 3bbace040f7f3 LF-9786: drm: imx mhdp: Fix hdmi could not work on imx8qm mek
- 937b1be4345a5 LF-9757-2 usb: chipidea: add workaround for chipidea PEC bug
- 631b6c4ab764a LF-9757-1 usb: ehci: add workaround for chipidea PORTSC.PEC bug
- 71d4faf68fdb7 LF-9761 arm64: dts: imx91p-9x9-qsb: add can1 support
- b3640979bbcdc LF-9759 arm64: dts: imx93: assign usdhc2 and usdhc3 root clock to 400MHz
- 8f2a7a1724ae3 LF-9756 ARM64: dts: imx8ulp: change parent clock for epdc
- a069b2188d3d9 LF-9755 dma: pxp_dma_v3: fix typo causing function break
- cd21416e925ff LF-9716 arm64: dts: imx93-14x14-evk: correct the GPIO pins for usdhc3
- 0c557d54f712e LF-7961-2 gpio: mxc: release the parent IRQ in runtime suspend
- c5ffde949bdc9 LF-7961-1 arm64: dts: imx8-ss-img: correct interrupt settings
- 7c17ba3e850ca LF-9749 media: csi: Fix dump issue against NULL pointer dereference
- 1dcae54578135 LF-9748 arm64: dts: imx91p-9x9-qsb: Add ON Tat Industrial Company KD50G21-40NT-A1 panel
- a50cd6b1c88e8 MLK-26128 watchdog: imx_sc_wdt: continue if the wdog already enabled
- ff60614911b36 LF-9333: ASoC: fsl_rpmsg: Move MCLK control to runtime suspend/resume phase
- c35b24511fe91 LF-9730 video: fbdev: mxc_ipuv3_fb: Check ipu_pre_config() return value
- 14ad34c73d9d5 LF-9726: fbdev: mipi dsi northwest: fix Coverity issues
- ba1f8ec957ff3 LF-9723 mxc: ipu3: ipu_common: Check source channel id against {proc,disp}_src_sel array sizes
- d547788ceb20e LF-9707 mxc: ipu3: prg: Check return value of regmap_field_read()
- 03db70e34ede5 LF-9705 mxc: ipu3: ipu_pixel_clk: Replace kzalloc() with devm_kzalloc()
- 6835aeea3ad4f LF-9704 mxc: ipu3: ipu_common: Get channel ID properly by get_chan_id()
- efbaa7313d85d ASoC: fsl_micfil: Use SET_SYSTEM_SLEEP_PM_OPS to simplify PM
- 9882439fa12ec ASoC: fsl_micfil: Add fsl_micfil_use_verid function
- 43c0276404f84 ASoC: fsl_micfil: Add new registers and new bit definition
- 394191408de07 LF-9708: arm64: dts: imx93-9x9-qsb-aud-hat: Use RPI 3v3 and 5v regulator
- 6af20bc25a961 LF-9376-7 arm64: dts: Enable PDM for SOF using simple-audio-card
- 857f39b5a9aec LF-9376-6: ASoC: SOF: imx8m: Add PDM clocks
- 1665ca32b6c38 LF-9376-5: ASoC: SOF: Add DAI configuration for PDM interface
- fb379b0515152 LF-9376-4: ASoC: SOF: imx8m: Add DAI driver entry for MICFIL PDM
- 3414a6d1776a2 LF-9376-3 ASoC: SOF: Add DAI configuration support for AMD platforms.
- a6623f1d9e0ad LF-9376-2 ASoC: dt-bindings: simple-card: Document new DAI flags playback-only/capture-only
- 0dbd91ac52ed0 LF-9376-1 ASoC: simple-card: Introduce playback-only/capture only DAI link flags
- f7e1d39ede83f tty: serial: fsl_lpuart: Clear the error flags by writing 1 for lpuart32 platforms
- 68f582679a943 usb: misc: ehset: fix wrong if condition
- 603f3d4eb6c74 LF-9567 clk: imx: fracn-gppll: update the pll table
- 6c8df343efd66 dt-bindings: net: fsl,backplane-anlt: new binding document
- 19aa941dc1bfc net: phy: mtip_backplane: add driver for MoreThanIP backplane AN/LT core
- 5a74b229d63dd net: phy: initialize phydev->master_slave_set to MASTER_SLAVE_CFG_UNKNOWN
- f10880f9fa611 net: phy: balance calls to ->suspend() and ->resume()
- 77eec138c0652 net: phy: add C73 base page helpers
- f177d41bcd6a8 net: mdio: add definition for Parallel Detection Failure bit
- 1d6cfa53ee63b net: mdio: Add dedicated C45 API to MDIO bus drivers
- 6a06325d822ed net: mdio: add mdiodev_c45_(read|write)
- 54214d8bf54d3 phy: lynx-28g: set up equalization for 25G according to AN12950
- 9efb96bdd5e16 phy: lynx-28g: add algorithm for IEEE 802.3 C72 (10GBase-KR) link training
- 1b08357f03ae1 phy: xgkr: add configuration interface for copper backplane Ethernet PHYs
- 2fe2978e3e003 phy: lynx-28g: introduce and add support for PHY_MODE_ETHERNET_PHY
- aba5658911f69 phy: lynx-28g: refactor the CDR lock check from the work to a function
- e290225bac1a8 phy: lynx-28g: convert raw iowrite32() calls to macros
- 8a66be0db8562 phy: lynx-28g: distinguish between 10GBASE-R and USXGMII
- 44b0b351ec4e8 phy: lynx-28g: refactor lane->interface to lane->mode
- 290910d2946e2 phy: lynx-28g: replace LYNX_28G_SGMIIaCR1_SGPCS_DIS with 0
- 69f1a10b70a62 phy: lynx-28g: restructure protocol configuration register accesses
- 442fe91b6c52c phy: lynx-28g: add debugging print in CDR lock workaround
- ab7ba9f4e6473 phy: lynx-28g: introduce and implement phy_check_cdr_lock()
- 2628c361d7fd9 phy: lynx-28g: truly power the lanes up or down
- 310bd4dbe9c3c phy: lynx-28g: don't concatenate macros for lynx_28g_lane_rmw() args "val" and "mask"
- d2347ebc15ab8 phy: lynx-28g: lock PHY while performing CDR lock workaround
- a6d2791bdc558 net: dpaa2-mac: skip pcs-handle search for phy-mode = "internal"
- 885fd846aa3d4 net: phy: aquantia: Add support for AQR115
- 3185d23b4c7ef LF-9695: media: csi-sam: fix typo issue
- e3136dbaebb88 LF-9689: media: isi: add isi mem2mem pause and restart function support
- 047c228f3809c LF-9592-3 arm64: dts: imx91p-9x9-qsb: add rtc pcf2131
- 6f75e421fe62c LF-9692 arm64: dts: imx91p-11x11-evk: Add lpspi support
- d25ae64050760 LF-9693 arm64: dts: imx91p-11x11-evk: add M.2 flexspi-nor card support
- f224e2c2e21b8 net: fec: enet-qos driver
- 0d82c50aa7de0 LF-9688-2: arm64: dts: imx93-9x9-qsb-rpmsg-lpv: Add a DT to support LPV
- 2c7d22b68cadd LF-9688-1: arm64: dts: imx93-9x9-qsb-rpmsg: Add a DT to support LPA
- 8c443964e7893 LF-9654 arm64: dts: imx93: update rsc table address
- a65901c206cd0 LF-9690 arm64: dts: imx91p-11x11-evk: Add i3c support
- 9084ae9a8087d MA-20999-4 ASoC: imx-pcm512x: Fix fall-through warning for Clang
- 7399ebe337ea1 LF-8722-3: drm: imx: mhdp: Set the i2c retries for iMX8QM
- 2fd7f0caabfd0 LF-8722-2: drm: bridge: Add API function for i2c retries
- ae2b079b07e16 LF-8722-1: include: drm: bridge: Add API to set maximum i2c retries
- a6c8834a72a4b LF-9356: firmware: ele-mu: fix for init fw api.
- 089289e8385d7 LF-9687 arm64: dts: imx8ulp: add usbphy tuning parameter for better eye diagram
- 8696d49659a9b usb: chipidea: imx: add one fsl picophy parameter tuning implementation
- 66f4e444ca61e usb: chipidea: imx: improve logic if samsung,picophy-* parameter is 0
- 021f0f5a629cf LF-9173 ARM: imx_v7_defconfig: Remove KERNEL_LZO config
- 1b6e300eabedd ARM: imx_v6_v7_defconfig: Remove KERNEL_LZO config
- 0374a315362ca MA-20197-3 uapi: mxc_v4l2: use __u32 instead of uint32_t
- 41652ad757958 MA-20999 i2c: imx: flexio: Fix fall-through warning for Clang
- 9988824340027 MA-21513 [#imx-3206] Fix AXI BUS ERROR on more than 4G DDR board.
- 157516dc9a978 MGS-7293: arm64: dts: imx8mq: Update sign-off GPU frequency
- 1acb5a4bc2648 LF-9625 arm64: dts: imx93-14x14-evk: add spi-nor support
- aa8df1ad4503c LF-9675-2 arm64: dts: imx91p-9x9-qsb: support spi-nand with M.2 interface
- c6418fee61250 LF-9675-1 arm64: configs: imx_v8_defconfig build spi-nand
- 0a711d8002455 LF-9652-02 arm64: dts: freescale: Add ld mode support dts for imx91p
- 66ef628e81651 LF-9652-01 soc: imx: update the mode switching code to support imx91/p
- 7e94f63be7a1e LF-9638 media: isi: Fix the isi-m2m play hang if convert format
- 7fd0720046e4b TBS: LF-9666-5 drm/imx: dw_mipi_dsi-imx: Fixup pixel clock in dsi->pdata.mode_fixup instead of hcomponents
- 6790e035943c5 TBS: LF-9666-4 arm64: dts: imx93: Add pixel clock item to dsi node
- 1368138b53626 TBS: LF-9666-3 dt-bindings: display: imx93-mipi-dsi: Add pixel clock item
- 8220d7b66bf0a LF-9666-2 drm/bridge: synopsys: dw-mipi-dsi: Set minimum lane byte clock cycles for HSA and HBP
- f94fc81531f84 LF-9666-1 drm/bridge: synopsys: dw-mipi-dsi: Add mode fixup support
- 247b118a57e18 LF-9674 arm64: dts: imx91p-11x11-evk: Add ON Tat Industrial Company KD50G21-40NT-A1 panel
- 6c7da4816bddf TBS: LF-9611-12 arm64: imx_v8_defconfig: Build out ON Tat Industrial Company KD50G21-40NT-A1 panel driver
- 7f601ab02025b TBS: LF-9611-11 arm64: imx.config: Build out ON Tat Industrial Company KD50G21-40NT-A1 panel driver
- 587ca7f03dc2c LF-9611-10 arm64: imx_v8_defconfig: Build in generic GPIO based backlight driver
- f26b17096b9e7 LF-9611-9 arm64: imx.config: Build in generic GPIO based backlight driver
- 3ff702c677b9f LF-9611-8 arm64: dts: imx93-9x9-qsb: Use gpio-backlight for LCD panel
- 8ed2e65eb33f9 LF-9611-7 arm64: dts: imx93-9x9-qsb: Use RPI 3v3 regulator for LCD panel
- 9e7fc2237a0bb LF-9611-6 backlight: gpio_backlight: Drop output GPIO direction check for initial power state
- 618cd7633c0c8 LF-9611-5 drm/bridge: panel: Add a device link between drm device and panel device
- 8f4b8a7bfafa9 TBS: LF-9611-4 Revert "LF-6416-3 drm/panel: Add ON Tat Industrial Company KD50G21-40NT-A1 panel driver"
- a91e92ca33458 TBS: LF-9611-3 Revert "LF-6416-2 dt-bindings: display: panel: Add ON Tat Industrial Company KD50G21-40NT-A1"
- 31110df2d0d14 LF-9611-2 drm/panel: panel-simple: Add ON Tat Industrial Company KD50G21-40NT-A1 panel
- 4f9ccdb4f9d53 LF-9611-1 dt-bindings: display: panel-simple: Add On Tat Industrial Company KD50G21-40NT-A1
- 28362bf8ad7d9 LF-9645-2: arm64: dts: imx91p-11x11-evk-aud-hat: Add a new DT to support AUD-HAT board
- 5a9957830609c LF-9645-1: arm64: dts: imx91p-11x11-evk-mqs: Add a new DT to support MQS
- 6d6a05c78c8b2 LF-9631 drm: mhdp imx8qm: Fix coverity issue
- 952eee48593d9 LF-9662 arm64: dts: imx8dx-orangebox: correct the irq trigger type
- e04d1f83b1e11 LF-9449-4 net: stmmac: dwmac-imx: pause the TXC clock in fixed-link
- 0c4662abd6b41 LF-9449-3: dts: arm64: freescale: enable SJA1105 evb on imx93auto evk
- a2d8c55011a13 LF-9643-02 arm64: dts: lx2160a-rdb: Update the external rtc device
- bd0ce93ec0210 LF-9643-01 arm64: defconfig: enable pcf2131 rtc by default
- dffc8cc65dc68 LF-9653: ARM: dts: imx6ul: rename imx6ul revd to reve
- 9344df7446774 LF-9646-2 soc: imx9: i.MX91P reuses i.MX93 SoC driver
- 92bb7f69603a2 LF-9646-1: soc: imx: remove the part related to i.MX9 from soc-imx8m.c
- cffcb796b5f45 MLK-26112: media: isi: Add V4L2_PIX_FMT_NV12M to is_yuv
- 928e6e7c35c1f LF-9639: media: ov5640: enable auto control mode for PCLK divider
- 56c769fd388e8 media: amphion: drop repeated codec data for vc1g format
- c4c493148cb29 media: amphion: drop repeated codec data for vc1l format
- fbc48899b6ef2 LF-9485-3 can: flexcan: add flag FLEXCAN_QUIRK_SETUP_STOP_MODE_GPR to imx93
- 5a9dc6f287fc4 ASoC: wm8960: Add DAC filter characteristics selection
- 49d1154717184 LF-9127-4 media: isi: Fix the dependency cycle issue
- 3e5687d6748ad LF-9609: media: ov5640: fix vblank unchange issue when work at dvp mode
- d5622dc4d9b0f Revert "LF-7244-08: media: i2c: ov5640: fix 1080P and 1024x768 abnormal image issue"
- ee567c9ef885e LF-9563-2: arm64: configs: imx_v8_defconfig build st sensor
- dda6a92943066 LF-9563-1: arm64: dts: imx8qm support RevD boards.
- 82685b1c1e9ef LF-9482-3: arm64: dts: imx8qxp support WCPU boards
- 82099891b9b75 LF-9482-2: arm64: config: add sensor support for imx8qxp WCPU boards
- 2382bd5d5a975 ASoC: codec: wm8960: add additional probe check for codec identification
- a550baf5520a9 LF-9584-3 arm64: dts: ims93: add nvmem support for eqos
- 0087ee0dab29d LF-9584-2 arm64: imx_v8_defconfig: set CONFIG_IMX_EL_ENCLAVE as builtin
- b82483f0f80a7 LF-9584-1 nvmem: imx: add the function of swapping 6bytes of MAC address
- 6ae3c85a05c97 LF-9574-2 arm64: dts: imx93: correct the offset of soc-uid
- 06369e9a7986b LF-9574-1 nvmem: imx: change the unit of offset
- 86aa7ec727cc2 LF-9592: arm64: dts: imx93-9x9-qsb: add rtc pcf2131
- a775e0e8225f4 MGS-7215 [#imx-3183] 0041-CL696035-KERNEL-SPACE-6.4.11_22Q2_NXP-Merge-CL696034
- f38bf113285d3 LF-9493: media: imx: Fix coverity issue in hdmirx
- 6acbe7aaae8ba LF-9276 media: mxc: pxp_v4l2: fix flickering issue found on special stream
- c3a00b880b472 LF-9127-3: media: isi: support suspend/resume when camera is running
- 5e6e2115d8a8f LF-9127-2: media: csi: Support suspend/resume when camera is running
- fb63b4abb6e65 LF-9127-1: arm64: dtsi: imx8ulp: Support suspend/resume when camera is running
- fa4d14d941d80 LF-9607: vpu: hantro: solve local variable underrun issue
- 4555b6bc74c6a LF-9606: vpu: hantro: solve Uninitialized scalar variable issue
- 6192d9574ca91 LF-9598 net: tsn: do not read from uninitialized pointer
- 9b70e0e11b04c MGS-7215 [#imx-3183] 0034-CL694252-KERNEL-SPACE-6.4.11_22Q2_NXP-IMX-3189-fix-t
- 80c48ac19c76d MGS-7215 [#imx-3183] 0030-CL693079-KERNEL-SPACE-6.4.11_22Q2_NXP-Merge-CL693076
- 5e08fdccc0459 LF-9449-2: dts: arm64: freescale: enable SJA1105 evb on imx8qxp
- 23b6c13677c4f LF-9449-1: arm64: imx_v8_defconfig: enable CONFIG_NET_DSA_SJA1105
- a281f76f84989 LF-9585: vpu: hantro_v4l2: solve coverity issue
- 0a2944739979a LF-9586 nvmem: imx: correct nregs
- 94636436a64c3 LF-9573: arm: imx: keep bit 10 (1T/2T mode) during frequency change
- bf989e212e849 LF-8904 usb: cdns3: imx: Rework system PM to avoid duplicated operations
- c3ff5969b8bd7 net: mdio: probe non-PHY MDIO devices in ACPI
- 9a06b8f28f83f LF-9509: dma: pxp_dma_v3: fix dereference after null check issue
- 9b774c1f34c64 LF-9476-3 nvmem: imx: update i.MX93 fuse read driver
- cbb8af315b291 LF-9476-2 nvmem: imx: update read_common_fuse with special ID
- 52da8d9436135 LF-9476-1 ele_base_msg: handle common fuse with special id
- 068e3680e592b LF-9535 soc: imx: split i.MX93 SoC device support from soc-imx8m.c
- 306b16e59925c LF-9506-4 tty: serial: fsl_lpuart: add IDLE interrupt support for rx_dma on imx7ulp/imx8ulp/imx8qxp
- 02e87c515c563 LF-9506-3 tty: serial: fsl_lpuart: move the lpuart32_int() below
- 533ec3db98004 LF-9506-2 tty: serial: fsl_lpuart: fix race on RX DMA shutdown
- 04f5ad071e50d LF-9506-1 tty: serial: fsl_lpuart: clean up EOP related code in lpuart driver
- 279cb390350eb LF-9533 clk: imx: clk-composite-7ulp: Check the PCC present bit
- f9ffaa006a452 LF-8969: vpu : hantro_encoder: optimize 32 bit interface
- d53c912980e30 LF-9490 arm64: dts: imx93: enable eDMA for lpspi devices
- 5f07fd6dbe244 net: dsa: sja1105: always enable the send_meta options
- 15eb108291852 net: dsa: tag_sja1105: fix MAC DA patching from meta frames
- 280f6fc24703c net: dsa: tag_sja1105: fix source port decoding in vlan_filtering=0 bridge mode
- 9375dbe939e91 net: bridge: keep ports without IFF_UNICAST_FLT in BR_PROMISC mode
- aa4b4e2c83bf4 net: dsa: tag_sja1105: always prefer source port information from INCL_SRCPT
- ed721d3b56efc net: dsa: sja1105: always enable the INCL_SRCPT option
- baf83eb410829 net: dsa: felix: don't drop PTP frames with tag_8021q when RX timestamping is disabled
- 17d180a332386 net: mscc: ocelot: don't keep PTP configuration of all ports in single structure
- c974a90834f89 net: mscc: ocelot: don't report that RX timestamping is enabled by default
- b19c5b5927bb6 LF-9427 arm64: dts: imx8dx-orangebox: update pcie and bluetooth settings
- 93353b675f71d LF-9311: arm64: dts: imx8dxl-evk: enable Bluetooth SCO audio
- ea901ee136892 MLK-26127-2 arm64: dts: imx91p-9x9-qsb: add lpspi slave support
- 36b4f7c5cd244 MLK-26127-1 arm64: dts: imx91p-9x9-qsb: add lpspi master support
- bc1825b74e98c MLK-26126 arm64: dts: imx91p-9x9-qsb: add i3c support
- 0d693a8d57f47 MLK-26124 arm64: dts: imx91p-9x9-qsb: add M.2 spi-nor card support
- ceea7c09610de MLK-26121 arm64: dts: freescale: Change A55 C1 status to fail on imx91p
- f05ba90f8abf9 MLK-26118-02: media: isi: add iMX91P support
- 1d5e18aec360a MLK-26118-01: arm64: dts: add camera device nodes for iMX91P
- d5303f5aeb71b MLK-26119: arm64: dts: imx91p-9x9-qsb-aud-hat: Add a new DT to support AUD-HAT board
- d222ffdf33a84 MLK-26116-02 arm64: dts: freescale: Add imx91p 11x11 evk board
- b43c3498e200b MLK-26116-01 arm64: dts: freescale: Change A55_1 node status to disabled on imx91p
- 8993e9bf2cebc MLK-26113-02 arm64: dts: freescale: Add i.mx91p 9x9 qsb board
- c9f48449a6b53 MLK-26113-01 soc: imx: Add imx91 phantom soc id support
- e3d23f0847d97 [HRPN-917] rpmsg: imx_rpmsg: Change the notifying to timeout mode
- bc953b433c677 net: dsa: felix: add back unstructured ethtool counters for FP and MM
- a7db9376940d7 net: mscc: ocelot: fix oversize frame dropping for preemptible TCs
- d22d613dea6a2 net: mscc: ocelot: extend ocelot->fwd_domain_lock to cover ocelot->tas_lock
- 09c1f66ddf780 LF-9199 usb: host: xhci: fix coverity checker CONSTANT_EXPRESSION_RESULT
- d4673b4f6e7ff LF-8969: vpu : hantro_vc8000e: optimize 32 bit interface
- bd76f067e0c8f LF-8969: vpu : hantro_h1: optimize 32 bit interface
- 626563c7d57e6 LF-9437 clk: imx: imx8dxl: drop duplicated entry
- 9aa94575091cb LF-9486 soc: imx8mp: support 128 bits UID
- 8416e93ab5393 MGS-7214: gpu: imx: import DMA_BUF module namespace
- 0cc124d18e90b LF-8093 soc: imx: imx8mp-blk-ctrl: add missing HSIO noc setting
- b88f6680f22f1 LF-9485-2 can: flexcan: remove the auto stop mode for IMX93
- 52dd192397827 LF-9485-1 arm64: dts: imx93: add gpr support for the imx93 A1 chip
- 84c0a2189d98a LF-9491: media: imx: imx8-isi-core: add ISI support for i.MX93 A1
- 78e5de09a5015 LF-8290 arm64: dts: imx93: add fsl,stop-mode for FEC to support WOL
- 5559a980a83be LF-9380-2: arm64: dts: imx8mp: add fdcc clock for hdmi blk driver
- 542a6373078be LF-9380-1: soc: imx8mp_blk: Add fdcc clock to hdmimix domain
- 2778dbb68fc3d LF-8969: vpu : hantro_845: optimize 32 bit interface
- 8af5982325c54 LF-9435: dma: pxp_dma_v3: fix dereference after null check
- 07bbc86684b88 LF-9490 arm64: dts: imx93: enable dma for lpuart devices
- f37debd855ad9 LF-9256: arm64: dts: imx93-11x11-evk-rpmsg: Disable unavailable devices
- 47e2dd23f1dea Bluetooth: btnxpuart: Fix compiler warnings
- f3d5080931c78 Bluetooth: btnxpuart: Enable flow control before checking boot signature
- 827ccee9136d6 Bluetooth: btnxpuart: Fix sparse warnings
- f7f50d6530eb3 Bluetooth: btnxpuart: Add support to download helper FW file for w8997
- dcac82c837e43 LF-9113 tty: serial: fsl_lpuart: Check the return value of dmaengine_tx_status
- 732adf0c1f876 LF9067: vpu: hantro: optimze 845 decoder suspend
- ac7bbfbad2fdc MGS-7088: dma: pxp: add generic dma-buf cache coherency management
- 5baa7bd53cc2a MGS-7088: uapi: pxp: add generic dma-buf cache coherency management
- 5b8ce4a903776 MGS-7214: gpu: imx: dpu-blit: add generic dma-buf cache coherency management
- 93cd0471a9f9d MMFMWK-9253: vpu: hantro: add mepg1 support
- b42f274cf1bd2 LF-9443 thermal: qoriq: Disable tmu central module
- 06421695dbb74 MGS-7215 mxc/gpu-viv: Integrate 6.4.11.p2 kernel driver
- 4b7e8f6c51e32 LF-7982: firmware: imx: fix dereferencing null pointer priv
- 018531830f1fb LF-7374: firmware: imx: fix coverity issue in seco-mu
- a3dbe29abe48e LF-9432 arm64: dts: imx8ulp: correct cm33 compatible