### PR TITLE
patches: fix upstream-status

### DIFF
--- a/dynamic-layers/chromium-browser-layer/recipes-browser/chromium/chromium/chromium.patch
+++ b/dynamic-layers/chromium-browser-layer/recipes-browser/chromium/chromium/chromium.patch
@@ -1,3 +1,4 @@
+Upstream-Status: Pending
 diff -Naur chromium-48.0.2548.0_org/third_party/libva/va/va_dec_jpeg.h chromium-48.0.2548.0/third_party/libva/va/va_dec_jpeg.h
 --- chromium-48.0.2548.0_org/third_party/libva/va/va_dec_jpeg.h	2016-05-27 11:45:31.248306710 -0500
 +++ chromium-48.0.2548.0/third_party/libva/va/va_dec_jpeg.h	2016-05-27 11:49:53.000000000 -0500

--- a/dynamic-layers/openembedded-layer/recipes-devtools/luajit/luajit/ppc-fixplt.patch
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/luajit/luajit/ppc-fixplt.patch
@@ -1,5 +1,4 @@
-Upstream-Status: Unknown
-
+Upstream-Status: Pending
 Signed-off-by: Khem Raj <raj.khem@gmail.com>
 
 libluajit is having symbols that can't be

--- a/dynamic-layers/qt4-layer/recipes-qt4/qt4/qt4/0001-Add-support-for-i.MX-codecs-to-phonon.patch
+++ b/dynamic-layers/qt4-layer/recipes-qt4/qt4/qt4/0001-Add-support-for-i.MX-codecs-to-phonon.patch
@@ -5,6 +5,7 @@ Subject: [PATCH] Add support for i.MX codecs to phonon
 
 Add support for i.MX codecs to phonon
 
+Upstream-Status: Pending
 Signed-off-by: Daniele Dall'Acqua <daniele.d@freescale.com>
 Signed-off-by: Rogerio Pimentel <rogerio.pimentel@freescale.com>
 ---

--- a/dynamic-layers/qt4-layer/recipes-qt4/qt4/qt4/0001-config.tests-add-DEFINES-to-compile-egl-test-with-im.patch
+++ b/dynamic-layers/qt4-layer/recipes-qt4/qt4/qt4/0001-config.tests-add-DEFINES-to-compile-egl-test-with-im.patch
@@ -4,6 +4,7 @@ Date: Thu, 29 Sep 2022 16:06:04 +0200
 Subject: [PATCH 1/2] config.tests: add DEFINES to compile egl test with
  imxgpu2d (Vivante)
 
+Upstream-Status: Pending
 Signed-off-by: Mauro Salvini <m.salvini@koansoftware.com>
 ---
  config.tests/unix/egl/egl.pro | 1 +

--- a/dynamic-layers/qt4-layer/recipes-qt4/qt4/qt4/0002-config.tests-add-DEFINES-to-compile-egl4gles1-test-w.patch
+++ b/dynamic-layers/qt4-layer/recipes-qt4/qt4/qt4/0002-config.tests-add-DEFINES-to-compile-egl4gles1-test-w.patch
@@ -4,6 +4,7 @@ Date: Thu, 29 Sep 2022 16:12:11 +0200
 Subject: [PATCH 2/2] config.tests: add DEFINES to compile egl4gles1 test with
  imxgpu2d (Vivante)
 
+Upstream-Status: Pending
 Signed-off-by: Mauro Salvini <m.salvini@koansoftware.com>
 ---
  config.tests/unix/egl4gles1/egl4gles1.pro | 1 +

--- a/dynamic-layers/qt4-layer/recipes-qt4/qt4/qt4/0002-i.MX-video-renderer-Allow-v4l-device-from-environmen.patch
+++ b/dynamic-layers/qt4-layer/recipes-qt4/qt4/qt4/0002-i.MX-video-renderer-Allow-v4l-device-from-environmen.patch
@@ -18,6 +18,7 @@ a particular session for use in multi-headed applications.
 The default is /dev/video17:
 	export v4lsinkdev=/dev/video17
 
+Upstream-Status: Pending
 Signed-off-by: Eric Nelson <eric.nelson@boundarydevices.com>
 ---
  src/3rdparty/phonon/gstreamer/widgetrenderer.cpp | 5 ++++-

--- a/dynamic-layers/qt5-layer/recipes-qt/qt5/qtbase/0014-Add-IMX-GPU-support.patch
+++ b/dynamic-layers/qt5-layer/recipes-qt/qt5/qtbase/0014-Add-IMX-GPU-support.patch
@@ -1,3 +1,4 @@
+Upstream-Status: Pending
 Index: git/mkspecs/linux-oe-g++/qmake.conf
 ===================================================================
 --- git.orig/mkspecs/linux-oe-g++/qmake.conf	2017-06-26 10:20:57.139653321 -0500

--- a/recipes-multimedia/imx-opencl-converter/imx-opencl-converter/0001-src-ocl.c-fix-wrong-integer-type.patch
+++ b/recipes-multimedia/imx-opencl-converter/imx-opencl-converter/0001-src-ocl.c-fix-wrong-integer-type.patch
@@ -15,6 +15,7 @@ In file included from .../recipe-sysroot/usr/include/CL/cl_ext.h:27,
  1348 |                       size_t *              param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
       |                       ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
 
+Upstream-Status: Pending
 Signed-off-by: Max Krummenacher <max.krummenacher@toradex.com>
 ---
  src/ocl.c | 2 +-

--- a/recipes-multimedia/imx-vpuwrap/imx-vpuwrap/0001-vpu_wrapper_hantro_encoder-add-sys-time.h-for-gettim.patch
+++ b/recipes-multimedia/imx-vpuwrap/imx-vpuwrap/0001-vpu_wrapper_hantro_encoder-add-sys-time.h-for-gettim.patch
@@ -6,6 +6,7 @@ Subject: [PATCH] vpu_wrapper_hantro_encoder: add sys/time.h for gettimeofday
 Fixes:
 | ../git/vpu_wrapper_hantro_encoder.c:953:3: error: implicit declaration of function 'gettimeofday' [-Wimplicit-function-declaration]
 
+Upstream-Status: Pending
 Signed-off-by: Max Krummenacher <max.krummenacher@toradex.com>
 ---
  vpu_wrapper_hantro_encoder.c | 1 +


### PR DESCRIPTION
OE-core enabled the picky QA check on Upstream-Status. commit b7fb91c797ab ("insane: add patch-status to default ERROR_QA") Add missing upstream-status respectively fix unknown 'unknown' state.

strict_status_re = re.compile(r"^Upstream-Status: (Pending|Submitted|Denied|Inappropriate|Backport|Inactive-Upstream)( .+)?$", re.MULTILINE)