### PR TITLE
imx-test: Use ROOT_HOME instead of hardcoded home directory

### DIFF
--- a/recipes-bsp/imx-test/imx-test_git.bb
+++ b/recipes-bsp/imx-test/imx-test_git.bb
@@ -73,11 +73,11 @@ do_install() {
     if [ -e ${WORKDIR}/clocks.sh ]; then
         install -m 755 ${WORKDIR}/clocks.sh ${D}/unit_tests/clocks.sh
     fi
-    install -d -m 0755 ${D}/home/root/
-    install -m 0644 ${WORKDIR}/memtool_profile ${D}/home/root/.profile
+    install -d -m 0755 ${D}${ROOT_HOME}/
+    install -m 0644 ${WORKDIR}/memtool_profile ${D}${ROOT_HOME}/.profile
 }
 
-FILES:${PN} += "/unit_tests /home/root/.profile"
+FILES:${PN} += "/unit_tests ${ROOT_HOME}/.profile"
 RDEPENDS:${PN} = "bash"
 
 FILES:${PN}-dbg += "/unit_tests/.debug"


### PR DESCRIPTION
Hardcoding the root home directory could cause issues when the ROOT_HOME is not set to '/home/root'. As example, the ROOT_HOME can be changed to '/root', which makes imx-test install files in the wrong folder.

Therefore, replace '/home/root' with '$ROOT_HOME'. Usually, ROOT_HOME is already set to '/home/root' [1].

[1] https://docs.yoctoproject.org/4.3.3/ref-manual/variables.html?highlight=variables#term-ROOT_HOME