### PR TITLE
Update linux-imx and linux-fslc-imx versions

### DIFF
--- a/conf/machine/imx6qdlsabreauto.conf
+++ b/conf/machine/imx6qdlsabreauto.conf
@@ -17,19 +17,27 @@ require conf/machine/include/imx-base.inc
 require conf/machine/include/arm/armv7a/tune-cortexa9.inc
 
 KERNEL_DEVICETREE = " \
-    imx6qp-sabreauto.dtb imx6qp-sabreauto-ecspi.dtb imx6qp-sabreauto-flexcan1.dtb \
-    imx6qp-sabreauto-gpmi-weim.dtb \
+    nxp/imx/imx6qp-sabreauto.dtb \
+    nxp/imx/imx6qp-sabreauto-ecspi.dtb \
+    nxp/imx/imx6qp-sabreauto-flexcan1.dtb \
+    nxp/imx/imx6qp-sabreauto-gpmi-weim.dtb \
     \
-    imx6q-sabreauto.dtb imx6q-sabreauto-gpmi-weim.dtb imx6q-sabreauto-ecspi.dtb \
-    imx6q-sabreauto-flexcan1.dtb imx6q-sabreauto-enetirq.dtb \
+    nxp/imx/imx6q-sabreauto.dtb \
+    nxp/imx/imx6q-sabreauto-gpmi-weim.dtb \
+    nxp/imx/imx6q-sabreauto-ecspi.dtb \
+    nxp/imx/imx6q-sabreauto-flexcan1.dtb \
+    nxp/imx/imx6q-sabreauto-enetirq.dtb \
     \
-    imx6dl-sabreauto.dtb imx6dl-sabreauto-gpmi-weim.dtb imx6dl-sabreauto-ecspi.dtb \
-    imx6dl-sabreauto-flexcan1.dtb imx6dl-sabreauto-enetirq.dtb \
+    nxp/imx/imx6dl-sabreauto.dtb \
+    nxp/imx/imx6dl-sabreauto-gpmi-weim.dtb \
+    nxp/imx/imx6dl-sabreauto-ecspi.dtb \
+    nxp/imx/imx6dl-sabreauto-flexcan1.dtb \
+    nxp/imx/imx6dl-sabreauto-enetirq.dtb \
 "
 KERNEL_DEVICETREE:use-mainline-bsp = " \
-    imx6qp-sabreauto.dtb \
-    imx6q-sabreauto.dtb \
-    imx6dl-sabreauto.dtb \
+    nxp/imx/imx6qp-sabreauto.dtb \
+    nxp/imx/imx6q-sabreauto.dtb \
+    nxp/imx/imx6dl-sabreauto.dtb \
 "
 
 UBOOT_CONFIG ??= " \

--- a/conf/machine/imx6qdlsabresd.conf
+++ b/conf/machine/imx6qdlsabresd.conf
@@ -17,23 +17,23 @@ require conf/machine/include/imx-base.inc
 require conf/machine/include/arm/armv7a/tune-cortexa9.inc
 
 KERNEL_DEVICETREE = " \
-	imx6qp-sabresd-btwifi.dtb \
-	imx6qp-sabresd.dtb \
-	imx6qp-sabresd-hdcp.dtb \
-	imx6qp-sabresd-ldo.dtb \
+	nxp/imx/imx6qp-sabresd-btwifi.dtb \
+	nxp/imx/imx6qp-sabresd.dtb \
+	nxp/imx/imx6qp-sabresd-hdcp.dtb \
+	nxp/imx/imx6qp-sabresd-ldo.dtb \
 	\
-	imx6q-sabresd-btwifi.dtb \
-	imx6q-sabresd.dtb \
-	imx6q-sabresd-enetirq.dtb \
-	imx6q-sabresd-hdcp.dtb \
-	imx6q-sabresd-ldo.dtb \
-	imx6q-sabresd-uart.dtb \
+	nxp/imx/imx6q-sabresd-btwifi.dtb \
+	nxp/imx/imx6q-sabresd.dtb \
+	nxp/imx/imx6q-sabresd-enetirq.dtb \
+	nxp/imx/imx6q-sabresd-hdcp.dtb \
+	nxp/imx/imx6q-sabresd-ldo.dtb \
+	nxp/imx/imx6q-sabresd-uart.dtb \
 	\
-	imx6dl-sabresd-btwifi.dtb \
-	imx6dl-sabresd.dtb \
-	imx6dl-sabresd-enetirq.dtb \
-	imx6dl-sabresd-hdcp.dtb \
-	imx6dl-sabresd-ldo.dtb \
+	nxp/imx/imx6dl-sabresd-btwifi.dtb \
+	nxp/imx/imx6dl-sabresd.dtb \
+	nxp/imx/imx6dl-sabresd-enetirq.dtb \
+	nxp/imx/imx6dl-sabresd-hdcp.dtb \
+	nxp/imx/imx6dl-sabresd-ldo.dtb \
 "
 KERNEL_DEVICETREE:use-mainline-bsp = " \
     nxp/imx/imx6qp-sabresd.dtb \

