### PR TITLE
layer.conf: Update to styhead

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -8,7 +8,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 BBFILE_COLLECTIONS += "freescale-layer"
 BBFILE_PATTERN_freescale-layer := "^${LAYERDIR}/"
 BBFILE_PRIORITY_freescale-layer = "5"
-LAYERSERIES_COMPAT_freescale-layer = "kirkstone langdale mickledore nanbield scarthgap"
+LAYERSERIES_COMPAT_freescale-layer = "styhead"
 LAYERDEPENDS_freescale-layer = "core"
 
 # Add the Freescale-specific licenses into the metadata


### PR DESCRIPTION
Drop all older release names as there have been potentially incompatible changes, e.g. the S must not point to WORKDIR.