### PR TITLE
Update imx-vpu-hantro and friends and fix compiler errors

### DIFF
--- a/recipes-bsp/imx-vpu-hantro-vc/imx-vpu-hantro-vc_1.9.1.bb
+++ b/recipes-bsp/imx-vpu-hantro-vc/imx-vpu-hantro-vc_1.9.1.bb
@@ -2,7 +2,7 @@
 
 DESCRIPTION = "i.MX VC8000E Encoder library"
 LICENSE = "Proprietary"
-LIC_FILES_CHKSUM = "file://COPYING;md5=5a0bf11f745e68024f37b4724a5364fe"
+LIC_FILES_CHKSUM = "file://COPYING;md5=db4762b09b6bda63da103963e6e081de"
 
 inherit fsl-eula-unpack
 
@@ -10,8 +10,7 @@ SRC_URI = "${FSL_MIRROR}/${BP}.bin;fsl-eula=true"
 
 S = "${WORKDIR}/${BPN}-${PV}"
 
-SRC_URI[md5sum] = "192b354d1c21836dc7338606e60b45ae"
-SRC_URI[sha256sum] = "62b5ba3c4aab21d0d4be3eee9b204a9bb50b83b6140ee1a3b27c648809bdfbaa"
+SRC_URI[sha256sum] = "84fcefa0619def2f009ca6651c5cffcda57fed29cd7060ef68be48c5d0d7814b"
 
 # SCR is the location and name of the Software Content Register file
 # relative to ${D}${D_SUBDIR}.

--- a/recipes-bsp/imx-vpu-hantro/imx-vpu-hantro-daemon_1.1.9.bb
+++ b/recipes-bsp/imx-vpu-hantro/imx-vpu-hantro-daemon_1.1.9.bb
@@ -7,8 +7,7 @@ DEPENDS = "imx-vpu-hantro"
 DEPENDS:append:mx8mp-nxp-bsp = " imx-vpu-hantro-vc"
 
 SRC_URI = "${FSL_MIRROR}/${BP}.tar.gz"
-SRC_URI[md5sum] = "23997361dab3054e5a3757a15d33db16"
-SRC_URI[sha256sum] = "ac2b60fb754792eedcfdfc8cf59663cfeaedc402857eff13ac97a911d2c65801"
+SRC_URI[sha256sum] = "80d6620063fd5e5506b05c907677b579d471a9b6daa8b26ffb963110cc680bf9"
 
 PLATFORM:mx8mm-nxp-bsp = "IMX8MM"
 PLATFORM:mx8mq-nxp-bsp = "IMX8MQ"

--- a/recipes-bsp/imx-vpu-hantro/imx-vpu-hantro_1.32.0.bb
+++ b/recipes-bsp/imx-vpu-hantro/imx-vpu-hantro_1.32.0.bb
@@ -17,6 +17,12 @@ PLATFORM:mx8mm-nxp-bsp = "IMX8MM"
 PLATFORM:mx8mq-nxp-bsp = "IMX8MQ"
 PLATFORM:mx8mp-nxp-bsp = "IMX8MP"
 
+#| ../../source/h264high/h264decapi.c:1803:22: error: assignment to 'const u8 *' {aka 'const unsigned char *'} from incompatible pointer type 'u32 *' {aka 'unsigned int *'} [-Wincompatible-pointer-types]
+#|  1803 |             ref_data = ref.virtual_address;
+#| ../../source/h264high/h264decapi.c:2086:22: error: assignment to 'const u8 *' {aka 'const unsigned char *'} from incompatible pointer type 'u32 *' {aka 'unsigned int *'} [-Wincompatible-pointer-types]
+#|  2086 |             ref_data = ref.virtual_address;
+
+CFLAGS += " -Wno-error=incompatible-pointer-types"
 EXTRA_OEMAKE = " \
     CROSS_COMPILE="${HOST_PREFIX}" \
     SDKTARGETSYSROOT="${STAGING_DIR_TARGET}" \

