### PR TITLE
[scarthgap] Migrate to use Linux kernel v6.11.0 in linux-fslc

### DIFF
--- a/recipes-kernel/cryptodev/cryptodev-module_%.bbappend
+++ b/recipes-kernel/cryptodev/cryptodev-module_%.bbappend
@@ -1,5 +1,12 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
+# Fix build for Linux 6.7-rc1: https://github.com/cryptodev-linux/cryptodev-linux/commit/5e7121e45ff283d30097da381fd7e97c4bb61364
+# Since Linux 6.7-rc1, no ahash algorithms set a nonzero alignmask,
+# and therefore `crypto_ahash_alignmask` has been removed.
+#
+# See also: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=0f8660c82b79af595b056f6b9f4f227edeb88574
+#           https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=c626910f3f1bbce6ad18bc613d895d2a089ed95e
+
 SRC_URI += " \
     file://fix-build-for-Linux-6.7-rc1.patch \
 "

--- a/recipes-kernel/cryptodev/cryptodev-module_%.bbappend
+++ b/recipes-kernel/cryptodev/cryptodev-module_%.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI += " \
+    file://fix-build-for-Linux-6.7-rc1.patch \
+"

--- a/recipes-kernel/cryptodev/files/fix-build-for-Linux-6.7-rc1.patch
+++ b/recipes-kernel/cryptodev/files/fix-build-for-Linux-6.7-rc1.patch
@@ -12,7 +12,7 @@ and therefore `crypto_ahash_alignmask` has been removed.
 See also: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=0f8660c82b79af595b056f6b9f4f227edeb88574
           https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=c626910f3f1bbce6ad18bc613d895d2a089ed95e
 
