### PR TITLE
imx-atf: Update 6.1.55-2.2.0 to 6.6.3-1.0.0

### DIFF
--- a/recipes-bsp/imx-atf/imx-atf_2.8.bb
+++ b/recipes-bsp/imx-atf/imx-atf_2.8.bb
@@ -9,7 +9,7 @@ PV .= "+git${SRCPV}"
 
 SRC_URI = "git://github.com/nxp-imx/imx-atf.git;protocol=https;branch=${SRCBRANCH}"
 SRCBRANCH = "lf_v2.8"
-SRCREV = "08e9d4eef2262c0dd072b4325e8919e06d349e02"
+SRCREV = "8dbe28631802a51b3ec8179b2c5635b00393ad97"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Part of https://github.com/Freescale/meta-freescale/issues/1777

Update to 8dbe28631 used in the NXP BSP release L6.6.3-1.0.0.

Relevant changes:
- 8dbe28631 LF-11383 imx95: Add support for q-channel/lpcg based wakeup sources
- 58f873d08 LF-11375 feat(imx95): flush L3 when system suspend
- da9bffd12 LF-11313 feat(plat) imx: imx95: clear LPIs enable
- 8d3073131 LF-11278 imx95: Ensure the cluster can be powered off in suspend.
- 8076903b6 LF-11057-2 feat(imx95): optimize cpuidle latency
- 9eb7b6ab1 LF-11057-1 feat(imx95): coding style cleanup
- 7d5458822 MA-21906 imx95: support Trusty OS
- d953d43e6 LF-10796 imx95: Move BL31 from OCRAM to DDR secure region
- d7fd4b3e2 LF-10524-08 feat(imx95): Make SCMI to be default enabled
- 657e94012 LF-10524-07 feat(imx93): get soc info from ele
- fa0639977 LF-10524-06 feat(imx95): add soc id sip support
- 5a7cf7a6e LF-10524-05 feat(imx95): add system reset support
- be087fa66 LF-10524-04 fix(imx95): fix bug with setting retention for L3 cache with SM
- 7c38f2de8 LF-10524-03 feat(imx95): initial support for i.MX95
- 61dd0e29a LF-10524-02: feat(scmi) update version to 3.0
- 18d066592 LF-10524-01 feat(scmi) add i.MX9 SCMI vendor CPU protocol
- 3a9f15ee0 LF-10857 feat(imx93): ignore s401 halt_ack_irq wakeup
- 41557d9d4 LF-10788: feat(imx93): refine the wakeupmix irq handling
- 04d5d6189 LF-10787 feat(imx93): save & restore WDOG when wakeupmix is power down