### PR TITLE
u-boot-imx: Update to lf-6.6.3-1.0.0

### DIFF
--- a/recipes-bsp/u-boot/u-boot-imx-common_2023.04.inc
+++ b/recipes-bsp/u-boot/u-boot-imx-common_2023.04.inc
@@ -5,8 +5,8 @@ LIC_FILES_CHKSUM = "file://Licenses/gpl-2.0.txt;md5=b234ee4d69f5fce4486a80fdaf4a
 
 SRC_URI = "git://github.com/nxp-imx/uboot-imx.git;protocol=https;branch=${SRCBRANCH}"
 SRCBRANCH = "lf_v2023.04"
-LOCALVERSION ?= "-imx_v2023.04_6.1.55-2.2.0"
-SRCREV = "49b102d98881fc28af6e0a8af5ea2186c1d90a5f"
+LOCALVERSION ?= "-imx_v2023.04_6.6.3-1.0.0"
+SRCREV = "f8a2983ec83afd43731d905b4ff0ffd57b57f2f0"
 
 DEPENDS += " \
     bc-native \


### PR DESCRIPTION
Part of https://github.com/Freescale/meta-freescale/issues/1777
Update the u-boot-imx to the tag lf-6.6.3-1.0.0, that is used in the NXP BSP LF6.6.3_1.0.0.