--- a/recipes-bsp/imx-vpu-hantro/imx-vpu-hantro_1.32.0.bb
+++ b/recipes-bsp/imx-vpu-hantro/imx-vpu-hantro_1.32.0.bb
@@ -2,13 +2,12 @@
 
 DESCRIPTION = "i.MX Hantro VPU library"
 LICENSE = "Proprietary"
-LIC_FILES_CHKSUM = "file://COPYING;md5=ea25d099982d035af85d193c88a1b479"
+LIC_FILES_CHKSUM = "file://COPYING;md5=44a8052c384584ba09077e85a3d1654f"
 
 PROVIDES = "virtual/imxvpu"
 
 SRC_URI = "${FSL_MIRROR}/${BP}.bin;fsl-eula=true"
-SRC_URI[md5sum] = "81b4eb801349a0c198b7cc43eb8b6097"
-SRC_URI[sha256sum] = "e868e12945b4f217e2e0511fdc2587875d6c9124e8673b67f1e7de367ff5012f"
+SRC_URI[sha256sum] = "f751ab7369d48e610ea3b6b0dc5a885c70a510861d6b46296ffc063fed370003"
 
 inherit fsl-eula-unpack use-imx-headers
 

--- a/recipes-multimedia/imx-vpuwrap/imx-vpuwrap/0001-vpu_wrapper_hantro_encoder-add-sys-time.h-for-gettim.patch
+++ b/recipes-multimedia/imx-vpuwrap/imx-vpuwrap/0001-vpu_wrapper_hantro_encoder-add-sys-time.h-for-gettim.patch
@@ -1,0 +1,28 @@
+From 482c639a0da4b093cfc029009604e9653ced33c4 Mon Sep 17 00:00:00 2001
+From: Max Krummenacher <max.krummenacher@toradex.com>
+Date: Thu, 13 Jun 2024 07:15:12 +0000
+Subject: [PATCH] vpu_wrapper_hantro_encoder: add sys/time.h for gettimeofday
+
+Fixes:
+| ../git/vpu_wrapper_hantro_encoder.c:953:3: error: implicit declaration of function 'gettimeofday' [-Wimplicit-function-declaration]
+
+Signed-off-by: Max Krummenacher <max.krummenacher@toradex.com>
+---
+ vpu_wrapper_hantro_encoder.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/vpu_wrapper_hantro_encoder.c b/vpu_wrapper_hantro_encoder.c
+index 3819c389320c..635c98bf1f19 100755
+--- a/vpu_wrapper_hantro_encoder.c
++++ b/vpu_wrapper_hantro_encoder.c
+@@ -24,6 +24,7 @@
+ #include <stdlib.h>
+ #include <string.h>
+ #include <time.h>
++#include <sys/time.h>
+ #include <semaphore.h>
+ 
+ #include "headers/OMX_Video.h"
+-- 
+2.42.0
+

--- a/recipes-multimedia/imx-vpuwrap/imx-vpuwrap_git.bb
+++ b/recipes-multimedia/imx-vpuwrap/imx-vpuwrap_git.bb
@@ -10,7 +10,10 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=2827219e81f28aba7c6a569f7c437fa7"
 DEPENDS = "virtual/imxvpu"
 DEPENDS:append:mx8mp-nxp-bsp = " imx-vpu-hantro-vc"
 
-SRC_URI = "git://github.com/NXP/imx-vpuwrap.git;protocol=https;branch=${SRCBRANCH}"
+SRC_URI = " \
+    git://github.com/NXP/imx-vpuwrap.git;protocol=https;branch=${SRCBRANCH} \
+    file://0001-vpu_wrapper_hantro_encoder-add-sys-time.h-for-gettim.patch \
+"
 SRCBRANCH = "MM_04.08.03_2312_L6.6.y"
 SRCREV = "f974cecdb00b4a214e4b5229f2279e772ee43306"
 


### PR DESCRIPTION
This updates imx-vpu-hantro to rel_imx_6.6.3_1.0.0.

GCC-14 set more warnings to errors, fix the errors. Note that GCC throws errors also if building the older recipe versions.