### PR TITLE
linux-imx: Update to NXP BSP LF6.6.36_2.1.0

### DIFF
--- a/recipes-kernel/linux/linux-imx-headers_6.6.bb
+++ b/recipes-kernel/linux/linux-imx-headers_6.6.bb
@@ -9,8 +9,8 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
 SRC_URI = "git://github.com/nxp-imx/linux-imx.git;protocol=https;branch=${SRCBRANCH}"
 SRCBRANCH = "lf-6.6.y"
-LOCALVERSION = "-6.6.23-2.0.0"
-SRCREV = "b586a521770e508d1d440ccb085c7696b9d6d387"
+LOCALVERSION = "-6.6.36-2.1.0"
+SRCREV = "d23d64eea5111e1607efcce1d601834fceec92cb"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-kernel/linux/linux-imx_6.6.bb
+++ b/recipes-kernel/linux/linux-imx_6.6.bb
@@ -13,8 +13,8 @@ i.MX Family Reference Boards. It includes support for many IPs such as GPU, VPU 
 require recipes-kernel/linux/linux-imx.inc
 
 SRCBRANCH = "lf-6.6.y"
-LOCALVERSION = "-6.6.23-2.0.0"
-SRCREV = "b586a521770e508d1d440ccb085c7696b9d6d387"
+LOCALVERSION = "-6.6.36-2.1.0"
+SRCREV = "d23d64eea5111e1607efcce1d601834fceec92cb"
 
 SRC_URI += " \
     file://0001-tty-vt-conmakehash-Don-t-mention-the-full-path-of-th.patch \
@@ -27,7 +27,7 @@ SRC_URI += " \
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "6.6.23"
+LINUX_VERSION = "6.6.36"
 
 KBUILD_DEFCONFIG:mx6-generic-bsp = "imx_v7_defconfig"
 KBUILD_DEFCONFIG:mx7-generic-bsp = "imx_v7_defconfig"


### PR DESCRIPTION
Update linux-imx and linux-imx-headers to LF6.6.36_2.1.0.