### PR TITLE
recipes-multimedia: Update for NXP release 6.1.55-2.2.0

### DIFF
--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -506,14 +506,14 @@ MACHINE_GSTREAMER_1_0_PLUGIN:mx8ulp-nxp-bsp ?= "imx-gst1.0-plugin"
 MACHINE_GSTREAMER_1_0_PLUGIN:mx93-nxp-bsp   ?= "imx-gst1.0-plugin"
 
 # GStreamer forked recipes
-PREFERRED_VERSION_gstreamer1.0:mx8-nxp-bsp              ??= "1.22.0.imx"
-PREFERRED_VERSION_gstreamer1.0-plugins-bad:mx8-nxp-bsp  ??= "1.22.0.imx"
-PREFERRED_VERSION_gstreamer1.0-plugins-base:mx8-nxp-bsp ??= "1.22.0.imx"
-PREFERRED_VERSION_gstreamer1.0-plugins-good:mx8-nxp-bsp ??= "1.22.0.imx"
-PREFERRED_VERSION_gstreamer1.0:mx9-nxp-bsp              ??= "1.22.0.imx"
-PREFERRED_VERSION_gstreamer1.0-plugins-bad:mx9-nxp-bsp  ??= "1.22.0.imx"
-PREFERRED_VERSION_gstreamer1.0-plugins-base:mx9-nxp-bsp ??= "1.22.0.imx"
-PREFERRED_VERSION_gstreamer1.0-plugins-good:mx9-nxp-bsp ??= "1.22.0.imx"
+PREFERRED_VERSION_gstreamer1.0:mx8-nxp-bsp              ??= "1.22.5.imx"
+PREFERRED_VERSION_gstreamer1.0-plugins-bad:mx8-nxp-bsp  ??= "1.22.5.imx"
+PREFERRED_VERSION_gstreamer1.0-plugins-base:mx8-nxp-bsp ??= "1.22.5.imx"
+PREFERRED_VERSION_gstreamer1.0-plugins-good:mx8-nxp-bsp ??= "1.22.5.imx"
+PREFERRED_VERSION_gstreamer1.0:mx9-nxp-bsp              ??= "1.22.5.imx"
+PREFERRED_VERSION_gstreamer1.0-plugins-bad:mx9-nxp-bsp  ??= "1.22.5.imx"
+PREFERRED_VERSION_gstreamer1.0-plugins-base:mx9-nxp-bsp ??= "1.22.5.imx"
+PREFERRED_VERSION_gstreamer1.0-plugins-good:mx9-nxp-bsp ??= "1.22.5.imx"
 
 # GStreamer copied recipes
 PREFERRED_VERSION_gst-devtools:mx8-nxp-bsp              ??= "1.22.0.imx"

--- a/recipes-multimedia/alsa/imx-alsa-plugins_git.bb
+++ b/recipes-multimedia/alsa/imx-alsa-plugins_git.bb
@@ -20,7 +20,7 @@ inherit autotools pkgconfig use-imx-headers
 PV = "1.0.26+${SRCPV}"
 
 SRC_URI = "git://github.com/nxp-imx/imx-alsa-plugins.git;protocol=https;branch=${SRCBRANCH}"
-SRCBRANCH = "MM_04.08.01_2308_L6.1.y"
+SRCBRANCH = "MM_04.08.02_2310_L6.1.y"
 SRCREV = "b2ba082e70333f187972ee4e85f63f9d2f608331"
 
 S = "${WORKDIR}/git"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.22.5.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.22.5.imx.bb
@@ -3,12 +3,12 @@
 # recipe. The second section customizes the recipe for i.MX.
 
 ########### OE-core copy ##################
-# Upstream hash: fb2d28e0315ece6180c87c7047587673024a09f7
+# Upstream hash: 937817e5164f8af8452aec03ae3c45cb23d63df9
 
 require gstreamer1.0-plugins-common.inc
 require gstreamer1.0-plugins-license.inc
 
-DESCRIPTION = "'Bad' GStreamer plugins and helper libraries "
+SUMMARY = "'Bad' GStreamer plugins and helper libraries "
 HOMEPAGE = "https://gstreamer.freedesktop.org/"
 BUGTRACKER = "https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad/-/issues"
 
