### PR TITLE
imx-mkimage: Update 6.6.3-1.0.0 to 6.6.23-2.0.0

### DIFF
--- a/recipes-bsp/imx-mkimage/imx-mkimage_git.inc
+++ b/recipes-bsp/imx-mkimage/imx-mkimage_git.inc
@@ -1,12 +1,12 @@
-# Copyright 2017-2022 NXP
+# Copyright 2017-2023 NXP
 
 DEPENDS = "zlib-native openssl-native"
 
 SRC_URI = "git://github.com/nxp-imx/imx-mkimage.git;protocol=https;branch=${SRCBRANCH} \
            file://0001-iMX8M-soc.mak-use-native-mkimage-from-sysroot.patch \
 "
-SRCBRANCH = "lf-6.6.3_1.0.0"
-SRCREV = "cbb99377cc2bb8f7cf213794c030e1c60423ef1f"
+SRCBRANCH = "lf-6.6.23_2.0.0"
+SRCREV = "ca5d6b2d3fd9ab15825b97f7ef6f1ce9a8644966"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Update recipes to NXP BSP version 6.6.23-2.0.0.
This commit introduces the 'imx95' target.