### PR TITLE
gstreamer: Downgrade non-forked recipes to match 1.22.5.imx

### DIFF
--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -519,6 +519,20 @@ PREFERRED_VERSION_gstreamer1.0-plugins-bad:mx9-nxp-bsp  ??= "1.22.5.imx"
 PREFERRED_VERSION_gstreamer1.0-plugins-base:mx9-nxp-bsp ??= "1.22.5.imx"
 PREFERRED_VERSION_gstreamer1.0-plugins-good:mx9-nxp-bsp ??= "1.22.5.imx"
 
+# GStreamer copied recipes
+PREFERRED_VERSION_gst-devtools:mx8-nxp-bsp              ??= "1.22.5.imx"
+PREFERRED_VERSION_gstreamer1.0-libav:mx8-nxp-bsp        ??= "1.22.5.imx"
+PREFERRED_VERSION_gstreamer1.0-plugins-ugly:mx8-nxp-bsp ??= "1.22.5.imx"
+PREFERRED_VERSION_gstreamer1.0-python:mx8-nxp-bsp       ??= "1.22.5.imx"
+PREFERRED_VERSION_gstreamer1.0-rtsp-server:mx8-nxp-bsp  ??= "1.22.5.imx"
+PREFERRED_VERSION_gstreamer1.0-vaapi:mx8-nxp-bsp        ??= "1.22.5.imx"
+PREFERRED_VERSION_gst-devtools:mx9-nxp-bsp              ??= "1.22.5.imx"
+PREFERRED_VERSION_gstreamer1.0-libav:mx9-nxp-bsp        ??= "1.22.5.imx"
+PREFERRED_VERSION_gstreamer1.0-plugins-ugly:mx9-nxp-bsp ??= "1.22.5.imx"
+PREFERRED_VERSION_gstreamer1.0-python:mx9-nxp-bsp       ??= "1.22.5.imx"
+PREFERRED_VERSION_gstreamer1.0-rtsp-server:mx9-nxp-bsp  ??= "1.22.5.imx"
+PREFERRED_VERSION_gstreamer1.0-vaapi:mx9-nxp-bsp        ??= "1.22.5.imx"
+
 # GStreamer downgrade ffmpeg
 PREFERRED_VERSION_ffmpeg:mx8-nxp-bsp ??= "4.4.1"
 PREFERRED_VERSION_ffmpeg:mx9-nxp-bsp ??= "4.4.1"

