### PR TITLE
u-boot-imx: Update to lf-6.6.36-2.1.0

### DIFF
--- a/recipes-bsp/u-boot/u-boot-imx-common_2024.04.inc
+++ b/recipes-bsp/u-boot/u-boot-imx-common_2024.04.inc
@@ -5,8 +5,8 @@ LIC_FILES_CHKSUM = "file://Licenses/gpl-2.0.txt;md5=b234ee4d69f5fce4486a80fdaf4a
 
 SRC_URI = "git://github.com/nxp-imx/uboot-imx.git;protocol=https;branch=${SRCBRANCH}"
 SRCBRANCH = "lf_v2024.04"
-LOCALVERSION ?= "-imx_v2024.04_6.6.23-2.0.0"
-SRCREV = "674440bc73e1dd483b84269cccfad89ab40af424"
+LOCALVERSION ?= "-imx_v2024.04_6.6.36-2.1.0"
+SRCREV = "de16f4f17221b2ff72b8cb18c28cd8a29f3c2710"
 
 DEPENDS += " \
     bc-native \


### PR DESCRIPTION
Update the u-boot-imx to the tag lf-6.6.36-2.1.0, that is used in the NXP BSP LF6.6.36_2.1.0. This commit adds the following changes:

    - de16f4f1722 configs: ls1088ardb: enable CONFIG_PHY_AQUANTIA
    - 291d018424c MA-22821 Adjust the fastboot offset used for avb verification
    - aefc41754b1 Pull request #135: MA-22768 Android: Enable NEON instruction acceleration as default on i.MX 95
    - dfabeeba1bf LFU-785 arm: dts: fsl-ls1088a: Enable USB nodes
    - f1b36b56740 MA-22768 Android: Enable NEON instruction acceleration as default on i.MX 95
    - 127c4143ced MA-22751-2 Android: Enable kaslr function on all android platforms
    - bbaa7cd97bc MA-22751-1 Enable kaslr function on all android platforms
    - 5c751212a6a Pull request #130: Feature/MA-22726 add rng driver for ele
    - 796b36cef2b LF-13165 imx91_evk/qsb: Align default mmcroot env with mmcdev
    - 02888f5a7aa MA-22726-4 imx95: android: seed the rng from bootloader
    - 01ca33808b4 MA-22726-3 android: enable ELE based RNG
    - aa49f8c2d44 MA-22726-2: ele: add rng driver
    - d5ac6715ff9 MA-22726-1 rework config CONFIG_DEK_BLOB_BUFFER
    - 6670dde79fe Pull request #128: Accelerate AVB process by NEON instruction
    - ed06f95670b MA-22734 Accelerate AVB process by NEON instruction
    - 54369cd719f LFU-782 imx95: add clk_ignore_unused for xen boot
    - 2b02a886a36 LF-12602-2 arm: dts: imx95-verdin: Change default splash screen to adv7535
    - 161f39fc7f3 LF-12602-1 imx95_verdin: Changes default kernel DTB file
    - c50050b80a7 LFU-781 ddr: imx9: Disable dynamic refresh rate when do mr operation
    - 7a7445a2113 LFU-780 imx9: wait ssar when power on power domain
    - 8ffdc89512f LFU-779-3 imx91_qsb: Add 1600MTS DDR timing files
    - ed0abd9a1b5 LFU-779-2 imx91_evk: Add 1600MTS DDR timing files
    - 14e6baf09c9 LFU-779-1 imx91: Support new variant part iMX9121
    - 579c5aba0c5 MA-22702 imx95: android: enable mcu image flash
    - 7606a94787d LFU-777 imx8ulp_evk: Update the DDR timing from latest RPA tool
    - 8807207c83f LFU-778 imx9: scmi: print SM version
    - 48cae0937d6 MA-22691 Android: Adjust the SPL size for imx93
    - f9dfd8a0b2e LFU-776 misc: imx_ele: Fix fuse read issue on OEM closed LC
    - 9d634dfc0f2 LFU-775 imx93_evk/qsb: Update DDR timing files with latest RPA
    - d4f81e6783b LFU-755-2 verdin-imx95: Workaround dead battery on USB typec
    - 9163beb516d LFU-755-1 imx95_evk: Workaround dead battery on USB typec
    - 28b40ba0525 Pull request #123: Verdin splash screen enable
    - f042d04a6b8 MA-22683 Android: Align defconfig with BSP for imx95_15x15_evk
    - ebb78124638 MA-22680 Android: Enable splash screen on i.MX95 verdin
    - a9efed38dca LFU-774 imx95: Fix ELE FW revision print bug
    - 2cd18693dc6 LFU-772 imx9: scmi: disable some clocks before booting linux
    - 6dfdc164edf LFU-768: mtd: rawnand: fsl_ifc: dynamic update register by nand info
    - eca8f851ae9 LFU-770-2 imx91_qsb: Add defconfig for M.2 flexspi NOR boot
    - fc232e192b8 LFU-770-1 arm: dts: imx91_qsb: Add DTS for M.2 flexspi NOR support
    - e3483987537 LFU-769 imx91_evk/qsb: Update DDR timing files from DDR tool
    - 92708586a64 LF-12889: laysercape: fixup: update esdhc node name to mmc
    - 8dffea7abad LFU-766-2 imx95_evk: Enable flexspi NOR support on 15x15 EVK
    - 642dbba7480 LFU-766-1 arm: dts: imx95-15x15-evk: add M.2 flexspi NOR support
    - 0f70d2f755a LFU-765-2 arm: dts: imx91: Fix incorrect MEDIA AXI clock rate
    - 43feb688fe6 LFU-765-1 imx91: clock: Fix incorrect bus clock rate
    - a7c8915150f LF-12901 thermal: imx91_tmu: Fix fuse map address for temperature sensor trim
    - b8478e99f8e LFU-764 imx95: evk/verdin: enable cpuidle
    - e409ae328e0 LFU-669-2 imx93: Call the ELE voltage APIs when set OD voltage
    - e813a6998a9 LFU-669-1 misc: ele_api: Add Voltage change start and finish APIs
    - ab09a34411a LFU-763-4 imx95_evk: Add defconfig for LVDS splash screen on 15x15 EVK
    - 6fdb6753233 LFU-763-3 arm: dts: Add DTS for BOE LVDS panel
    - 8a0487a9e01 LFU-763-2 video: imx95-ldb: Update LDB driver for single channel
    - 600129e81df LFU-763-1 video: simple_panel: Add BOE LVDS panel
    - aab772b45f7 LFU-759-4 verdin_imx95: Enable splash screen for MIPI-DSI
    - b028fc838e9 LFU-759-3 arm: dts: imx95: Add dts for Verdin board MIPI DSI
    - 90f5fca16f7 LFU-759-2 video: video_link: Move ahead duplicated link check
    - 47f1e9cb8da LFU-759-1 video: lontium-lt8912b: Add driver for lt8912b
    - ea69aa79fdb LFU-762-2 imx91_qsb: Update board codes to enable splash screen
    - e28478b3238 LFU-762-1 arm: dts: imx91_qsb: add DTS for tianma parallel LCD panel
    - 3a27b0c3ac1 LFU-761-2 imx8ulp: Align serial No to UID[0] and UID[1] with big endian
    - be59f7acab0 LFU-761-1 imx9: Print UID in big endian format for EL2GO
    - 36c93488d60 MA-22653 imx95: restore the verdin elemu1 node
    - c31ba1f4ce8 LFU-760 configs: imx95: enlarge dom0 mem
    - 2a3c1cf36a0 LFU-756 misc: ele_mu: clear RR when initialize MU
    - bcc07c08ee2 LFU-758: spi: nxp_fspi: Add extra delay after flexspi DLL locked
    - 9d4171ff039 LFU-757 imx93: Fix DDR QB training data generation build failure
    - 491e26cbbc8 MA-22635 Fix i.mx91/i.mx93 build error
    - c6e7cbb0551 MA-22628 Android: Enable encrypted boot for imx95
    - e8429da2961 MA-22459 Remove the dek_blob dest buffer from stack for imx95
    - 4b99a1ea7d8 LFU-754-3 misc: fuse: Remove FUSE_BANKS macro
    - 3ba29ac19a1 LFU-754-2 misc: fuse: Add shadow fuse read and write
    - 7821b84f323 LFU-754-1 misc: ele_api: Add read/write shadow fuse APIs
    - 1434b0ec2d8 MA-22546 imx95: fix rpmb not reliable issue
    - d9f174f315b MA-22461 Android: Follow BSP update the imx93 defconfig
    - 9811741f98e MA-22560 Fix spl can't switch to another slot when verification failed