### PR TITLE
imx-gpu-viv: Fix EGL dependencies

### DIFF
--- a/recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc
+++ b/recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc
@@ -335,10 +335,10 @@ ALLOW_EMPTY:${PN} = "1"
 
 FILES:libclc-imx = "${libdir}/libCLC${SOLIBS}"
 
+FILES:libegl-imx = "${libdir}/libEGL${REALSOLIBS} ${libdir}/libEGL${SOLIBS} "
+FILES:libegl-imx-dev = "${includedir}/EGL ${includedir}/KHR ${libdir}/pkgconfig/egl.pc"
 # libEGL.so is used by some demo apps from Freescale
 INSANE_SKIP:libegl-imx += "dev-so"
-FILES:libegl-imx = "${libdir}/libEGL${REALSOLIBS} ${libdir}/libEGL${SOLIBSDEV} "
-FILES:libegl-imx-dev = "${includedir}/EGL ${includedir}/KHR ${libdir}/pkgconfig/egl.pc"
 
 FILES:libgal-imx = "${libdir}/libGAL${SOLIBS} ${libdir}/libGAL_egl${SOLIBS}"
 FILES:libgal-imx-dev = "${includedir}/HAL"
@@ -349,7 +349,7 @@ INSANE_SKIP:libgal-imx += "build-deps"
 
 FILES:libvsc-imx = "${libdir}/libVSC${SOLIBS}"
 
-FILES:libgbm-imx           = "${libdir}/libgbm*${REALSOLIBS} ${libdir}/libgbm${SOLIBSDEV} ${libdir}/libgbm_viv${SOLIBSDEV}"
+FILES:libgbm-imx           = "${libdir}/libgbm*${REALSOLIBS} ${libdir}/libgbm${SOLIBS} ${libdir}/libgbm_viv${SOLIBS}"
 FILES:libgbm-imx-dev       = "${libdir}/pkgconfig/gbm.pc ${includedir}/gbm.h"
 RDEPENDS:libgbm-imx:append = " libdrm"
 INSANE_SKIP:libgbm-imx += "dev-so"
@@ -377,25 +377,25 @@ OPENCL_VX_INTRINSIC_EXTENSION_PACKAGES:mx8qm-nxp-bsp = "libclc-imx libopencl-imx
 OPENCL_VX_INTRINSIC_EXTENSION_PACKAGES:mx8mp-nxp-bsp = "libclc-imx libopencl-imx-dev"
 INSANE_SKIP:libopenvx-imx += "dev-deps"
 
+FILES:libgl-imx = "${libdir}/libGL${REALSOLIBS}"
+FILES:libgl-imx-dev = "${libdir}/libGL${SOLIBSDEV} ${includedir}/GL ${libdir}/pkgconfig/gl.pc"
 # libGL is only targeting X11 backend, and in case if Wayland-only is used -
 # package QA complains on missing RDEPENDS, which are only available for X11.
 # Skip "file-rdeps" QA for this package.
-FILES:libgl-imx = "${libdir}/libGL${REALSOLIBS}"
-FILES:libgl-imx-dev = "${libdir}/libGL${SOLIBSDEV} ${includedir}/GL ${libdir}/pkgconfig/gl.pc"
 INSANE_SKIP:libgl-imx += "file-rdeps"
 
-# libEGL needs to open libGLESv1.so
-INSANE_SKIP:libgles1-imx += "dev-so"
 FILES:libgles1-imx = "${libdir}/libGLESv1*${REALSOLIBS} ${libdir}/libGLESv1*${SOLIBS} ${libdir}/libGLES_*${REALSOLIBS} ${libdir}/libGLES_*${SOLIBS}"
-FILES:libgles1-imx-dev = "${includedir}/GLES ${libdir}/libGLESv1*${SOLIBS} ${libdir}/pkgconfig/glesv1_cm.pc"
+FILES:libgles1-imx-dev = "${includedir}/GLES ${libdir}/pkgconfig/glesv1_cm.pc"
 RPROVIDES:libgles1-imx = "libgles-imx"
 RPROVIDES:libgles1-imx-dev = "libgles-imx-dev"
