### PR TITLE
kernel-module-nxp-wlan: Update to 6.6.3-1.0.0

### DIFF
--- a/recipes-kernel/kernel-modules/kernel-module-nxp-wlan_git.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-nxp-wlan_git.bb
@@ -8,10 +8,10 @@ RREPLACES:${PN} = "kernel-module-nxp89xx"
 RPROVIDES:${PN} = "kernel-module-nxp89xx"
 RCONFLICTS:${PN} = "kernel-module-nxp89xx"
 
-SRCBRANCH = "lf-6.1.55_2.2.0"
+SRCBRANCH = "lf-6.6.3_1.0.0"
 MRVL_SRC ?= "git://github.com/nxp-imx/mwifiex.git;protocol=https"
 SRC_URI = "${MRVL_SRC};branch=${SRCBRANCH}"
-SRCREV = "952d10f3349426f917636a4560974117eb6eef5b"
+SRCREV = "a84df583155bad2a396a937056805550bdf655ab"
 
 S = "${WORKDIR}/git/mxm_wifiex/wlan_src"
 


### PR DESCRIPTION
Don't know if you're already working on this and/or have other routines for these things, but I needed to do this change in order to make wifi work on my IMX8MP-EVK with scarthgap, and I thought I might just as well create a PR for it.