### PR TITLE
kernel-module-isp-vvcam: prevent build warning

### DIFF
--- a/recipes-kernel/kernel-modules/kernel-module-isp-vvcam_4.2.2.24.2.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-isp-vvcam_4.2.2.24.2.bb
@@ -13,6 +13,8 @@ S = "${WORKDIR}/git/vvcam/v4l2"
 
 inherit module
 
+MODULES_MODULE_SYMVERS_LOCATION = "dwe"
+
 DEBUG_PREFIX_MAP:prepend = " \
     -fmacro-prefix-map=${WORKDIR}/git/vvcam=/usr/src/debug/${PN}/${EXTENDPE}${PV}-${PR} \
     -fdebug-prefix-map=${WORKDIR}/git/vvcam=/usr/src/debug/${PN}/${EXTENDPE}${PV}-${PR} "


### PR DESCRIPTION
I see this also on scarthgap so I propose if it is accepted to also backport to scarthgap.