### PR TITLE
u-boot-imx: Update to lf-6.1.55-2.2.0

### DIFF
--- a/recipes-bsp/u-boot/u-boot-imx-common_2023.04.inc
+++ b/recipes-bsp/u-boot/u-boot-imx-common_2023.04.inc
@@ -5,8 +5,8 @@ LIC_FILES_CHKSUM = "file://Licenses/gpl-2.0.txt;md5=b234ee4d69f5fce4486a80fdaf4a
 
 SRC_URI = "git://github.com/nxp-imx/uboot-imx.git;protocol=https;branch=${SRCBRANCH}"
 SRCBRANCH = "lf_v2023.04"
-LOCALVERSION ?= "-imx_v2023.04_6.1.36-2.1.0"
-SRCREV = "1e5b6c6bf246a38654d07e7e23f333ad0e7d42d0"
+LOCALVERSION ?= "-imx_v2023.04_6.1.55-2.2.0"
+SRCREV = "49b102d98881fc28af6e0a8af5ea2186c1d90a5f"
 
 DEPENDS += " \
     bc-native \


### PR DESCRIPTION
Tested building for imx93-14x14-lpddr4x-evk, imx8ulp-lpddr4-evk: OK

This partially closes the task "U-Boot (i.MX variants)" of https://github.com/Freescale/meta-freescale/issues/1715

Update the u-boot-imx to the tag lf-6.1.55-2.2.0, that is used in the NXP BSP LF6.1.55_2.2.0.

Relevant changes:
- 49b102d9888 LFU-611 arm: dts: imx93: update anatop node
- 0fdbf5df153 efi_loader: support all uclasses in device path
- b64f06fee79 efi_loader: Fix warnings for unaligned accesses
- d23550de2fe efi_loader: Fix flexible array member definitions
- d17db0235cc LF-10422-2 dts: imx93: Fix date reset fail
- f78da92266a LF-10422-1 rtc: Fix date reset fail
- ee041d63eae LFU-600 imx8mp_evk: Change back kernel DTB to old EVK board
- 26768c4e470 MA-21741-1 Correct some uboot attributes which about hardware
- 173766cc50c MA-21741-2 Add uboot attribute: "product" and "variant"
- 706344af2ea LFU-589-2: board: freescale: imx8ulp evk9: lpddr4 auto low power
- 13db67ead47 LFU-595-4 imx: cmd_fspinand: Change FCB according to chip size
- 76f9544730f LFU-595-3 arm: dts: imx93: Update flexspi pinctrl
- 63b45080588 LFU-595-2 mtd: nand: spi: Add GD5F2GM7 SPI NAND flash
- 1edf99a0e9a LFU-595-1 mtd: nand: spi: Add W25N02KW SPI NAND flash
- 3d5860591a7 MA-21705 trusty: sync storage commands
- d04a12231e0 Pull request #99: Lf v2023.04 588
- 0e637917405 LFU-593-3 Revert "LF-7673-1 imx93: enable auto cmd12 for usdhc"
- db9d3c9f949 LFU-593-2 dts: imx93: adjust USDHC pad's driver strength
- 0d33167e0cc LFU-593-1 dts: imx93: set SION for cmd and data pad of USDHC
- c634376bcc1 LFU-594-2 imx93_evk: drop some nodes for system ready
- 43d0b9ee78b LFU-594-1 arm: dts: imx93: drop dmas property and update flexspi compatible
- 77199228ac5 LFU-588-2: arm: mach imx8ulp: upower api optional osc mode
- 9e0360f7dc3 LFU-588-1: arm: mach imx8ulp: upower api update osc freq
- 9b1c278e0e8 LFU-592 imx93_11x11_evk: Enable LEGACY_IMAGE_FORMAT support
- b4115d9b9c1 LFU-591-2 arm: dts: imx93: update enet/eqos nodes
- f47863be180 LFU-591-1 clk: imx93: fix enet1 parent
- 97daa1fed0b Pull request #101: LFU-589: board: freescale: imx8ulp evk9: lpddr4 auto low power
- b9c466fec2d LFU-567-4: board: freescale: imx8ulp evk: spl pmic settigs
- 4db16c1e021 LFU-567-3: board: freescale: imx8ulp evk: spl: gpio operation range
- b900f1f6736 LFU-567-2: arm: mach imx8ulp: soc: apd gpio port cell compensation
- 0db5e1c8d8c LFU-567-1: arm: mach imx8ulp: soc: apd gpio port operation range
- 66eb772ff29 LF-10303-3 imx9: imx93_evk: support distro boot for SR-IR 2.0
- 58faac1cd58 LF-10303-2 configs: imx93_11x11_evk: update defconfig with savedefconfig
- 04a9824683f LF-10303-1 watchdog: ulp_wdog: guard reset_cpu with condition check
- 837334cb419 LFU-590 imx: ELE: Fix ELE FW version bug
- e7233703b7f MA-21160 Add fastboot command to provision and get dek blob
- 82d2426d5e9 LFU-586-2 imx93: Add Low performance parts 9302/9301 support
- 1433b5c7c70 LFU-586-1 imx9: Add 233Mhz DDR PLL frequency
- 430d25663d3 LFU-589: board: freescale: imx8ulp evk9: lpddr4 auto low power
- 45f29b12aab LFU-585 imx9: mask the wdog reset in src by default on i.mx9
- f5024c786ba LFU-587: [optee] build failure with secure boot enabled
- 370600c348d Pull request #97: Lf v2023.04
- 284688b529c LFU-434: useless initialization of a variable eliminated
- 2db728cbd11 LFU-434: unused variable issue eliminated by checking for errors
- c76edb3c878 LF-10025: Added ls1021atwr secure boot QSPI support
- 6b8b0f345bc MA-21650 android: add imx8mq wevk dedicated defconfig