### PR TITLE
imx93-evk.inc: Change MACHINEOVERRIDES order

### DIFF
--- a/conf/machine/include/imx93-evk.inc
+++ b/conf/machine/include/imx93-evk.inc
@@ -1,7 +1,8 @@
+MACHINEOVERRIDES =. "mx93:"
+
 require conf/machine/include/imx-base.inc
 require conf/machine/include/arm/armv8-2a/tune-cortexa55.inc
 
-MACHINEOVERRIDES =. "mx93:"
 MACHINE_FEATURES += "pci wifi bluetooth"
 MACHINE_FEATURES:append:use-nxp-bsp = " optee jailhouse nxpiw612-sdio"
 


### PR DESCRIPTION
After [1] the MACHINEOVERRIDES for imx93 based machines became:

 MACHINEOVERRIDES="imx-generic-bsp:imx-nxp-bsp:imxdrm:imxpxp:mx9-generic-bsp:
                   mx9-nxp-bsp:mx93-generic-bsp:mx93-nxp-bsp:aarch64:armv8-2a:
                   use-nxp-bsp:imx93-11x11-lpddr4x-evk"

which is different from what we had before. It impacts how some recipes are choosen, for example u-boot.

After this patch, the MACHINEOVERRIDES goes back to what we had before. Just like the following:

 MACHINEOVERRIDES="aarch64:armv8-2a:use-nxp-bsp:imx-generic-bsp:imx-nxp-bsp:
                   imxdrm:imxpxp:mx9-generic-bsp:mx9-nxp-bsp:mx93-generic-bsp:
                   mx93-nxp-bsp:imx93-11x11-lpddr4x-evk"

[1] https://github.com/Freescale/meta-freescale/pull/1714