### PR TITLE
linux: drop the old style kernels unshared S

### DIFF
--- a/recipes-kernel/linux/linux-imx.inc
+++ b/recipes-kernel/linux/linux-imx.inc
@@ -19,8 +19,6 @@ PV = "${LINUX_VERSION}+git${SRCPV}"
 
 SRC_URI = "git://github.com/nxp-imx/linux-imx;protocol=https;branch=${SRCBRANCH}"
 
-S = "${WORKDIR}/git"
-
 # Tell to kernel class that we would like to use our defconfig to configure the kernel.
 # Otherwise, the --allnoconfig would be used per default which leads to mis-configured
 # kernel.

--- a/recipes-kernel/linux/linux-qoriq.inc
+++ b/recipes-kernel/linux/linux-qoriq.inc
@@ -5,8 +5,6 @@ SUMMARY = "Linux Kernel for NXP QorIQ platforms"
 SECTION = "kernel"
 LICENSE = "GPL-2.0-only"
 
-S = "${WORKDIR}/git"
-
 DEPENDS:append = " libgcc"
 # not put Images into /boot of rootfs, install kernel-image if needed
 RRECOMMENDS:${KERNEL_PACKAGE_NAME}-base = ""


### PR DESCRIPTION
The default source code location for kernel is defined on the kernel.bbclass and it was 'S = "${STAGING_KERNEL_DIR}"'

In reality, although the kernel has its code in 'S = "${WORKDIR}/git"' it ends up being moved to '${STAGING_KERNEL_DIR}' in the do_symlink_kernsrc kernel.bbclass function.

With this change, the do_symlink_kernsrc kernel.bbclass function will no longer create the symbolic link and the final result will be the same.