### PR TITLE
Restore default bootloader to untagged version

### DIFF
--- a/classes/imx-boot-container.bbclass
+++ b/classes/imx-boot-container.bbclass
@@ -96,7 +96,7 @@ do_deploy:append() {
                     if [ ! -f "${DEPLOYDIR}/imx-boot" ]; then
                         ln -sf flash.bin-${MACHINE}-${type} flash.bin
                         ln -sf flash.bin-${MACHINE}-${type} imx-boot
-
+                        ln -sf flash.bin.tagged imx-boot.tagged
                     else
                         bbwarn "Use custom wks.in for $UBOOT_CONFIG = $type"
                     fi

--- a/classes/uuu_bootloader_tag.bbclass
+++ b/classes/uuu_bootloader_tag.bbclass
@@ -1,12 +1,20 @@
-# Append a tag to the bootloader image used in the SD card image. The tag
-# contains the size of the bootloader image so UUU can easily find the end of
-# the bootloader in the SD card image.
+# Create a tagged boot partition file for the SD card image file. The tag
+# contains the size of the boot partition image so UUU can easily find
+# the end of it in the SD card image file.
+#
+# IMPORTANT: The tagged boot partition file should never be used directly with
+#            UUU, as it can cause UUU to hang.
+
+UUU_BOOTLOADER                 = "${UBOOT_BINARY}"
+UUU_BOOTLOADER:mx8-generic-bsp = "${@d.getVar('UBOOT_PROVIDES_BOOT_CONTAINER') == '0' and 'imx-boot' or 'flash.bin'}"
+UUU_BOOTLOADER:mx9-generic-bsp = "${@d.getVar('UBOOT_PROVIDES_BOOT_CONTAINER') == '0' and 'imx-boot' or 'flash.bin'}"
+
 do_deploy:append() {
     if [ "${UUU_BOOTLOADER}" != "" ]; then
-        cp ${DEPLOYDIR}/${UUU_BOOTLOADER}   ${DEPLOYDIR}/${UUU_BOOTLOADER_TAGGED}
-        cp ${DEPLOYDIR}/${UUU_BOOTLOADER}   ${DEPLOYDIR}/${UUU_BOOTLOADER_UNTAGGED}
-        ln -sf ${UUU_BOOTLOADER_TAGGED}     ${DEPLOYDIR}/${UUU_BOOTLOADER}
-        stat -L -cUUUBURNXXOEUZX7+A-XY5601QQWWZ%sEND ${DEPLOYDIR}/${UUU_BOOTLOADER_TAGGED} \
-                                         >> ${DEPLOYDIR}/${UUU_BOOTLOADER_TAGGED}
+        cp ${DEPLOYDIR}/${UUU_BOOTLOADER} \
+           ${DEPLOYDIR}/${UUU_BOOTLOADER}.tagged
+        stat -L -cUUUBURNXXOEUZX7+A-XY5601QQWWZ%sEND \
+             ${DEPLOYDIR}/${UUU_BOOTLOADER}.tagged \
+             >> ${DEPLOYDIR}/${UUU_BOOTLOADER}.tagged
     fi
 }

--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -653,9 +653,9 @@ WKS_FILE_DEPENDS:append:imx-generic-bsp:mx9-generic-bsp = " \
     ${@oe.utils.ifelse(d.getVar('UBOOT_PROVIDES_BOOT_CONTAINER') == '0', 'imx-boot', '')} \
 "
 
-SOC_DEFAULT_WKS_FILE ?= "imx-uboot-bootpart.wks.in"
-SOC_DEFAULT_WKS_FILE:mx8-generic-bsp ?= "imx-imx-boot-bootpart.wks.in"
+SOC_DEFAULT_WKS_FILE                 ?= "imx-uboot-bootpart.wks.in"
 SOC_DEFAULT_WKS_FILE:mxs-generic-bsp ?= "imx-uboot-mxs-bootpart.wks.in"
+SOC_DEFAULT_WKS_FILE:mx8-generic-bsp ?= "imx-imx-boot-bootpart.wks.in"
 SOC_DEFAULT_WKS_FILE:mx9-generic-bsp ?= "imx-imx-boot-bootpart.wks.in"
 
 WKS_FILE ?= "${SOC_DEFAULT_WKS_FILE}"

--- a/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
+++ b/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
@@ -22,9 +22,7 @@ DEPENDS:append:mx93-generic-bsp = " u-boot-mkimage-native dtc-native"
 
 inherit deploy uuu_bootloader_tag
 
-UUU_BOOTLOADER        = "imx-boot"
-UUU_BOOTLOADER_TAGGED = "imx-boot-tagged"
-UUU_BOOTLOADER_UNTAGGED = "imx-boot-untagged"
+UUU_BOOTLOADER = "imx-boot"
 
 # Add CFLAGS with native INCDIR & LIBDIR for imx-mkimage build
 CFLAGS = "-O2 -Wall -std=c99 -I ${STAGING_INCDIR_NATIVE} -L ${STAGING_LIBDIR_NATIVE}"

--- a/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
+++ b/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
@@ -19,14 +19,12 @@ DEPENDS += " \
 DEPENDS += "xxd-native"
 DEPENDS:append:mx8m-generic-bsp = " u-boot-mkimage-native dtc-native"
 DEPENDS:append:mx93-generic-bsp = " u-boot-mkimage-native dtc-native"
-BOOT_NAME = "imx-boot"
-PROVIDES = "${BOOT_NAME}"
 
 inherit deploy uuu_bootloader_tag
 
-UUU_BOOTLOADER        = "${BOOT_NAME}"
-UUU_BOOTLOADER_TAGGED = "${BOOT_NAME}-tagged"
-UUU_BOOTLOADER_UNTAGGED = "${BOOT_NAME}-untagged"
+UUU_BOOTLOADER        = "imx-boot"
+UUU_BOOTLOADER_TAGGED = "imx-boot-tagged"
+UUU_BOOTLOADER_UNTAGGED = "imx-boot-untagged"
 
 # Add CFLAGS with native INCDIR & LIBDIR for imx-mkimage build
 CFLAGS = "-O2 -Wall -std=c99 -I ${STAGING_INCDIR_NATIVE} -L ${STAGING_LIBDIR_NATIVE}"
@@ -222,7 +220,7 @@ do_compile() {
                     UBOOT_DTB_NAME_EXTRA="${dtb_name}"
                 fi
                 UBOOT_NAME_EXTRA="u-boot-${MACHINE}.bin-${UBOOT_CONFIG_EXTRA}"
-                BOOT_CONFIG_MACHINE_EXTRA="${BOOT_NAME}-${MACHINE}-${UBOOT_CONFIG_EXTRA}.bin"
+                BOOT_CONFIG_MACHINE_EXTRA="imx-boot-${MACHINE}-${UBOOT_CONFIG_EXTRA}.bin"
 
                 for target in ${IMXBOOT_TARGETS}; do
                     compile_${SOC_FAMILY}
@@ -273,7 +271,7 @@ do_install () {
         bbnote "UBOOT_CONFIG = $type"
 
         UBOOT_CONFIG_EXTRA="$type"
-        BOOT_CONFIG_MACHINE_EXTRA="${BOOT_NAME}-${MACHINE}-${UBOOT_CONFIG_EXTRA}.bin"
+        BOOT_CONFIG_MACHINE_EXTRA="imx-boot-${MACHINE}-${UBOOT_CONFIG_EXTRA}.bin"
 
         for target in ${IMXBOOT_TARGETS}; do
             install -m 0644 ${S}/${BOOT_CONFIG_MACHINE_EXTRA}-${target} ${D}/boot/
@@ -380,7 +378,7 @@ do_deploy() {
     for type in ${UBOOT_CONFIG}; do
         UBOOT_CONFIG_EXTRA="$type"
         UBOOT_NAME_EXTRA="u-boot-${MACHINE}.bin-${UBOOT_CONFIG_EXTRA}"
-        BOOT_CONFIG_MACHINE_EXTRA="${BOOT_NAME}-${MACHINE}-${UBOOT_CONFIG_EXTRA}.bin"
+        BOOT_CONFIG_MACHINE_EXTRA="imx-boot-${MACHINE}-${UBOOT_CONFIG_EXTRA}.bin"
 
         if [ -e ${DEPLOY_DIR_IMAGE}/u-boot-spl.bin-${MACHINE}-${UBOOT_CONFIG_EXTRA} ] ; then
             install -m 0644 ${DEPLOY_DIR_IMAGE}/u-boot-spl.bin-${MACHINE}-${UBOOT_CONFIG_EXTRA} \
@@ -399,9 +397,9 @@ do_deploy() {
             install -m 0644 ${S}/${BOOT_CONFIG_MACHINE_EXTRA}-${target} ${DEPLOYDIR}
         done
 
-        # The first UBOOT_CONFIG listed will be the ${BOOT_NAME} binary
-        if [ ! -f "${DEPLOYDIR}/${UUU_BOOTLOADER}" ]; then
-            ln -sf ${BOOT_CONFIG_MACHINE_EXTRA}-${IMAGE_IMXBOOT_TARGET} ${DEPLOYDIR}/${BOOT_NAME}
+        # The first UBOOT_CONFIG listed will be the imx-boot binary
+        if [ ! -f "${DEPLOYDIR}/imx-boot" ]; then
+            ln -sf ${BOOT_CONFIG_MACHINE_EXTRA}-${IMAGE_IMXBOOT_TARGET} ${DEPLOYDIR}/imx-boot
         else
             bbwarn "Use custom wks.in for $UBOOT_CONFIG = $type"
         fi

--- a/recipes-bsp/u-boot/u-boot-fslc_2024.07.bb
+++ b/recipes-bsp/u-boot/u-boot-fslc_2024.07.bb
@@ -6,8 +6,6 @@ order to provide support for some backported features and fixes, or because it \
 was submitted for revision and it takes some time to become part of a stable \
 version, or because it is not applicable for upstreaming."
 
-inherit ${@oe.utils.ifelse(d.getVar('UBOOT_PROVIDES_BOOT_CONTAINER') == '1', 'imx-boot-container', '')}
-
 DEPENDS += "bc-native dtc-native python3-setuptools-native gnutls-native"
 
 PROVIDES += "u-boot u-boot-mfgtool"
@@ -20,6 +18,9 @@ B = "${WORKDIR}/build"
 EXTRA_OEMAKE += 'HOSTCC="${BUILD_CC} ${BUILD_CPPFLAGS}" \
                  HOSTLDFLAGS="${BUILD_LDFLAGS}" \
                  HOSTSTRIP=true'
+
+inherit ${@oe.utils.ifelse(d.getVar('UBOOT_PROVIDES_BOOT_CONTAINER') == '1', 'imx-boot-container', '')}
+inherit uuu_bootloader_tag
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 COMPATIBLE_MACHINE = "(imx-generic-bsp)"

--- a/recipes-bsp/u-boot/u-boot-imx_2024.04.bb
+++ b/recipes-bsp/u-boot/u-boot-imx_2024.04.bb
@@ -9,15 +9,10 @@ PROVIDES += "u-boot u-boot-mfgtool"
 
 inherit uuu_bootloader_tag
 
-UUU_BOOTLOADER                          = ""
-UUU_BOOTLOADER:mx6-generic-bsp          = "${UBOOT_BINARY}"
-UUU_BOOTLOADER:mx7-generic-bsp          = "${UBOOT_BINARY}"
-UUU_BOOTLOADER_TAGGED                   = ""
-UUU_BOOTLOADER_TAGGED:mx6-generic-bsp   = "u-boot-tagged.${UBOOT_SUFFIX}"
-UUU_BOOTLOADER_TAGGED:mx7-generic-bsp   = "u-boot-tagged.${UBOOT_SUFFIX}"
-UUU_BOOTLOADER_UNTAGGED                 = ""
-UUU_BOOTLOADER_UNTAGGED:mx6-generic-bsp = "u-boot-untagged.${UBOOT_SUFFIX}"
-UUU_BOOTLOADER_UNTAGGED:mx7-generic-bsp = "u-boot-untagged.${UBOOT_SUFFIX}"
+# The UUU tag goes on the boot partition. For 8+, the boot partition image
+# is imx-boot, so disable UUU-tagging here
+UUU_BOOTLOADER:mx8-generic-bsp = ""
+UUU_BOOTLOADER:mx9-generic-bsp = ""
 
 do_deploy:append:mx8m-generic-bsp() {
     # Deploy u-boot-nodtb.bin and fsl-imx8m*-XX.dtb for mkimage to generate boot binary

--- a/wic/imx-imx-boot-bootpart.wks.in
+++ b/wic/imx-imx-boot-bootpart.wks.in
@@ -13,7 +13,7 @@
 # 0 |        8MiB          72MiB          72MiB + rootfs + IMAGE_EXTRA_SPACE (default 10MiB)
 #   ${IMX_BOOT_SEEK} 32 or 33kiB, see reference manual
 #
-part u-boot --source rawcopy --sourceparams="file=imx-boot" --ondisk mmcblk --no-table --align ${IMX_BOOT_SEEK}
+part u-boot --source rawcopy --sourceparams="file=imx-boot.tagged" --ondisk mmcblk --no-table --align ${IMX_BOOT_SEEK}
 part /boot --source bootimg-partition --ondisk mmcblk --fstype=vfat --label boot --active --align 8192 --size 64
 part / --source rootfs --ondisk mmcblk --fstype=ext4 --label root --align 8192
 

--- a/wic/imx-imx-boot.wks.in
+++ b/wic/imx-imx-boot.wks.in
@@ -13,7 +13,7 @@
 # 0 |        8MiB            8MiB + rootfs + IMAGE_EXTRA_SPACE (default 10MiB)
 #   ${IMX_BOOT_SEEK} 32 or 33kiB, see reference manual
 #
-part u-boot --source rawcopy --sourceparams="file=imx-boot" --ondisk mmcblk --no-table --align ${IMX_BOOT_SEEK}
+part u-boot --source rawcopy --sourceparams="file=imx-boot.tagged" --ondisk mmcblk --no-table --align ${IMX_BOOT_SEEK}
 part / --source rootfs --ondisk mmcblk --fstype=ext4 --label root --align 8192
 
 bootloader --ptable msdos

--- a/wic/imx-uboot-bootpart.wks.in
+++ b/wic/imx-uboot-bootpart.wks.in
@@ -12,7 +12,7 @@
 # | |         |              |
 # 0 1kiB    4MiB          16MiB + rootfs + IMAGE_EXTRA_SPACE (default 10MiB)
 #
-part u-boot --source rawcopy --sourceparams="file=${UBOOT_BINARY}" --ondisk mmcblk --no-table --align 1
+part u-boot --source rawcopy --sourceparams="file=${UBOOT_BINARY}.tagged" --ondisk mmcblk --no-table --align 1
 part /boot --source bootimg-partition --ondisk mmcblk --fstype=vfat --label boot --active --align 4096 --size 16
 part / --source rootfs --ondisk mmcblk --fstype=ext4 --label root --align 4096
 

--- a/wic/imx-uboot-spl-bootpart.wks.in
+++ b/wic/imx-uboot-spl-bootpart.wks.in
@@ -13,7 +13,7 @@
 # 0 1kiB  69kiB   4MiB          16MiB + rootfs + IMAGE_EXTRA_SPACE (default 10MiB)
 #
 part SPL --source rawcopy --sourceparams="file=SPL" --ondisk mmcblk --no-table --align 1
-part u-boot --source rawcopy --sourceparams="file=${UBOOT_BINARY}" --ondisk mmcblk --no-table --align 69
+part u-boot --source rawcopy --sourceparams="file=${UBOOT_BINARY}.tagged" --ondisk mmcblk --no-table --align 69
 part /boot --source bootimg-partition --ondisk mmcblk --fstype=vfat --label boot --active --align 4096 --size 16
 part / --source rootfs --ondisk mmcblk --fstype=ext4 --label root --align 4096
 

--- a/wic/imx-uboot-spl.wks.in
+++ b/wic/imx-uboot-spl.wks.in
@@ -13,7 +13,7 @@
 # 0 1kiB  69kiB   4MiB + rootfs + IMAGE_EXTRA_SPACE (default 10MiB)
 #
 part SPL --source rawcopy --sourceparams="file=SPL" --ondisk mmcblk --no-table --align 1
-part u-boot --source rawcopy --sourceparams="file=${UBOOT_BINARY}" --ondisk mmcblk --no-table --align 69
+part u-boot --source rawcopy --sourceparams="file=${UBOOT_BINARY}.tagged" --ondisk mmcblk --no-table --align 69
 part / --source rootfs --ondisk mmcblk --fstype=ext4 --label root --align 4096
 
 bootloader --ptable msdos

--- a/wic/imx-uboot.wks
+++ b/wic/imx-uboot.wks
@@ -12,7 +12,7 @@
 # | |         |              |
 # 0 1kiB    4MiB + rootfs + IMAGE_EXTRA_SPACE (default 10MiB)
 #
-part u-boot --source rawcopy --sourceparams="file=u-boot.imx" --ondisk mmcblk --no-table --align 1
+part u-boot --source rawcopy --sourceparams="file=${UBOOT_BINARY}.tagged" --ondisk mmcblk --no-table --align 1
 part / --source rootfs --ondisk mmcblk --fstype=ext4 --label root --align 4096
 
 bootloader --ptable msdos


### PR DESCRIPTION
The introduction of the UUU-tagged bootloader causes problems for the non-wic case, as reported here [1] and here [2].

[1] https://github.com/Freescale/meta-freescale/pull/1762
[2] https://github.com/nxp-imx/mfgtools/issues/416

This PR is an attempt to improve the original feature by limiting the use of the tagged file to the wic case, while restoring the default file back to the untagged version. This does effectively revert [1] as no longer needed.
