### PR TITLE
optee-os: work-around buildpaths QA error of staticdev

### DIFF
--- a/recipes-security/optee-imx/optee-os-fslc.inc
+++ b/recipes-security/optee-imx/optee-os-fslc.inc
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2021 NXP
+# Copyright (C) 2017-2021,2024 NXP
 
 SUMMARY = "OPTEE OS"
 DESCRIPTION = "OPTEE OS"
@@ -83,5 +83,8 @@ addtask deploy after do_compile before do_install
 FILES:${PN} = "${nonarch_base_libdir}/firmware/ ${nonarch_base_libdir}/optee_armtz/"
 FILES:${PN}-staticdev = "${includedir}/optee/"
 RDEPENDS:${PN}-dev += "${PN}-staticdev"
+
+# FIXME: Build paths are currently embedded
+INSANE_SKIP:${PN}-staticdev += "buildpaths"
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"


### PR DESCRIPTION
Fix the QA Error:
ERROR: optee-os-4.2.0.imx-r0 do_package_qa: QA Issue: File /usr/include/optee/export-user_ta_arm64/lib/libutils.a in package optee-os-staticdev contains reference to TMPDIR [buildpaths] ERROR: optee-os-4.2.0.imx-r0 do_package_qa: QA Issue: File /usr/include/optee/export-user_ta_arm64/lib/libdl.a in package optee-os-staticdev contains reference to TMPDIR [buildpaths] ERROR: optee-os-4.2.0.imx-r0 do_package_qa: QA Issue: File /usr/include/optee/export-user_ta_arm64/lib/libmbedtls.a in package optee-os-staticdev contains reference to TMPDIR [buildpaths] ERROR: optee-os-4.2.0.imx-r0 do_package_qa: QA Issue: File /usr/include/optee/export-user_ta_arm64/lib/libutee.a in package optee-os-staticdev contains reference to TMPDIR [buildpaths] ERROR: optee-os-4.2.0.imx-r0 do_package_qa: Fatal QA errors were found, failing task. ERROR: Logfile of failure stored in: /../build-imx93-11x11-lpddr4x-evk/tmp/work/imx93_11x11_lpddr4x_evk-poky-linux/optee-os/4.2.0.imx/temp/log.do_package_qa.2422162 ERROR: Task (/../meta-freescale/recipes-security/optee-imx/optee-os_4.2.0.imx.bb:do_package_qa) failed with exit code '1'