### PR TITLE
[scarthgap] weston-init: Fix RDP support

### DIFF
--- a/recipes-graphics/wayland/weston-init.bbappend
+++ b/recipes-graphics/wayland/weston-init.bbappend
@@ -58,6 +58,9 @@ PACKAGECONFIG[use-g2d] = ",,"
 PACKAGECONFIG[xwayland] = ",,"
 
 do_install:append() {
+    # Replace the template variables
+    sed -i -e 's,@bindir@,${bindir},g' ${D}${sysconfdir}/xdg/weston/weston.ini
+
     if [ -f "${WORKDIR}/weston.config" ]; then
         install -Dm0755 ${WORKDIR}/weston.config ${D}${sysconfdir}/default/weston
     fi
@@ -88,6 +91,4 @@ do_install:append() {
     if [ "${@bb.utils.contains('PACKAGECONFIG', 'xwayland', 'yes', 'no', d)}" = "no" ]; then
         sed -i -e "s/^xwayland=true/#xwayland=true/g" ${D}${sysconfdir}/xdg/weston/weston.ini
     fi
-
-    sed -i -e 's,@bindir@,${bindir},g' ${D}${sysconfdir}/xdg/weston/weston.ini
 }


### PR DESCRIPTION
The modification of the weston.ini command line necessary for RDP support is missing. The problem is the weston.ini template contains `@bindir@`, while the sed operation for the modification contains `${bindir}`.

Fix the problem by moving the replacement of `@bindir@` to the top of the function `do_install:append()`.

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>
(cherry picked from commit 1963104c4ad7367686c910c70a07cbc7df3cd6c5)