### PR TITLE
Upgrade mcore-demos, jailhouse-imx and imx-mkimage to LF6.6.36_2.1.0

### DIFF
--- a/recipes-bsp/imx-mkimage/imx-mkimage_git.inc
+++ b/recipes-bsp/imx-mkimage/imx-mkimage_git.inc
@@ -5,8 +5,8 @@ DEPENDS = "zlib-native openssl-native"
 SRC_URI = "git://github.com/nxp-imx/imx-mkimage.git;protocol=https;branch=${SRCBRANCH} \
            file://0001-iMX8M-soc.mak-use-native-mkimage-from-sysroot.patch \
 "
-SRCBRANCH = "lf-6.6.23_2.0.0"
-SRCREV = "ca5d6b2d3fd9ab15825b97f7ef6f1ce9a8644966"
+SRCBRANCH = "lf-6.6.36_2.1.0"
+SRCREV = "4622115cbc037f79039c4522faeced4aabea986b"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-extended/jailhouse/jailhouse-imx_git.bb
+++ b/recipes-extended/jailhouse/jailhouse-imx_git.bb
@@ -16,8 +16,8 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=9fa7f895f96bde2d47fd5b7d95b6ba4d \
 PROVIDES = "jailhouse"
 RPROVIDES:${PN} += "jailhouse"
 
-SRCBRANCH = "lf-6.6.23_2.0.0"
-SRCREV = "ce11ba42dfa34f96aca76016a51d21e5d2539001"
+SRCBRANCH = "lf-6.6.36_2.1.0"
+SRCREV = "327e56941e3e96ef9a291d2decb7add21078d8de"
 
 IMX_JAILHOUSE_SRC ?= "git://github.com/nxp-imx/imx-jailhouse.git;protocol=https"
 SRC_URI = "${IMX_JAILHOUSE_SRC};branch=${SRCBRANCH} \

--- a/recipes-fsl/mcore-demos/README
+++ b/recipes-fsl/mcore-demos/README
@@ -4,7 +4,8 @@ The M4 demo app version of each SoCs are followed:
 * 1.0.1 -- i.MX 7D
 
 The M7 demo app version of each SoCs are followed:
-* 2.16.000 --  i.MX 8MP , 8MNULite, 8MN, i.MX95
+* 2.16.000 --  i.MX 8MP , 8MNULite, 8MN
+* 2.16.001 --  i.MX95
 
 The M33 demo app version of each SoCs are followed:
 * 2.16.000 --  i.MX 8ULP, i.MX 93

--- a/recipes-fsl/mcore-demos/imx-m7-demos_2.16.001.bb
+++ b/recipes-fsl/mcore-demos/imx-m7-demos_2.16.001.bb
@@ -1,0 +1,11 @@
+# Copyright 2023-2024 NXP
+# Released under the MIT license (see COPYING.MIT for the terms)
+
+require imx-mcore-demos.inc
+
+LIC_FILES_CHKSUM:mx95-nxp-bsp = "file://COPYING;md5=ca53281cc0caa7e320d4945a896fb837"
+
+SRC_URI[imx95.md5sum] = "70f4a0ab4f65beef113dd544c4b3be8c"
+SRC_URI[imx95.sha256sum] = "0569f128e2068c509dcd4afe6689a62cdb5a4ac9f8eb1b522b2bfaac0e7d09fd"
+
+COMPATIBLE_MACHINE = "(mx95-nxp-bsp)"


### PR DESCRIPTION
Related-to: #1953