### PR TITLE
qtbase: Enable wayland knob when in distro features

### DIFF
--- a/dynamic-layers/qt6-layer/recipes-qt/qt6/qtbase_%.bbappend
+++ b/dynamic-layers/qt6-layer/recipes-qt/qt6/qtbase_%.bbappend
@@ -41,6 +41,10 @@ PACKAGECONFIG_PLATFORM:use-mainline-bsp = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'x11', '', 'eglfs', d)}"
 
 PACKAGECONFIG += " \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', '${PACKAGECONFIG_WAYLAND}', '', d)}"
+PACKAGECONFIG_WAYLAND = "wayland"
+
+PACKAGECONFIG += " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'vulkan', '${PACKAGECONFIG_VULKAN}', '', d)}"
 PACKAGECONFIG_VULKAN = ""
 PACKAGECONFIG_VULKAN:imxgpu = " \


### PR DESCRIPTION
Mimic the behavior from recipe proper here since we override packageconfig defaults. With QT 6.7, qtbase built without wayland support is not sufficient to build rest of QT components e.g. qtwayland errors out during build/configure

    ERROR: Qt Wayland Client requires QtGui to be build with support for wayland

Therefore add it when wayland is in distro features.