### PR TITLE
Scarthgap: linux-fslc-imx: 6.6: Support Olimex i.MX8MP

### DIFF
--- a/recipes-kernel/linux/linux-fslc-imx_6.6.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_6.6.bb
@@ -53,7 +53,7 @@ require linux-imx.inc
 
 KBRANCH = "6.6-1.0.x-imx"
 SRC_URI = "git://github.com/Freescale/linux-fslc.git;branch=${KBRANCH};protocol=https"
-SRCREV = "d8b0bac40433ce7ef0a7493948bad27a6e223c08"
+SRCREV = "13ed4e83694299049a3d4449fdb61471292ef19b"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.


### PR DESCRIPTION
Update the kernel version to support for Olimex iMX8MP-SOM-4GB-IND and iMX8MP-SOM-EVB-IND.

Relevant changes:
- 13ed4e836942 ("Merge pull request #673 from leon-anavi/imx8mp-olimex")
- 6cdcd7103c2f ("imx8mp-olimex.dts: Olimex iMX8MP-SOM-EVB-IND")