+# libEGL does dlopen of libGLESv1.so
+INSANE_SKIP:libgles1-imx += "dev-so"
 
-# libEGL needs to open libGLESv2.so
-INSANE_SKIP:libgles2-imx += "dev-so"
 FILES:libgles2-imx = "${libdir}/libGLESv2${REALSOLIBS} ${libdir}/libGLESv2${SOLIBS}"
 FILES:libgles2-imx-dev = "${includedir}/GLES2 ${libdir}/pkgconfig/glesv2.pc"
 RDEPENDS:libgles2-imx = "libglslc-imx"
+# libEGL does dlopen of libGLESv2.so
+INSANE_SKIP:libgles2-imx += "dev-so"
 
 FILES:libgles3-imx-dev = "${includedir}/GLES3"
 # as long as there is no libgles3: ship libgles3-dev along with

--- a/recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc
+++ b/recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc
@@ -377,12 +377,14 @@ OPENCL_VX_INTRINSIC_EXTENSION_PACKAGES:mx8qm-nxp-bsp = "libclc-imx libopencl-imx
 OPENCL_VX_INTRINSIC_EXTENSION_PACKAGES:mx8mp-nxp-bsp = "libclc-imx libopencl-imx-dev"
 INSANE_SKIP:libopenvx-imx += "dev-deps"
 
-FILES:libgl-imx = "${libdir}/libGL${REALSOLIBS}"
-FILES:libgl-imx-dev = "${libdir}/libGL${SOLIBSDEV} ${includedir}/GL ${libdir}/pkgconfig/gl.pc"
+FILES:libgl-imx = "${libdir}/libGL${REALSOLIBS} ${libdir}/libGL${SOLIBS}"
+FILES:libgl-imx-dev = "${includedir}/GL ${libdir}/pkgconfig/gl.pc"
 # libGL is only targeting X11 backend, and in case if Wayland-only is used -
 # package QA complains on missing RDEPENDS, which are only available for X11.
 # Skip "file-rdeps" QA for this package.
 INSANE_SKIP:libgl-imx += "file-rdeps"
+# libEGL does dlopen of libGL.so
+INSANE_SKIP:libgl-imx += "dev-so"
 
 FILES:libgles1-imx = "${libdir}/libGLESv1*${REALSOLIBS} ${libdir}/libGLESv1*${SOLIBS} ${libdir}/libGLES_*${REALSOLIBS} ${libdir}/libGLES_*${SOLIBS}"
 FILES:libgles1-imx-dev = "${includedir}/GLES ${libdir}/pkgconfig/glesv1_cm.pc"
@@ -411,8 +413,10 @@ FILES:libopencl-imx = "${libdir}/libOpenCL${REALSOLIBS} \
 FILES:libopencl-imx-dev = "${includedir}/CL ${libdir}/libOpenCL${SOLIBSDEV}"
 RDEPENDS:libopencl-imx= "libclc-imx"
 
-FILES:libopenvg-imx = "${libdir}/libOpenVG*${REALSOLIBS}"
-FILES:libopenvg-imx-dev = "${includedir}/VG ${libdir}/libOpenVG*${SOLIBSDEV} ${libdir}/pkgconfig/vg.pc"
+FILES:libopenvg-imx = "${libdir}/libOpenVG*${REALSOLIBS} ${libdir}/libOpenVG*${SOLIBS}"
+FILES:libopenvg-imx-dev = "${includedir}/VG ${libdir}/pkgconfig/vg.pc"
+# libEGL does dlopen of libOpenVG.so
+INSANE_SKIP:libopenvg-imx += "dev-so"
 
 FILES:libvdk-imx = "${libdir}/libVDK*${REALSOLIBS}"
 FILES:libvdk-imx-dev = "${includedir}/*vdk*.h ${libdir}/libVDK${SOLIBSDEV}"


### PR DESCRIPTION
For each of the EGL rendering APIs, the EGL implementation does a dlopen for the unversioned library link to the rendering API implementation. So, a runtime dependency is needed for the -dev package of each such rendering API implementation.

Fixes: #1744