### PR TITLE
recipes-multimedia: imx-*: Update 6.6.3-1.0.0 to 6.6.23-2.0.0

### DIFF
--- a/recipes-multimedia/imx-codec/imx-codec_4.9.0.bb
+++ b/recipes-multimedia/imx-codec/imx-codec_4.9.0.bb
@@ -5,14 +5,14 @@
 DESCRIPTION = "Freescale Multimedia codec libs"
 LICENSE = "Proprietary"
 SECTION = "multimedia"
-LIC_FILES_CHKSUM = "file://COPYING;md5=44a8052c384584ba09077e85a3d1654f"
+LIC_FILES_CHKSUM = "file://COPYING;md5=10c0fda810c63b052409b15a5445671a"
 
 # Backward compatibility
 PROVIDES += "libfslcodec"
 
 SRC_URI = "${FSL_MIRROR}/${BP}.bin;fsl-eula=true"
-SRC_URI[md5sum] = "7ae1615aad2c0456b9be2ab804a6267e"
-SRC_URI[sha256sum] = "9facb3541903b4a6c6baa906f8c2c6cc01fc8c7b82a726c8da6d3681d4ed720b"
+SRC_URI[md5sum] = "2208aa871e51aacf1910c59c24694572"
+SRC_URI[sha256sum] = "1a41a3cad9e0f4baa904fcec896105d3474e18d13f169dad1172d5691fc11c9a"
 
 inherit fsl-eula-unpack autotools pkgconfig
 

--- a/recipes-multimedia/imx-dsp/imx-dsp-codec-ext_2.1.8.bb
+++ b/recipes-multimedia/imx-dsp/imx-dsp-codec-ext_2.1.8.bb
@@ -2,14 +2,14 @@
 
 DESCRIPTION = "i.MX DSP Codec Wrapper and Lib owned by NXP"
 LICENSE = "Proprietary"
-LIC_FILES_CHKSUM = "file://COPYING;md5=44a8052c384584ba09077e85a3d1654f"
+LIC_FILES_CHKSUM = "file://COPYING;md5=10c0fda810c63b052409b15a5445671a"
 
 inherit fsl-eula-unpack autotools pkgconfig
 
 SRC_URI = "${FSL_MIRROR}/${BP}.bin;fsl-eula=true"
 
-SRC_URI[md5sum] = "32251bc952ca7b9a4b12fadb9328a8c1"
-SRC_URI[sha256sum] = "0baa82410a77c68e39aaa987d91b41c94255d62294fa2f5a399169f3068862cc"
+SRC_URI[md5sum] = "4250b61f23f49de9500ea8208f6e2be9"
+SRC_URI[sha256sum] = "fa30f3e1b13e570d7c6f0a5f335c11fc3c6336a266fd3a4941e27c4c2a5b13d3"
 
 EXTRA_OECONF:append:mx8qm-nxp-bsp = " --enable-imx8qmqxp"
 EXTRA_OECONF:append:mx8qxp-nxp-bsp = " --enable-imx8qmqxp"

--- a/recipes-multimedia/imx-dsp/imx-dsp_2.1.8.bb
+++ b/recipes-multimedia/imx-dsp/imx-dsp_2.1.8.bb
@@ -2,15 +2,15 @@
 
 DESCRIPTION = "i.MX DSP Wrapper, Firmware Binary, Codec Libraries"
 LICENSE = "Proprietary"
-LIC_FILES_CHKSUM = "file://COPYING;md5=44a8052c384584ba09077e85a3d1654f"
+LIC_FILES_CHKSUM = "file://COPYING;md5=10c0fda810c63b052409b15a5445671a"
 
 
 inherit fsl-eula-unpack autotools pkgconfig
 
 SRC_URI = "${FSL_MIRROR}/${BP}.bin;fsl-eula=true"
 
-SRC_URI[md5sum] = "199f88716f289e93e0954fa6475a3cbc"
-SRC_URI[sha256sum] = "83eaef592de33b4d5e8fae63d798cc955bf3c414911c87afeb65a20af01fb0b6"
+SRC_URI[md5sum] = "6699e619f941cfa2e2b99cc2a99b7575"
+SRC_URI[sha256sum] = "5d42c8f39fb36bcc48e9f0c4caffd125b89c257fa8eccb3b61608bc690a16462"
 
 EXTRA_OECONF = " \
     -datadir=${base_libdir}/firmware \

--- a/recipes-multimedia/imx-parser/imx-parser_4.9.0.bb
+++ b/recipes-multimedia/imx-parser/imx-parser_4.9.0.bb
@@ -5,7 +5,7 @@
 DESCRIPTION = "Freescale Multimedia parser libs"
 LICENSE = "Proprietary"
 SECTION = "multimedia"