--- a/conf/machine/imx6slevk.conf
+++ b/conf/machine/imx6slevk.conf
@@ -9,12 +9,12 @@ MACHINEOVERRIDES =. "mx6sl:"
 include conf/machine/include/imx-base.inc
 require conf/machine/include/arm/armv7a/tune-cortexa9.inc
 
-KERNEL_DEVICETREE = "imx6sl-evk.dtb"
+KERNEL_DEVICETREE = "nxp/imx/imx6sl-evk.dtb"
 KERNEL_DEVICETREE:append:use-nxp-bsp = " \
-    imx6sl-evk-btwifi.dtb \
-    imx6sl-evk-csi.dtb \
-    imx6sl-evk-ldo.dtb \
-    imx6sl-evk-uart.dtb \
+    nxp/imx/imx6sl-evk-btwifi.dtb \
+    nxp/imx/imx6sl-evk-csi.dtb \
+    nxp/imx/imx6sl-evk-ldo.dtb \
+    nxp/imx/imx6sl-evk-uart.dtb \
 "
 
 UBOOT_MAKE_TARGET = "u-boot.imx"

--- a/conf/machine/imx6sllevk.conf
+++ b/conf/machine/imx6sllevk.conf
@@ -9,10 +9,10 @@ MACHINEOVERRIDES =. "mx6sll:"
 include conf/machine/include/imx-base.inc
 require conf/machine/include/arm/armv7a/tune-cortexa9.inc
 
-KERNEL_DEVICETREE = "imx6sll-evk.dtb"
+KERNEL_DEVICETREE = "nxp/imx/imx6sll-evk.dtb"
 KERNEL_DEVICETREE:append:use-nxp-bsp = " \
-    imx6sll-evk-btwifi.dtb \
-    imx6sll-evk-reva.dtb"
+    nxp/imx/imx6sll-evk-btwifi.dtb \
+    nxp/imx/imx6sll-evk-reva.dtb"
 
 UBOOT_MAKE_TARGET = "u-boot.imx"
 UBOOT_SUFFIX = "imx"

--- a/conf/machine/imx6sxsabreauto.conf
+++ b/conf/machine/imx6sxsabreauto.conf
@@ -9,8 +9,8 @@ MACHINEOVERRIDES =. "mx6sx:"
 require conf/machine/include/imx-base.inc
 require conf/machine/include/arm/armv7a/tune-cortexa9.inc
 
-KERNEL_DEVICETREE = "imx6sx-sabreauto.dtb"
-KERNEL_DEVICETREE:use-mainline-bsp = "imx6sx-sabreauto.dtb"
+KERNEL_DEVICETREE = "nxp/imx/imx6sx-sabreauto.dtb"
+KERNEL_DEVICETREE:use-mainline-bsp = "nxp/imx/imx6sx-sabreauto.dtb"
 
 UBOOT_MAKE_TARGET = "u-boot.imx"
 UBOOT_SUFFIX = "imx"