@@ -17,7 +17,7 @@ SRC_URI = "https://gstreamer.freedesktop.org/src/gst-plugins-bad/gst-plugins-bad
            file://0002-avoid-including-sys-poll.h-directly.patch \
            file://0004-opencv-resolve-missing-opencv-data-dir-in-yocto-buil.patch \
            "
-SRC_URI[sha256sum] = "3c9d9300f5f4fb3e3d36009379d1fb6d9ecd79c1a135df742b8a68417dd663a1"
+SRC_URI[sha256sum] = "e64e75cdafd7ff2fc7fc34e855b06b1e3ed227cc06fa378d17bbcd76780c338c"
 
 S = "${WORKDIR}/gst-plugins-bad-${PV}"
 
@@ -67,7 +67,7 @@ PACKAGECONFIG[libde265]        = "-Dlibde265=enabled,-Dlibde265=disabled,libde26
 PACKAGECONFIG[libssh2]         = "-Dcurl-ssh2=enabled,-Dcurl-ssh2=disabled,libssh2"
 PACKAGECONFIG[lcms2]           = "-Dcolormanagement=enabled,-Dcolormanagement=disabled,lcms"
 PACKAGECONFIG[modplug]         = "-Dmodplug=enabled,-Dmodplug=disabled,libmodplug"
-PACKAGECONFIG[msdk]            = "-Dmsdk=enabled,-Dmsdk=disabled,intel-mediasdk"
+PACKAGECONFIG[msdk]            = "-Dmsdk=enabled -Dmfx_api=oneVPL,-Dmsdk=disabled,onevpl-intel-gpu"
 PACKAGECONFIG[neon]            = "-Dneon=enabled,-Dneon=disabled,neon"
 PACKAGECONFIG[openal]          = "-Dopenal=enabled,-Dopenal=disabled,openal-soft"
 PACKAGECONFIG[opencv]          = "-Dopencv=enabled,-Dopencv=disabled,opencv"
@@ -182,13 +182,13 @@ LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=4fbd65380cdd255951079008b364516c"
 
 DEPENDS:append:imxgpu2d = " virtual/libg2d"
 
-SRC_URI:remove  = "https://gstreamer.freedesktop.org/src/gst-plugins-bad/gst-plugins-bad-${PV}.tar.xz \
+SRC_URI:remove = "https://gstreamer.freedesktop.org/src/gst-plugins-bad/gst-plugins-bad-${PV}.tar.xz \
                    file://0001-fix-maybe-uninitialized-warnings-when-compiling-with.patch \
                    file://0002-avoid-including-sys-poll.h-directly.patch"
 SRC_URI:prepend = "${GST1.0-PLUGINS-BAD_SRC};branch=${SRCBRANCH} "
 GST1.0-PLUGINS-BAD_SRC ?= "gitsm://github.com/nxp-imx/gst-plugins-bad.git;protocol=https"
-SRCBRANCH = "MM_04.08.01_2308_L6.1.y"
-SRCREV = "fd7a399c3a9c43b5675bc2497ad8a23540bf720e"
+SRCBRANCH = "MM_04.08.02_2310_L6.1.y"
+SRCREV = "e4edcda6b110f42eca1f2cc20bc935edf7e66d6d" 
 
 S = "${WORKDIR}/git"
 

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.22.5.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.22.5.imx.bb
@@ -3,11 +3,11 @@
 # recipe. The second section customizes the recipe for i.MX.
 
 ########### OE-core copy ##################
-# Upstream hash: fb2d28e0315ece6180c87c7047587673024a09f7
+# Upstream hash: 937817e5164f8af8452aec03ae3c45cb23d63df9
 
 require gstreamer1.0-plugins-common.inc
 
-DESCRIPTION = "'Base' GStreamer plugins and helper libraries"
+SUMMARY = "'Base' GStreamer plugins and helper libraries"
 HOMEPAGE = "https://gstreamer.freedesktop.org/"
 BUGTRACKER = "https://gitlab.freedesktop.org/gstreamer/gst-plugins-base/-/issues"
 LICENSE = "LGPL-2.1-or-later"
@@ -18,7 +18,7 @@ SRC_URI = "https://gstreamer.freedesktop.org/src/gst-plugins-base/gst-plugins-ba
            file://0003-viv-fb-Make-sure-config.h-is-included.patch \
            file://0002-ssaparse-enhance-SSA-text-lines-parsing.patch \
            "
