### PR TITLE
Fix OP-TEE libteec version

### DIFF
--- a/recipes-security/optee-imx/optee-client-fslc.inc
+++ b/recipes-security/optee-imx/optee-client-fslc.inc
@@ -25,9 +25,9 @@ EXTRA_OEMAKE = " \
 do_install () {
 	oe_runmake -C ${S} install
 
-	install -D -p -m0644 ${B}/export/usr/lib/libteec.so.1.0.0 ${D}${libdir}/libteec.so.1.0.0
-	ln -sf libteec.so.1.0.0 ${D}${libdir}/libteec.so.1
-	ln -sf libteec.so.1.0.0 ${D}${libdir}/libteec.so
+	install -D -p -m0644 ${B}/export/usr/lib/libteec.so.2.0.0 ${D}${libdir}/libteec.so.2.0.0
+	ln -sf libteec.so.2.0.0 ${D}${libdir}/libteec.so.2
+	ln -sf libteec.so.2.0.0 ${D}${libdir}/libteec.so
 
 	install -D -p -m0644 ${B}/export/usr/lib/libckteec.so.0.1.0 ${D}${libdir}/libckteec.so.0.1.0
 	ln -sf libckteec.so.0.1.0 ${D}${libdir}/libckteec.so.0


### PR DESCRIPTION
Fixes regression introduced by 79fd80f1 ("optee: Upgrade optee recipes from 4.0.0.imx to 4.2.0.imx").

Please backport to scarthgap as well.