### PR TITLE
gstreamer1.0-plugins-base: Don't always enable viv-fb

### DIFF
--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.22.%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.22.%.bbappend
@@ -6,7 +6,7 @@ PACKAGECONFIG_GL:use-mainline-bsp = \
     "${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'gles2 egl gbm', '', d)}"
 
 # The i.MX8 uses KMS instead of the Vivante specific framebuffer API.
-# The i.MX7 does not have a GPU.
+# The i.MX7 does not have a GPU, except for ULP.
 # This leaves the i.MX6 - with the vendor BSP - as the remaining use case for viv-fb.
 #
 # (Note that viv-fb is about the _windowing system_. Vivante direct texture support
@@ -14,3 +14,4 @@ PACKAGECONFIG_GL:use-mainline-bsp = \
 # which was fixed in GStreamer 1.22.5. Since then, the direct texture support is
 # detected by Meson by checking for direct texture symbols like "glTexDirectVIV".)
 PACKAGECONFIG_GL:append:mx6-nxp-bsp = " viv-fb "
+PACKAGECONFIG_GL:append:mx7ulp-nxp-bsp = " viv-fb "

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.22.5.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.22.5.imx.bb
@@ -125,12 +125,6 @@ S = "${WORKDIR}/git"
 
 inherit use-imx-headers
 
-# Prior to version 1.22.5, viv-fb is coupled with the Vivante direct texture feature.
-# For this reason, in these older versions, viv-fb must be enabled always, even when
-# building for SoCs like the i.MX8 that do not support the viv-fb windowing system.
-# TODO: Once this .imx recipe is upgraded to 1.22.5 or newer, drop this line.
-PACKAGECONFIG_GL:append = " viv-fb "
-
 PACKAGECONFIG_REMOVE ?= "jpeg"
 PACKAGECONFIG:remove = "${PACKAGECONFIG_REMOVE}"
 PACKAGECONFIG:append:imxgpu2d = " g2d"


### PR DESCRIPTION
GStreamer is now 1.22.5 and as commented drop the viv-fb append.