### PR TITLE
cryptodev-module: Add patch fix for prepare kernel v6.11.0 in scarthgap

### DIFF
--- a/recipes-kernel/cryptodev/cryptodev-module_%.bbappend
+++ b/recipes-kernel/cryptodev/cryptodev-module_%.bbappend
@@ -1,0 +1,12 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+# Fix build for Linux 6.7-rc1: https://github.com/cryptodev-linux/cryptodev-linux/commit/5e7121e45ff283d30097da381fd7e97c4bb61364
+# Since Linux 6.7-rc1, no ahash algorithms set a nonzero alignmask,
+# and therefore `crypto_ahash_alignmask` has been removed.
+#
+# See also: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=0f8660c82b79af595b056f6b9f4f227edeb88574
+#           https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=c626910f3f1bbce6ad18bc613d895d2a089ed95e
+
+SRC_URI += " \
+    file://fix-build-for-Linux-6.7-rc1.patch \
+"

--- a/recipes-kernel/cryptodev/cryptodev-module_%.bbappend
+++ b/recipes-kernel/cryptodev/cryptodev-module_%.bbappend
@@ -7,6 +7,6 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 # See also: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=0f8660c82b79af595b056f6b9f4f227edeb88574
 #           https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=c626910f3f1bbce6ad18bc613d895d2a089ed95e
 
-SRC_URI += " \
+SRC_URI:append:imx-generic-bsp = " \
     file://fix-build-for-Linux-6.7-rc1.patch \
 "

--- a/recipes-kernel/cryptodev/files/fix-build-for-Linux-6.7-rc1.patch
+++ b/recipes-kernel/cryptodev/files/fix-build-for-Linux-6.7-rc1.patch
@@ -1,0 +1,37 @@
+From 5e7121e45ff283d30097da381fd7e97c4bb61364 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Joan=20Bruguera=20Mic=C3=B3?= <joanbrugueram@gmail.com>
+Date: Sun, 10 Dec 2023 13:57:55 +0000
+Subject: [PATCH] Fix build for Linux 6.7-rc1
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Since Linux 6.7-rc1, no ahash algorithms set a nonzero alignmask,
+and therefore `crypto_ahash_alignmask` has been removed.
+
+See also: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=0f8660c82b79af595b056f6b9f4f227edeb88574
+          https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=c626910f3f1bbce6ad18bc613d895d2a089ed95e
+
+Upstream-Status: Backport [https://github.com/cryptodev-linux/cryptodev-linux/commit/5e7121e45ff283d30097da381fd7e97c4bb61364]
+
+Signed-off-by: Joan Bruguera Micó <joanbrugueram@gmail.com>
+---
+ cryptlib.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/cryptlib.c b/cryptlib.c
+index 4d739e5..0e59d4c 100644
+--- a/cryptlib.c
++++ b/cryptlib.c
+@@ -381,7 +381,11 @@ int cryptodev_hash_init(struct hash_data *hdata, const char *alg_name,
+ 	}
+ 
+ 	hdata->digestsize = crypto_ahash_digestsize(hdata->async.s);
++#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 7, 0))
+ 	hdata->alignmask = crypto_ahash_alignmask(hdata->async.s);
++#else
++	hdata->alignmask = 0;
++#endif
+ 
+ 	init_completion(&hdata->async.result.completion);
+ 


### PR DESCRIPTION
Fix build for Linux 6.7-rc1: https://github.com/cryptodev-linux/cryptodev-linux/commit/5e7121e45ff283d30097da381fd7e97c4bb61364
Since Linux 6.7-rc1, no ahash algorithms set a nonzero alignmask, and therefore `crypto_ahash_alignmask` has been removed.

See also:
- https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=0f8660c82b79af595b056f6b9f4f227edeb88574
- https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=c626910f3f1bbce6ad18bc613d895d2a089ed95e
