### PR TITLE
linux-imx-headers: update to lf-6.1.36-2.1.0

### DIFF
--- a/recipes-kernel/linux/linux-imx-headers_6.1.bb
+++ b/recipes-kernel/linux/linux-imx-headers_6.1.bb
@@ -9,8 +9,8 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
 SRC_URI = "git://github.com/nxp-imx/linux-imx.git;protocol=https;branch=${SRCBRANCH}"
 SRCBRANCH = "lf-6.1.y"
-LOCALVERSION = "-6.1.22-2.0.0"
-SRCREV = "66e442bc7fdcc935e6faa94c743f653263d4ed67"
+LOCALVERSION = "-6.1.36-2.1.0"
+SRCREV = "04b05c5527e9af8d81254638c307df07dc9a5dd3"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Update the headers from the linux-imx kernel to be aligned with the NXP BSP LF6.1.36-2.1.0.