### PR TITLE
conf/layer: add bmaptool compatibility for old versions

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -28,6 +28,12 @@ ${IMX_MIRROR}   http://download.ossystems.com.br/bsp/freescale/source/ \n \
 # implemented in imx GL driver implementation
 COMPATIBLE_HOST:pn-xdg-desktop-portal-wlr:imxgpu = "(null)"
 
+# For compatibility with layers before scarthgap
+PROVIDES:pn-bmap-tools-native = "bmaptool-native"
+RPROVIDES:pn-bmap-tools-native:bmap-tools-native = "bmaptool-native"
+PROVIDES:pn-bmap-tools = "bmaptool"
+RPROVIDES:pn-bmap-tools:bmap-tools = "bmaptool"
+
 BBFILES_DYNAMIC += " \
     aglprofilegraphical:${LAYERDIR}/dynamic-layers/aglprofilegraphical/*/*/*.bb \
     aglprofilegraphical:${LAYERDIR}/dynamic-layers/aglprofilegraphical/*/*/*.bbappend \


### PR DESCRIPTION
- Fixup for: cf8b57d9 imx-base.inc: Rename bmap-tools to bmaptool
- This makes it possible to use the master branch with oe-core before the scarthgap release.