-LIC_FILES_CHKSUM = "file://COPYING;md5=44a8052c384584ba09077e85a3d1654f"
+LIC_FILES_CHKSUM = "file://COPYING;md5=10c0fda810c63b052409b15a5445671a"
 
 # For backwards compatibility
 PROVIDES += "libfslparser"
@@ -14,8 +14,8 @@ RPROVIDES:${PN} = "libfslparser"
 RCONFLICTS:${PN} = "libfslparser"
 
 SRC_URI = "${FSL_MIRROR}/${BP}.bin;fsl-eula=true"
-SRC_URI[md5sum] = "9bca484287f5592b86ed10c1761a3fcc"
-SRC_URI[sha256sum] = "b25267eefb4618b2ba8d6aba46a5b4e09621a44115036fc896e0777006472043"
+SRC_URI[md5sum] = "700b4cf3ba547dc740a064787f528af0"
+SRC_URI[sha256sum] = "2f0fc3955f824936c359b3cb738549213823b0c366b2362bba593058da745677"
 
 inherit fsl-eula-unpack autotools pkgconfig
 

--- a/recipes-multimedia/imx-vpuwrap/imx-vpuwrap/0001-vpu_wrapper_hantro_VCencoder-add-sys-time.h-for-gett.patch
+++ b/recipes-multimedia/imx-vpuwrap/imx-vpuwrap/0001-vpu_wrapper_hantro_VCencoder-add-sys-time.h-for-gett.patch
@@ -1,0 +1,31 @@
+From a57daf8f58cf69be06de8ebc9eab3a3077143760 Mon Sep 17 00:00:00 2001
+From: Hiago De Franco <hiago.franco@toradex.com>
+Date: Fri, 26 Jul 2024 14:43:55 -0300
+Subject: [PATCH] vpu_wrapper_hantro_VCencoder: add sys/time.h for gettimeofday
+
+Fixes:
+| ../git/vpu_wrapper_hantro_VCencoder.c:1965:5: error: implicit declaration of function 'gettimeofday' [-Wimplicit-function-declaration]
+|  1965 |     gettimeofday (&pObj->tvBegin, NULL);
+|       |     ^~~~~~~~~~~~
+
+Upstream-Status: Submitted [https://github.com/nxp-imx/imx-vpuwrap/pull/2]
+Signed-off-by: Hiago De Franco <hiago.franco@toradex.com>
+---
+ vpu_wrapper_hantro_VCencoder.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/vpu_wrapper_hantro_VCencoder.c b/vpu_wrapper_hantro_VCencoder.c
+index efae31a77ca4..6185cfc067d1 100755
+--- a/vpu_wrapper_hantro_VCencoder.c
++++ b/vpu_wrapper_hantro_VCencoder.c
+@@ -17,6 +17,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
++#include <sys/time.h>
+ #include <time.h>
+ #include <math.h>
+ #include <fcntl.h>
+--
+2.39.2
+

--- a/recipes-multimedia/imx-vpuwrap/imx-vpuwrap_git.bb
+++ b/recipes-multimedia/imx-vpuwrap/imx-vpuwrap_git.bb
@@ -5,7 +5,7 @@
 DESCRIPTION = "Freescale Multimedia VPU wrapper"
 LICENSE = "Proprietary"
 SECTION = "multimedia"
-LIC_FILES_CHKSUM = "file://COPYING;md5=2827219e81f28aba7c6a569f7c437fa7"
+LIC_FILES_CHKSUM = "file://COPYING;md5=10c0fda810c63b052409b15a5445671a"
 
 DEPENDS = "virtual/imxvpu"
 DEPENDS:append:mx8mp-nxp-bsp = " imx-vpu-hantro-vc"
@@ -13,9 +13,10 @@ DEPENDS:append:mx8mp-nxp-bsp = " imx-vpu-hantro-vc"
 SRC_URI = " \
     git://github.com/NXP/imx-vpuwrap.git;protocol=https;branch=${SRCBRANCH} \
     file://0001-vpu_wrapper_hantro_encoder-add-sys-time.h-for-gettim.patch \
+    file://0001-vpu_wrapper_hantro_VCencoder-add-sys-time.h-for-gett.patch \
 "
-SRCBRANCH = "MM_04.08.03_2312_L6.6.y"
-SRCREV = "f974cecdb00b4a214e4b5229f2279e772ee43306"
+SRCBRANCH = "MM_04.09.00_2405_L6.6.y"
+SRCREV = "73093da30dc4053c9f69813a6447091bfca5429b"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Update the following recipes to NXP BSP 6.6.23-2.0.0:
- imx-codec 4.9.0
- imx-dsp 2.1.8
- imx-parser 4.9.0
- imx-vpuwrap (branch MM_04.09.00_2405_L6.6.y)