### PR TITLE
u-boot-qoriq: add 'python3-setuptools-native' to depends

### DIFF
--- a/recipes-bsp/u-boot/u-boot-qoriq_2021.04.bb
+++ b/recipes-bsp/u-boot/u-boot-qoriq_2021.04.bb
@@ -23,7 +23,7 @@ PV:append = "+fslgit"
 LOCALVERSION = "+fsl"
 
 INHIBIT_DEFAULT_DEPS = "1"
-DEPENDS = "libgcc virtual/${TARGET_PREFIX}gcc bison-native bc-native swig-native python3-native"
+DEPENDS = "libgcc virtual/${TARGET_PREFIX}gcc bison-native bc-native swig-native python3-native python3-setuptools-native"
 DEPENDS:append:qoriq-arm64 = " dtc-native"
 DEPENDS:append:qoriq-arm = " dtc-native"
 DEPENDS:append:qoriq-ppc = " boot-format-native"


### PR DESCRIPTION
Building this recipe on an Unbuntu 20.04 host results in the following erro:

    Traceback (most recent call last):
      File "u-boot-qoriq/2021.04+fslgit-r0/git/tools/binman/binman", line 39, in <module>
        from binman import control
      File "u-boot-qoriq/2021.04+fslgit-r0/git/tools/binman/../binman/control.py", line 11, in <module>
        import pkg_resources
    ModuleNotFoundError: No module named 'pkg_resources'

With the added dependency the build completes.