### PR TITLE
mcode-demos: Update to LF6.1.55_2.2.0

### DIFF
--- a/recipes-fsl/mcore-demos/README
+++ b/recipes-fsl/mcore-demos/README
@@ -1,11 +1,13 @@
 The M4 demo app version of each SoCs are followed:
-* 2.13.0 -- i.MX 7ULP, 8MQ, 8MM
+* 2.14.0 -- i.MX 7ULP, 8MQ
+* 2.14.1 -- i.MX 8MM
 * 2.9.0 -- i.MX 8DXL, 8QM, 8QXP
 * 1.0.1 -- i.MX 7D
 
 The M7 demo app version of each SoCs are followed:
-* 2.13.0 -- i.MX 8MNULite, 8MN
-* 2.13.1 -- i.MX 8MP
+* 2.14.0 -- i.MX 8MNULite, 8MN
+* 2.14.1 -- i.MX 8MP
 
 The M33 demo app version of each SoCs are followed:
-* 2.14.0 -- i.MX 8ULP,i.MX 93
+* 2.14.1 -- i.MX 8ULP
+* 2.14.2 -- i.MX 93

--- a/recipes-fsl/mcore-demos/imx-m33-demos_2.14.2.bb
+++ b/recipes-fsl/mcore-demos/imx-m33-demos_2.14.2.bb
@@ -1,0 +1,12 @@
+# Copyright 2023 NXP
+# Released under the MIT license (see COPYING.MIT for the terms)
+
+require imx-mcore-demos.inc
+
+LIC_FILES_CHKSUM:mx93-nxp-bsp = "file://COPYING;md5=2827219e81f28aba7c6a569f7c437fa7"
+
+
+SRC_URI[imx93.md5sum] = "3f420c28fdc159ecd5148a931a5ff02c"
+SRC_URI[imx93.sha256sum] = "31f6e8b08edb677614e65b11bbcc796218691fe746b84ec2503b8a5060d69ef2"
+
+COMPATIBLE_MACHINE = "(mx93-nxp-bsp)"


### PR DESCRIPTION
This updates only adds a new version of imx-m33-demos only for imx93. 

This also updates the info on README to the current status.