### PR TITLE
uuu_bootloader_tag.bbclass: Use UUU_BOOTLOADER_TAGGED variable

### DIFF
--- a/classes/uuu_bootloader_tag.bbclass
+++ b/classes/uuu_bootloader_tag.bbclass
@@ -6,7 +6,7 @@ do_deploy:append() {
         cp ${DEPLOYDIR}/${UUU_BOOTLOADER}   ${DEPLOYDIR}/${UUU_BOOTLOADER_TAGGED}
         cp ${DEPLOYDIR}/${UUU_BOOTLOADER}   ${DEPLOYDIR}/${UUU_BOOTLOADER_UNTAGGED}
         ln -sf ${UUU_BOOTLOADER_TAGGED}     ${DEPLOYDIR}/${UUU_BOOTLOADER}
-        stat -L -cUUUBURNXXOEUZX7+A-XY5601QQWWZ%sEND ${DEPLOYDIR}/${UUU_BOOTLOADER} \
-                                         >> ${DEPLOYDIR}/${UUU_BOOTLOADER}
+        stat -L -cUUUBURNXXOEUZX7+A-XY5601QQWWZ%sEND ${DEPLOYDIR}/${UUU_BOOTLOADER_TAGGED} \
+                                         >> ${DEPLOYDIR}/${UUU_BOOTLOADER_TAGGED}
     fi
 }


### PR DESCRIPTION
Use UUU_BOOTLOADER_TAGGED variable instead of UUU_BOOTLOADER in the stat function to make the code more specific and easy to read.