### PR TITLE
linux-fslc-imx: 6.6: Update kernel to fix i.MX93 boot

### DIFF
--- a/recipes-kernel/linux/linux-fslc-imx_6.6.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_6.6.bb
@@ -53,7 +53,7 @@ require linux-imx.inc
 
 KBRANCH = "6.6-1.0.x-imx"
 SRC_URI = "git://github.com/Freescale/linux-fslc.git;branch=${KBRANCH};protocol=https"
-SRCREV = "a1f3157034fe4da2c3c5662f4e54ffb3b964903e"
+SRCREV = "d8b0bac40433ce7ef0a7493948bad27a6e223c08"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.


### PR DESCRIPTION
Update the kernel version to fix i.MX93 boot by selecting CONFIG_GPIO_VF610.

Relevant changes:
    - d8b0bac40433 ("Merge pull request #672 from fabioestevam/imx93evk")
    - e9ea6badf7e5 ("arm64: imx_v8_defconfig: Enable CONFIG_GPIO_VF610")