--- a/conf/machine/imx6sxsabresd.conf
+++ b/conf/machine/imx6sxsabresd.conf
@@ -10,19 +10,19 @@ require conf/machine/include/imx-base.inc
 require conf/machine/include/arm/armv7a/tune-cortexa9.inc
 
 KERNEL_DEVICETREE = " \
-    imx6sx-sdb.dtb \
-    imx6sx-sdb-reva.dtb \
-    imx6sx-sdb-sai.dtb \
+    nxp/imx/imx6sx-sdb.dtb \
+    nxp/imx/imx6sx-sdb-reva.dtb \
+    nxp/imx/imx6sx-sdb-sai.dtb \
 "
 KERNEL_DEVICETREE:append:use-nxp-bsp = " \
-    imx6sx-sdb-btwifi.dtb \
-    imx6sx-sdb-emmc.dtb \
-    imx6sx-sdb-lcdif1.dtb \
-    imx6sx-sdb-ldo.dtb \
-    imx6sx-sdb-m4.dtb \
-    imx6sx-sdb-mqs.dtb \
-    imx6sx-sdb-pcie-ep.dtb \
-    imx6sx-sdb-reva-ldo.dtb \
+    nxp/imx/imx6sx-sdb-btwifi.dtb \
+    nxp/imx/imx6sx-sdb-emmc.dtb \
+    nxp/imx/imx6sx-sdb-lcdif1.dtb \
+    nxp/imx/imx6sx-sdb-ldo.dtb \
+    nxp/imx/imx6sx-sdb-m4.dtb \
+    nxp/imx/imx6sx-sdb-mqs.dtb \
+    nxp/imx/imx6sx-sdb-pcie-ep.dtb \
+    nxp/imx/imx6sx-sdb-reva-ldo.dtb \
 "
 
 UBOOT_MAKE_TARGET = "u-boot.imx"

--- a/conf/machine/imx6ulevk.conf
+++ b/conf/machine/imx6ulevk.conf
@@ -12,16 +12,16 @@ include conf/machine/include/arm/armv7a/tune-cortexa7.inc
 MACHINE_FEATURES += "wifi bluetooth bcm4339 bcm43455 nxp8987-sdio"
 
 KERNEL_DEVICETREE = " \
-    imx6ul-14x14-evk-btwifi.dtb \
-    imx6ul-14x14-evk-btwifi-sdio3_0.dtb \
-    imx6ul-14x14-evk-csi.dtb \
-    imx6ul-14x14-evk.dtb \
-    imx6ul-14x14-evk-ecspi.dtb \
-    imx6ul-14x14-evk-ecspi-slave.dtb \
-    imx6ul-14x14-evk-emmc.dtb \
-    imx6ul-14x14-evk-gpmi-weim.dtb \
+    nxp/imx/imx6ul-14x14-evk-btwifi.dtb \
+    nxp/imx/imx6ul-14x14-evk-btwifi-sdio3_0.dtb \
+    nxp/imx/imx6ul-14x14-evk-csi.dtb \
+    nxp/imx/imx6ul-14x14-evk.dtb \
+    nxp/imx/imx6ul-14x14-evk-ecspi.dtb \
+    nxp/imx/imx6ul-14x14-evk-ecspi-slave.dtb \
+    nxp/imx/imx6ul-14x14-evk-emmc.dtb \
+    nxp/imx/imx6ul-14x14-evk-gpmi-weim.dtb \
 "
-KERNEL_DEVICETREE:use-mainline-bsp = "imx6ul-14x14-evk.dtb"
+KERNEL_DEVICETREE:use-mainline-bsp = "nxp/imx/imx6ul-14x14-evk.dtb"
 
 ### u-boot-fslc settings ###
 

--- a/conf/machine/imx6ullevk.conf
+++ b/conf/machine/imx6ullevk.conf
@@ -12,13 +12,13 @@ include conf/machine/include/arm/armv7a/tune-cortexa7.inc
 MACHINE_FEATURES += "wifi bluetooth bcm4339 bcm43455 nxp8801-sdio nxp8987-sdio"
 
 KERNEL_DEVICETREE = " \
-    imx6ull-14x14-evk.dtb \
+    nxp/imx/imx6ull-14x14-evk.dtb \
 "
 
 KERNEL_DEVICETREE:append:use-nxp-bsp = " \
-    imx6ull-14x14-evk-btwifi.dtb \
-    imx6ull-14x14-evk-emmc.dtb \
-    imx6ull-14x14-evk-gpmi-weim.dtb \
+    nxp/imx/imx6ull-14x14-evk-btwifi.dtb \
+    nxp/imx/imx6ull-14x14-evk-emmc.dtb \
+    nxp/imx/imx6ull-14x14-evk-gpmi-weim.dtb \
 "
 
 UBOOT_MAKE_TARGET = "u-boot.imx"