--- a/recipes-multimedia/gstreamer/gst-devtools_1.22.5.imx.bb
+++ b/recipes-multimedia/gstreamer/gst-devtools_1.22.5.imx.bb
@@ -1,0 +1,52 @@
+SUMMARY = "Gstreamer validation tool"
+DESCRIPTION = "A Tool to test GStreamer components"
+HOMEPAGE = "https://gstreamer.freedesktop.org/documentation/gst-devtools/index.html"
+SECTION = "multimedia"
+
+LICENSE = "LGPL-2.1-or-later"
+LIC_FILES_CHKSUM = "file://validate/COPYING;md5=a6f89e2100d9b6cdffcea4f398e37343"
+
+S = "${WORKDIR}/gst-devtools-1.22.5"
+
+SRC_URI = "https://gstreamer.freedesktop.org/src/gst-devtools/gst-devtools-1.22.5.tar.xz \
+           file://0001-connect-has-a-different-signature-on-musl.patch \
+           "
+
+SRC_URI[sha256sum] = "2add1519aa6eeb01d544cb94293688ee3bc2079f6bca6075bf5c23d00a0921be"
+
+DEPENDS = "json-glib glib-2.0 glib-2.0-native gstreamer1.0 gstreamer1.0-plugins-base"
+RRECOMMENDS:${PN} = "git"
+
+FILES:${PN} += "${datadir}/gstreamer-1.0/* ${libdir}/gst-validate-launcher/* ${libdir}/gstreamer-1.0/*"
+
+inherit meson pkgconfig gettext upstream-version-is-even gobject-introspection
+
+# TODO: put this in a gettext.bbclass patch
+def gettext_oemeson(d):
+    if d.getVar('USE_NLS') == 'no':
+        return '-Dnls=disabled'
+    # Remove the NLS bits if USE_NLS is no or INHIBIT_DEFAULT_DEPS is set
+    if d.getVar('INHIBIT_DEFAULT_DEPS') and not oe.utils.inherits(d, 'cross-canadian'):
+        return '-Dnls=disabled'
+    return '-Dnls=enabled'
+
+# Build GstValidateVideo
+PACKAGECONFIG[cairo] = "-Dcairo=enabled,-Dcairo=disabled,cairo"
+
+EXTRA_OEMESON += " \
+    -Ddoc=disabled \
+    -Ddebug_viewer=disabled \
+    -Dtests=disabled \
+    -Dvalidate=enabled \
+    ${@gettext_oemeson(d)} \
+"
+
+do_install:append () {
+     for fn in ${bindir}/gst-validate-launcher \
+         ${libdir}/gst-validate-launcher/python/launcher/config.py; do
+             sed -i -e 's,${B},/usr/src/debug/${PN},g' -e 's,${S},/usr/src/debug/${PN},g' ${D}$fn
+     done
+}
+
+GIR_MESON_ENABLE_FLAG = "enabled"
+GIR_MESON_DISABLE_FLAG = "disabled"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-libav_1.22.5.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-libav_1.22.5.imx.bb
@@ -1,0 +1,28 @@
+SUMMARY = "Libav-based GStreamer 1.x plugin"
+DESCRIPTION = "Contains a GStreamer plugin for using the encoders, decoders, \
+muxers, and demuxers provided by FFmpeg."
+HOMEPAGE = "http://gstreamer.freedesktop.org/"
+SECTION = "multimedia"
+
+# ffmpeg has comercial license flags so add it as we need ffmpeg as a dependency
+LICENSE_FLAGS = "commercial"
+LICENSE = "LGPL-2.1-or-later"
+LIC_FILES_CHKSUM = "file://COPYING;md5=69333daa044cb77e486cc36129f7a770 \
+                    file://ext/libav/gstav.h;beginline=1;endline=18;md5=a752c35267d8276fd9ca3db6994fca9c \
+                    "
+
+SRC_URI = "https://gstreamer.freedesktop.org/src/gst-libav/gst-libav-1.22.5.tar.xz"
+SRC_URI[sha256sum] = "8583f0c1f4fcb01eed11fa1e3c21126543a8bd739ed4fc1db31f756a5ab01d9a"
+
+S = "${WORKDIR}/gst-libav-1.22.5"
+
+DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base ffmpeg"
+
+inherit meson pkgconfig upstream-version-is-even
+
+EXTRA_OEMESON += " \
+    -Dtests=disabled \
+"
+
+FILES:${PN} += "${libdir}/gstreamer-1.0/*.so"
+FILES:${PN}-staticdev += "${libdir}/gstreamer-1.0/*.a"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly_1.22.5.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly_1.22.5.imx.bb
@@ -1,0 +1,45 @@
+require gstreamer1.0-plugins-common.inc
+require gstreamer1.0-plugins-license.inc
+
+SUMMARY = "'Ugly GStreamer plugins"
+HOMEPAGE = "https://gstreamer.freedesktop.org/"
+BUGTRACKER = "https://gitlab.freedesktop.org/gstreamer/gst-plugins-ugly/-/issues"
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=a6f89e2100d9b6cdffcea4f398e37343 \
+                   "
+
+LICENSE = "LGPL-2.1-or-later & GPL-2.0-or-later"
+LICENSE_FLAGS = "commercial"
+
+SRC_URI = " \
+            https://gstreamer.freedesktop.org/src/gst-plugins-ugly/gst-plugins-ugly-1.22.5.tar.xz \
+            "
+SRC_URI[sha256sum] = "2680473b218158f18467cac3e1c50291b7ff4e0710dd350a59eaacbc29c09a54"
+
+S = "${WORKDIR}/gst-plugins-ugly-1.22.5"
+
+DEPENDS += "gstreamer1.0-plugins-base"
+
+GST_PLUGIN_SET_HAS_EXAMPLES = "0"
+
+PACKAGECONFIG ??= " \
+    ${GSTREAMER_ORC} \
+"
+
+PACKAGECONFIG[amrnb]    = "-Damrnb=enabled,-Damrnb=disabled,opencore-amr"
+PACKAGECONFIG[amrwb]    = "-Damrwbdec=enabled,-Damrwbdec=disabled,opencore-amr"
+PACKAGECONFIG[a52dec]   = "-Da52dec=enabled,-Da52dec=disabled,liba52"
+PACKAGECONFIG[cdio]     = "-Dcdio=enabled,-Dcdio=disabled,libcdio"
+PACKAGECONFIG[dvdread]  = "-Ddvdread=enabled,-Ddvdread=disabled,libdvdread"
+PACKAGECONFIG[mpeg2dec] = "-Dmpeg2dec=enabled,-Dmpeg2dec=disabled,mpeg2dec"
+PACKAGECONFIG[x264]     = "-Dx264=enabled,-Dx264=disabled,x264"
+
+GSTREAMER_GPL = "${@bb.utils.filter('PACKAGECONFIG', 'a52dec cdio dvdread mpeg2dec x264', d)}"
+
+EXTRA_OEMESON += " \
+    -Ddoc=disabled \
+    -Dsidplay=disabled \
+"
+
+FILES:${PN}-amrnb += "${datadir}/gstreamer-1.0/presets/GstAmrnbEnc.prs"
+FILES:${PN}-x264 += "${datadir}/gstreamer-1.0/presets/GstX264Enc.prs"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-python_1.22.5.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-python_1.22.5.imx.bb
@@ -1,0 +1,30 @@
+SUMMARY = "Python bindings for GStreamer 1.0"
+DESCRIPTION = "GStreamer Python binding overrides (complementing the bindings \
+provided by python-gi) "
+HOMEPAGE = "http://cgit.freedesktop.org/gstreamer/gst-python/"
+SECTION = "multimedia"
+
+LICENSE = "LGPL-2.1-or-later"
+LIC_FILES_CHKSUM = "file://COPYING;md5=c34deae4e395ca07e725ab0076a5f740"
+
+SRC_URI = "https://gstreamer.freedesktop.org/src/${PNREAL}/${PNREAL}-1.22.5.tar.xz"
+SRC_URI[sha256sum] = "bf05232415cf6018142ae51dd3b897bb73432687b5ce1786bf46edc6298ce5b0"
+
+DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base python3-pygobject"
+RDEPENDS:${PN} += "gstreamer1.0 gstreamer1.0-plugins-base python3-pygobject"
+
+PNREAL = "gst-python"
+
+S = "${WORKDIR}/${PNREAL}-1.22.5"
+
+EXTRA_OEMESON += "\
+    -Dtests=disabled \
+    -Dplugin=enabled \
+    -Dlibpython-dir=${libdir} \
+"
+
+inherit meson pkgconfig setuptools3-base upstream-version-is-even features_check
+
+FILES:${PN} += "${libdir}/gstreamer-1.0"
+
+REQUIRED_DISTRO_FEATURES = "gobject-introspection-data"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-rtsp-server_1.22.5.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-rtsp-server_1.22.5.imx.bb
@@ -1,0 +1,31 @@
+SUMMARY = "A library on top of GStreamer for building an RTSP server"
+HOMEPAGE = "http://cgit.freedesktop.org/gstreamer/gst-rtsp-server/"
+SECTION = "multimedia"
+LICENSE = "LGPL-2.1-or-later"
+LIC_FILES_CHKSUM = "file://COPYING;md5=69333daa044cb77e486cc36129f7a770"
+
+DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base"
+
+PNREAL = "gst-rtsp-server"
+
+SRC_URI = "https://gstreamer.freedesktop.org/src/${PNREAL}/${PNREAL}-1.22.5.tar.xz"
+
+SRC_URI[sha256sum] = "f343eb54964ebd4d8c071be5eecad586f28feb0156e036e06b148d0e7febb1c0"
+
+S = "${WORKDIR}/${PNREAL}-1.22.5"
+
+inherit meson pkgconfig upstream-version-is-even gobject-introspection
+
+EXTRA_OEMESON += " \
+    -Ddoc=disabled \
+    -Dexamples=disabled \
+    -Dtests=disabled \
+"
+
+GIR_MESON_ENABLE_FLAG = "enabled"
+GIR_MESON_DISABLE_FLAG = "disabled"
+
+# Starting with 1.8.0 gst-rtsp-server includes dependency-less plugins as well
+require gstreamer1.0-plugins-packaging.inc
+
+CVE_PRODUCT += "gst-rtsp-server"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-vaapi_1.22.5.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-vaapi_1.22.5.imx.bb
@@ -1,0 +1,53 @@
+SUMMARY = "VA-API support to GStreamer"
+HOMEPAGE = "https://gstreamer.freedesktop.org/"
+DESCRIPTION = "gstreamer-vaapi consists of a collection of VA-API \
+based plugins for GStreamer and helper libraries: `vaapidecode', \
+`vaapiconvert', and `vaapisink'."
+
+REALPN = "gstreamer-vaapi"
+
+LICENSE = "LGPL-2.1-or-later"
+LIC_FILES_CHKSUM = "file://COPYING.LIB;md5=4fbd65380cdd255951079008b364516c"
+
+SRC_URI = "https://gstreamer.freedesktop.org/src/${REALPN}/${REALPN}-1.22.5.tar.xz"
+
+SRC_URI[sha256sum] = "a9a550267c9584df0e8c70434d30476e8fd0018b733c1c1ee33deaf422bdb24b"
+
+S = "${WORKDIR}/${REALPN}-1.22.5"
+DEPENDS = "libva gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-bad"
+
+inherit meson pkgconfig features_check upstream-version-is-even
+
+REQUIRED_DISTRO_FEATURES ?= "opengl"
+
+EXTRA_OEMESON += " \
+    -Ddoc=disabled \
+    -Dexamples=disabled \
+    -Dtests=enabled \
+"
+
+PACKAGES =+ "${PN}-tests"
+
+# OpenGL packageconfig factored out to make it easy for distros
+# and BSP layers to pick either glx, egl, or no GL. By default,
+# try detecting X11 first, and if found (with OpenGL), use GLX,
+# otherwise try to check if EGL can be used.
+PACKAGECONFIG_GL ?= "${@bb.utils.contains('DISTRO_FEATURES', 'x11 opengl', 'glx', \
+                        bb.utils.contains('DISTRO_FEATURES',     'opengl', 'egl', \
+                                                                       '', d), d)}"
+
+PACKAGECONFIG ??= "drm encoders \
+                   ${PACKAGECONFIG_GL} \
+                   ${@bb.utils.filter('DISTRO_FEATURES', 'wayland x11', d)}"
+
+PACKAGECONFIG[drm] = "-Ddrm=enabled,-Ddrm=disabled,udev libdrm"
+PACKAGECONFIG[egl] = "-Degl=enabled,-Degl=disabled,virtual/egl"
+PACKAGECONFIG[encoders] = "-Dencoders=enabled,-Dencoders=disabled"
+PACKAGECONFIG[glx] = "-Dglx=enabled,-Dglx=disabled,virtual/libgl"
+PACKAGECONFIG[wayland] = "-Dwayland=enabled,-Dwayland=disabled,wayland-native wayland wayland-protocols"
+PACKAGECONFIG[x11] = "-Dx11=enabled,-Dx11=disabled,virtual/libx11 libxrandr libxrender"
+
+FILES:${PN} += "${libdir}/gstreamer-*/*.so"
+FILES:${PN}-dbg += "${libdir}/gstreamer-*/.debug"
+FILES:${PN}-dev += "${libdir}/gstreamer-*/*.a"
+FILES:${PN}-tests = "${bindir}/*"


### PR DESCRIPTION
Add the full set of 1.22.5 compatible recipes with the following exceptions due to build breaks for obsolete components:
- gstreamer1.0-omx: Drop the recipe
- gstreamer1.0-plugins-ugly: Drop liba52 and mpeg2dec support

These exceptions mirror changes in the upstream support:
9c21815339 gstreamer1.0: update 1.22.11 -> 1.24.3
90fbfe9fe1 liba52: remove the recipe
d46660e6c0 mpeg2dec: remove the recipe

(From OE-Core rev: ae9c64cd2291f4b24ac442816a4e354e47c70933)