-Upstream-Status: Pending
+Upstream-Status: Backport [https://github.com/cryptodev-linux/cryptodev-linux/commit/5e7121e45ff283d30097da381fd7e97c4bb61364]
 
 Signed-off-by: Joan Bruguera Micó <joanbrugueram@gmail.com>
 ---

--- a/recipes-kernel/cryptodev/files/fix-build-for-Linux-6.7-rc1.patch
+++ b/recipes-kernel/cryptodev/files/fix-build-for-Linux-6.7-rc1.patch
@@ -1,0 +1,37 @@
+From 5e7121e45ff283d30097da381fd7e97c4bb61364 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Joan=20Bruguera=20Mic=C3=B3?= <joanbrugueram@gmail.com>
+Date: Sun, 10 Dec 2023 13:57:55 +0000
+Subject: [PATCH] Fix build for Linux 6.7-rc1
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Since Linux 6.7-rc1, no ahash algorithms set a nonzero alignmask,
+and therefore `crypto_ahash_alignmask` has been removed.
+
+See also: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=0f8660c82b79af595b056f6b9f4f227edeb88574
+          https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=c626910f3f1bbce6ad18bc613d895d2a089ed95e
+
+Upstream-Status: Pending
+
+Signed-off-by: Joan Bruguera Micó <joanbrugueram@gmail.com>
+---
+ cryptlib.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/cryptlib.c b/cryptlib.c
+index 4d739e5..0e59d4c 100644
+--- a/cryptlib.c
++++ b/cryptlib.c
+@@ -381,7 +381,11 @@ int cryptodev_hash_init(struct hash_data *hdata, const char *alg_name,
+ 	}
+ 
+ 	hdata->digestsize = crypto_ahash_digestsize(hdata->async.s);
++#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 7, 0))
+ 	hdata->alignmask = crypto_ahash_alignmask(hdata->async.s);
++#else
++	hdata->alignmask = 0;
++#endif
+ 
+ 	init_completion(&hdata->async.result.completion);
+ 

--- a/recipes-kernel/linux/linux-fslc_6.10.bb
+++ b/recipes-kernel/linux/linux-fslc_6.10.bb
@@ -14,6 +14,10 @@ require linux-imx.inc
 
 SRC_URI = "git://github.com/Livius90/linux-fslc.git;branch=${KBRANCH};protocol=https"
 
+DEPENDS += " \
+    coreutils-native \
+"
+
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #

--- a/recipes-kernel/linux/linux-fslc_6.10.bb
+++ b/recipes-kernel/linux/linux-fslc_6.10.bb
@@ -12,7 +12,7 @@ upstreaming."
 
 require linux-imx.inc
 
-SRC_URI = "git://github.com/Livius90/linux-fslc.git;branch=${KBRANCH};protocol=https"
+SRC_URI = "git://github.com/Freescale/linux-fslc.git;branch=${KBRANCH};protocol=https"
 
 DEPENDS += " \
     coreutils-native \
@@ -23,10 +23,10 @@ DEPENDS += " \
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "6.10.9"
+LINUX_VERSION = "6.10.10"
 
 KBRANCH = "6.10.x+fslc"
-SRCREV = "1611860f184a2c9e74ed593948d43657734a7098"
+SRCREV = "049be94099ea5ba8338526c5a4f4f404b9dcaf54"
 
 KBUILD_DEFCONFIG:mx5-generic-bsp = "imx_v6_v7_defconfig"
 KBUILD_DEFCONFIG:mx6-generic-bsp = "imx_v6_v7_defconfig"

--- a/recipes-kernel/linux/linux-fslc_6.10.bb
+++ b/recipes-kernel/linux/linux-fslc_6.10.bb
@@ -12,17 +12,17 @@ upstreaming."
 
 require linux-imx.inc
 
-SRC_URI = "git://github.com/Freescale/linux-fslc.git;branch=${KBRANCH};protocol=https"
+SRC_URI = "git://github.com/Livius90/linux-fslc.git;branch=${KBRANCH};protocol=https"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "6.6.36"
+LINUX_VERSION = "6.10.9"
 
-KBRANCH = "6.6.x+fslc"
-SRCREV = "44101c9bc5277baa5a678b43ac0b4d95cf03afa8"
+KBRANCH = "6.10.x+fslc"
+SRCREV = "1611860f184a2c9e74ed593948d43657734a7098"
 
 KBUILD_DEFCONFIG:mx5-generic-bsp = "imx_v6_v7_defconfig"
 KBUILD_DEFCONFIG:mx6-generic-bsp = "imx_v6_v7_defconfig"

--- a/recipes-kernel/linux/linux-fslc_6.11.bb
+++ b/recipes-kernel/linux/linux-fslc_6.11.bb
@@ -23,10 +23,10 @@ DEPENDS += " \
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "6.10.10"
+LINUX_VERSION = "6.11.0"
 
-KBRANCH = "6.10.x+fslc"
-SRCREV = "049be94099ea5ba8338526c5a4f4f404b9dcaf54"
+KBRANCH = "6.11.x+fslc"
+SRCREV = "98f7e32f20d28ec452afb208f9cffc08448a2652"
 
 KBUILD_DEFCONFIG:mx5-generic-bsp = "imx_v6_v7_defconfig"
 KBUILD_DEFCONFIG:mx6-generic-bsp = "imx_v6_v7_defconfig"


### PR DESCRIPTION
It was tested without any errors on the following boards:

- i.MX7D Pico-Pi - work :white_check_mark:
- i.MX93 11x11 EVK - work :white_check_mark:

To get and migrate the latest mainline kernel branch to [linux-fslc repo](https://github.com/Freescale/linux-fslc):
```bash
    git clone --single-branch --branch 6.11.x+fslc https://github.com/Livius90/linux-fslc.git
    cd linux-fslc
    git remote add fslc-mirror https://github.com/Freescale/linux-fslc.git
    git push -u fslc-mirror
```

Notes:
- you can use [linux-6.11.y](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.11.y) branch from [mainline Linux repo](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git) for migrating also.
- cryptodev-module: need to apply "[Fix build for Linux 6.7-rc1](https://github.com/cryptodev-linux/cryptodev-linux/commit/5e7121e45ff283d30097da381fd7e97c4bb61364)" patch otherwise cryptodev-linux 1.13 is not able to build in scarthgap. In further Yocto release branch it will not need in the future, because cryptodev-linux 1.14 got this [patch/fix finally](https://github.com/cryptodev-linux/cryptodev-linux/compare/cryptodev-linux-1.13...cryptodev-linux-1.14).


