### PR TITLE
udev-rules-imx: Drop setting S

### DIFF
--- a/recipes-core/udev/udev-rules-imx.bb
+++ b/recipes-core/udev/udev-rules-imx.bb
@@ -4,8 +4,6 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda
 
 SRC_URI = " file://10-imx.rules"
 
-S = "${WORKDIR}"
-
 do_install () {
 	install -d ${D}${sysconfdir}/udev/rules.d
 	install -m 0644 ${UNPACKDIR}/10-imx.rules ${D}${sysconfdir}/udev/rules.d/


### PR DESCRIPTION
Setting S here to something local is redundant moreover master oe-core flags it now

Using S = ${WORKDIR} is no longer supported