### PR TITLE
imx-boot: inherit from uboot-config rather than uboot-sign

### DIFF
--- a/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
+++ b/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
@@ -104,6 +104,7 @@ compile_mx8m() {
     cp ${DEPLOY_DIR_IMAGE}/${UBOOT_NAME_EXTRA}                     ${BOOT_STAGING}/u-boot.bin
 
 }
+
 compile_mx8() {
     bbnote 8QM boot binary build
     cp ${DEPLOY_DIR_IMAGE}/${BOOT_TOOLS}/${SC_FIRMWARE_NAME} ${BOOT_STAGING}/scfw_tcm.bin
@@ -162,7 +163,7 @@ do_compile() {
     if ${DEPLOY_OPTEE}; then
         cp ${DEPLOY_DIR_IMAGE}/tee.bin ${BOOT_STAGING}
     fi
-   for type in ${UBOOT_CONFIG}; do
+    for type in ${UBOOT_CONFIG}; do
         if [ "${@d.getVarFlags('UBOOT_DTB_NAME')}" = "None" ]; then
             UBOOT_DTB_NAME_FLAGS="${type}:${UBOOT_DTB_NAME}"
         else

--- a/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
+++ b/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
@@ -7,7 +7,7 @@ LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6"
 SECTION = "BSP"
 
-inherit use-imx-security-controller-firmware uboot-sign
+inherit use-imx-security-controller-firmware uboot-config
 
 DEPENDS += " \
     u-boot \
@@ -71,11 +71,7 @@ SOC_FAMILY:mx93-generic-bsp   = "mx93"
 
 REV_OPTION ?= "REV=${IMX_SOC_REV_UPPER}"
 
-do_uboot_assemble_fitimage:prepend:imx-generic-bsp() {
-    for config in ${UBOOT_MACHINE}; do
-        mkdir -p ${B}/${config}
-    done
-}
+UBOOT_DTB_BINARY ?= "u-boot.dtb"
 
 compile_mx8m() {
     bbnote 8MQ/8MM/8MN/8MP boot binary build


### PR DESCRIPTION
Since commit `5e12dc911d0c541f43aa6d0c046fb87e8b7c1f7e` on layer `openembedded-core`, the class `uboot-sign` is supposed to be inherited by u-boot recipes only, but the imx-boot recipe is currently inheriting it. With this commit we change this situation by inheriting from `uboot-config` instead so it can access relevant variables related to the U-Boot configuration without inheriting the tasks defined by uboot-sign which pertain exclusively to u-boot recipes (uboot_generate_rsa_keys, uboot_assemble_fitimage); this in turn allows us to get rid of the prepend to `uboot_assemble_fitimage` which only existed to allow that extraneous task to succeed.

Nevertheless, the main issue solved by the commit is a conflict that happens when imx-boot is used together a U-Boot configured not to generate a boot container, i.e. with `UBOOT_PROVIDES_BOOT_CONTAINER="0"` in which case both the U-Boot and the imx-boot recipe would try to deploy the same files due to to extraneous tasks inherited, leading to build errors like this:

```
ERROR: imx-boot-1.0-r0 do_deploy: Recipe imx-boot is trying to install
  files into a shared area when those files already exist. The files
  and the manifests listing them are:
  /workdir/.../deploy/images/colibri-imx8x/u-boot-colibri-imx8x.dtb
    (matched in manifest-colibri_imx8x-u-boot-toradex.deploy)
  /workdir/.../deploy/images/colibri-imx8x/u-boot.dtb
    (matched in manifest-colibri_imx8x-u-boot-toradex.deploy)
  ...
```

As part of this change we set variable `UBOOT_DTB_BINARY` to match the setting in uboot-sign.bbclass, which duplicates information. This is not ideal but it should work as that value is unlikely to change. The ideal solution would likely be setting it in uboot-config.bbclass (provided by layer `openembedded-core`); that's left as a future improvement.