--- a/conf/machine/imx6ulz-14x14-evk.conf
+++ b/conf/machine/imx6ulz-14x14-evk.conf
@@ -12,12 +12,12 @@ include conf/machine/include/arm/armv7a/tune-cortexa7.inc
 MACHINE_FEATURES += "wifi bluetooth bcm4339 bcm43455 nxp8987-sdio"
 
 KERNEL_DEVICETREE = " \
-    imx6ulz-14x14-evk.dtb \
+    nxp/imx/imx6ulz-14x14-evk.dtb \
 "
 KERNEL_DEVICETREE:append:use-nxp-bsp = " \
-    imx6ulz-14x14-evk-btwifi.dtb \
-    imx6ulz-14x14-evk-emmc.dtb \
-    imx6ulz-14x14-evk-gpmi-weim.dtb \
+    nxp/imx/imx6ulz-14x14-evk-btwifi.dtb \
+    nxp/imx/imx6ulz-14x14-evk-emmc.dtb \
+    nxp/imx/imx6ulz-14x14-evk-gpmi-weim.dtb \
 "
 
 UBOOT_MAKE_TARGET = "u-boot.imx"

--- a/conf/machine/imx7dsabresd.conf
+++ b/conf/machine/imx7dsabresd.conf
@@ -11,18 +11,18 @@ include conf/machine/include/arm/armv7a/tune-cortexa7.inc
 
 MACHINE_FEATURES += "pci wifi bluetooth bcm4339 bcm43455 nxp8987-sdio"
 
-KERNEL_DEVICETREE = "imx7d-sdb.dtb"
+KERNEL_DEVICETREE = "nxp/imx/imx7d-sdb.dtb"
 KERNEL_DEVICETREE:append:use-nxp-bsp = " \
-    imx7d-sdb-epdc.dtb \
-    imx7d-sdb-gpmi-weim.dtb \
-    imx7d-sdb-m4.dtb \
-    imx7d-sdb-mipi-dsi.dtb \
-    imx7d-sdb-mqs.dtb \
-    imx7d-sdb-pcie-ep.dtb \
-    imx7d-sdb-qspi.dtb \
-    imx7d-sdb-reva.dtb \
-    imx7d-sdb-sht11.dtb \
-    imx7d-sdb-usd-wifi.dtb \
+    nxp/imx/imx7d-sdb-epdc.dtb \
+    nxp/imx/imx7d-sdb-gpmi-weim.dtb \
+    nxp/imx/imx7d-sdb-m4.dtb \
+    nxp/imx/imx7d-sdb-mipi-dsi.dtb \
+    nxp/imx/imx7d-sdb-mqs.dtb \
+    nxp/imx/imx7d-sdb-pcie-ep.dtb \
+    nxp/imx/imx7d-sdb-qspi.dtb \
+    nxp/imx/imx7d-sdb-reva.dtb \
+    nxp/imx/imx7d-sdb-sht11.dtb \
+    nxp/imx/imx7d-sdb-usd-wifi.dtb \
 "
 
 UBOOT_MAKE_TARGET = "u-boot.imx"

--- a/conf/machine/imx7ulpevk.conf
+++ b/conf/machine/imx7ulpevk.conf
@@ -12,20 +12,20 @@ include conf/machine/include/arm/armv7a/tune-cortexa7.inc
 MACHINE_FEATURES += "pci wifi bluetooth bcm43430 nxp8987-sdio"
 
 KERNEL_DEVICETREE = " \
-	imx7ulp-evk.dtb \
+	nxp/imx/imx7ulp-evk.dtb \
 "
 KERNEL_DEVICETREE:append:use-nxp-bsp = " \
-	imx7ulp-evk-ft5416.dtb \
-	imx7ulp-evk-mipi.dtb \
-	imx7ulp-evkb.dtb \
-	imx7ulp-evkb-emmc.dtb \
-	imx7ulp-evkb-lpuart.dtb \
-	imx7ulp-evkb-mipi.dtb \
-	imx7ulp-evkb-rm68191-qhd.dtb \
-	imx7ulp-evkb-rm68200-wxga.dtb \
-	imx7ulp-evkb-sd1.dtb \
-	imx7ulp-evkb-sensors-to-i2c5.dtb \
-	imx7ulp-evkb-spi-slave.dtb \
+	nxp/imx/imx7ulp-evk-ft5416.dtb \
+	nxp/imx/imx7ulp-evk-mipi.dtb \
+	nxp/imx/imx7ulp-evkb.dtb \
+	nxp/imx/imx7ulp-evkb-emmc.dtb \
+	nxp/imx/imx7ulp-evkb-lpuart.dtb \
+	nxp/imx/imx7ulp-evkb-mipi.dtb \
+	nxp/imx/imx7ulp-evkb-rm68191-qhd.dtb \
+	nxp/imx/imx7ulp-evkb-rm68200-wxga.dtb \
+	nxp/imx/imx7ulp-evkb-sd1.dtb \
+	nxp/imx/imx7ulp-evkb-sensors-to-i2c5.dtb \
+	nxp/imx/imx7ulp-evkb-spi-slave.dtb \
 "
 
 UBOOT_MAKE_TARGET = "u-boot.imx"

