### PR TITLE
imx-mkimage: Update for NXP release 6.1.55-2.2.0

### DIFF
--- a/recipes-bsp/imx-mkimage/imx-mkimage_git.inc
+++ b/recipes-bsp/imx-mkimage/imx-mkimage_git.inc
@@ -5,8 +5,8 @@ DEPENDS = "zlib-native openssl-native"
 SRC_URI = "git://github.com/nxp-imx/imx-mkimage.git;protocol=https;branch=${SRCBRANCH} \
            file://0001-iMX8M-soc.mak-use-native-mkimage-from-sysroot.patch \
 "
-SRCBRANCH = "lf-6.1.36_2.1.0"
-SRCREV = "5a0faefc223e51e088433663b6e7d6fbce89bf59"
+SRCBRANCH = "lf-6.1.55_2.2.0"
+SRCREV = "c4365450fb115d87f245df2864fee1604d97c06a"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
This closes "imx-mkimage" of https://github.com/Freescale/meta-freescale/issues/1715

Relevant changes:
- c436545 LF-10397 imx8: Fix SCU container file offset issue
- 5c97f59 imx9: Fix flash_singleboot_spinand broken
- c684071 iMX9: Add signature DTS file
- e019f61 imx9: Add System ready relevant targets
- 5c58565 Support MSEL option for MX95 SM.
- d683e41 Add FW header support
- 703bc3c Update LPDDR5 FW to v202306
- cc6c3a4 imx95: Clean up targets in soc.mak and update Readme.imx95
- 3686be1 Add SM target with OEI+SM+M7(TCM)+AP.
- e8d6d79 Update SM targets.  Add SM target with M7 image in DDR.
- 2ae36d5 Add SM+M7 target for i.MX9.
- 3b13c36 Replace the OEI image with the prebuilt one
- b41f521 Add SM only target for i.MX9.
- 0eaf132 Introduce LPDDR_FW_PREFIX parameter
- 3b69364 add Readme for i.MX95
- f308051 add temp m33 oei.bin from ROM team
- 94e72ee update for entry and lpboot
- 4fb55b7 imx95: Add targets to include M7 image
- 68e4acb Add support for both OEI entry and destination addresses
- fae7490 Add the target that embed OEI and Synopsys PHY FW
- 17b2a94 Update to support meta data for i.MX9
- b437ce9 add a new target for zebu
- 241701b support M7
- 72439ea support i.MX95 OEI
- 4648479 imx9: enable a55 image when lpboot for i.MX95
- 092a1a9 imx9: make AHAB_IMG could be passed from command line
- 6ef5326 iMX9: use -m33 & a55
- e9bf5c4 mkimage_imx8: add m33 option
- ae6a77f Fix autobuild failure
- 621803d Update Yocto build name to Common [YOCIMX-7230]
- 3fefc2a Add example usage for autobuild
- e439c8e Fix README and SCR permission
- e1acbb6 Extract common logic from autobuild.mak
- e8ed7ad Use common boottools location [YOCIMX-7189]