### PR TITLE
Upgrade OP-TEE to LF6.1.55-2.2.0 NXP BSP

### DIFF
--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -595,8 +595,8 @@ PREFERRED_VERSION_vulkan-validation-layers:imxvulkan ??= "1.3.239.0.imx"
 # Use i.MX optee Version
 PREFERRED_VERSION_optee-os:mx8-nxp-bsp     ??= "4.0.0.imx"
 PREFERRED_VERSION_optee-os:mx9-nxp-bsp     ??= "4.0.0.imx"
-PREFERRED_VERSION_optee-client:mx8-nxp-bsp ??= "3.21.0.imx"
-PREFERRED_VERSION_optee-client:mx9-nxp-bsp ??= "3.21.0.imx"
+PREFERRED_VERSION_optee-client:mx8-nxp-bsp ??= "4.0.0.imx"
+PREFERRED_VERSION_optee-client:mx9-nxp-bsp ??= "4.0.0.imx"
 PREFERRED_VERSION_optee-test:mx8-nxp-bsp   ??= "3.21.0.imx"
 PREFERRED_VERSION_optee-test:mx9-nxp-bsp   ??= "3.21.0.imx"
 

--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -597,8 +597,8 @@ PREFERRED_VERSION_optee-os:mx8-nxp-bsp     ??= "4.0.0.imx"
 PREFERRED_VERSION_optee-os:mx9-nxp-bsp     ??= "4.0.0.imx"
 PREFERRED_VERSION_optee-client:mx8-nxp-bsp ??= "4.0.0.imx"
 PREFERRED_VERSION_optee-client:mx9-nxp-bsp ??= "4.0.0.imx"
-PREFERRED_VERSION_optee-test:mx8-nxp-bsp   ??= "3.21.0.imx"
-PREFERRED_VERSION_optee-test:mx9-nxp-bsp   ??= "3.21.0.imx"
+PREFERRED_VERSION_optee-test:mx8-nxp-bsp   ??= "4.0.0.imx"
+PREFERRED_VERSION_optee-test:mx9-nxp-bsp   ??= "4.0.0.imx"
 
 # Use i.MX opencv Version
 PREFERRED_VERSION_opencv:mx8-nxp-bsp ??= "4.6.0.imx"

--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -593,8 +593,8 @@ PREFERRED_VERSION_vulkan-tools:imxvulkan             ??= "1.3.239.0.imx"
 PREFERRED_VERSION_vulkan-validation-layers:imxvulkan ??= "1.3.239.0.imx"
 
 # Use i.MX optee Version
-PREFERRED_VERSION_optee-os:mx8-nxp-bsp     ??= "3.21.0.imx"
-PREFERRED_VERSION_optee-os:mx9-nxp-bsp     ??= "3.21.0.imx"
+PREFERRED_VERSION_optee-os:mx8-nxp-bsp     ??= "4.0.0.imx"
+PREFERRED_VERSION_optee-os:mx9-nxp-bsp     ??= "4.0.0.imx"
 PREFERRED_VERSION_optee-client:mx8-nxp-bsp ??= "3.21.0.imx"
 PREFERRED_VERSION_optee-client:mx9-nxp-bsp ??= "3.21.0.imx"
 PREFERRED_VERSION_optee-test:mx8-nxp-bsp   ??= "3.21.0.imx"

--- a/recipes-security/optee-imx/optee-client_4.0.0.imx.bb
+++ b/recipes-security/optee-imx/optee-client_4.0.0.imx.bb
@@ -1,7 +1,7 @@
 require optee-client-fslc-imx.inc
 
-SRCBRANCH = "lf-6.1.36_2.1.0"
-SRCREV = "8533e0e6329840ee96cf81b6453f257204227e6c"
+SRCBRANCH = "lf-6.1.55_2.2.0"
+SRCREV = "acb0885c117e73cb6c5c9b1dd9054cb3f93507ee"
 
 DEPENDS += "util-linux"
 EXTRA_OEMAKE += "PKG_CONFIG=pkg-config"

