### PR TITLE
gstreamer1.0-plugins-ugly: remove unbuildable default packageconfigs

### DIFF
--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly_1.24.0.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly_1.24.0.imx.bb
@@ -24,7 +24,6 @@ GST_PLUGIN_SET_HAS_EXAMPLES = "0"
 
 PACKAGECONFIG ??= " \
     ${GSTREAMER_ORC} \
-    a52dec mpeg2dec \
 "
 
 PACKAGECONFIG[a52dec]   = "-Da52dec=enabled,-Da52dec=disabled,liba52"


### PR DESCRIPTION
Openembedded core after scarthgap removed the recipes providing liba52 and mpeg2dec with commit 90fbfe9fe1da ("liba52: remove the recipe") and commit d46660e6c083 ("mpeg2dec: remove the recipe").

Thus don't set by default the packageconfigs depending on these. If someone needs it these should be enabled in a bbappend together with additionally bringing back the dependencies.