### PR TITLE
meta-freescale: update waffle patch to compatible with version 1.7.2

### DIFF
--- a/recipes-graphics/waffle/waffle/0001-meson-Add-missing-wayland-dependency-on-EGL.patch
+++ b/recipes-graphics/waffle/waffle/0001-meson-Add-missing-wayland-dependency-on-EGL.patch
@@ -35,7 +35,7 @@ Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>
    )
    dep_wayland_scanner = dependency(
 @@ -120,7 +122,7 @@ else
-     wayland_xdg_shell_xml = join_paths(dep_wayland_proto.get_pkgconfig_variable('pkgdatadir'),
+     wayland_xdg_shell_xml = join_paths(dep_wayland_proto.get_variable(pkgconfig: 'pkgdatadir'),
      'stable/xdg-shell/xdg-shell.xml')
    endif
 -  build_wayland = dep_egl.found() and dep_wayland_client.found() and dep_wayland_egl.found() and dep_wayland_scanner.found() and dep_wayland_proto.found()


### PR DESCRIPTION
In yocto release kirkstone, waffle package is upgraded from 1.7.0 to 1.7.2, and there is below error reported when applying patch: Applying patch 0001-meson-Add-missing-wayland-dependency-on-EGL.patch patching file meson.build
Hunk #1 succeeded at 65 (offset 2 lines).
Hunk #2 succeeded at 107 (offset 2 lines).
Hunk #3 succeeded at 126 with fuzz 1 (offset 4 lines). So, adjust the patch context to compatible with version 1.7.2