### PR TITLE
6.6.3-1.0.0: update imx-lib and kernel-module-isp-vvcam

### DIFF
--- a/recipes-bsp/imx-lib/imx-lib_git.bb
+++ b/recipes-bsp/imx-lib/imx-lib_git.bb
@@ -13,7 +13,7 @@ PE = "1"
 PV = "5.9+${SRCPV}"
 
 SRC_URI = "git://github.com/nxp-imx/imx-lib.git;protocol=https;branch=${SRCBRANCH}"
-SRCBRANCH = "lf-6.1.55_2.2.0"
+SRCBRANCH = "lf-6.6.3_1.0.0"
 SRCREV = "8f124c3914d82019849fb697baeb730e4cb1b547"
 
 S = "${WORKDIR}/git"

--- a/recipes-kernel/kernel-modules/kernel-module-isp-vvcam_4.2.2.24.1.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-isp-vvcam_4.2.2.24.1.bb
@@ -6,8 +6,8 @@ LIC_FILES_CHKSUM = "file://${S}/../LICENSE;md5=64381a6ea83b48c39fe524c85f65fb44"
 
 SRC_URI = "${ISP_KERNEL_SRC};branch=${SRCBRANCH}"
 ISP_KERNEL_SRC ?= "git://github.com/nxp-imx/isp-vvcam.git;protocol=https"
-SRCBRANCH = "lf-6.1.55_2.2.0"
-SRCREV = "2c762259b979d7ec5a2e17df6ad823de49d43a28" 
+SRCBRANCH = "lf-6.6.3_1.0.0"
+SRCREV = "2102360b58d9d1b36bc0c654c8301e4014b33951"
 
 S = "${WORKDIR}/git/vvcam/v4l2"
 


### PR DESCRIPTION
This seems to be the latest update for https://github.com/Freescale/meta-freescale/issues/1777
(if we are not going to add imx95 right now)