### PR TITLE
imx-imx-boot-bootpart.wks.in: Increase /boot partition 64 MiB -> 256 MiB

### DIFF
--- a/wic/imx-imx-boot-bootpart.wks.in
+++ b/wic/imx-imx-boot-bootpart.wks.in
@@ -10,11 +10,11 @@
 #  - ---------- -------------- --------------
 # ^ ^          ^              ^              ^
 # | |          |              |              |
-# 0 |        8MiB          72MiB          72MiB + rootfs + IMAGE_EXTRA_SPACE (default 10MiB)
+# 0 |        8MiB          264MiB         264MiB + rootfs + IMAGE_EXTRA_SPACE (default 10MiB)
 #   ${IMX_BOOT_SEEK} 32 or 33kiB, see reference manual
 #
 part u-boot --source rawcopy --sourceparams="file=imx-boot.tagged" --ondisk mmcblk --no-table --align ${IMX_BOOT_SEEK}
-part /boot --source bootimg-partition --ondisk mmcblk --fstype=vfat --label boot --active --align 8192 --size 64
+part /boot --source bootimg-partition --ondisk mmcblk --fstype=vfat --label boot --active --align 8192 --size 256
 part / --source rootfs --ondisk mmcblk --fstype=ext4 --label root --align 8192
 
 bootloader --ptable msdos


### PR DESCRIPTION
For i.MX 9 a typical kernel is 35 MB. With gcov, that increases to 75 MB
or more. Bump the /boot partition size accordingly.