--- a/recipes-security/optee-imx/optee-os/0001-core-Define-section-attributes-for-clang.patch
+++ b/recipes-security/optee-imx/optee-os/0001-core-Define-section-attributes-for-clang.patch
@@ -1,4 +1,4 @@
-From b73c3d2829d3661ca66b5cc6b4181f3bf973b13f Mon Sep 17 00:00:00 2001
+From ef83625c9a5f50610e25aa860c4b9c5e64723a66 Mon Sep 17 00:00:00 2001
 From: Emekcan Aras <emekcan.aras@arm.com>
 Date: Wed, 21 Dec 2022 10:55:58 +0000
 Subject: [PATCH 1/4] core: Define section attributes for clang
@@ -36,15 +36,15 @@ Signed-off-by: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>
  core/arch/arm/kernel/thread.c    | 19 +++++++++++++++--
  core/arch/arm/mm/core_mmu_lpae.c | 35 +++++++++++++++++++++++++++----
  core/arch/arm/mm/core_mmu_v7.c   | 36 +++++++++++++++++++++++++++++---
- core/arch/arm/mm/pgt_cache.c     | 12 ++++++++++-
  core/kernel/thread.c             | 13 +++++++++++-
+ core/mm/pgt_cache.c              | 12 ++++++++++-
  5 files changed, 104 insertions(+), 11 deletions(-)
 
 diff --git a/core/arch/arm/kernel/thread.c b/core/arch/arm/kernel/thread.c
-index 22ef932f9..7a9078d2e 100644
+index 66833b3a0..b3eb9cf9a 100644
 --- a/core/arch/arm/kernel/thread.c
 +++ b/core/arch/arm/kernel/thread.c
-@@ -44,15 +44,30 @@ static size_t thread_user_kcode_size __nex_bss;
+@@ -45,15 +45,30 @@ static size_t thread_user_kcode_size __nex_bss;
  #if defined(CFG_CORE_UNMAP_CORE_AT_EL0) && \
  	defined(CFG_CORE_WORKAROUND_SPECTRE_BP_SEC) && defined(ARM64)
  long thread_user_kdata_sp_offset __nex_bss;
@@ -78,10 +78,10 @@ index 22ef932f9..7a9078d2e 100644
  
  #ifdef ARM32
 diff --git a/core/arch/arm/mm/core_mmu_lpae.c b/core/arch/arm/mm/core_mmu_lpae.c
-index 6df2c68cf..a877e4965 100644
+index 4c8b85e39..1885e1d3f 100644
 --- a/core/arch/arm/mm/core_mmu_lpae.c
 +++ b/core/arch/arm/mm/core_mmu_lpae.c
-@@ -238,19 +238,46 @@ typedef uint16_t l1_idx_t;
+@@ -234,19 +234,46 @@ typedef uint16_t l1_idx_t;
  typedef uint64_t base_xlat_tbls_t[CFG_TEE_CORE_NB_CORE][NUM_BASE_LEVEL_ENTRIES];
  typedef uint64_t xlat_tbl_t[XLAT_TABLE_ENTRIES];
  
@@ -133,7 +133,7 @@ index 6df2c68cf..a877e4965 100644
   * TAs page table entry inside a level 1 page table.
   *
 diff --git a/core/arch/arm/mm/core_mmu_v7.c b/core/arch/arm/mm/core_mmu_v7.c
-index 58596be84..98fa58635 100644
+index 61e703da8..1960c08ca 100644
 --- a/core/arch/arm/mm/core_mmu_v7.c
 +++ b/core/arch/arm/mm/core_mmu_v7.c
 @@ -204,16 +204,46 @@ typedef uint32_t l1_xlat_tbl_t[NUM_L1_ENTRIES];
