### PR TITLE
imx-alsa-plugins: Update 6.6.3-1.0.0 to 6.6.23-2.0.0

### DIFF
--- a/recipes-multimedia/alsa/imx-alsa-plugins_git.bb
+++ b/recipes-multimedia/alsa/imx-alsa-plugins_git.bb
@@ -20,7 +20,7 @@ inherit autotools pkgconfig use-imx-headers
 PV = "1.0.26+${SRCPV}"
 
 SRC_URI = "git://github.com/nxp-imx/imx-alsa-plugins.git;protocol=https;branch=${SRCBRANCH}"
-SRCBRANCH = "MM_04.08.03_2312_L6.6.y"
+SRCBRANCH = "MM_04.09.00_2405_L6.6.y"
 SRCREV = "b2ba082e70333f187972ee4e85f63f9d2f608331"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Update to the new branch, for now the same hash is being used.