-SRC_URI[sha256sum] = "f53672294f3985d56355c8b1df8f6b49c8c8721106563e19f53be3507ff2229d"
+SRC_URI[sha256sum] = "edd4338b45c26a9af28c0d35aab964a024c3884ba6f520d8428df04212c8c93a"
 
 S = "${WORKDIR}/gst-plugins-base-${PV}"
 
@@ -28,7 +28,8 @@ inherit gobject-introspection
 
 # opengl packageconfig factored out to make it easy for distros
 # and BSP layers to choose OpenGL APIs/platforms/window systems
-PACKAGECONFIG_GL ?= "${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'gles2 egl', '', d)}"
+PACKAGECONFIG_X11 = "${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'opengl glx', '', d)}"
+PACKAGECONFIG_GL ?= "${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'gles2 egl ${PACKAGECONFIG_X11}', '', d)}"
 
 PACKAGECONFIG ??= " \
     ${GSTREAMER_ORC} \
@@ -39,7 +40,7 @@ PACKAGECONFIG ??= " \
 "
 
 OPENGL_APIS = 'opengl gles2'
-OPENGL_PLATFORMS = 'egl'
+OPENGL_PLATFORMS = 'egl glx'
 
 X11DEPENDS = "virtual/libx11 libsm libxrender libxv"
 X11ENABLEOPTS = "-Dx11=enabled -Dxvideo=enabled -Dxshm=enabled"
@@ -68,6 +69,7 @@ PACKAGECONFIG[gles2]        = ",,virtual/libgles2"
 
 # OpenGL platform packageconfigs
 PACKAGECONFIG[egl]          = ",,virtual/egl"
+PACKAGECONFIG[glx]          = ",,virtual/libgl"
 
 # OpenGL window systems (except for X11)
 PACKAGECONFIG[gbm]          = ",,virtual/libgbm libgudev libdrm"
@@ -116,8 +118,8 @@ SRC_URI:remove = " \
 SRC_URI:prepend = "${GST1.0-PLUGINS-BASE_SRC};branch=${SRCBRANCH} "
 SRC_URI:append = " file://0001-gstallocator-Fix-typcasts.patch"
 GST1.0-PLUGINS-BASE_SRC ?= "gitsm://github.com/nxp-imx/gst-plugins-base.git;protocol=https"
-SRCBRANCH = "MM_04.08.01_2308_L6.1.y"
-SRCREV = "f7c109c3b09645266ad41139253f32cf70a7d692"
+SRCBRANCH = "MM_04.08.02_2310_L6.1.y"
+SRCREV = "53a12f4e39773ca5b052eccbf0476d4ebd3ac08e" 
 
 S = "${WORKDIR}/git"
 

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.22.5.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.22.5.imx.bb
@@ -3,19 +3,19 @@
 # recipe. The second section customizes the recipe for i.MX.
 
 ########### OE-core copy ##################
-# Upstream hash: fb2d28e0315ece6180c87c7047587673024a09f7
+# Upstream hash: 937817e5164f8af8452aec03ae3c45cb23d63df9
 
 require gstreamer1.0-plugins-common.inc
 
-DESCRIPTION = "'Good' GStreamer plugins"
+SUMMARY = "'Good' GStreamer plugins"
 HOMEPAGE = "https://gstreamer.freedesktop.org/"
 BUGTRACKER = "https://gitlab.freedesktop.org/gstreamer/gst-plugins-good/-/issues"
 
 SRC_URI = "https://gstreamer.freedesktop.org/src/gst-plugins-good/gst-plugins-good-${PV}.tar.xz \
            file://0001-qt-include-ext-qt-gstqtgl.h-instead-of-gst-gl-gstglf.patch \
-           "
+           file://0001-v4l2-Define-ioctl_req_t-for-posix-linux-case.patch"
 
-SRC_URI[sha256sum] = "582e617271e7f314d1a2211e3e3856ae2e4303c8c0d6114e9c4a5ea5719294b0"
+SRC_URI[sha256sum] = "b67b31313a54c6929b82969d41d3cfdf2f58db573fb5f491e6bba5d84aea0778"
 
 S = "${WORKDIR}/gst-plugins-good-${PV}"
 