@@ -186,35 +186,11 @@ index 58596be84..98fa58635 100644
  
  struct mmu_partition {
  	l1_xlat_tbl_t *l1_table;
-diff --git a/core/arch/arm/mm/pgt_cache.c b/core/arch/arm/mm/pgt_cache.c
-index 79553c6d2..b9efdf427 100644
---- a/core/arch/arm/mm/pgt_cache.c
-+++ b/core/arch/arm/mm/pgt_cache.c
-@@ -410,8 +410,18 @@ void pgt_init(void)
- 	 * has a large alignment, while .bss has a small alignment. The current
- 	 * link script is optimized for small alignment in .bss
- 	 */
-+#ifdef __clang__
-+#pragma clang section bss=".nozi.mmu.l2"
-+#endif
- 	static uint8_t pgt_tables[PGT_CACHE_SIZE][PGT_SIZE]
--			__aligned(PGT_SIZE) __section(".nozi.pgt_cache");
-+			__aligned(PGT_SIZE)
-+#ifndef __clang__
-+			__section(".nozi.pgt_cache")
-+#endif
-+			;
-+#ifdef __clang__
-+#pragma clang section bss=""
-+#endif
- 	size_t n;
- 
- 	for (n = 0; n < ARRAY_SIZE(pgt_tables); n++) {
 diff --git a/core/kernel/thread.c b/core/kernel/thread.c
-index e48294b3b..8de9064ca 100644
+index 2a1f22dce..5516b6771 100644
 --- a/core/kernel/thread.c
 +++ b/core/kernel/thread.c
-@@ -38,13 +38,24 @@ struct thread_core_local thread_core_local[CFG_TEE_CORE_NB_CORE] __nex_bss;
+@@ -39,13 +39,24 @@ static uint32_t end_canary_value = 0xababab00;
  	name[stack_num][sizeof(name[stack_num]) / sizeof(uint32_t) - 1]
  #endif
  
@@ -240,7 +216,30 @@ index e48294b3b..8de9064ca 100644
  #define GET_STACK(stack) ((vaddr_t)(stack) + STACK_SIZE(stack))
  
  DECLARE_STACK(stack_tmp, CFG_TEE_CORE_NB_CORE, STACK_TMP_SIZE,
+diff --git a/core/mm/pgt_cache.c b/core/mm/pgt_cache.c
+index 79553c6d2..b9efdf427 100644
+--- a/core/mm/pgt_cache.c
++++ b/core/mm/pgt_cache.c
+@@ -410,8 +410,18 @@ void pgt_init(void)
+ 	 * has a large alignment, while .bss has a small alignment. The current
+ 	 * link script is optimized for small alignment in .bss
+ 	 */
++#ifdef __clang__
++#pragma clang section bss=".nozi.mmu.l2"
++#endif
+ 	static uint8_t pgt_tables[PGT_CACHE_SIZE][PGT_SIZE]
+-			__aligned(PGT_SIZE) __section(".nozi.pgt_cache");
++			__aligned(PGT_SIZE)
++#ifndef __clang__
++			__section(".nozi.pgt_cache")
++#endif
++			;
++#ifdef __clang__
++#pragma clang section bss=""
++#endif
+ 	size_t n;
+ 
+ 	for (n = 0; n < ARRAY_SIZE(pgt_tables); n++) {
 -- 
-2.40.1
-
+2.43.2
 

--- a/recipes-security/optee-imx/optee-os/0002-optee-enable-clang-support.patch
+++ b/recipes-security/optee-imx/optee-os/0002-optee-enable-clang-support.patch
@@ -1,4 +1,4 @@
-From c67f63d4e7bbe7b21b4c9ef49ae84c6725794aa9 Mon Sep 17 00:00:00 2001
+From 2ba573c9763329fbfdfacc8393d565ab747cac4d Mon Sep 17 00:00:00 2001
 From: Brett Warren <brett.warren@arm.com>
 Date: Wed, 23 Sep 2020 09:27:34 +0100
 Subject: [PATCH 2/4] optee: enable clang support
@@ -30,5 +30,5 @@ index a045beee8..1ebe2f702 100644
  
  # Core ASLR relies on the executable being ready to run from its preferred load
 -- 
-2.40.1
+2.43.2
 

--- a/recipes-security/optee-imx/optee-os/0003-arm32-libutils-libutee-ta-add-.note.GNU-stack-sectio.patch
+++ b/recipes-security/optee-imx/optee-os/0003-arm32-libutils-libutee-ta-add-.note.GNU-stack-sectio.patch
@@ -1,4 +1,4 @@
-From f23fb3381422c613890f77c26d11e377234481c6 Mon Sep 17 00:00:00 2001
+From 6f738803a59613ec4a683ddbc1747ebffd75a4e6 Mon Sep 17 00:00:00 2001
 From: Jerome Forissier <jerome.forissier@linaro.org>
 Date: Tue, 23 Aug 2022 12:31:46 +0000
 Subject: [PATCH 3/4] arm32: libutils, libutee, ta: add .note.GNU-stack section
@@ -129,5 +129,5 @@ index cd9a12f9d..ccdc19928 100644
   * This function is the bottom of the user call stack. Mark it as such so that
   * the unwinding code won't try to go further down.
 -- 
-2.40.1
+2.43.2
 

--- a/recipes-security/optee-imx/optee-os/0004-core-link-add-no-warn-rwx-segments.patch
+++ b/recipes-security/optee-imx/optee-os/0004-core-link-add-no-warn-rwx-segments.patch
@@ -1,4 +1,4 @@
-From b53f5542102b8088448134202c30ca563f5b3c04 Mon Sep 17 00:00:00 2001
+From a63f82f74e015eb662242cdb51ef814e3f576829 Mon Sep 17 00:00:00 2001
 From: Jerome Forissier <jerome.forissier@linaro.org>
 Date: Fri, 5 Aug 2022 09:48:03 +0200
 Subject: [PATCH 4/4] core: link: add --no-warn-rwx-segments
@@ -25,7 +25,7 @@ Signed-off-by: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>
  1 file changed, 4 insertions(+), 2 deletions(-)
 
 diff --git a/core/arch/arm/kernel/link.mk b/core/arch/arm/kernel/link.mk
-index e8a518254..60e08966f 100644
+index 49e9f4fa1..9e1cc172f 100644
 --- a/core/arch/arm/kernel/link.mk
 +++ b/core/arch/arm/kernel/link.mk
 @@ -37,6 +37,7 @@ link-ldflags += --sort-section=alignment
@@ -63,5 +63,5 @@ index e8a518254..60e08966f 100644
  	      $(libgcccore)
  cleanfiles += $(link-out-dir)/init.o
 -- 
-2.40.1
+2.43.2
 

--- a/recipes-security/optee-imx/optee-os_4.0.0.imx.bb
+++ b/recipes-security/optee-imx/optee-os_4.0.0.imx.bb
@@ -8,5 +8,5 @@ SRC_URI += " \
     file://0003-arm32-libutils-libutee-ta-add-.note.GNU-stack-sectio.patch \
     file://0004-core-link-add-no-warn-rwx-segments.patch \
 "
-SRCBRANCH = "lf-6.1.36_2.1.0"
-SRCREV = "4e32281904b15af9ddbdf00f73e1c08eae21c695"
+SRCBRANCH = "lf-6.1.55_2.2.0"
+SRCREV = "a303fc80f7c4bd713315687a1fa1d6ed136e78ee"

--- a/recipes-security/optee-imx/optee-test_4.0.0.imx.bb
+++ b/recipes-security/optee-imx/optee-test_4.0.0.imx.bb
@@ -4,7 +4,7 @@ require optee-test-fslc.inc
 
 SRC_URI = "git://github.com/nxp-imx/imx-optee-test.git;protocol=https;branch=${SRCBRANCH}"
 
-SRCBRANCH = "lf-6.1.36_2.1.0"
-SRCREV = "e0ebd5193070e0215b5389da191bc33f4f478222"
+SRCBRANCH = "lf-6.1.55_2.2.0"
+SRCREV = "38efacef3b14b32a6792ceaebe211b5718536fbb"
 
 COMPATIBLE_MACHINE = "(imx-nxp-bsp)"


### PR DESCRIPTION
This PR closes the "Upgrade OP-TEE" task of https://github.com/Freescale/meta-freescale/issues/1715