### PR TITLE
pipewire: Exclude gstreamer from PACKAGECONFIG list for i.MX 6, 7, 8 and 93

### DIFF
--- a/dynamic-layers/multimedia-layer/recipes-multimedia/pipewire/pipewire_%.bbappend
+++ b/dynamic-layers/multimedia-layer/recipes-multimedia/pipewire/pipewire_%.bbappend
@@ -6,7 +6,10 @@ SYSTEMD_AUTO_ENABLE:imx-nxp-bsp = "disable"
 
 DEPENDS:append:mx95-nxp-bsp = " libdrm"
 
-PACKAGECONFIG:remove:imx-nxp-bsp = "gstreamer"
+PACKAGECONFIG:remove:mx6-nxp-bsp = "gstreamer"
+PACKAGECONFIG:remove:mx7-nxp-bsp = "gstreamer"
+PACKAGECONFIG:remove:mx8-nxp-bsp = "gstreamer"
+PACKAGECONFIG:remove:mx93-nxp-bsp = "gstreamer"
 PACKAGECONFIG:class-target:append:imx-nxp-bsp = " ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'bluez-lc3', '', d)}"
 
 # FIXME: Needs to qualify on PACKAGECONFIG


### PR DESCRIPTION
Add gstreamer back to PACKAGECONFIG.
Also need backport to branch scarthgap.
