### PR TITLE
Add first i.MX 95 based machine

### DIFF
--- a/classes/use-imx-security-controller-firmware.bbclass
+++ b/classes/use-imx-security-controller-firmware.bbclass
@@ -23,6 +23,7 @@ SECO_FIRMWARE_NAME:mx8dx-generic-bsp  ?= "mx8qx${IMX_SOC_REV_LOWER}-ahab-contain
 SECO_FIRMWARE_NAME:mx8dxl-generic-bsp ?= "mx8dxl${IMX_SOC_REV_LOWER}-ahab-container.img"
 SECO_FIRMWARE_NAME:mx8ulp-generic-bsp ?= "mx8ulp${IMX_SOC_REV_LOWER}-ahab-container.img"
 SECO_FIRMWARE_NAME:mx93-generic-bsp   ?= "mx93${IMX_SOC_REV_LOWER}-ahab-container.img"
+SECO_FIRMWARE_NAME:mx95-generic-bsp   ?= "mx95${IMX_SOC_REV_LOWER}-ahab-container.img"
 
 python () {
     if "mx8m-generic-bsp" in d.getVar('MACHINEOVERRIDES').split(":"):

--- a/conf/machine/imx95-19x19-verdin.conf
+++ b/conf/machine/imx95-19x19-verdin.conf
@@ -1,0 +1,72 @@
+#@TYPE: Machine
+#@NAME: Toradex i.MX 95 19x19 Verdin board
+#@SOC: i.MX95
+#@DESCRIPTION: Machine configuration for Toradex i.MX 95 19x19 Verdin board
+#@MAINTAINER: Flora Hu <flora.hu@nxp.com>
+
+MACHINEOVERRIDES =. "mx95:"
+
+require conf/machine/include/imx95-evk.inc
+IMX_DEFAULT_BSP = "nxp"
+
+KERNEL_DEVICETREE_BASENAME = "imx95-19x19-verdin"
+
+KERNEL_DEVICETREE:append:use-nxp-bsp = " \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-adv7535.dtb \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-adv7535.dtbo \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-adv7535-ap1302.dtb \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-ap1302.dtb \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-ap1302.dtbo \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-lt8912.dtb \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-lt8912.dtbo \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-lt8912-ap1302.dtb \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-lt9611uxc.dtb \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-lt9611uxc.dtbo \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-lt9611uxc-ap1302.dtb \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-os08a20.dtb \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-os08a20.dtbo \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-os08a20-isp-lt8912.dtb \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-ox03c10.dtb \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-ox03c10.dtbo \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-ox03c10-isp-lt8912.dtb \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-ox05b1s.dtb \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-ox05b1s.dtbo \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-ox05b1s-isp-lt8912.dtb \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-panel-cap-touch-10inch-dsi.dtb \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-panel-cap-touch-10inch-dsi.dtbo \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-panel-cap-touch-10inch-lvds.dtb \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-rm692c9.dtb \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-rm692c9.dtbo \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-rpmsg.dtb \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-ti-serdes.dtb \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-ti-serdes.dtbo \
+"
+
+UBOOT_CONFIG_BASENAME = "imx95_19x19_verdin"
+
+UBOOT_CONFIG ??= "sd"
+UBOOT_CONFIG[sd]    = "${UBOOT_CONFIG_BASENAME}_defconfig"
+UBOOT_CONFIG[fspi]  = "${UBOOT_CONFIG_BASENAME}_fspi_defconfig"
+
+IMXBOOT_TARGETS = "flash_a55"
+
+OEI_BOARD  = "mx95lp5"
+DDR_TYPE   = "lpddr5"
+
+DDR_FIRMWARE_NAME = " \
+    lpddr5_dmem_v202311.bin \
+    lpddr5_dmem_qb_v202311.bin \
+    lpddr5_imem_v202311.bin \
+    lpddr5_imem_qb_v202311.bin \
+"
+
+IMXBOOT_VARIANT = ""
+
+# The System Manager Firmware Name corresponds to a particular binary implementation
+# in the Yocto deploy folder. The name is comprised of the Firmware Basename and the
+# default system manager Config name, e.g., m33_image-mx95evk.bin and
+# m33_image-mx95evk_fusa.bin for the standard BSP version and FuSa version, respectively
+# The System Manager Firmware Basename is an alias used by imx-boot instead of using
+# a unique name for each implementation, e.g., m33_image.bin for i.MX 95
+SYSTEM_MANAGER_FIRMWARE_BASENAME ?= "m33_image"
+SYSTEM_MANAGER_FIRMWARE_NAME     ?= "m33_image-mx95evk"

--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -166,6 +166,7 @@ DEFAULTTUNE:mx8qm-generic-bsp  ?= "cortexa72-cortexa53-crypto"
 DEFAULTTUNE:mx8x-generic-bsp   ?= "cortexa35-crypto"
 DEFAULTTUNE:mx8ulp-generic-bsp ?= "cortexa35-crypto"
 DEFAULTTUNE:mx93-generic-bsp   ?= "cortexa55"
+DEFAULTTUNE:mx95-generic-bsp   ?= "cortexa55"
 
 INHERIT += "machine-overrides-extender"
 
@@ -221,6 +222,7 @@ MACHINEOVERRIDES_EXTENDER:mx8dxl:use-nxp-bsp = "imx-generic-bsp:imx-nxp-bsp:imxf
 MACHINEOVERRIDES_EXTENDER:mx8ulp:use-nxp-bsp = "imx-generic-bsp:imx-nxp-bsp:imxdrm:imxgpu:imxgpu2d:imxgpu3d:imxvulkan:mx8-generic-bsp:mx8-nxp-bsp:mx8ulp-generic-bsp:mx8ulp-nxp-bsp"
 
 MACHINEOVERRIDES_EXTENDER:mx93:use-nxp-bsp  = "imx-generic-bsp:imx-nxp-bsp:imxdrm:imxpxp:mx9-generic-bsp:mx9-nxp-bsp:mx93-generic-bsp:mx93-nxp-bsp"
+MACHINEOVERRIDES_EXTENDER:mx95:use-nxp-bsp  = "imx-generic-bsp:imx-nxp-bsp:imxdrm:imxdpu:imxgpu:imxgpu2d:imxgpu3d:mx9-generic-bsp:mx9-nxp-bsp:mx95-generic-bsp:mx95-nxp-bsp"
 
 #######
 ### Mainline BSP specific overrides
@@ -264,6 +266,7 @@ MACHINEOVERRIDES_EXTENDER:mx8dxl:use-mainline-bsp = "imx-generic-bsp:imx-mainlin
 MACHINEOVERRIDES_EXTENDER:mx8ulp:use-mainline-bsp = "imx-generic-bsp:imx-mainline-bsp:mx8-generic-bsp:mx8-mainline-bsp:mx8ulp-generic-bsp:mx8ulp-mainline-bsp"
 
 MACHINEOVERRIDES_EXTENDER:mx93:use-mainline-bsp  = "imx-generic-bsp:imx-mainline-bsp:mx9-generic-bsp:mx9-mainline-bsp:mx93-generic-bsp:mx93-mainline-bsp"
+MACHINEOVERRIDES_EXTENDER:mx95:use-mainline-bsp  = "imx-generic-bsp:imx-mainline-bsp:mx9-generic-bsp:mx9-mainline-bsp:mx95-generic-bsp:mx95-mainline-bsp"
 
 MACHINEOVERRIDES_EXTENDER_FILTER_OUT = " \
     mx6 \
@@ -295,6 +298,7 @@ MACHINEOVERRIDES_EXTENDER_FILTER_OUT = " \
     mx8dxl \
     mx8ulp \
     mx93 \
+    mx95 \
 "
 
 MACHINEOVERRIDES_FILTERED_OUT_QA_ERROR = "%s overrides cannot be used and need conversion to use the new BSP-specific overrides. Check 'meta-freescale/scripts/convert-bsp-specific-overrides'."
@@ -323,6 +327,7 @@ MACHINE_SOCARCH_SUFFIX:mx8dx-nxp-bsp   = "-mx8"
 MACHINE_SOCARCH_SUFFIX:mx8dxl-nxp-bsp  = "-mx8xl"
 MACHINE_SOCARCH_SUFFIX:mx8ulp-nxp-bsp  = "-mx8ulp"
 MACHINE_SOCARCH_SUFFIX:mx93-nxp-bsp    = "-mx93"
+MACHINE_SOCARCH_SUFFIX:mx95-nxp-bsp    = "-mx95"
 
 # For Mainline we use a single SoC suffix as we don't have different build options
 MACHINE_SOCARCH_SUFFIX:imx-mainline-bsp = "-imx"
@@ -400,6 +405,8 @@ IMX_EXTRA_FIRMWARE:mx8m-generic-bsp   = "imx-boot-firmware-files"
 IMX_EXTRA_FIRMWARE:mx8x-generic-bsp   = "imx-sc-firmware imx-seco"
 IMX_EXTRA_FIRMWARE:mx8ulp-generic-bsp = "firmware-upower firmware-ele-imx"
 IMX_EXTRA_FIRMWARE:mx93-generic-bsp   = "imx-boot-firmware-files firmware-ele-imx"
+PREFERRED_PROVIDER_virtual/imx-system-manager ??= "imx-system-manager"
+IMX_EXTRA_FIRMWARE:mx95-generic-bsp   = "imx-boot-firmware-files firmware-ele-imx virtual/imx-system-manager imx-oei"
 
 # Firmware
 MACHINE_FIRMWARE ?= ""
@@ -420,6 +427,7 @@ MACHINE_FIRMWARE:append:mx8mp-generic-bsp    = " linux-firmware-imx-sdma-imx7d f
 MACHINE_FIRMWARE:append:mx8mq-generic-bsp    = " linux-firmware-imx-sdma-imx7d"
 MACHINE_FIRMWARE:append:mx8qxp-generic-bsp   = " linux-firmware-imx-sdma-imx7d firmware-imx-vpu-amphion"
 MACHINE_FIRMWARE:append:mx8dx-generic-bsp    = " linux-firmware-imx-sdma-imx7d firmware-imx-vpu-amphion"
+MACHINE_FIRMWARE:append:mx95-generic-bsp     = " firmware-imx-vpu-wave"
 MACHINE_FIRMWARE:append:imx-mainline-bsp     = " linux-firmware-imx-sdma-imx6q linux-firmware-imx-sdma-imx7d firmware-imx-vpu-imx6q firmware-imx-vpu-imx6d"
 
 MACHINE_EXTRA_RRECOMMENDS += "${MACHINE_FIRMWARE}"

--- a/conf/machine/include/imx95-evk.inc
+++ b/conf/machine/include/imx95-evk.inc
@@ -1,0 +1,56 @@
+require conf/machine/include/imx-base.inc
+require conf/machine/include/arm/armv8-2a/tune-cortexa55.inc
+
+MACHINE_FEATURES += "pci wifi bluetooth optee"
+MACHINE_FEATURES:append:use-nxp-bsp = " nxpwifi-all-pcie nxpwifi-all-sdio jailhouse dpdk xen"
+
+KERNEL_DEVICETREE = " \
+    freescale/${KERNEL_DEVICETREE_BASENAME}.dtb \
+"
+
+IMX_DEFAULT_BOOTLOADER:use-nxp-bsp = "u-boot-imx"
+IMX_DEFAULT_BOOTLOADER:use-mainline-bsp = "u-boot-fslc"
+
+LOADADDR = ""
+UBOOT_SUFFIX = "bin"
+UBOOT_MAKE_TARGET = ""
+
+SPL_BINARY = "spl/u-boot-spl.bin"
+
+UBOOT_CONFIG ??= "sd"
+UBOOT_CONFIG[sd] = "${UBOOT_CONFIG_BASENAME}_evk_defconfig,sdcard"
+UBOOT_CONFIG[fspi] = "${UBOOT_CONFIG_BASENAME}_evk_fspi_defconfig"
+
+ATF_PLATFORM = "imx95"
+OEI_CONFIGS = "ddr tcm"
+OEI_CORE   = "m33"
+OEI_SOC    = "mx95"
+OEI_BOARD  ?= "mx95lp5"
+DDR_TYPE   ?= "lpddr5"
+
+IMXBOOT_VARIANTS = "alt jailhouse netc"
+
+# Multiple system manager configs by IMXBOOT_VARIANT
+SYSTEM_MANAGER_CONFIG = "${@bb.utils.contains('IMXBOOT_VARIANT', 'alt',       'mx95alt', \
+                            bb.utils.contains('IMXBOOT_VARIANT', 'jailhouse', 'mx95evkjailhouse', \
+                            bb.utils.contains('IMXBOOT_VARIANT', 'netc',      'mx95netc', \
+                                                                              'mx95evk', d), d), d)}"
+
+# imx-boot (flash.bin) targets based on UBOOT_CONFIG and IMXBOOT_VARIANT
+IMXBOOT_TARGETS_SD = "${@bb.utils.contains('IMXBOOT_VARIANT', 'alt',       '${IMXBOOT_TARGETS_BASENAME}_alt', \
+                         bb.utils.contains('IMXBOOT_VARIANT', 'jailhouse', '${IMXBOOT_TARGETS_BASENAME}_jailhouse', \
+                         bb.utils.contains('IMXBOOT_VARIANT', 'netc',      '${IMXBOOT_TARGETS_BASENAME}_netc', \
+                                                                           '${IMXBOOT_TARGETS_BASENAME}_all ${IMXBOOT_TARGETS_BASENAME}_a55', d), d), d)} \
+"
+
+IMXBOOT_TARGETS = " \
+    ${@bb.utils.contains('UBOOT_CONFIG', 'fspi', '${IMXBOOT_TARGETS_BASENAME}_a55_flexspi', '${IMXBOOT_TARGETS_SD}', d)} \
+"
+
+IMX_BOOT_SOC_TARGET = "iMX95"
+IMX_BOOT_SEEK = "32"
+
+# We have to disable SERIAL_CONSOLE due to auto-serial-console
+SERIAL_CONSOLES = "115200;ttyLP0"
+
+IMX_DEFAULT_BSP = "nxp"

--- a/dynamic-layers/arm-toolchain/recipes-bsp/imx-system-manager/imx-system-manager.inc
+++ b/dynamic-layers/arm-toolchain/recipes-bsp/imx-system-manager/imx-system-manager.inc
@@ -1,0 +1,42 @@
+# Set generic compiler for system manager core
+INHIBIT_DEFAULT_DEPS = "1"
+DEPENDS = "${SM_COMPILER}"
+SM_COMPILER ?= "gcc-arm-none-eabi-native"
+PROVIDES += "virtual/imx-system-manager"
+
+inherit deploy
+
+# Set monitor mode for none, one, or two
+PACKAGECONFIG[m0] = "M=0,,,,,m1 m2"
+PACKAGECONFIG[m1] = ",,,,,m0 m2"
+PACKAGECONFIG[m2] = "M=2,,,,,m0 m1"
+
+SYSTEM_MANAGER_CONFIG ?= "INVALID"
+
+LDFLAGS[unexport] = "1"
+
+EXTRA_OEMAKE = " \
+    V=y \
+    SM_CROSS_COMPILE=arm-none-eabi- \
+    ${PACKAGECONFIG_CONFARGS} \
+"
+
+do_configure() {
+    oe_runmake config=${SYSTEM_MANAGER_CONFIG} clean
+    oe_runmake config=${SYSTEM_MANAGER_CONFIG} cfg
+}
+
+do_compile() {
+    oe_runmake config=${SYSTEM_MANAGER_CONFIG}
+}
+
+do_install[noexec] = "1"
+
+addtask deploy after do_compile
+do_deploy() {
+    install -D -p -m 0644 \
+        ${B}/build/${SYSTEM_MANAGER_CONFIG}/${SYSTEM_MANAGER_FIRMWARE_BASENAME}.bin \
+        ${DEPLOYDIR}/${SYSTEM_MANAGER_FIRMWARE_BASENAME}-${SYSTEM_MANAGER_CONFIG}.bin
+}
+
+COMPATIBLE_MACHINE = "(mx95-generic-bsp)"

--- a/dynamic-layers/arm-toolchain/recipes-bsp/imx-system-manager/imx-system-manager_1.0.0.bb
+++ b/dynamic-layers/arm-toolchain/recipes-bsp/imx-system-manager/imx-system-manager_1.0.0.bb
@@ -1,0 +1,23 @@
+SUMMARY = "i.MX System Manager Firmware"
+DESCRIPTION = "\
+The System Manager (SM) is a firmware that runs on a Cortex-M processor on \
+many NXP i.MX processors. The Cortex-M is the boot core, runs the boot ROM \
+which loads the SM (and other boot code), and then branches to the SM. The \
+SM then configures some aspects of the hardware such as isolation mechanisms \
+and then starts other cores in the system. After starting these cores, it \
+enters a service mode where it provides access to clocking, power, sensor, \
+and pin control via a client RPC API based on ARM's System Control and \
+Management Interface (SCMI)."
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=b66f32a90f9577a5a3255c21d79bc619"
+
+SRC_URI = "${IMX_SYSTEM_MANAGER_SRC};branch=${SRCBRANCH}"
+IMX_SYSTEM_MANAGER_SRC ?= "git://github.com/nxp-imx/imx-sm.git;protocol=https"
+SRCBRANCH = "master"
+SRCREV = "709deccd9338399eb39b5cf99a60eab4fa60d539"
+
+S = "${WORKDIR}/git"
+
+require imx-system-manager.inc
+
+PACKAGECONFIG ??= "m2"

--- a/recipes-kernel/linux/linux-imx-headers_6.6.bb
+++ b/recipes-kernel/linux/linux-imx-headers_6.6.bb
@@ -9,8 +9,8 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
 SRC_URI = "git://github.com/nxp-imx/linux-imx.git;protocol=https;branch=${SRCBRANCH}"
 SRCBRANCH = "lf-6.6.y"
-LOCALVERSION = "-6.6.23-2.0.0"
-SRCREV = "b586a521770e508d1d440ccb085c7696b9d6d387"
+LOCALVERSION = "-6.6.36-2.1.0"
+SRCREV = "d23d64eea5111e1607efcce1d601834fceec92cb"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-kernel/linux/linux-imx_6.6.bb
+++ b/recipes-kernel/linux/linux-imx_6.6.bb
@@ -13,8 +13,8 @@ i.MX Family Reference Boards. It includes support for many IPs such as GPU, VPU 
 require recipes-kernel/linux/linux-imx.inc
 
 SRCBRANCH = "lf-6.6.y"
-LOCALVERSION = "-6.6.23-2.0.0"
-SRCREV = "b586a521770e508d1d440ccb085c7696b9d6d387"
+LOCALVERSION = "-6.6.36-2.1.0"
+SRCREV = "d23d64eea5111e1607efcce1d601834fceec92cb"
 
 SRC_URI += " \
     file://0001-tty-vt-conmakehash-Don-t-mention-the-full-path-of-th.patch \
@@ -27,7 +27,7 @@ SRC_URI += " \
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "6.6.23"
+LINUX_VERSION = "6.6.36"
 
 KBUILD_DEFCONFIG:mx6-generic-bsp = "imx_v7_defconfig"
 KBUILD_DEFCONFIG:mx7-generic-bsp = "imx_v7_defconfig"

--- a/recipes-security/optee-imx/optee-os-fslc-imx.inc
+++ b/recipes-security/optee-imx/optee-os-fslc-imx.inc
@@ -22,5 +22,6 @@ PLATFORM_FLAVOR:mx8dx-nxp-bsp     = "mx8dxmek"
 PLATFORM_FLAVOR:mx8dxl-nxp-bsp    = "mx8dxlevk"
 PLATFORM_FLAVOR:mx8ulp-nxp-bsp    = "mx8ulpevk"
 PLATFORM_FLAVOR:mx93-nxp-bsp      = "mx93evk"
+PLATFORM_FLAVOR:mx95-nxp-bsp      = "mx95evk"
 
 COMPATIBLE_MACHINE = "(imx-nxp-bsp)"


### PR DESCRIPTION
Update the recipes to support i.MX 95 based boards.

The [i.MX 95 Verdin Evaluation Kit](https://www.nxp.com/webapp/connect/displayPartnerProfile.sp?partnerId=4900&offeringId=48065) is a kit developed together with NXP. Port the machine from meta-imx.
@flora2086 Should I keep you as the maintainer here or do you prefere if I put myself in?

The SoC features a ARM Mali GPU. I'm still working to port the mali-imx recipe providing the drivers. So any recipe depending on virtual/egl and friends will throw an error during building for an i.MX 95 based machine.

Note that the new machine depends on imx-system-manager and imx-oei which both depend on meta-arm-toolchain. This is not yet reflected anywhere. (layer.conf, repo manifest, fsl-community-bsp-base)

The image builds and boots to a login prompt with core-image-minimal (MACHINE=imx95-19x19-verdin, DISTRO=fsl-wayland).


