### PR TITLE
linux-fslc-imx: Bump revision to 2bfda7392

### DIFF
--- a/recipes-kernel/linux/linux-fslc-imx_6.1.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_6.1.bb
@@ -58,7 +58,7 @@ KERNEL_DEVICETREE_32BIT_COMPATIBILITY_UPDATE = "1"
 
 KBRANCH = "6.1-2.2.x-imx"
 SRC_URI = "git://github.com/Freescale/linux-fslc.git;branch=${KBRANCH};protocol=https"
-SRCREV = "32a344619c750cdcbe31bed754adc1b30d362e45"
+SRCREV = "2bfda7392e6621dd9060f87d7f9d601bb1906dbf"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.


### PR DESCRIPTION
This commit includes the following changes:
    - 2bfda7392e66 Merge pull request #658 from tq-niebelm/6.1-2.2.x-imx
    - 86a389d3e879 Merge remote-tracking branch 'lf-6.1.y' into 6.1-2.2.x-imx
    - dad30ee71946 Merge pull request #657 from tq-niebelm/fslc-6.1-2.2.x-imx-fixes
    - 5f6af3b30755 arm64: dts: imx8mm: fix csi nodes for NXP vendor stack
    - 2443a1146bfd phy: phy-fsl-lynx-28g: fix wrong merge resolve
    - 4e3fc5471376 Merge pull request #652 from schiffermtq/6.1-2.2.x-imx-fixes
    - 2047384fddad i2c: imx: fix lockdep issue
    - 4e0b61655262 ARM: dts: imx7s: fix ARM timer definition
    - e0170f358bd1 ARM: imx: fix OCOTP compatible string on i.MX6SLL and i.MX6ULL
    - 8ff00014e030 ARM: imx: fix i.MX7D-only build with CONFIG_SMP
    - 1f7da780d0e7 ARM: imx: fix i.MX7D-only build with CONFIG_OPTEE
    - 658bd1c4e0d1 ARM: imx: include i.MX6SX DDR freq implementation for i.MX6UL
    - 5bf7454667aa ARM: imx: do not include smp_wfe_imx6.S for i.MX6SX
    - cfe00450b7cf ARM: imx: enable HAVE_IMX_BUSFREQ for i.MX6
    - 62447ea0e0eb ARM: imx: do not build busfreq without HAVE_IMX_BUSFREQ