@@ -102,12 +102,15 @@ LIC_FILES_CHKSUM = " \
 DEPENDS += "${@bb.utils.contains('PACKAGECONFIG', 'v4l2', '${DEPENDS_V4L2}', '', d)}"
 DEPENDS_V4L2 = "${@bb.utils.contains_any('DISTRO_FEATURES', 'wayland x11', '', 'libdrm', d)}"
 
-SRC_URI:remove  = "https://gstreamer.freedesktop.org/src/gst-plugins-good/gst-plugins-good-${PV}.tar.xz \
-                   file://0001-qt-include-ext-qt-gstqtgl.h-instead-of-gst-gl-gstglf.patch"
+SRC_URI:remove = "https://gstreamer.freedesktop.org/src/gst-plugins-good/gst-plugins-good-${PV}.tar.xz \
+                file://0001-qt-include-ext-qt-gstqtgl.h-instead-of-gst-gl-gstglf.patch \
+                file://0001-v4l2-Define-ioctl_req_t-for-posix-linux-case.patch \
+"
+
 SRC_URI:prepend = "${GST1.0-PLUGINS-GOOD_SRC};branch=${SRCBRANCH} "
 GST1.0-PLUGINS-GOOD_SRC ?= "gitsm://github.com/nxp-imx/gst-plugins-good.git;protocol=https"
-SRCBRANCH = "MM_04.08.01_2308_L6.1.y"
-SRCREV = "ca3ef27dd4020393bfda546a25a3fa28314276e1"
+SRCBRANCH = "MM_04.08.02_2310_L6.1.y"
+SRCREV = "a4631334ad32abc513bde8f73491ef345f865a48"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-multimedia/gstreamer/gstreamer1.0_1.22.5.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0_1.22.5.imx.bb
@@ -3,7 +3,7 @@
 # recipe. The second section customizes the recipe for i.MX.
 
 ########### OE-core copy ##################
-# Upstream hash: fb2d28e0315ece6180c87c7047587673024a09f7
+# Upstream hash: 937817e5164f8af8452aec03ae3c45cb23d63df9
 
 SUMMARY = "GStreamer 1.0 multimedia framework"
 DESCRIPTION = "GStreamer is a multimedia framework for encoding and decoding video and sound. \
@@ -29,7 +29,7 @@ SRC_URI = "https://gstreamer.freedesktop.org/src/gstreamer/gstreamer-${PV}.tar.x
            file://0003-tests-use-a-dictionaries-for-environment.patch;striplevel=3 \
            file://0004-tests-add-helper-script-to-run-the-installed_tests.patch;striplevel=3 \
            "
-SRC_URI[sha256sum] = "78d21b5469ac93edafc6d8ceb63bc82f6cbbee94d2f866cca6b9252157ee0a09"
+SRC_URI[sha256sum] = "4408d7930f381809e85917acc19712f173261ba85bdf20c5567b2a21b1193b61"
 
 PACKAGECONFIG ??= "${@bb.utils.contains('PTEST_ENABLED', '1', 'tests', '', d)} \
                    check \
@@ -93,8 +93,8 @@ LIC_FILES_CHKSUM = " \
 SRC_URI:remove = "https://gstreamer.freedesktop.org/src/gstreamer/gstreamer-${PV}.tar.xz"
 SRC_URI:prepend = "${GST1.0_SRC};branch=${SRCBRANCH} "
 GST1.0_SRC ?= "gitsm://github.com/nxp-imx/gstreamer.git;protocol=https"
-SRCBRANCH = "MM_04.08.01_2308_L6.1.y"
-SRCREV = "95112902507718085231a933cdfe54e3997d1b28"
+SRCBRANCH = "MM_04.08.02_2310_L6.1.y"
+SRCREV = "e51e577a730191911b7050216814bede1b9545ae" 
 
 S = "${WORKDIR}/git"
 

--- a/recipes-multimedia/gstreamer/imx-gst1.0-plugin_git.bb
+++ b/recipes-multimedia/gstreamer/imx-gst1.0-plugin_git.bb
@@ -6,23 +6,34 @@
 DESCRIPTION = "Gstreamer freescale plugins"
 LICENSE = "GPL-2.0-only & LGPL-2.0-only & LGPL-2.1-only"
 SECTION = "multimedia"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=fbc093901857fcd118f065f900982c24"
 
