### PR TITLE
libimxvpuapi2: Bump revision to 8639837a246f

### DIFF
--- a/recipes-multimedia/libimxvpuapi/libimxvpuapi2_2.3.0.bb
+++ b/recipes-multimedia/libimxvpuapi/libimxvpuapi2_2.3.0.bb
@@ -11,7 +11,7 @@ DEPENDS:append:mx8mp-nxp-bsp = " imx-vpu-hantro-vc"
 PV .= "+git${SRCPV}"
 
 SRCBRANCH ?= "master"
-SRCREV = "6f803f46d6b53a08cf02fc3d440072e01e2f3a09"
+SRCREV = "8639837a246f8d85fba8a707c130239aeabc0a19"
 SRC_URI = "git://github.com/Freescale/libimxvpuapi.git;branch=${SRCBRANCH};protocol=https"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
After bumping gstreamer1.0-plugins-imx build is failing. Here is a snippet of the build error:

| ../git/ext/vpu/gstimxvpuenc.c:473:20: error: 'ImxVpuApiEncOpenParams' has no member named 'fixed_intra_quantization'
|         open_params->fixed_intra_quantization =
imx_vpu_enc->fixed_intra_quantization;
|                    ^~

Fix it by updating libimxvpuapi2 to the current HEAD of its repository.