### PR TITLE
imx-boot: Fix 8M non multi-config build problem

### DIFF
--- a/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
+++ b/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
@@ -104,7 +104,9 @@ compile_mx8m() {
         cp ${DEPLOY_DIR_IMAGE}/${BOOT_TOOLS}/${UBOOT_DTB_NAME_EXTRA} \
                                                              ${BOOT_STAGING}
     fi
-    ln -sf ${UBOOT_DTB_NAME_EXTRA}                           ${BOOT_STAGING}/${UBOOT_DTB_NAME}
+    if [ "${UBOOT_DTB_NAME_EXTRA}" != "${UBOOT_DTB_NAME}" ] ; then
+        ln -sf ${UBOOT_DTB_NAME_EXTRA}                       ${BOOT_STAGING}/${UBOOT_DTB_NAME}
+    fi
 
     cp ${DEPLOY_DIR_IMAGE}/${BOOT_TOOLS}/u-boot-nodtb.bin-${MACHINE}-${UBOOT_CONFIG_EXTRA} \
                                                              ${BOOT_STAGING}/u-boot-nodtb.bin


### PR DESCRIPTION
The fix made in commit 2db7047ba40e
("imx-boot: Fix 8M multi-config build problems")
broke builds not using U-Boot multi-config, as the link created ends up being a simple recursive link when UBOOT_DTB_NAME_EXTRA is the same as UBOOT_DTB_NAME.

It fails with something like this:
```
| ./../scripts/dtb_check.sh imx8mq-evk.dtb evk.dtb imx8mq-var-dart-dt8mcustomboard.dtb
|  Can't find u-boot DTB file, please copy from u-boot
```

caused by a symlink like this:
```
lrwxrwxrwx 1 1000 1000 35 Oct 29 21:32 imx8mq-var-dart-dt8mcustomboard.dtb -> imx8mq-var-dart-dt8mcustomboard.dtb
```

Fixes: 2db7047ba40e ("imx-boot: Fix 8M multi-config build problems")