### PR TITLE
imx-gpu-viv-6: Replace WORKDIR refrences with UNPACKDIR

### DIFF
--- a/recipes-core/udev/udev-rules-imx.bb
+++ b/recipes-core/udev/udev-rules-imx.bb
@@ -8,5 +8,5 @@ S = "${WORKDIR}"
 
 do_install () {
 	install -d ${D}${sysconfdir}/udev/rules.d
-	install -m 0644 ${WORKDIR}/10-imx.rules ${D}${sysconfdir}/udev/rules.d/
+	install -m 0644 ${UNPACKDIR}/10-imx.rules ${D}${sysconfdir}/udev/rules.d/
 }

--- a/recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc
+++ b/recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc
@@ -274,7 +274,7 @@ do_install () {
                 rm -rf ${D}$f
             done
         else
-            install -Dm 0644 ${WORKDIR}/imx_icd.json ${D}${sysconfdir}/vulkan/icd.d/imx_icd.json
+            install -Dm 0644 ${UNPACKDIR}/imx_icd.json ${D}${sysconfdir}/vulkan/icd.d/imx_icd.json
             sed -i "s,%libdir%,${libdir}," ${D}${sysconfdir}/vulkan/icd.d/imx_icd.json
             sed -i "s,%api_version%,${LIBVULKAN_API_VERSION}," ${D}${sysconfdir}/vulkan/icd.d/imx_icd.json
         fi


### PR DESCRIPTION
This is now must with master branch of oe-core