### PR TITLE
recipes-security: optee-imx: optee-*: Upgrade BSP to LF6.6.36_2.1.0

### DIFF
--- a/recipes-security/optee-imx/optee-client_4.2.0.imx.bb
+++ b/recipes-security/optee-imx/optee-client_4.2.0.imx.bb
@@ -1,6 +1,6 @@
 require optee-client-fslc-imx.inc
 
-SRCBRANCH = "lf-6.6.23_2.0.0"
+SRCBRANCH = "lf-6.6.36_2.1.0"
 SRCREV = "3eac340a781c00ccd61b151b0e9c22a8c6e9f9f0" 
 
 DEPENDS += "util-linux"

--- a/recipes-security/optee-imx/optee-os_4.2.0.imx.bb
+++ b/recipes-security/optee-imx/optee-os_4.2.0.imx.bb
@@ -8,5 +8,5 @@ SRC_URI += " \
     file://0003-arm32-libutils-libutee-ta-add-.note.GNU-stack-sectio.patch \
     file://0004-core-link-add-no-warn-rwx-segments.patch \
 "
-SRCBRANCH = "lf-6.6.23_2.0.0"
-SRCREV = "c6be5b572452a2808d1a34588fd10e71715e23cf"
+SRCBRANCH = "lf-6.6.36_2.1.0"
+SRCREV = "612bc5a642a4608d282abeee2349d86de996d7ee"

--- a/recipes-security/optee-imx/optee-test_4.2.0.imx.bb
+++ b/recipes-security/optee-imx/optee-test_4.2.0.imx.bb
@@ -4,7 +4,7 @@ require optee-test-fslc.inc
 
 SRC_URI = "git://github.com/nxp-imx/imx-optee-test.git;protocol=https;branch=${SRCBRANCH}"
 
-SRCBRANCH = "lf-6.6.23_2.0.0"
-SRCREV = "07682f1b1b41ec0bfa507286979b36ab8d344a96"
+SRCBRANCH = "lf-6.6.36_2.1.0"
+SRCREV = "5b52b48a73b4cc3f228ec66ae6cf9920897bb2e6"
 
 COMPATIBLE_MACHINE = "(imx-nxp-bsp)"


### PR DESCRIPTION
Upgrade optee-client, optee-os and optee-test to new NXP BSP LF6.6.36_2.1.0.

Related-to: #1953 