### PR TITLE
Revert "linux: drop the old style kernels unshared S"

### DIFF
--- a/recipes-kernel/linux/linux-imx.inc
+++ b/recipes-kernel/linux/linux-imx.inc
@@ -19,6 +19,8 @@ PV = "${LINUX_VERSION}+git${SRCPV}"
 
 SRC_URI = "git://github.com/nxp-imx/linux-imx;protocol=https;branch=${SRCBRANCH}"
 
+S = "${WORKDIR}/git"
+
 # Tell to kernel class that we would like to use our defconfig to configure the kernel.
 # Otherwise, the --allnoconfig would be used per default which leads to mis-configured
 # kernel.

--- a/recipes-kernel/linux/linux-qoriq.inc
+++ b/recipes-kernel/linux/linux-qoriq.inc
@@ -5,6 +5,8 @@ SUMMARY = "Linux Kernel for NXP QorIQ platforms"
 SECTION = "kernel"
 LICENSE = "GPL-2.0-only"
 
+S = "${WORKDIR}/git"
+
 DEPENDS:append = " libgcc"
 # not put Images into /boot of rootfs, install kernel-image if needed
 RRECOMMENDS:${KERNEL_PACKAGE_NAME}-base = ""


### PR DESCRIPTION
This reverts commit 6dcdeccc845145a666fd30e7e48cf3d18988974e.

My conclusion was wrong because the source will be move to the STAGING_KERNEL_DIR only when we use the kernel-yocto.bbclass. This is because the same logic of moving sources is replicated here too.

Fix https://github.com/Freescale/meta-freescale/issues/1855