### PR TITLE
imx6qdlsabresd: Change device tree paths to linux mainline

### DIFF
--- a/conf/machine/imx6qdlsabresd.conf
+++ b/conf/machine/imx6qdlsabresd.conf
@@ -36,9 +36,9 @@ KERNEL_DEVICETREE = " \
 	imx6dl-sabresd-ldo.dtb \
 "
 KERNEL_DEVICETREE:use-mainline-bsp = " \
-    imx6qp-sabresd.dtb \
-    imx6q-sabresd.dtb \
-    imx6dl-sabresd.dtb \
+    nxp/imx/imx6qp-sabresd.dtb \
+    nxp/imx/imx6q-sabresd.dtb \
+    nxp/imx/imx6dl-sabresd.dtb \
 "
 
 UBOOT_CONFIG ??= " \


### PR DESCRIPTION
Change device tree paths to linux mainline, this was changed to the latest linux version.