### PR TITLE
imx-oei: use `MACHINE_ARCH` as `PACKAGE_ARCH`

### DIFF
--- a/dynamic-layers/arm-toolchain/recipes-bsp/imx-oei/imx-oei_1.0.0.bb
+++ b/dynamic-layers/arm-toolchain/recipes-bsp/imx-oei/imx-oei_1.0.0.bb
@@ -15,6 +15,8 @@ S = "${WORKDIR}/git"
 
 inherit deploy
 
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
 OEI_CONFIGS ?= "UNDEFINED"
 OEI_CORE    ?= "UNDEFINED"
 OEI_SOC     ?= "UNDEFINED"


### PR DESCRIPTION
The recipe build changes depending on the `OEI_BOARD` value, which is machine-specific.

This should also be backported to scarthgap branch