### PR TITLE
tinycompress: use https-protocol to download sources

### DIFF
--- a/recipes-multimedia/tinycompress/tinycompress_1.1.6.bb
+++ b/recipes-multimedia/tinycompress/tinycompress_1.1.6.bb
@@ -3,7 +3,7 @@ LICENSE = "LGPL-2.1-only | BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://COPYING;md5=cf9105c1a2d4405cbe04bbe3367373a0"
 DEPENDS = "alsa-lib"
 
-SRC_URI = "git://git.alsa-project.org/tinycompress.git;protocol=git;branch=master \
+SRC_URI = "git://git.alsa-project.org/http/tinycompress.git;protocol=https;branch=master \
            file://0001-tinycompress-Add-id3-decoding.patch \
            file://0002-cplay-Support-wave-file.patch \
            file://0003-cplay-Add-pause-feature.patch \


### PR DESCRIPTION
In some network-environments download with git-protocol is not possible. By switching to https the sources are accessable.