### PR TITLE
pipewire: Add libcamera back to PACKAGECONFIG for i.MX 95

### DIFF
--- a/dynamic-layers/multimedia-layer/recipes-multimedia/pipewire/pipewire_%.bbappend
+++ b/dynamic-layers/multimedia-layer/recipes-multimedia/pipewire/pipewire_%.bbappend
@@ -6,7 +6,6 @@ SYSTEMD_AUTO_ENABLE:imx-nxp-bsp = "disable"
 
 DEPENDS:append:mx95-nxp-bsp = " libdrm"
 
-PACKAGECONFIG:remove:mx95-nxp-bsp = "libcamera"
 PACKAGECONFIG:remove:imx-nxp-bsp = "gstreamer"
 PACKAGECONFIG:class-target:append:imx-nxp-bsp = " ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'bluez-lc3', '', d)}"
 


### PR DESCRIPTION
Add libcamera plugins back for i.MX 95. 
Also need merge back to branch scarthgap.