### PR TITLE
recipes-multimedia: Upgrade to NXP release 6.6.3_1.0.0

### DIFF
--- a/recipes-multimedia/alsa/alsa-lib/0001-pcm-Fix-segfault-with-32bit-libs.patch
+++ b/recipes-multimedia/alsa/alsa-lib/0001-pcm-Fix-segfault-with-32bit-libs.patch
@@ -1,0 +1,115 @@
+From 0e3dfb9f705ca78be34cd70fd59d67c431e29cc7 Mon Sep 17 00:00:00 2001
+From: Takashi Iwai <tiwai@suse.de>
+Date: Sat, 9 Sep 2023 17:42:03 +0200
+Subject: [PATCH] pcm: Fix segfault with 32bit libs
+
+Upstream-Status: Backport [https://github.com/alsa-project/alsa-lib/commit/0e3dfb9f705ca78be34cd70fd59d67c431e29cc7]
+
+The recent rearrangement of header inclusion order caused a regression
+showing segfaults on 32bit Arm.  The primary reason is the
+inconsistent compile condition depending on the inclusion of config.h;
+while most of other code include pcm_local.h (that implicitly includes
+config.h) at first, pcm_direct.c doesn't do it, hence the access with
+direct plugins crashes.
+
+For fixing it, we need to include config.h at the beginning.  But,
+it's better to include pcm_local.h for all relevant code for
+consistency.  The patch does it, and also it adds the guard in
+pcm_local.h for double inclusions.
+
+Fixes: ad3a8b8b314e ("reshuffle included files to include config.h as first")
+Link: https://github.com/alsa-project/alsa-lib/issues/352
+Signed-off-by: Takashi Iwai <tiwai@suse.de>
+---
+ src/pcm/pcm_direct.c | 1 +
+ src/pcm/pcm_dmix.c   | 2 +-
+ src/pcm/pcm_dshare.c | 1 +
+ src/pcm/pcm_dsnoop.c | 1 +
+ src/pcm/pcm_local.h  | 5 +++++
+ src/pcm/pcm_shm.c    | 1 +
+ 6 files changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/src/pcm/pcm_direct.c b/src/pcm/pcm_direct.c
+index 040fc160..e53e5923 100644
+--- a/src/pcm/pcm_direct.c
++++ b/src/pcm/pcm_direct.c
+@@ -19,6 +19,7 @@
+  *
+  */
+   
++#include "pcm_local.h"
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <stddef.h>
+diff --git a/src/pcm/pcm_dmix.c b/src/pcm/pcm_dmix.c
+index 7cd3c508..55cae3e7 100644
+--- a/src/pcm/pcm_dmix.c
++++ b/src/pcm/pcm_dmix.c
+@@ -26,7 +26,7 @@
+  *
+  */
+   
+-#include "config.h"
++#include "pcm_local.h"
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <stddef.h>
+diff --git a/src/pcm/pcm_dshare.c b/src/pcm/pcm_dshare.c
+index 454b39a9..c0329098 100644
+--- a/src/pcm/pcm_dshare.c
++++ b/src/pcm/pcm_dshare.c
+@@ -26,6 +26,7 @@
+  *
+  */
+   
++#include "pcm_local.h"
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <stddef.h>
+diff --git a/src/pcm/pcm_dsnoop.c b/src/pcm/pcm_dsnoop.c
+index d3ce300c..bf67c68a 100644
+--- a/src/pcm/pcm_dsnoop.c
++++ b/src/pcm/pcm_dsnoop.c
+@@ -26,6 +26,7 @@
+  *
+  */
+   
++#include "pcm_local.h"
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <stddef.h>
+diff --git a/src/pcm/pcm_local.h b/src/pcm/pcm_local.h
+index 6a0e71e7..152c92c3 100644
+--- a/src/pcm/pcm_local.h
++++ b/src/pcm/pcm_local.h
+@@ -20,6 +20,9 @@
+  *
+  */
+ 
++#ifndef __PCM_LOCAL_H
++#define __PCM_LOCAL_H
++
+ #include "config.h"
+ 
+ #include <stdio.h>
+@@ -1223,3 +1226,5 @@ static inline void snd_pcm_unlock(snd_pcm_t *pcm)
+ #define snd_pcm_lock(pcm)		do {} while (0)
+ #define snd_pcm_unlock(pcm)		do {} while (0)
+ #endif /* THREAD_SAFE_API */
++
++#endif /* __PCM_LOCAL_H */
+diff --git a/src/pcm/pcm_shm.c b/src/pcm/pcm_shm.c
+index f0bfd934..d9596547 100644
+--- a/src/pcm/pcm_shm.c
++++ b/src/pcm/pcm_shm.c
+@@ -26,6 +26,7 @@
+  *
+  */
+   
++#include "pcm_local.h"
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <stddef.h>
+-- 
+2.25.1
+

--- a/recipes-multimedia/alsa/alsa-lib/0001-pcm-rate-fix-the-crash-in-snd_pcm_rate_may_wait_for_.patch
+++ b/recipes-multimedia/alsa/alsa-lib/0001-pcm-rate-fix-the-crash-in-snd_pcm_rate_may_wait_for_.patch
@@ -1,0 +1,41 @@
+From aa4f56c3c952269c36464cc0da9db5a1381648fa Mon Sep 17 00:00:00 2001
+From: Jaroslav Kysela <perex@perex.cz>
+Date: Wed, 9 Nov 2022 08:11:42 +0100
+Subject: [PATCH] pcm: rate - fix the crash in
+
+Upstream-Status: Backport
+
+ snd_pcm_rate_may_wait_for_avail_min()
+
+The pcm argument passed to the conversion function in
+snd_pcm_plugin_may_wait_for_avail_min_conv() should be
+pcm->fast_op_arg.
+
+Test command: arecord -Dplughw:x -r12000 -c2 -fS16_LE -M temp.wav
+
+Fixes: d9dbb57b ("pcm: rate - rewrite the may_wait_for_avail_min callback for the rate plugin")
+
+BugLink: https://lore.kernel.org/alsa-devel/1667793912-18957-1-git-send-email-shengjiu.wang@nxp.com/
+Fixes: https://github.com/alsa-project/alsa-lib/issues/282
+Reported-by: Shengjiu Wang <shengjiu.wang@nxp.com>
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+---
+ src/pcm/pcm_plugin.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/pcm/pcm_plugin.c b/src/pcm/pcm_plugin.c
+index 6bb90b8b..ec64604c 100644
+--- a/src/pcm/pcm_plugin.c
++++ b/src/pcm/pcm_plugin.c
+@@ -622,7 +622,7 @@ int snd_pcm_plugin_may_wait_for_avail_min_conv(
+ 		 * This code is also used by extplug, but extplug does not allow to alter the sampling rate.
+ 		 */
+ 		if (conv)
+-			needed_slave_avail_min = conv(pcm, needed_slave_avail_min);
++			needed_slave_avail_min = conv(pcm->fast_op_arg, needed_slave_avail_min);
+ 
+ 		if (slave->avail_min != needed_slave_avail_min) {
+ 			snd_pcm_sw_params_t *swparams;
+-- 
+2.34.1
+

--- a/recipes-multimedia/alsa/alsa-lib/0007-add-conf-for-imx-cs42448-sound-card.patch
+++ b/recipes-multimedia/alsa/alsa-lib/0007-add-conf-for-imx-cs42448-sound-card.patch
@@ -1,0 +1,107 @@
+From 97d5e09a4166b45c567026e51b8a25ef5d7d587d Mon Sep 17 00:00:00 2001
+From: Chancel Liu <chancel.liu@nxp.com>
+Date: Fri, 29 Jul 2022 16:12:37 +0800
+Subject: [PATCH] add conf for imx-cs42448 sound card
+
+Upstream-Status: Inappropriate [i.MX specific]
+
+Signed-off-by: Chancel Liu <chancel.liu@nxp.com>
+---
+ src/conf/cards/CS42448.conf | 58 +++++++++++++++++++++++++++++++++++++
+ src/conf/cards/Makefile.am  |  3 +-
+ src/conf/cards/aliases.conf |  1 +
+ 3 files changed, 61 insertions(+), 1 deletion(-)
+ create mode 100644 src/conf/cards/CS42448.conf
+
+diff --git a/src/conf/cards/CS42448.conf b/src/conf/cards/CS42448.conf
+new file mode 100644
+index 00000000..28ba5c48
+--- /dev/null
++++ b/src/conf/cards/CS42448.conf
+@@ -0,0 +1,58 @@
++#
++# Configuration for the CS42448 chip
++#
++
++# default with dmix & dsnoop
++CS42448.pcm.default {
++	@args [ CARD ]
++	@args.CARD {
++		type string
++	}
++	type asym
++	playback.pcm {
++		type plug
++		slave.pcm {
++			@func concat
++			strings [ "dmix:" $CARD ",FORMAT=S32_LE" ]
++		}
++	}
++	capture.pcm {
++		type plug
++		slave.pcm {
++			@func concat
++			strings [ "dsnoop:" $CARD ",FORMAT=S32_LE" ]
++		}
++	}
++}
++
++<confdir:pcm/surround51.conf>
++
++CS42448.pcm.surround51.0 {
++	@args [ CARD ]
++	@args.CARD {
++		type string
++	}
++	type plug
++	slave.pcm {
++		type hw
++		card $CARD
++	}
++	slave.channels 6
++}
++
++<confdir:pcm/surround71.conf>
++
++CS42448.pcm.surround71.0 {
++	@args [ CARD ]
++	@args.CARD {
++		type string
++	}
++	type plug
++	slave.pcm {
++		type hw
++		card $CARD
++	}
++	slave.channels 8
++}
++
++# vim: ft=alsaconf
+diff --git a/src/conf/cards/Makefile.am b/src/conf/cards/Makefile.am
+index 70b9bab3..6aba20b4 100644
+--- a/src/conf/cards/Makefile.am
++++ b/src/conf/cards/Makefile.am
+@@ -62,7 +62,8 @@ cfg_files = aliases.conf \
+ 	CS42888.conf \
+ 	IMX-HDMI.conf \
+ 	AK4458.conf \
+-	IMX-XCVR.conf
++	IMX-XCVR.conf \
++	CS42448.conf
+ 
+ if BUILD_ALISP
+ cfg_files += aliases.alisp
+diff --git a/src/conf/cards/aliases.conf b/src/conf/cards/aliases.conf
+index e824145d..a40d3731 100644
+--- a/src/conf/cards/aliases.conf
++++ b/src/conf/cards/aliases.conf
+@@ -61,6 +61,7 @@ imx-cs42888 cards.CS42888
+ imx-hdmi-soc cards.IMX-HDMI
+ ak4458-audio cards.AK4458
+ imx-audio-xcvr cards.IMX-XCVR
++imx-cs42448 cards.CS42448
+ 
+ <confdir:ctl/default.conf>
+ <confdir:pcm/default.conf>
+-- 
+2.17.1

--- a/recipes-multimedia/alsa/alsa-lib_%.bbappend
+++ b/recipes-multimedia/alsa/alsa-lib_%.bbappend
@@ -4,7 +4,13 @@ IMX_PATCH = " \
     file://0001-add-conf-for-multichannel-support-in-imx.patch \
     file://0005-add-ak4458-conf-for-multichannel-support.patch \
     file://0006-add-conf-for-iMX-XCVR-sound-card.patch \
+    file://0007-add-conf-for-imx-cs42448-sound-card.patch \
+    file://0001-pcm-rate-fix-the-crash-in-snd_pcm_rate_may_wait_for_.patch \
+    file://0001-pcm-Fix-segfault-with-32bit-libs.patch \
 "
 SRC_URI:append:imx-nxp-bsp = "${IMX_PATCH}"
 
 PACKAGE_ARCH:imx-nxp-bsp = "${MACHINE_SOCARCH}"
+
+GLIBC_64BIT_TIME_FLAGS = ""
+INSANE_SKIP:append = " 32bit-time"

--- a/recipes-multimedia/alsa/imx-alsa-plugins_git.bb
+++ b/recipes-multimedia/alsa/imx-alsa-plugins_git.bb
@@ -20,7 +20,7 @@ inherit autotools pkgconfig use-imx-headers
 PV = "1.0.26+${SRCPV}"
 
 SRC_URI = "git://github.com/nxp-imx/imx-alsa-plugins.git;protocol=https;branch=${SRCBRANCH}"
-SRCBRANCH = "MM_04.08.02_2310_L6.1.y"
+SRCBRANCH = "MM_04.08.03_2312_L6.6.y"
 SRCREV = "b2ba082e70333f187972ee4e85f63f9d2f608331"
 
 S = "${WORKDIR}/git"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.22.5.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.22.5.imx.bb
@@ -187,8 +187,8 @@ SRC_URI:remove = "https://gstreamer.freedesktop.org/src/gst-plugins-bad/gst-plug
                    file://0002-avoid-including-sys-poll.h-directly.patch"
 SRC_URI:prepend = "${GST1.0-PLUGINS-BAD_SRC};branch=${SRCBRANCH} "
 GST1.0-PLUGINS-BAD_SRC ?= "gitsm://github.com/nxp-imx/gst-plugins-bad.git;protocol=https"
-SRCBRANCH = "MM_04.08.02_2310_L6.1.y"
-SRCREV = "e4edcda6b110f42eca1f2cc20bc935edf7e66d6d" 
+SRCBRANCH = "MM_04.08.03_2312_L6.6.y"
+SRCREV = "9de821c50b4dd7af2407d9c3d078020704510a20"
 
 S = "${WORKDIR}/git"
 
@@ -204,6 +204,11 @@ PACKAGECONFIG_REMOVE ?= " \
 PACKAGECONFIG:remove = "${PACKAGECONFIG_REMOVE}"
 PACKAGECONFIG:append:mx8-nxp-bsp = " kms tinycompress"
 
+PACKAGECONFIG:append = " ${PACKAGECONFIG_G2D}"
+PACKAGECONFIG_G2D          ??= ""
+PACKAGECONFIG_G2D:imxgpu2d ??= "g2d"
+
+PACKAGECONFIG[g2d] = ",,virtual/libg2d"
 PACKAGECONFIG[tinycompress]    = "-Dtinycompress=enabled,-Dtinycompress=disabled,tinycompress"
 
 EXTRA_OEMESON += " \

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.22.5.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.22.5.imx.bb
@@ -118,16 +118,19 @@ SRC_URI:remove = " \
 SRC_URI:prepend = "${GST1.0-PLUGINS-BASE_SRC};branch=${SRCBRANCH} "
 SRC_URI:append = " file://0001-gstallocator-Fix-typcasts.patch"
 GST1.0-PLUGINS-BASE_SRC ?= "gitsm://github.com/nxp-imx/gst-plugins-base.git;protocol=https"
-SRCBRANCH = "MM_04.08.02_2310_L6.1.y"
-SRCREV = "53a12f4e39773ca5b052eccbf0476d4ebd3ac08e" 
+SRCBRANCH = "MM_04.08.03_2312_L6.6.y"
+SRCREV = "c4333767ea122c182ba4e14cababe8dbe2a1b882"
 
 S = "${WORKDIR}/git"
 
 inherit use-imx-headers
 
-PACKAGECONFIG_REMOVE ?= "jpeg"
 PACKAGECONFIG:remove = "${PACKAGECONFIG_REMOVE}"
-PACKAGECONFIG:append:imxgpu2d = " g2d"
+PACKAGECONFIG_REMOVE ?= "jpeg"
+
+PACKAGECONFIG:append = " ${PACKAGECONFIG_G2D}"
+PACKAGECONFIG_G2D          ??= ""
+PACKAGECONFIG_G2D:imxgpu2d ??= "g2d"
 
 PACKAGECONFIG[g2d] = ",,virtual/libg2d"
 PACKAGECONFIG[viv-fb] = ",,virtual/libgles2"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.22.5.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.22.5.imx.bb
@@ -97,6 +97,8 @@ LIC_FILES_CHKSUM = " \
     file://LICENSE.txt;md5=a6f89e2100d9b6cdffcea4f398e37343 \
     file://gst/replaygain/rganalysis.c;beginline=1;endline=23;md5=b60ebefd5b2f5a8e0cab6bfee391a5fe \
 "
+# Enable pulsesink in gstreamer
+PACKAGECONFIG:append = "${@bb.utils.contains('DISTRO_FEATURES', 'pulseaudio', 'pulseaudio', '', d)}"
 
 # fb implementation of v4l2 uses libdrm
 DEPENDS += "${@bb.utils.contains('PACKAGECONFIG', 'v4l2', '${DEPENDS_V4L2}', '', d)}"
@@ -109,8 +111,14 @@ SRC_URI:remove = "https://gstreamer.freedesktop.org/src/gst-plugins-good/gst-plu
 
 SRC_URI:prepend = "${GST1.0-PLUGINS-GOOD_SRC};branch=${SRCBRANCH} "
 GST1.0-PLUGINS-GOOD_SRC ?= "gitsm://github.com/nxp-imx/gst-plugins-good.git;protocol=https"
-SRCBRANCH = "MM_04.08.02_2310_L6.1.y"
-SRCREV = "a4631334ad32abc513bde8f73491ef345f865a48"
+SRCBRANCH = "MM_04.08.03_2312_L6.6.y"
+SRCREV = "d361360510c97dc23abbfcdd22dff8214890527d"
+
+# set 32bit compile timer for 32-bit platform
+GLIBC_64BIT_TIME_FLAGS:mx6-nxp-bsp = ""
+GLIBC_64BIT_TIME_FLAGS:mx7-nxp-bsp = ""
+INSANE_SKIP:mx6-nxp-bsp:append = " 32bit-time"
+INSANE_SKIP:mx7-nxp-bsp:append = " 32bit-time"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-multimedia/gstreamer/gstreamer1.0_1.22.5.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0_1.22.5.imx.bb
@@ -74,6 +74,8 @@ FILES:${PN}-dev += "${libdir}/gstreamer-1.0/*.a ${libdir}/gstreamer-1.0/include"
 FILES:${PN}-bash-completion += "${datadir}/bash-completion/completions/ ${datadir}/bash-completion/helpers/gst*"
 FILES:${PN}-dbg += "${datadir}/gdb ${datadir}/gstreamer-1.0/gdb"
 
+RDEPENDS:${PN}-ptest:append:libc-glibc = " glibc-gconv-iso8859-5"
+
 CVE_PRODUCT = "gstreamer"
 
 PTEST_BUILD_HOST_FILES = ""
@@ -93,8 +95,8 @@ LIC_FILES_CHKSUM = " \
 SRC_URI:remove = "https://gstreamer.freedesktop.org/src/gstreamer/gstreamer-${PV}.tar.xz"
 SRC_URI:prepend = "${GST1.0_SRC};branch=${SRCBRANCH} "
 GST1.0_SRC ?= "gitsm://github.com/nxp-imx/gstreamer.git;protocol=https"
-SRCBRANCH = "MM_04.08.02_2310_L6.1.y"
-SRCREV = "e51e577a730191911b7050216814bede1b9545ae" 
+SRCBRANCH = "MM_04.08.03_2312_L6.6.y"
+SRCREV = "1a43c16272a7f4274eb8260e03206a57f317d823"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-multimedia/gstreamer/imx-gst1.0-plugin_git.bb
+++ b/recipes-multimedia/gstreamer/imx-gst1.0-plugin_git.bb
@@ -4,8 +4,8 @@
 # Released under the MIT license (see COPYING.MIT for the terms)
 
 DESCRIPTION = "Gstreamer freescale plugins"
-LICENSE = "GPL-2.0-only & LGPL-2.0-only & LGPL-2.1-only"
 SECTION = "multimedia"
+LICENSE = "GPL-2.0-only & LGPL-2.0-only & LGPL-2.1-only"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=fbc093901857fcd118f065f900982c24"
 
 DEPENDS = " \
@@ -19,7 +19,7 @@ DEPENDS = " \
 DEPENDS:append:mx6-nxp-bsp = " imx-lib"
 DEPENDS:append:mx7-nxp-bsp = " imx-lib"
 DEPENDS:append:mx8ulp-nxp-bsp = " imx-lib"
-DEPENDS:append:mx9-nxp-bsp = " imx-lib"
+DEPENDS:append:mx93-nxp-bsp = " imx-lib"
 DEPENDS:append:imxvpu = " imx-vpuwrap"
 DEPENDS:append:imxfbdev:imxgpu = " libdrm"
 DEPENDS_IMXGPU        = ""
@@ -27,13 +27,14 @@ DEPENDS_IMXGPU:imxgpu = "${DEPENDS_IMX_OPENCL_CONVERTER}"
 DEPENDS_IMX_OPENCL_CONVERTER               = ""
 DEPENDS_IMX_OPENCL_CONVERTER:mx8-nxp-bsp   = "imx-opencl-converter"
 DEPENDS_IMX_OPENCL_CONVERTER:mx8mm-nxp-bsp = ""
+DEPENDS_IMX_OPENCL_CONVERTER:mx95-nxp-bsp   = "imx-opencl-converter"
 
 # For backwards compatibility
-RREPLACES:${PN} = "gst1.0-fsl-plugin"
-RPROVIDES:${PN} = "gst1.0-fsl-plugin"
+RREPLACES:${PN}  = "gst1.0-fsl-plugin"
+RPROVIDES:${PN}  = "gst1.0-fsl-plugin"
 RCONFLICTS:${PN} = "gst1.0-fsl-plugin"
 
-PV = "4.8.2+git${SRCPV}"
+PV = "4.8.3+git${SRCPV}"
 
 SRC_URI = "git://github.com/nxp-imx/imx-gst1.0-plugin.git;protocol=https;branch=${SRCBRANCH} \
            file://0001-aiurdemux-Fix-type-of-USER_DATA_LOCATION.patch \
@@ -48,8 +49,8 @@ SRC_URI = "git://github.com/nxp-imx/imx-gst1.0-plugin.git;protocol=https;branch=
            file://0010-provide-declaration-for-aiur_register_external_typef.patch \
            file://0011-meson-Undef-_TIME_BITS-along-with-_FILE_OFFSET_BITS.patch \
            "
-SRCBRANCH = "MM_04.08.02_2310_L6.1.y"
-SRCREV = "a72df52acfec5f849ec93906e33cb50da01b0b2e" 
+SRCBRANCH = "MM_04.08.03_2312_L6.6.y"
+SRCREV = "91c7fec888cf8932c91e354331aad94975cae3ff"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-multimedia/imx-codec/imx-codec_4.8.3.bb
+++ b/recipes-multimedia/imx-codec/imx-codec_4.8.3.bb
@@ -5,14 +5,14 @@
 DESCRIPTION = "Freescale Multimedia codec libs"
 LICENSE = "Proprietary"
 SECTION = "multimedia"
-LIC_FILES_CHKSUM = "file://COPYING;md5=2827219e81f28aba7c6a569f7c437fa7"
+LIC_FILES_CHKSUM = "file://COPYING;md5=44a8052c384584ba09077e85a3d1654f"
 
 # Backward compatibility
 PROVIDES += "libfslcodec"
 
 SRC_URI = "${FSL_MIRROR}/${BP}.bin;fsl-eula=true"
-SRC_URI[md5sum] = "1977bab8d89972f08d9eee0122a64603"
-SRC_URI[sha256sum] = "b0744a91c265202a79a019c72f17cae01fd5b63a3ba451592b6c8349d95719e0"
+SRC_URI[md5sum] = "7ae1615aad2c0456b9be2ab804a6267e"
+SRC_URI[sha256sum] = "9facb3541903b4a6c6baa906f8c2c6cc01fc8c7b82a726c8da6d3681d4ed720b"
 
 inherit fsl-eula-unpack autotools pkgconfig
 

--- a/recipes-multimedia/imx-dsp/imx-dsp-codec-ext_2.1.7.bb
+++ b/recipes-multimedia/imx-dsp/imx-dsp-codec-ext_2.1.7.bb
@@ -2,14 +2,14 @@
 
 DESCRIPTION = "i.MX DSP Codec Wrapper and Lib owned by NXP"
 LICENSE = "Proprietary"
-LIC_FILES_CHKSUM = "file://COPYING;md5=2827219e81f28aba7c6a569f7c437fa7"
+LIC_FILES_CHKSUM = "file://COPYING;md5=44a8052c384584ba09077e85a3d1654f"
 
 inherit fsl-eula-unpack autotools pkgconfig
 
 SRC_URI = "${FSL_MIRROR}/${BP}.bin;fsl-eula=true"
 
-SRC_URI[md5sum] = "d211febb231717649d35553d22a50578"
-SRC_URI[sha256sum] = "d5f312d742493aee7e1f1304916aca8264bcf8d3f7de7e1522d30ba33efb6a8a"
+SRC_URI[md5sum] = "32251bc952ca7b9a4b12fadb9328a8c1"
+SRC_URI[sha256sum] = "0baa82410a77c68e39aaa987d91b41c94255d62294fa2f5a399169f3068862cc"
 
 EXTRA_OECONF:append:mx8qm-nxp-bsp = " --enable-imx8qmqxp"
 EXTRA_OECONF:append:mx8qxp-nxp-bsp = " --enable-imx8qmqxp"

--- a/recipes-multimedia/imx-dsp/imx-dsp_2.1.7.bb
+++ b/recipes-multimedia/imx-dsp/imx-dsp_2.1.7.bb
@@ -2,15 +2,15 @@
 
 DESCRIPTION = "i.MX DSP Wrapper, Firmware Binary, Codec Libraries"
 LICENSE = "Proprietary"
-LIC_FILES_CHKSUM = "file://COPYING;md5=2827219e81f28aba7c6a569f7c437fa7"
+LIC_FILES_CHKSUM = "file://COPYING;md5=44a8052c384584ba09077e85a3d1654f"
 
 
 inherit fsl-eula-unpack autotools pkgconfig
 
 SRC_URI = "${FSL_MIRROR}/${BP}.bin;fsl-eula=true"
 
-SRC_URI[md5sum] = "07ff97f93abe2bc6117a120e534e70d4"
-SRC_URI[sha256sum] = "5eab0259228746499990afe8de758a6ed505ec3fbd8a8adfc87a83c46a69bf2c"
+SRC_URI[md5sum] = "199f88716f289e93e0954fa6475a3cbc"
+SRC_URI[sha256sum] = "83eaef592de33b4d5e8fae63d798cc955bf3c414911c87afeb65a20af01fb0b6"
 
 EXTRA_OECONF = " \
     -datadir=${base_libdir}/firmware \

--- a/recipes-multimedia/imx-opencl-converter/imx-opencl-converter_0.2.0.bb
+++ b/recipes-multimedia/imx-opencl-converter/imx-opencl-converter_0.2.0.bb
@@ -2,17 +2,17 @@
 DESCRIPTION = "NXP Multimedia opencl converter lib"
 LICENSE = "Proprietary"
 SECTION = "multimedia"
-LIC_FILES_CHKSUM = "file://COPYING;md5=2827219e81f28aba7c6a569f7c437fa7"
+LIC_FILES_CHKSUM = "file://COPYING;md5=44a8052c384584ba09077e85a3d1654f"
 DEPENDS = "opencl-headers"
 
 SRC_URI = "${FSL_MIRROR}/${BP}.bin;fsl-eula=true"
-SRC_URI[md5sum] = "426f4b1df6fe123f769aa8a0d7ef17d8"
-SRC_URI[sha256sum] = "16612be09675c2abe9c62337e6932b2e3fb788b1ec95ecede757350c4abf6870"
+SRC_URI[md5sum] = "dc668682189ce740fb46073e62f58066"
+SRC_URI[sha256sum] = "9f283df500c57421b87d96d9af7022ab490bc241aa28d00755beaadabbcd754b"
 
 inherit fsl-eula-unpack autotools pkgconfig meson
 
 FILES:${PN} += "${datadir}/"
 
 COMPATIBLE_MACHINE               = "(^$)"
-COMPATIBLE_MACHINE:imxgpu        = "(mx8-nxp-bsp)"
+COMPATIBLE_MACHINE:imxgpu        = "(mx8-nxp-bsp|mx95-nxp-bsp)"
 COMPATIBLE_MACHINE:mx8mm-nxp-bsp = "(^$)"

--- a/recipes-multimedia/imx-parser/imx-parser_4.8.3.bb
+++ b/recipes-multimedia/imx-parser/imx-parser_4.8.3.bb
@@ -5,7 +5,7 @@
 DESCRIPTION = "Freescale Multimedia parser libs"
 LICENSE = "Proprietary"
 SECTION = "multimedia"
-LIC_FILES_CHKSUM = "file://COPYING;md5=2827219e81f28aba7c6a569f7c437fa7"
+LIC_FILES_CHKSUM = "file://COPYING;md5=44a8052c384584ba09077e85a3d1654f"
 
 # For backwards compatibility
 PROVIDES += "libfslparser"
@@ -14,8 +14,8 @@ RPROVIDES:${PN} = "libfslparser"
 RCONFLICTS:${PN} = "libfslparser"
 
 SRC_URI = "${FSL_MIRROR}/${BP}.bin;fsl-eula=true"
-SRC_URI[md5sum] = "2e862fce70bc82649057ed552473d982"
-SRC_URI[sha256sum] = "20f326821ced5d6855f81794b66ec1f0c334e9ec7a9be1368a9b4dc501b666c6"
+SRC_URI[md5sum] = "9bca484287f5592b86ed10c1761a3fcc"
+SRC_URI[sha256sum] = "b25267eefb4618b2ba8d6aba46a5b4e09621a44115036fc896e0777006472043"
 
 inherit fsl-eula-unpack autotools pkgconfig
 

--- a/recipes-multimedia/imx-vpuwrap/imx-vpuwrap_git.bb
+++ b/recipes-multimedia/imx-vpuwrap/imx-vpuwrap_git.bb
@@ -11,8 +11,8 @@ DEPENDS = "virtual/imxvpu"
 DEPENDS:append:mx8mp-nxp-bsp = " imx-vpu-hantro-vc"
 
 SRC_URI = "git://github.com/NXP/imx-vpuwrap.git;protocol=https;branch=${SRCBRANCH}"
-SRCBRANCH = "MM_04.08.02_2310_L6.1.y"
-SRCREV = "6f9b4c82e37688f50d756529d90b48c3cc80f2f6" 
+SRCBRANCH = "MM_04.08.03_2312_L6.6.y"
+SRCREV = "f974cecdb00b4a214e4b5229f2279e772ee43306"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-multimedia/pipewire/pipewire/0001-launch-allow-pipewire-pulse-can-be-started-by-root.patch
+++ b/recipes-multimedia/pipewire/pipewire/0001-launch-allow-pipewire-pulse-can-be-started-by-root.patch
@@ -1,0 +1,41 @@
+From 2cac94185824aa7df07ec48a2872f3d26d517a6d Mon Sep 17 00:00:00 2001
+From: Shengjiu Wang <shengjiu.wang@nxp.com>
+Date: Tue, 28 Nov 2023 10:23:42 +0800
+Subject: [PATCH] launch: allow pipewire-pulse can be started by root.
+
+revert commit 8942f6b40 ("launch: avoid autostarting pipewire-pulse
+systemd units for root")
+
+Upstream-Status: Inappropriate [i.MX specific]
+Signed-off-by: Shengjiu Wang <shengjiu.wang@nxp.com>
+---
+ src/daemon/systemd/user/pipewire-pulse.service.in | 1 -
+ src/daemon/systemd/user/pipewire-pulse.socket     | 1 -
+ 2 files changed, 2 deletions(-)
+
+diff --git a/src/daemon/systemd/user/pipewire-pulse.service.in b/src/daemon/systemd/user/pipewire-pulse.service.in
+index 73d22e532..da7728ee3 100644
+--- a/src/daemon/systemd/user/pipewire-pulse.service.in
++++ b/src/daemon/systemd/user/pipewire-pulse.service.in
+@@ -14,7 +14,6 @@ Description=PipeWire PulseAudio
+ # After=pipewire-pulse.socket is not needed, as it is already implicit in the
+ # socket-service relationship, see systemd.socket(5).
+ Requires=pipewire-pulse.socket
+-ConditionUser=!root
+ Wants=pipewire.service pipewire-session-manager.service
+ After=pipewire.service pipewire-session-manager.service
+ Conflicts=pulseaudio.service
+diff --git a/src/daemon/systemd/user/pipewire-pulse.socket b/src/daemon/systemd/user/pipewire-pulse.socket
+index 1ae5edafb..d27fb0e26 100644
+--- a/src/daemon/systemd/user/pipewire-pulse.socket
++++ b/src/daemon/systemd/user/pipewire-pulse.socket
+@@ -1,6 +1,5 @@
+ [Unit]
+ Description=PipeWire PulseAudio
+-ConditionUser=!root
+ Conflicts=pulseaudio.socket
+ 
+ [Socket]
+-- 
+2.34.1
+

--- a/recipes-multimedia/pipewire/pipewire_%.bbappend
+++ b/recipes-multimedia/pipewire/pipewire_%.bbappend
@@ -1,0 +1,14 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI:append:imx-nxp-bsp = " file://0001-launch-allow-pipewire-pulse-can-be-started-by-root.patch"
+
+SYSTEMD_AUTO_ENABLE:imx-nxp-bsp = "disable"
+
+DEPENDS:append:mx95-nxp-bsp = " libdrm"
+
+PACKAGECONFIG:remove:mx95-nxp-bsp = "libcamera"
+PACKAGECONFIG:remove:imx-nxp-bsp = "gstreamer"
+PACKAGECONFIG:class-target:append:imx-nxp-bsp = " ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'bluez-lc3', '', d)}"
+
+# FIXME: Needs to qualify on PACKAGECONFIG
+SYSTEMD_SERVICE:${PN}-pulse = "pipewire-pulse.service"


### PR DESCRIPTION
Updated:
        - alsa-lib update to 6.6.3_1.0.0 release and skip QA check for 32bit timer
        - gstreamer1.0-plugins-bad_1.22.5.imx update to 6.6.3_1.0.0 release, enable g2d
        - gstreamer1.0-plugins-base_1.22.5.imx update to 6.6.3_1.0.0 release, add opengl dependencies
        - gstreamer1.0-plugins-good_1.22.5.imx update to 6.6.3_1.0.0 release, enable pulseaudio and 32bit timer
        - gstreamer1.0_1.22.5.imx update to 6.6.3_1.0.0 release and add runtime dependency glibc-gconv-iso8859-5
        - imx-gst1.0-plugin update to 6.6.3_1.0.0 release
        - imx-vpuwrap update to 6.6.3_1.0.0 release

Upgraded:
        - imx-codec: 4.8.2 -> 4.8.3
        - imx-dsp-codec-ext: 2.1.6 -> 2.1.7
        - imx-dsp: 2.1.6 -> 2.1.7
        - imx-parser: 4.8.2 -> 4.8.3
        - imx-opencl-converter: 0.1 -> 0.2.0
New feature:
        - pipewire_1.0.0