### PR TITLE
cairo: Drop the removed packageconfigs

### DIFF
--- a/recipes-graphics/cairo/cairo_%.bbappend
+++ b/recipes-graphics/cairo/cairo_%.bbappend
@@ -1,6 +1,3 @@
-PACKAGECONFIG:append:imxgpu3d = " egl glesv2"
-PACKAGECONFIG:remove:imxgpu3d = "opengl"
-
 # links with imx-gpu libs which are pre-built for glibc
 # gcompat will address it during runtime
 LDFLAGS:append:imxgpu:libc-musl = " -Wl,--allow-shlib-undefined"


### PR DESCRIPTION
These packageconfigs are gone with migration to meson in 1.18+

Fixes
ERROR: cairo-1.18.0-r0 do_configure: QA Issue: cairo: invalid PACKAGECONFIG: egl [invalid-packageconfig] ERROR: cairo-1.18.0-r0 do_configure: QA Issue: cairo: invalid PACKAGECONFIG: glesv2 [invalid-packageconfig]