### PR TITLE
u-boot-imx_2023.04.bb: Add UUU_BOOTLOADER_UNTAGGED variable

### DIFF
--- a/recipes-bsp/u-boot/u-boot-imx_2023.04.bb
+++ b/recipes-bsp/u-boot/u-boot-imx_2023.04.bb
@@ -9,12 +9,15 @@ PROVIDES += "u-boot u-boot-mfgtool"
 
 inherit uuu_bootloader_tag
 
-UUU_BOOTLOADER                        = ""
-UUU_BOOTLOADER:mx6-generic-bsp        = "${UBOOT_BINARY}"
-UUU_BOOTLOADER:mx7-generic-bsp        = "${UBOOT_BINARY}"
-UUU_BOOTLOADER_TAGGED                 = ""
-UUU_BOOTLOADER_TAGGED:mx6-generic-bsp = "u-boot-tagged.${UBOOT_SUFFIX}"
-UUU_BOOTLOADER_TAGGED:mx7-generic-bsp = "u-boot-tagged.${UBOOT_SUFFIX}"
+UUU_BOOTLOADER                          = ""
+UUU_BOOTLOADER:mx6-generic-bsp          = "${UBOOT_BINARY}"
+UUU_BOOTLOADER:mx7-generic-bsp          = "${UBOOT_BINARY}"
+UUU_BOOTLOADER_TAGGED                   = ""
+UUU_BOOTLOADER_TAGGED:mx6-generic-bsp   = "u-boot-tagged.${UBOOT_SUFFIX}"
+UUU_BOOTLOADER_TAGGED:mx7-generic-bsp   = "u-boot-tagged.${UBOOT_SUFFIX}"
+UUU_BOOTLOADER_UNTAGGED                 = ""
+UUU_BOOTLOADER_UNTAGGED:mx6-generic-bsp = "u-boot-untagged.${UBOOT_SUFFIX}"
+UUU_BOOTLOADER_UNTAGGED:mx7-generic-bsp = "u-boot-untagged.${UBOOT_SUFFIX}"
 
 do_deploy:append:mx8m-generic-bsp() {
     # Deploy u-boot-nodtb.bin and fsl-imx8m*-XX.dtb for mkimage to generate boot binary


### PR DESCRIPTION
After commit 5a906365fd29 ("uuu_bootloader_tag.bbclass: Add UUU_BOOTLOADER_UNTAGGED"), the option for a untagged binary was added to uuu_bootloader_tag.bbclass. The u-boot-imx recipe also uses this binary, thefore add UUU_BOOTLOADER_TAGGED to this recipe as well.