### PR TITLE
imx-boot-container: Assign weak init value for `IMX_BOOT_CONTAINER_FIRMWARE_SOC`

### DIFF
--- a/classes/imx-boot-container.bbclass
+++ b/classes/imx-boot-container.bbclass
@@ -27,7 +27,7 @@
 ATF_MACHINE_NAME = "bl31-${ATF_PLATFORM}.bin"
 ATF_MACHINE_NAME:append = "${@bb.utils.contains('MACHINE_FEATURES', 'optee', '-optee', '', d)}"
 
-IMX_BOOT_CONTAINER_FIRMWARE_SOC = ""
+IMX_BOOT_CONTAINER_FIRMWARE_SOC ?= ""
 IMX_BOOT_CONTAINER_FIRMWARE_SOC:mx8mq-generic-bsp = " \
     signed_dp_imx8m.bin \
     signed_hdmi_imx8m.bin \


### PR DESCRIPTION
Assign weak init value for `IMX_BOOT_CONTAINER_FIRMWARE_SOC` to be able override it for future i.MX SoCs.