### PR TITLE
linux-fslc: Fix TMPDIR build failure

### DIFF
--- a/recipes-kernel/linux/linux-fslc_6.6.bb
+++ b/recipes-kernel/linux/linux-fslc_6.6.bb
@@ -22,7 +22,7 @@ SRC_URI = "git://github.com/Freescale/linux-fslc.git;branch=${KBRANCH};protocol=
 LINUX_VERSION = "6.6.36"
 
 KBRANCH = "6.6.x+fslc"
-SRCREV = "32a79dc5c8f69f1eb7b10b7707b0078fb2fdfa98"
+SRCREV = "44101c9bc5277baa5a678b43ac0b4d95cf03afa8"
 
 KBUILD_DEFCONFIG:mx5-generic-bsp = "imx_v6_v7_defconfig"
 KBUILD_DEFCONFIG:mx6-generic-bsp = "imx_v6_v7_defconfig"


### PR DESCRIPTION
The build failures:

ERROR: linux-fslc-6.6.36+git-r0 do_package_qa: QA Issue: File /usr/src/debug/linux-fslc/6.6.36+git/lib/oid_registry_data.c in package linux-fslc-src contains reference to TMPDIR [buildpaths] ERROR: linux-fslc-6.6.36+git-r0 do_package_qa: Fatal QA errors were found, failing task.

ERROR: linux-fslc-6.6.36+git-r0 do_package_qa: QA Issue: File /usr/src/debug/linux-fslc/6.6.36+git/drivers/tty/vt/consolemap_deftbl.c in package linux-fslc-src contains reference to TMPDIR ERROR: linux-fslc-6.6.36+git-r0 do_package_qa: Fatal QA errors were found, failing task.

ERROR: linux-fslc-6.6.36+git-r0 do_package_qa: QA Issue: File /usr/src/debug/linux-fslc/6.6.36+git/drivers/video/logo/logo_linux_clut224.c in package linux-fslc-src contains reference to TMPDIR [buildpaths] ERROR: linux-fslc-6.6.36+git-r0 do_package_qa: Fatal QA errors were found, failing task

The relevant changes:

 8f24666d05968 tty: vt: conmakehash: cope with abs_srctree no longer in env
 7ea30dacfb713 lib/build_OID_registry: don't mention the full path of the script in output
 0f806d7395704 video: logo: Drop full path of the input filename in generated fil