### PR TITLE
gstreamer1.0-omx: Remove bbappend file

### DIFF
--- a/recipes-multimedia/gstreamer/gstreamer1.0-omx_%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-omx_%.bbappend
@@ -1,1 +1,0 @@
-EXTRA_OEMESON:append:imx-nxp-bsp = " -Dtests=disabled -Dexamples=disabled"


### PR DESCRIPTION
gstreamer1.0-omx has been removed from oe-core since:

commit 9c21815339afb85f558d8a1e0365614320cdc7d7
Author: Alexander Kanavin <alex@linutronix.de>
Date:   Mon May 27 20:12:13 2024 +0200

    gstreamer1.0: update 1.22.11 -> 1.24.3

    Drop gstreamer1.0-omx recipe as upstream has removed it:
    https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/4976

    kate plugin dropped from bad.

    amrnb/amrwb moved from ugly to good.

    Signed-off-by: Alexander Kanavin <alex@linutronix.de>
    Signed-off-by: Alexandre Belloni <alexandre.belloni@bootlin.com>
    Signed-off-by: Richard Purdie <richard.purdie@linuxfoundation.org>

Remove the gstreamer1.0-omx bbappend file.