### PR TITLE
imx-system-manager: use `MACHINE_ARCH` as `PACKAGE_ARCH`

### DIFF
--- a/dynamic-layers/arm-toolchain/recipes-bsp/imx-system-manager/imx-system-manager.inc
+++ b/dynamic-layers/arm-toolchain/recipes-bsp/imx-system-manager/imx-system-manager.inc
@@ -6,6 +6,8 @@ PROVIDES += "virtual/imx-system-manager"
 
 inherit deploy
 
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
 # Set monitor mode for none, one, or two
 PACKAGECONFIG[m0] = "M=0,,,,,m1 m2"
 PACKAGECONFIG[m1] = ",,,,,m0 m2"


### PR DESCRIPTION
The recipe build changes depending on the `SYSTEM_MANAGER_CONFIG` value, which is machine-specific.