### PR TITLE
imx-base.inc: Rename bmap-tools to bmaptool

### DIFF
--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -637,7 +637,7 @@ WKS_FILE_DEPENDS ?= " \
     virtual/bootloader \
     \
     e2fsprogs-native \
-    bmap-tools-native \
+    bmaptool-native \
     ${@bb.utils.contains('MACHINE_FEATURES', 'optee', '${OPTEE_WKS_FILE_DEPENDS}', '', d)} \
 "
 


### PR DESCRIPTION
bmaptool is now part of the Yocto Project and their recipe renamed it to bmaptool.