### PR TITLE
u-boot-fslc: Bump to revison 5b4d66dd

### DIFF
--- a/recipes-bsp/u-boot/u-boot-fslc-common_2024.07.inc
+++ b/recipes-bsp/u-boot/u-boot-fslc-common_2024.07.inc
@@ -10,7 +10,7 @@ DEPENDS += "flex-native bison-native"
 
 SRC_URI = "git://github.com/Freescale/u-boot-fslc.git;branch=${SRCBRANCH};protocol=https"
 
-SRCREV = "1406c04f60f5c375e0fc77b9f661aecd08dff45e"
+SRCREV = "5b4d66dd41432d36c22bcdfa2d1ca4afc3a1c2fc"
 SRCBRANCH = "2024.07+fslc"
 
 PV = "2024.07+fslc+git${SRCPV}"


### PR DESCRIPTION
This commit changes the u-boot-fslc source revision to 5b4d66dd. This new revison fix a issue with imx8mq bootloader.