### PR TITLE
uuu_bootloader_tag.bbclass: Add UUU_BOOTLOADER_UNTAGGED

### DIFF
--- a/classes/uuu_bootloader_tag.bbclass
+++ b/classes/uuu_bootloader_tag.bbclass
@@ -4,6 +4,7 @@
 do_deploy:append() {
     if [ "${UUU_BOOTLOADER}" != "" ]; then
         cp ${DEPLOYDIR}/${UUU_BOOTLOADER}   ${DEPLOYDIR}/${UUU_BOOTLOADER_TAGGED}
+        cp ${DEPLOYDIR}/${UUU_BOOTLOADER}   ${DEPLOYDIR}/${UUU_BOOTLOADER_UNTAGGED}
         ln -sf ${UUU_BOOTLOADER_TAGGED}     ${DEPLOYDIR}/${UUU_BOOTLOADER}
         stat -L -cUUUBURNXXOEUZX7+A-XY5601QQWWZ%sEND ${DEPLOYDIR}/${UUU_BOOTLOADER} \
                                          >> ${DEPLOYDIR}/${UUU_BOOTLOADER}

--- a/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
+++ b/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
@@ -25,6 +25,7 @@ inherit deploy uuu_bootloader_tag
 
 UUU_BOOTLOADER        = "${BOOT_NAME}"
 UUU_BOOTLOADER_TAGGED = "${BOOT_NAME}-tagged"
+UUU_BOOTLOADER_UNTAGGED = "${BOOT_NAME}-untagged"
 
 # Add CFLAGS with native INCDIR & LIBDIR for imx-mkimage build
 CFLAGS = "-O2 -Wall -std=c99 -I ${STAGING_INCDIR_NATIVE} -L ${STAGING_LIBDIR_NATIVE}"


### PR DESCRIPTION
    Add UUU_BOOTLOADER_UNTAGGED flag to add the possibility to deploy a
    imx-boot binary without the tagged footer
    'UUUBURNXXOEUZX7+A-XY5601QQWWZ%sEN' at the end.

    The addition of the footer 'UUUBURNXXOEUZX7+A-XY5601QQWWZ%sEN' at the end
    causes issues when the binary is loaded into RAM memory, this footer may
    cause issues where the binary size exceeds the typical USB package size
    used by UUU (1021 bytes).

    As example, if the footer is split across two distinct USB packages,
    such as sending 'UUUBURNXXXOE' in the last packet and
    'UZX7+A-XY5601QQWWZ%sEND' in the next one, it can lead to UUU halting
    while waiting for a response in SDPS mode.

    After sending 'UUUBURNXXXOE', iMX8MP's boot room starts SPL, not waiting
    for the next packet ('UZX7+A-XY5601QQWWZ%sEND'), leading to UUU
    breaking.

    Therefore, deploy both binaries separately (-tagged and -untagged) to
    allow users to choose the appropriate binary.