### PR TITLE
kernel-module-nxp-wlan: Update 6.6.3-1.0.0 to 6.6.23-2.0.0

### DIFF
--- a/recipes-kernel/kernel-modules/kernel-module-nxp-wlan_git.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-nxp-wlan_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "NXP Wi-Fi driver for module 88w8801/8987/8997/9098 IW416/612"
 LICENSE = "GPL-2.0-only"
-LIC_FILES_CHKSUM = "file://../../LICENSE;md5=ab04ac0f249af12befccb94447c08b77"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=ab04ac0f249af12befccb94447c08b77"
 
 # For backwards compatibility
 PROVIDES += "kernel-module-nxp89xx"
@@ -8,12 +8,12 @@ RREPLACES:${PN} = "kernel-module-nxp89xx"
 RPROVIDES:${PN} = "kernel-module-nxp89xx"
 RCONFLICTS:${PN} = "kernel-module-nxp89xx"
 
-SRCBRANCH = "lf-6.6.3_1.0.0"
+SRCBRANCH = "lf-6.6.23_2.0.0"
 MRVL_SRC ?= "git://github.com/nxp-imx/mwifiex.git;protocol=https"
 SRC_URI = "${MRVL_SRC};branch=${SRCBRANCH}"
-SRCREV = "a84df583155bad2a396a937056805550bdf655ab"
+SRCREV = "88372772badbf30152b3ad12ae251dc567095cab"
 
-S = "${WORKDIR}/git/mxm_wifiex/wlan_src"
+S = "${WORKDIR}/git"
 
 inherit module
 


### PR DESCRIPTION
Update mwifiex to the new NXP BSP 6.6.23-2.0.0.

#1861