### PR TITLE
Revert "waffle: Fix broken patches"

### DIFF
--- a/recipes-graphics/waffle/waffle/0001-meson-Add-missing-wayland-dependency-on-EGL.patch
+++ b/recipes-graphics/waffle/waffle/0001-meson-Add-missing-wayland-dependency-on-EGL.patch
@@ -18,7 +18,7 @@ Index: git/meson.build
 ===================================================================
 --- git.orig/meson.build
 +++ git/meson.build
-@@ -64,6 +64,7 @@ dep_drm = _dep_null
+@@ -65,6 +65,7 @@ dep_gl = _dep_null
  dep_egl = _dep_null
  dep_wayland_client = _dep_null
  dep_wayland_egl = _dep_null
@@ -26,7 +26,7 @@ Index: git/meson.build
  dep_wayland_scanner = _dep_null
  dep_wayland_proto = _dep_null
  dep_x11_xcb = _dep_null
-@@ -104,7 +105,8 @@ else
+@@ -106,7 +107,8 @@ else
    dep_wayland_client = dependency(
      'wayland-client', version : '>= 1.10', required : get_option('wayland'),
    )
@@ -36,7 +36,7 @@ Index: git/meson.build
      'wayland-egl', version : '>= 9.1', required : get_option('wayland'),
    )
    dep_wayland_scanner = dependency(
-@@ -122,7 +124,7 @@ else
+@@ -124,7 +126,7 @@ else
      wayland_xdg_shell_xml = join_paths(dep_wayland_proto.get_variable(pkgconfig: 'pkgdatadir'),
      'stable/xdg-shell/xdg-shell.xml')
    endif
@@ -44,4 +44,4 @@ Index: git/meson.build
 +  build_wayland = dep_egl.found() and dep_wayland_client.found() and dep_wayland_egl.found() and dep_wayland_scanner.found() and dep_wayland_proto.found() and dep_wayland_wayland_egl.found()
  
    # We're interested only in the headers provided
-   # FINISHME: make x11_xcb compile-only dependency
+   # FINISHME: make x11_xcb and udev compile-only dependency

--- a/recipes-graphics/waffle/waffle/0002-meson-Separate-surfaceless-option-from-x11.patch
+++ b/recipes-graphics/waffle/waffle/0002-meson-Separate-surfaceless-option-from-x11.patch
@@ -14,11 +14,9 @@ Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>
  meson.build | 5 ++++-
  1 file changed, 4 insertions(+), 1 deletion(-)
 
-Index: git/meson.build
-===================================================================
---- git.orig/meson.build
-+++ git/meson.build
-@@ -72,6 +72,7 @@ dep_gbm = _dep_null
+--- a/meson.build
++++ b/meson.build
+@@ -72,6 +72,7 @@ dep_udev = _dep_null
  dep_cocoa = _dep_null
  dep_core_foundation = _dep_null
  dep_gl_headers = _dep_null
@@ -26,13 +24,17 @@ Index: git/meson.build
  
  # Get dependencies
  if build_wgl
-@@ -99,7 +100,8 @@ else
-   build_gbm = dep_drm.found() and dep_egl.found() and dep_gbm.found()
+@@ -96,10 +97,11 @@ else
+   dep_egl = dependency('egl', required : get_option('gbm'))
+   dep_gbm = dependency('gbm', required : get_option('gbm'))
+   dep_udev = dependency('libudev', required : get_option('gbm'))
++  dep_surfaceless_egl = dependency('egl', required : get_option('surfaceless_egl'))
++  dep_surfaceless_gbm = dependency('gbm', required : get_option('surfaceless_egl'))
+   build_gbm = dep_egl.found() and dep_gbm.found() and dep_udev.found()
  
-   dep_egl = dependency('egl', required : get_option('surfaceless_egl'))
+-  dep_egl = dependency('egl', required : get_option('surfaceless_egl'))
 -  build_surfaceless = dep_egl.found()
-+  dep_gbm = dependency('gbm', required : get_option('surfaceless_egl'))
-+  build_surfaceless = dep_egl.found() and dep_gbm.found()
++  build_surfaceless = dep_surfaceless_egl.found() and dep_surfaceless_gbm.found()
  
    dep_egl = dependency('egl', required : get_option('wayland'))
    dep_wayland_client = dependency(


### PR DESCRIPTION
The patches for waffle 1.8.0 on master are not compatible with scarthgap. From here, scarthgap will be split from master.

This reverts commit 259541a36cd2cebaa32cced885da33cb30205dc8.