### PR TITLE
kernel-module-isp-vvcam: Update 6.6.3-1.0.0 to 6.6.23-2.0.0

### DIFF
--- a/recipes-kernel/kernel-modules/kernel-module-isp-vvcam_4.2.2.24.2.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-isp-vvcam_4.2.2.24.2.bb
@@ -6,8 +6,8 @@ LIC_FILES_CHKSUM = "file://${S}/../LICENSE;md5=64381a6ea83b48c39fe524c85f65fb44"
 
 SRC_URI = "${ISP_KERNEL_SRC};branch=${SRCBRANCH}"
 ISP_KERNEL_SRC ?= "git://github.com/nxp-imx/isp-vvcam.git;protocol=https"
-SRCBRANCH = "lf-6.6.3_1.0.0"
-SRCREV = "2102360b58d9d1b36bc0c654c8301e4014b33951"
+SRCBRANCH = "lf-6.6.y_2.0.0"
+SRCREV = "ab77b0521615d3f279263ba67439aed887d525d7"
 
 S = "${WORKDIR}/git/vvcam/v4l2"
 


### PR DESCRIPTION
Update to the new NXP BSP 6.6.23-2.0.0.