Relevant changes:
- f8a2983ec83 LFU-646-2 arm: imx: Fix coverity issue (Unintentional integer overflow)
- 89291cfd36e LFU-646-1 arm: imx: Fix coverity issue 36261228: Use after free
- 9b3315f59f6 LFU-647 mmc: Fix coverity issue 28682987: Logically dead code
- b72b414f4bc LFU-643 misc: imx_ele: Fix FSB redundancy fuse word check
- 398fdef0c06 MA-22105 android: imx8q: use default mcu reserved memory
- c1505f0cda5 LFU-639 ddr: imx95: add CRC field in quick boot state
- 3bdcde9e46c LFU-638 imx95-Titan: Fix I2C address conflict and I2C7 speed
- c1665b45e75 LFU-637 doc:imx:ahab Add i.MX95 Information to Secure Boot documentation
- 9e960b15dfb LF-11213-2 arm: dts: imx95: Update USB3.0 nodes
- 4c1cf0a09c8 LF-11213-1 usb: xhci-imx8m: Fix reference clock period issue
- 708942fdbfd LFU-635-3 titan-imx95: Add Toradex iMX95 Titan board support
- 822f0d2b411 LFU-635-2 arm: dts: Add DTS for Toradex iMX95 Titan EVK
- 4487e2901e6 LFU-635-1 net: fsl_enetc: Fix enetc id issue on iMX95
- c5f891339fa LF-11115 imx: ahab: Use authenticated header for images loading
- 93ac26d6345 LFU-634 imx95: evk: add xen boot command
- 1e02deaab94 LFU-633-2 imx95_evk: Enable UHS for SD and HS400ES for eMMC
- ade3c564414 LFU-633-1 arm: dts: imx95_evk: Update eMMC and SD pad setting
- 02d793b463d LFU-609-1 ddr: imx95: change QB training data address
- 46571fc06a2 LFU-632 imx95_evk: Power up hsiomix for USB gadget used in SPL
- 9f832f67948 LF-10799-2: mtd: spi-nor: remove redundant and enable 4k subsector
- 587050c2279 [SPSDK-2975] Add command for raw ELE message call
- e5128cd6447 LFU-631 imx95_evk: Change default kernel DTB
- 35cde0dd1cb LFU-628-3 imx95: enable scmi thermal
- 14891a9d9d8 LFU-628-2 imx9: scmi: correct the value of temperature from scmi thermal
- 3ca247d4099 LFU-628-1 thermal: scmi: Support scmi to get and set config of sensor
- 1a37dcea25e LF-10799: mtd: spi-nor: enable 4k subsector erase flag
- bc0f1de7b41 Revert "LFU-626 imx: imx95: workaround NETC suspend/resume"
- bd40703215c LFU-630-3 imx95_evk: Update board codes for secure boot
- 3fbcaea1cff LFU-630-2 imx9: Change container header temp buffer address
- c5941ab6fd8 LFU-630-1 imx: ele_ahab: Update FSB LMDA status register for i.MX95
- ca29d281448 LFU-629 imx95: evk: update root cell mem
- de5fbccd960 LFU-627 imx95_evk: Fix USB host restart crash
- bcb95e645a1 LFU-383 imx: ele_ahab: Add ahab_commit command in uboot
- 78f83b1fb15 LFU-625 configs: imx95: add Jailhouse boot command
- fd3d93aa8f9 LFU-626 imx: imx95: workaround NETC suspend/resume
- 1d95053b07d LFU-624-2 imx9: Add v2x_status and ele_info commands
- bab2f4939cf LFU-624-1 misc: ele_api: Add V2X Get State API
- d3c0a03c4fb LFU-602-8 power: pmic: add XRST macro define
- d90ffcc0856 LFU-602-7 power: pmic: optimize pmic pca9451a log format
- e9975695c4e LFU-602-6 power: pmic: optimize pmic pf0900 probe function
- 748cf1610dd LFU-602-5 configs: imx93_11x11_evk_pf0900: add new config to support pmic pf0900
- 07f3af44006 LFU-602-4 imx93: modify the pmic pf0900 config
- ab7ac08d9cf LFU-602-3 arm: dts: imx93: add new dts to support pmic pf0900
- c6a7188e692 MA-21906-2 imx95: add trusty enabled defconfig
- c3133cbdc3c MA-21906-4 imx95: support Trusty OS
- 64d2e2b37db MA-21906-2 imx95: start ELE RNG context
- 1733150991c MA-21834 android: add imx95 build target
- 1f8d66aa564 LFU-622-3 dts: imx95: Update ELE MU compatible string
- 33ddcc818a3 LFU-622-2 imx95: soc: Use ELE MU driver name for device probe
- 61f2003ac41 LFU-622-1 misc: s4mu: Update ELE MU to get TR/RR number from HW
- 3fd61d37778 LFU-621 imx9: soc: correct pcie node
- 93f8a7712c3 LFU-616-2 imx9: scmi: Override h_spl_load_read with trampoline buffer
- 80e025237f6 LFU-616-1 spl: mmc: Change the h_spl_load_read to weak
- 3f751ab4d24 LFU-620 imx: imx95: add get_reset_reason
- c7247b42fac LFU-619 mailbox: imx-mu: update the rx timeout value
- 56e88034824 LFU-615 firmware: scmi: smt: use io helpers
- b276f6b802c LFU-618 imx95_evk: Reset flexspi NOR before SPL probe it
- 343970cf376 LFU-614 mmc: fsl_esdhc_imx: reset tunning logic
- 521069ea73a LFU-613 net: fsl_enetc: Fix NETC RX BD and buffer issue
- 7d7075ecb54 LFU-609 ddr: imx95: add QB training data collect function
- 5561f9ff884 LFU-610 imx95_evk: power off NETC before booting OS
- ad6e3ee3a08 LFU-608 enetc: imx95: support to get mac address from fuse
- da7dd6cd732 LFU-598-2 power: regulator: Support pmic pf5300
- 98dc8268b20 LFU-598-1 power: pmic: Support pmic pf5300
- c60048f9e70 LFU-597-2 power: regulator: Support pmic pf0900
- a44cbddd57f LFU-597-1 power: pmic: Support pmic pf0900
- d8376baa055 LFU-607-3 board: imx95_evk: enable HSIO_TOP for gadget usb
- 6ceb9283fb8 LFU-607-2 arm: dts: imx95: add power domain for usb
- 7e0114243a7 LFU-607-1 configs: imx95: enable CONFIG_SCMI_POWER_DOMAIN
- 7307ab28752 LFU-604-45 imx95_evk: Support flexspi NOR boot
- 4b7dd4e5c77 LFU-604-44 arm: dts: imx95-evk: Enable flexspi nor nodes for SPL
- f41d22bc645 LFU-604-43 imx9: config m7 node accorind to power status
- cee23306323 LFU-604-42 imx9: config pcie node according to fuse settings
- a813c12350b LFU-604-41 imx95_evk: Add iMX95 19x19 EVK board support
- 2b40e19b8ad LFU-604-40 arm: dts: imx95_evk: Add iMX95 19x19 EVK board DTS files
- e37f611d915 LFU-604-39 mtd: spi-nor: Add mt35xu01gbba octal mode SPI NOR flash
- 0f43ec14c3d LFU-604-38 net: fsl_enetc: Update enetc driver to support iMX95
- 162d9784c01 LFU-604-37 gpio: rgpio2p: Update compatible string
- e78405c89c9 LFU-604-36 gpio: adp5585: Add SPL config for ADP5585 driver
- 98f795c5bbc LFU-604-35 xhci-imx8m: Update the uctl and fladj setting for 24M ref clock
- df57675c4cd LFU-604-34 usb: Update Kconfig to enable driver on iMX95
- f6bdce81aa5 LFU-604-33 usb: gadget: ci_udc: support i.MX95
- 4027958087b LFU-604-32 usb: host: ehci_mx6: support i.MX95
- 87aab636473 LFU-604-31 fastboot: Update codes for iMX95 UUU downloading
- 7b93f358100 LFU-604-30 clk: clk_scmi: Fix assigned clock issue
- ef05acea42d LFU-604-29 scmi: Update parent clock set ID
- 3dbc7a67302 LFU-604-28 clk: clk_scmi: Add workaround for set_rate/enable/disable
- 75ffb3a967f LFU-604-27 imx: container: Check V2X FW container
- c410abb022a LFU-604-26 imx_ele: fuse: Read fuse from ELE when SM is enabled
- 125ff383141 LFU-604-25 imx9: bootaux: Pass core_id to specify the M core
- 76bcb9f1e39 LFU-604-24 imx_ele: add ELE release aux API
- 1f4fa0a6b05 LFU-604-23 arm: dts: Add iMX95 DTSi and dt-binding files
- 12ef2752666 LFU-604-22 imx9: Add iMX95 Kconfig and Makefile
- 36f69c1bba5 LFU-604-21 imx9: scmi: Add iMX95 SOC and clock codes
- d6888e6bfc2 LFU-604-20 imx9: Move codes to native sub-folder for non-SCMI
- 159b95cc64e LFU-604-19 arm: global_data: add scmi pointer
- 57dc11420e3 LFU-604-18 clk: add SPL_CLK_SCMI option
- e67be21ac17 LFU-604-17 clk: scmi: support probe in pre-reloc stage
- 6a44dbfd181 LFU-604-16 firmware: scmi: mailbox: support probe in pre-reloc stage
- d32c10ebe01 LFU-604-15 scmi_protocols: add PERF protocol ID
- d2d38b85248 LFU-604-14 scmi_protocols: add MISC ID
- 614e6d3b33b LFU-604-13 clk: scmi: support set parent
- abb8b90ce81 LFU-604-12 pinctrl: nxp: add SCMI pinctrl driver
- 17e15ac02d3 LFU-604-11 firmware: scmi: use CONFIG_SCMI_POWER_DOMAIN as check condition
- f04e4b2e022 LFU-604-10 firmware: scmi: fix get channel
- 38f903772ea LFU-604-9 firmware: scmi: dump error string
- 5749cc5ffd9 LFU-604-8 scmi: smt: enable doorbel return
- 96a80b34dd6 LFU-604-7 firmware: scmi: use PAGE_SIZE alignement for ARM64
- e8dbcf61afb LFU-604-6 scmi_agent: add SCMI_MSG macro
- f1c5bef0098 LFU-604-5 mailbox: support timeout when sending
- b5ae5f5e445 LFU-604-4 mailbox: add i.MX MU driver
- 2f31bc166e0 LFU-604-3 Revert "MLK-14938-23 mailbox: enable mbox_send non-blocking use"
- 7e94f7b45c3 LFU-604-2 Revert "MLK-14938-24 mailbox: add imx mu DM mailbox driver"
- 18d56c3fc6d LFU-604-1 imx: Kconfig: make IMX8_ROMAPI configurable
- 485afae20fe LFU-605 imx8/imx8m: Extend NAND kernel part in mtdparts to 64MB