### PR TITLE
Follow 6.6-2.0.x-imx instead of 6.6-1.0.x-imx

### DIFF
--- a/recipes-kernel/linux/linux-fslc-imx_6.6.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_6.6.bb
@@ -28,7 +28,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v6.6.28
+#    tag: v6.6.23
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
@@ -51,16 +51,16 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 
 require linux-imx.inc
 
-KBRANCH = "6.6-1.0.x-imx"
+KBRANCH = "6.6-2.0.x-imx"
 SRC_URI = "git://github.com/Freescale/linux-fslc.git;branch=${KBRANCH};protocol=https"
-SRCREV = "13ed4e83694299049a3d4449fdb61471292ef19b"
+SRCREV = "dd280fd310dd5fabbff7393175ee9d7a6aea6b34"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "6.6.28"
+LINUX_VERSION = "6.6.23"
 
 KBUILD_DEFCONFIG:mx6-generic-bsp = "imx_v7_defconfig"
 KBUILD_DEFCONFIG:mx7-generic-bsp = "imx_v7_defconfig"


### PR DESCRIPTION
To be honest, I don't know the exact differences between 6.6-1.0.x-imx and 6.6-2.0.x-imx. We need driver extensions like [this](https://github.com/nxp-imx/linux-imx/commit/e4bb4171226413cb8fe800eebf970171f2e6eefe), which is only available in 6.6-2.0.x-imx.

Note:

6.6-1.0.x-imx points to 6.6.28
6.6-2.0.x-imx points to 6.6.23
After the merge we should upgrade the (6.6-2.0.x-imx) kernel to 6.6.51 anyway. Any concerns?