### PR TITLE
uuu: add libtinyxml2 to the build dependencies

### DIFF
--- a/recipes-devtools/uuu/uuu_git.bb
+++ b/recipes-devtools/uuu/uuu_git.bb
@@ -13,6 +13,6 @@ inherit cmake pkgconfig
 
 S = "${WORKDIR}/git"
 
-DEPENDS = "libusb zlib bzip2 openssl zstd"
+DEPENDS = "libusb zlib bzip2 openssl zstd libtinyxml2"
 
 BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
tinyxml2 build dependency has been introduced in:
https://github.com/nxp-imx/mfgtools/commit/e6c6874714f63cce96077921813a33f30463b914