-DEPENDS = "imx-codec imx-parser gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-bad"
+DEPENDS = " \
+    gstreamer1.0 \
+    gstreamer1.0-plugins-base \
+    gstreamer1.0-plugins-bad \
+    imx-codec \
+    imx-parser \
+    ${DEPENDS_IMXGPU} \
+"
 DEPENDS:append:mx6-nxp-bsp = " imx-lib"
 DEPENDS:append:mx7-nxp-bsp = " imx-lib"
 DEPENDS:append:mx8ulp-nxp-bsp = " imx-lib"
 DEPENDS:append:mx9-nxp-bsp = " imx-lib"
 DEPENDS:append:imxvpu = " imx-vpuwrap"
 DEPENDS:append:imxfbdev:imxgpu = " libdrm"
+DEPENDS_IMXGPU        = ""
+DEPENDS_IMXGPU:imxgpu = "${DEPENDS_IMX_OPENCL_CONVERTER}"
+DEPENDS_IMX_OPENCL_CONVERTER               = ""
+DEPENDS_IMX_OPENCL_CONVERTER:mx8-nxp-bsp   = "imx-opencl-converter"
+DEPENDS_IMX_OPENCL_CONVERTER:mx8mm-nxp-bsp = ""
 
 # For backwards compatibility
 RREPLACES:${PN} = "gst1.0-fsl-plugin"
 RPROVIDES:${PN} = "gst1.0-fsl-plugin"
 RCONFLICTS:${PN} = "gst1.0-fsl-plugin"
 
-LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=fbc093901857fcd118f065f900982c24"
-
-PV = "4.8.1+git${SRCPV}"
+PV = "4.8.2+git${SRCPV}"
 
 SRC_URI = "git://github.com/nxp-imx/imx-gst1.0-plugin.git;protocol=https;branch=${SRCBRANCH} \
            file://0001-aiurdemux-Fix-type-of-USER_DATA_LOCATION.patch \
@@ -37,8 +48,8 @@ SRC_URI = "git://github.com/nxp-imx/imx-gst1.0-plugin.git;protocol=https;branch=
            file://0010-provide-declaration-for-aiur_register_external_typef.patch \
            file://0011-meson-Undef-_TIME_BITS-along-with-_FILE_OFFSET_BITS.patch \
            "
-SRCBRANCH = "MM_04.08.01_2308_L6.1.y"
-SRCREV = "903c03e8611a107508b1f60e4736df208e72247d"
+SRCBRANCH = "MM_04.08.02_2310_L6.1.y"
+SRCREV = "a72df52acfec5f849ec93906e33cb50da01b0b2e" 
 
 S = "${WORKDIR}/git"
 

--- a/recipes-multimedia/imx-codec/imx-codec_4.8.2.bb
+++ b/recipes-multimedia/imx-codec/imx-codec_4.8.2.bb
@@ -5,14 +5,14 @@
 DESCRIPTION = "Freescale Multimedia codec libs"
 LICENSE = "Proprietary"
 SECTION = "multimedia"
-LIC_FILES_CHKSUM = "file://COPYING;md5=db4762b09b6bda63da103963e6e081de"
+LIC_FILES_CHKSUM = "file://COPYING;md5=2827219e81f28aba7c6a569f7c437fa7"
 
 # Backward compatibility
 PROVIDES += "libfslcodec"
 
-SRC_URI = "${FSL_MIRROR}/${BPN}-${PV}.bin;fsl-eula=true"
-SRC_URI[md5sum] = "a47f6407459ab4889e1bd9651b9dd40b"
-SRC_URI[sha256sum] = "0d0668dadbd69c40c1d0e29cbf4082df008a7cb7ec7e5cfe7d8f228395bdaf58"
+SRC_URI = "${FSL_MIRROR}/${BP}.bin;fsl-eula=true"
+SRC_URI[md5sum] = "1977bab8d89972f08d9eee0122a64603"
+SRC_URI[sha256sum] = "b0744a91c265202a79a019c72f17cae01fd5b63a3ba451592b6c8349d95719e0"
 
 inherit fsl-eula-unpack autotools pkgconfig
 