--- a/recipes-kernel/linux/linux-fslc-imx_6.6.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_6.6.bb
@@ -54,18 +54,16 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 
 require linux-imx.inc
 
-KERNEL_DEVICETREE_32BIT_COMPATIBILITY_UPDATE = "1"
-
-KBRANCH = "6.1-2.2.x-imx"
+KBRANCH = "6.6-1.0.x-imx"
 SRC_URI = "git://github.com/Freescale/linux-fslc.git;branch=${KBRANCH};protocol=https"
-SRCREV = "2bfda7392e6621dd9060f87d7f9d601bb1906dbf"
+SRCREV = "ccf0a99701a701fb48a04e31ffe3f9d585a8374a"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "6.1.70"
+LINUX_VERSION = "6.6.3"
 
 KBUILD_DEFCONFIG:mx6-generic-bsp = "imx_v7_defconfig"
 KBUILD_DEFCONFIG:mx7-generic-bsp = "imx_v7_defconfig"
@@ -73,7 +71,7 @@ KBUILD_DEFCONFIG:mx8-generic-bsp = "imx_v8_defconfig"
 KBUILD_DEFCONFIG:mx9-generic-bsp = "imx_v8_defconfig"
 
 # Local version indicates the branch name in the NXP kernel tree where patches are collected from.
-LOCALVERSION = "-lf-6.1.y"
+LOCALVERSION = "-lf-6.6.y"
 
 DEFAULT_PREFERENCE = "1"
 

--- a/recipes-kernel/linux/linux-imx-headers_6.6.bb
+++ b/recipes-kernel/linux/linux-imx-headers_6.6.bb
@@ -8,9 +8,9 @@ LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
 SRC_URI = "git://github.com/nxp-imx/linux-imx.git;protocol=https;branch=${SRCBRANCH}"
-SRCBRANCH = "lf-6.1.y"
-LOCALVERSION = "-6.1.55-2.2.0"
-SRCREV = "770c5fe2c1d1529fae21b7043911cd50c6cf087e"
+SRCBRANCH = "lf-6.6.y"
+LOCALVERSION = "-6.6.3-1.0.0"
+SRCREV = "ccf0a99701a701fb48a04e31ffe3f9d585a8374a"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-kernel/linux/linux-imx_6.6.bb
+++ b/recipes-kernel/linux/linux-imx_6.6.bb
@@ -12,18 +12,16 @@ i.MX Family Reference Boards. It includes support for many IPs such as GPU, VPU 
 
 require recipes-kernel/linux/linux-imx.inc
 
-KERNEL_DEVICETREE_32BIT_COMPATIBILITY_UPDATE = "1"
-
-SRCBRANCH = "lf-6.1.y"
-LOCALVERSION = "-6.1.55-2.2.0"
-SRCREV = "770c5fe2c1d1529fae21b7043911cd50c6cf087e"
+SRCBRANCH = "lf-6.6.y"
+LOCALVERSION = "-6.6.3-1.0.0"
+SRCREV = "ccf0a99701a701fb48a04e31ffe3f9d585a8374a"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "6.1.55"
+LINUX_VERSION = "6.6.3"
 
 KBUILD_DEFCONFIG:mx6-generic-bsp = "imx_v7_defconfig"
 KBUILD_DEFCONFIG:mx7-generic-bsp = "imx_v7_defconfig"


### PR DESCRIPTION
This PR updates the linux-imx and linux-fslc-imx to the branches based on linux 6.6 version