### PR TITLE
imx93: rearrange repeated overrides

### DIFF
--- a/conf/machine/imx93-11x11-lpddr4x-evk.conf
+++ b/conf/machine/imx93-11x11-lpddr4x-evk.conf
@@ -4,8 +4,6 @@
 #@DESCRIPTION: Machine configuration for NXP i.MX 93 11x11 EVK with LPDDR4X
 #@MAINTAINER: Jun Zhu <junzhu@nxp.com>
 
-MACHINEOVERRIDES =. "mx93:"
-
 require include/imx93-evk.inc
 
 KERNEL_DEVICETREE_BASENAME = "imx93-11x11-evk"

--- a/conf/machine/imx93-14x14-lpddr4x-evk.conf
+++ b/conf/machine/imx93-14x14-lpddr4x-evk.conf
@@ -4,8 +4,6 @@
 #@DESCRIPTION: Machine configuration for NXP i.MX 93 14x14 EVK with LPDDR4X
 #@MAINTAINER: Jun Zhu <junzhu@nxp.com>
 
-MACHINEOVERRIDES =. "mx93:"
-
 require conf/machine/include/imx93-evk.inc
 
 KERNEL_DEVICETREE_BASENAME = "imx93-14x14-evk"

--- a/conf/machine/imx93-9x9-lpddr4-qsb.conf
+++ b/conf/machine/imx93-9x9-lpddr4-qsb.conf
@@ -4,8 +4,6 @@
 #@DESCRIPTION: Machine configuration for NXP i.MX93 9x9 QSB with LPDDR4
 #@MAINTAINER: Jun Zhu <junzhu@nxp.com>
 
-MACHINEOVERRIDES =. "mx93:"
-
 require include/imx93-evk.inc
 
 KERNEL_DEVICETREE_BASENAME = "imx93-9x9-qsb"

--- a/conf/machine/include/imx93-evk.inc
+++ b/conf/machine/include/imx93-evk.inc
@@ -1,6 +1,7 @@
 require conf/machine/include/imx-base.inc
 require conf/machine/include/arm/armv8-2a/tune-cortexa55.inc
 
+MACHINEOVERRIDES =. "mx93:"
 MACHINE_FEATURES += "pci wifi bluetooth"
 MACHINE_FEATURES:append:use-nxp-bsp = " optee jailhouse nxpiw612-sdio"
 


### PR DESCRIPTION
The three machines require imx93-evk.inc, and the mx93 override is common to all of them, so it can be moved to imx93-evk.inc to avoid repetition.