### PR TITLE
Fix uboot localversion

### DIFF
--- a/classes/fsl-u-boot-localversion.bbclass
+++ b/classes/fsl-u-boot-localversion.bbclass
@@ -29,8 +29,8 @@ do_compile:prepend() {
 			head=`git --git-dir=${S}/.git rev-parse --verify --short $hash 2> /dev/null`
 		fi
 		patches=`git --git-dir=${S}/.git rev-list --count $head..HEAD 2> /dev/null`
-		printf "%s%s%s%s" +g $head +p $patches > ${S}/.scmversion
-		printf "%s%s%s%s" +g $head +p $patches > ${B}/.scmversion
+		printf "%s%s%s%s%s" "${UBOOT_LOCALVERSION}" +g $head +p $patches > ${S}/.scmversion
+		printf "%s%s%s%s%s" "${UBOOT_LOCALVERSION}" +g $head +p $patches > ${B}/.scmversion
 	else
 		printf "%s" "${UBOOT_LOCALVERSION}" > ${S}/.scmversion
 		printf "%s" "${UBOOT_LOCALVERSION}" > ${B}/.scmversion

--- a/classes/fsl-u-boot-localversion.bbclass
+++ b/classes/fsl-u-boot-localversion.bbclass
@@ -17,21 +17,21 @@ UBOOT_LOCALVERSION = "${LOCALVERSION}"
 do_compile:prepend() {
 	if [ "${SCMVERSION}" = "y" ]; then
 		# Add GIT revision to the local version
-                if [ "${SRCREV}" = "INVALID" ]; then
-                        hash=${SRCREV_machine}
-                else
-                        hash=${SRCREV}
-                fi
-                if [ "$hash" = "AUTOINC" ]; then
-                        branch=`git --git-dir=${S}/.git  symbolic-ref --short -q HEAD`
-                        head=`git --git-dir=${S}/.git rev-parse --verify --short origin/${branch} 2> /dev/null`
-                else
-                        head=`git --git-dir=${S}/.git rev-parse --verify --short $hash 2> /dev/null`
-                fi
-                patches=`git --git-dir=${S}/.git rev-list --count $head..HEAD 2> /dev/null`
-                printf "%s%s%s%s" +g $head +p $patches > ${S}/.scmversion
-                printf "%s%s%s%s" +g $head +p $patches > ${B}/.scmversion
-        else
+		if [ "${SRCREV}" = "INVALID" ]; then
+			hash=${SRCREV_machine}
+		else
+			hash=${SRCREV}
+		fi
+		if [ "$hash" = "AUTOINC" ]; then
+			branch=`git --git-dir=${S}/.git  symbolic-ref --short -q HEAD`
+			head=`git --git-dir=${S}/.git rev-parse --verify --short origin/${branch} 2> /dev/null`
+		else
+			head=`git --git-dir=${S}/.git rev-parse --verify --short $hash 2> /dev/null`
+		fi
+		patches=`git --git-dir=${S}/.git rev-list --count $head..HEAD 2> /dev/null`
+		printf "%s%s%s%s" +g $head +p $patches > ${S}/.scmversion
+		printf "%s%s%s%s" +g $head +p $patches > ${B}/.scmversion
+	else
 		printf "%s" "${UBOOT_LOCALVERSION}" > ${S}/.scmversion
 		printf "%s" "${UBOOT_LOCALVERSION}" > ${B}/.scmversion
 	fi


### PR DESCRIPTION
Fixes regression introduced by
d7e13f19fbf9 ("fsl-u-boot-localversion.bbclass: fix SRCREV_machine and AUTOREV use cases")

Please backport to scarthgap as well.