--- a/recipes-multimedia/imx-dsp/imx-dsp-codec-ext_2.1.6.bb
+++ b/recipes-multimedia/imx-dsp/imx-dsp-codec-ext_2.1.6.bb
@@ -2,14 +2,14 @@
 
 DESCRIPTION = "i.MX DSP Codec Wrapper and Lib owned by NXP"
 LICENSE = "Proprietary"
-LIC_FILES_CHKSUM = "file://COPYING;md5=db4762b09b6bda63da103963e6e081de"
+LIC_FILES_CHKSUM = "file://COPYING;md5=2827219e81f28aba7c6a569f7c437fa7"
 
 inherit fsl-eula-unpack autotools pkgconfig
 
 SRC_URI = "${FSL_MIRROR}/${BP}.bin;fsl-eula=true"
 
-SRC_URI[md5sum] = "4619cebbad2f312b950a9ad2b2e30e24"
-SRC_URI[sha256sum] = "89ac92b348aa70c81dcbf6a9ee4bc99bec56a491a89f5ba9854eab77e5fd4298"
+SRC_URI[md5sum] = "d211febb231717649d35553d22a50578"
+SRC_URI[sha256sum] = "d5f312d742493aee7e1f1304916aca8264bcf8d3f7de7e1522d30ba33efb6a8a"
 
 EXTRA_OECONF:append:mx8qm-nxp-bsp = " --enable-imx8qmqxp"
 EXTRA_OECONF:append:mx8qxp-nxp-bsp = " --enable-imx8qmqxp"
@@ -23,5 +23,5 @@ INHIBIT_SYSROOT_STRIP = "1"
 INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
 INSANE_SKIP:${PN} = "arch dev-so ldflags"
 
-FILES:${PN} += "${libdir}/imx-mm/audio-codec ${datadir}/imx-mm"
+FILES:${PN} += "${libdir}/imx-mm/audio-codec/dsp ${datadir}/imx-mm"
 COMPATIBLE_MACHINE = "(mx8qm-nxp-bsp|mx8qxp-nxp-bsp|mx8dx-nxp-bsp|mx8mp-nxp-bsp|mx8ulp-nxp-bsp)"

--- a/recipes-multimedia/imx-dsp/imx-dsp_2.1.6.bb
+++ b/recipes-multimedia/imx-dsp/imx-dsp_2.1.6.bb
@@ -2,15 +2,15 @@
 
 DESCRIPTION = "i.MX DSP Wrapper, Firmware Binary, Codec Libraries"
 LICENSE = "Proprietary"
-LIC_FILES_CHKSUM = "file://COPYING;md5=db4762b09b6bda63da103963e6e081de"
+LIC_FILES_CHKSUM = "file://COPYING;md5=2827219e81f28aba7c6a569f7c437fa7"
 
 
 inherit fsl-eula-unpack autotools pkgconfig
 
 SRC_URI = "${FSL_MIRROR}/${BP}.bin;fsl-eula=true"
 
-SRC_URI[md5sum] = "2b2581a4b24735f4e449a161a334e04d"
-SRC_URI[sha256sum] = "11f4e89c0d3c61ac591aa3e00e345d7cc8d0d2627a915253f920cdcf4492a7d5"
+SRC_URI[md5sum] = "07ff97f93abe2bc6117a120e534e70d4"
+SRC_URI[sha256sum] = "5eab0259228746499990afe8de758a6ed505ec3fbd8a8adfc87a83c46a69bf2c"
 
 EXTRA_OECONF = " \
     -datadir=${base_libdir}/firmware \

