### PR TITLE
uuu-bin: upgrade 1.4.243 -> 1.5.165

### DIFF
--- a/recipes-devtools/uuu/uuu-bin_1.5.165.bb
+++ b/recipes-devtools/uuu/uuu-bin_1.5.165.bb
@@ -15,9 +15,9 @@ SRC_URI = " \
     https://github.com/nxp-imx/mfgtools/releases/download/uuu_${PV}/uuu.exe;downloadfilename=uuu-${PV}.exe;name=Windows \
 "
 
-SRC_URI[Linux.sha256sum] = "dfb2a6dca337ebd59675ea5ce7f1bce6724e3b901bcb455126d4bf9bdfa2e585"
-SRC_URI[Mac.sha256sum] = "399efa4bc7e3eb452fefe89ef5e2e453b516ea716658a963a890c430ad81a471"
-SRC_URI[Windows.sha256sum] = "f3f178e7be161c7dc058dbcd35c8cfa1516981e7c4f915fe0256ae4cda7f101e"
+SRC_URI[Linux.sha256sum] = "f863bba022202361d19e5026be0af408d307f78d2dbf2c139fb7eaaabd220442"
+SRC_URI[Mac.sha256sum] = "62da0bd7e333931fba100823aa50133621c7e6047be0546bc12e29c0ea78a4d8"
+SRC_URI[Windows.sha256sum] = "013ed8bb45e21b971b6b3a5802c5f154733913714bece0b020cb770a809cd206"
 
 S = "${WORKDIR}"
 


### PR DESCRIPTION
Bump to the latest pre-release tag, matching the uuu recipe (using the 1.5.x series)

Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>
(cherry picked from commit bd7974c113c9a231a0c09c5bd649157da32ec027)