### PR TITLE
mesa-etnaviv-env: prevent warning

### DIFF
--- a/recipes-graphics/mesa/mesa-etnaviv-env_0.1.bb
+++ b/recipes-graphics/mesa/mesa-etnaviv-env_0.1.bb
@@ -9,6 +9,8 @@ SRC_URI = "\
     file://mesa-etnaviv.sh \
 "
 
+S = "${UNPACKDIR}"
+
 do_configure[noexec] = "1"
 do_compile[noexec] = "1"
 


### PR DESCRIPTION
Prevent the following warning by setting S to an existing directory. (no real problem was seen but the warning)

| WARNING: mesa-etnaviv-env-0.1-r0 do_unpack: mesa-etnaviv-env:
|     the directory ${WORKDIR}/${BP} (.../mesa-etnaviv-env/0.1/mesa-etnaviv-env-0.1)
|     pointed to by the S variable doesn't exist - please set S within
|     the recipe to point to where source has been unpacked to