--- a/recipes-multimedia/imx-opencl-converter/imx-opencl-converter_0.1.bb
+++ b/recipes-multimedia/imx-opencl-converter/imx-opencl-converter_0.1.bb
@@ -1,0 +1,18 @@
+# Copyright 2023 NXP
+DESCRIPTION = "NXP Multimedia opencl converter lib"
+LICENSE = "Proprietary"
+SECTION = "multimedia"
+LIC_FILES_CHKSUM = "file://COPYING;md5=2827219e81f28aba7c6a569f7c437fa7"
+DEPENDS = "opencl-headers"
+
+SRC_URI = "${FSL_MIRROR}/${BP}.bin;fsl-eula=true"
+SRC_URI[md5sum] = "426f4b1df6fe123f769aa8a0d7ef17d8"
+SRC_URI[sha256sum] = "16612be09675c2abe9c62337e6932b2e3fb788b1ec95ecede757350c4abf6870"
+
+inherit fsl-eula-unpack autotools pkgconfig meson
+
+FILES:${PN} += "${datadir}/"
+
+COMPATIBLE_MACHINE               = "(^$)"
+COMPATIBLE_MACHINE:imxgpu        = "(mx8-nxp-bsp)"
+COMPATIBLE_MACHINE:mx8mm-nxp-bsp = "(^$)"

--- a/recipes-multimedia/imx-parser/imx-parser_4.8.2.bb
+++ b/recipes-multimedia/imx-parser/imx-parser_4.8.2.bb
@@ -5,7 +5,7 @@
 DESCRIPTION = "Freescale Multimedia parser libs"
 LICENSE = "Proprietary"
 SECTION = "multimedia"
-LIC_FILES_CHKSUM = "file://COPYING;md5=db4762b09b6bda63da103963e6e081de"
+LIC_FILES_CHKSUM = "file://COPYING;md5=2827219e81f28aba7c6a569f7c437fa7"
 
 # For backwards compatibility
 PROVIDES += "libfslparser"
@@ -14,8 +14,8 @@ RPROVIDES:${PN} = "libfslparser"
 RCONFLICTS:${PN} = "libfslparser"
 
 SRC_URI = "${FSL_MIRROR}/${BP}.bin;fsl-eula=true"
-SRC_URI[md5sum] = "c7a8aae8114d0756ed858000b78e9d8e"
-SRC_URI[sha256sum] = "73b8ce76507f25d72192862a939405625086a6631fba6f58e4e6bef2614fd202"
+SRC_URI[md5sum] = "2e862fce70bc82649057ed552473d982"
+SRC_URI[sha256sum] = "20f326821ced5d6855f81794b66ec1f0c334e9ec7a9be1368a9b4dc501b666c6"
 
 inherit fsl-eula-unpack autotools pkgconfig
 

--- a/recipes-multimedia/imx-vpuwrap/imx-vpuwrap_git.bb
+++ b/recipes-multimedia/imx-vpuwrap/imx-vpuwrap_git.bb
@@ -5,14 +5,14 @@
 DESCRIPTION = "Freescale Multimedia VPU wrapper"
 LICENSE = "Proprietary"
 SECTION = "multimedia"
-LIC_FILES_CHKSUM = "file://COPYING;md5=db4762b09b6bda63da103963e6e081de"
+LIC_FILES_CHKSUM = "file://COPYING;md5=2827219e81f28aba7c6a569f7c437fa7"
 
 DEPENDS = "virtual/imxvpu"
 DEPENDS:append:mx8mp-nxp-bsp = " imx-vpu-hantro-vc"
 
 SRC_URI = "git://github.com/NXP/imx-vpuwrap.git;protocol=https;branch=${SRCBRANCH}"
-SRCBRANCH = "MM_04.08.01_2308_L6.1.y"
-SRCREV = "1fe7cb6e94898f35e8b3b3afdbf5d6bf064cc126"
+SRCBRANCH = "MM_04.08.02_2310_L6.1.y"
+SRCREV = "6f9b4c82e37688f50d756529d90b48c3cc80f2f6" 
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Upgraded:
 - gstreamer1.0-plugins-bad:     1.22.0 -> 1.22.5
 - gstreamer1.0-plugins-base:    1.22.0 -> 1.22.5
 - gstreamer1.0-plugins-good:    1.22.0 -> 1.22.5
 - gstreamer1.0:                 1.22.0 -> 1.22.5
 - imx-codec:                    4.8.1 -> 4.8.2
 - imx-dsp:                      2.1.5 -> 2.1.6
 - imx-dsp-codec-ext:            2.1.5 -> 2.1.6
 - imx-parser:                             4.8.1 -> 4.8.2

Updated:
 - imx-alsa-plugins_git.bb
 - imx-gst1.0-plugin_git.bb
 - imx-vpuwrap_git.bb


New feature:
 - imx-opencl-converter_0.1.bb