### PR TITLE
imx93-11x11: Fix KERNEL_DEVICETREE

### DIFF
--- a/conf/machine/imx93-11x11-lpddr4x-evk.conf
+++ b/conf/machine/imx93-11x11-lpddr4x-evk.conf
@@ -13,11 +13,11 @@ KERNEL_DEVICETREE:append:use-nxp-bsp = " \
     freescale/${KERNEL_DEVICETREE_BASENAME}-boe-wxga-lvds-panel.dtb \
     freescale/${KERNEL_DEVICETREE_BASENAME}-flexio-i2c.dtb \
     freescale/${KERNEL_DEVICETREE_BASENAME}-flexspi-m2.dtb \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-i2c-spi-slave.dtb \
     freescale/${KERNEL_DEVICETREE_BASENAME}-i3c.dtb \
     freescale/${KERNEL_DEVICETREE_BASENAME}-inmate.dtb \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-iw612-otbr.dtb \
     freescale/${KERNEL_DEVICETREE_BASENAME}-ld.dtb \
-    freescale/${KERNEL_DEVICETREE_BASENAME}-lpspi-slave.dtb \
-    freescale/${KERNEL_DEVICETREE_BASENAME}-lpspi.dtb \
     freescale/${KERNEL_DEVICETREE_BASENAME}-lpuart.dtb \
     freescale/${KERNEL_DEVICETREE_BASENAME}-mqs.dtb \
     freescale/${KERNEL_DEVICETREE_BASENAME}-mt9m114.dtb \


### PR DESCRIPTION
Use updated kernel device tree for imx93-11x11 board.