### PR TITLE
jailhouse-imx: upgrade to 6.1.36-2.1.0

### DIFF
--- a/recipes-extended/jailhouse/jailhouse-imx_git.bb
+++ b/recipes-extended/jailhouse/jailhouse-imx_git.bb
@@ -19,7 +19,8 @@ RPROVIDES:${PN} += "jailhouse"
 SRCBRANCH = "lf-6.1.22_2.0.0"
 SRCREV = "e090abc70bb395f705f85659ad92bdafbe407628"
 
-SRC_URI = "git://github.com/nxp-imx/imx-jailhouse.git;protocol=https;branch=${SRCBRANCH}"
+IMX_JAILHOUSE_SRC ?= "git://github.com/nxp-imx/imx-jailhouse.git;protocol=https"
+SRC_URI = "${IMX_JAILHOUSE_SRC};branch=${SRCBRANCH}"
 
 DEPENDS = " \
     make-native \

--- a/recipes-extended/jailhouse/jailhouse-imx_git.bb
+++ b/recipes-extended/jailhouse/jailhouse-imx_git.bb
@@ -93,6 +93,7 @@ FILES:${PN}:remove = "${libdir}/*"
 FILES:pyjailhouse = "${PYTHON_SITEPACKAGES_DIR}"
 
 RDEPENDS:${PN} += " \
+    pyjailhouse \
     python3-curses \
     python3-datetime \
     python3-mmap \

--- a/recipes-extended/jailhouse/jailhouse-imx_git.bb
+++ b/recipes-extended/jailhouse/jailhouse-imx_git.bb
@@ -16,8 +16,8 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=9fa7f895f96bde2d47fd5b7d95b6ba4d \
 PROVIDES = "jailhouse"
 RPROVIDES:${PN} += "jailhouse"
 
-SRCBRANCH = "lf-6.1.22_2.0.0"
-SRCREV = "e090abc70bb395f705f85659ad92bdafbe407628"
+SRCBRANCH = "lf-6.1.36_2.1.0"
+SRCREV = "d3484c68313c2c837eb213ca1aa373e491fbc55f"
 
 IMX_JAILHOUSE_SRC ?= "git://github.com/nxp-imx/imx-jailhouse.git;protocol=https"
 SRC_URI = "${IMX_JAILHOUSE_SRC};branch=${SRCBRANCH}"

--- a/recipes-extended/jailhouse/jailhouse-imx_git.bb
+++ b/recipes-extended/jailhouse/jailhouse-imx_git.bb
@@ -91,6 +91,7 @@ PACKAGE_BEFORE_PN = "pyjailhouse"
 FILES:${PN} += "${nonarch_base_libdir}/firmware ${libexecdir} ${sbindir} ${JH_DATADIR}"
 # Remove libdir/* appended by setuptools3-base.bbclass for module split to work correctly
 FILES:${PN}:remove = "${libdir}/*"
+FILES:${PN}-dev += "${RECIPE_SYSROOT_NATIVE}${PYTHON_SITEPACKAGES_DIR}/*"
 FILES:pyjailhouse = "${PYTHON_SITEPACKAGES_DIR}"
 
 RDEPENDS:${PN} += " \


### PR DESCRIPTION
This closes the task in https://github.com/Freescale/meta-freescale/issues/1655

Tested building for imx8mm-lpddr4-evk, imx8mq-lpddr4-wevk, imx8ulp-lpddr4-evk.