### PR TITLE
linux-fslc-imx: 6.6: Fix merging issues

### DIFF
--- a/recipes-kernel/linux/linux-fslc-imx_6.6.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_6.6.bb
@@ -53,7 +53,7 @@ require linux-imx.inc
 
 KBRANCH = "6.6-1.0.x-imx"
 SRC_URI = "git://github.com/Freescale/linux-fslc.git;branch=${KBRANCH};protocol=https"
-SRCREV = "776652a165f5bbf30c68a5f6213d75b02e8df11c"
+SRCREV = "a1f3157034fe4da2c3c5662f4e54ffb3b964903e"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.


### PR DESCRIPTION
Relevant changes:
- a1f3157034fe4 Merge pull request #670 from DiogoSilva014/6.6-1.0.x-imx-lpcg
- 55720fcb81c3e arch: arm64: freescale: imx8qm: fix flexcan clocks
- 9203cfabdfb68 Merge pull request #668 from DiogoSilva014/6.6-1.0.x-imx-fix-lpcg
- d6110c170fb98 Revert lpcg indice changes
- 2df26cdfbbbe0 Merge pull request #667 from MrCry0/6.6-1.0.x-imx-fix-imx8-usdhc
- a744d880dbb46 arch: arm64: freescale: imx8: fix sdhci clocks