### PR TITLE
cairo: Return back packageconfigs for 1.16.0

### DIFF
--- a/recipes-graphics/cairo/cairo_%.bbappend
+++ b/recipes-graphics/cairo/cairo_%.bbappend
@@ -1,3 +1,8 @@
+# Cairo 1.16.0 used in kirkstone, langdale, mickledore and nanbield still
+# requires to replace opengl with the egl/gles for success building.
+PACKAGECONFIG:append:imxgpu3d = " ${@bb.utils.contains('PV', '1.16.0', 'egl glesv2', '', d)}"
+PACKAGECONFIG:remove:imxgpu3d = " ${@bb.utils.contains('PV', '1.16.0', 'opengl', '', d)}"
+
 # links with imx-gpu libs which are pre-built for glibc
 # gcompat will address it during runtime
 LDFLAGS:append:imxgpu:libc-musl = " -Wl,--allow-shlib-undefined"


### PR DESCRIPTION
This fixes the https://github.com/Freescale/meta-freescale/issues/1735

The master branch of meta-freescale is compatible with multiply Yocto releases since Kirstone.

Before Scarthgap cairo needs to be compiled with egl/gles. Return back replacing GL libraries for cairo 1.16.0 to fix rhe building issue [1].

[1]
2024-01-13 03:04:58 - INFO     - | cairo/1.16.0/recipe-sysroot-native/usr/bin/aarch64-lms-linux/../../libexec/aarch64-lms-linux/gcc/aarch64-lms-linux/13.2.0/ld: ../../boilerplate/.libs/libcairoboilerplate.a(cairo-boilerplate-glx.o): in function `_cairo_boilerplate_gl_cleanup':
2024-01-13 03:04:58 - INFO     - | cairo/1.16.0-r0/boilerplate/cairo-boilerplate-glx.c:60:(.text+0x16c): undefined reference to `glXDestroyContext'
2024-01-13 03:04:58 - INFO     - | cairo/1.16.0/recipe-sysroot-native/usr/bin/aarch64-lms-linux/../../libexec/aarch64-lms-linux/gcc/aarch64-lms-linux/13.2.0/ld: ../../boilerplate/.libs/libcairoboilerplate.a(cairo-boilerplate-glx.o): in function `_cairo_boilerplate_gl_create_surface':
2024-01-13 03:04:58 - INFO     - | cairo/1.16.0-r0/boilerplate/cairo-boilerplate-glx.c:123:(.text+0x288): undefined reference to `glXChooseVisual'
...
2024-01-13 03:04:58 - INFO     - | collect2: error: ld returned 1 exit status

Fixes: 0e478bde ("cairo: Drop the removed packageconfigs")