### PR TITLE
Scarthgap: linux-fslc-imx: 6.6: Update

### DIFF
--- a/recipes-kernel/linux/linux-fslc-imx_6.6.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_6.6.bb
@@ -57,7 +57,7 @@ require linux-imx.inc
 
 KBRANCH = "6.6-2.1.x-imx"
 SRC_URI = "git://github.com/Freescale/linux-fslc.git;branch=${KBRANCH};protocol=https"
-SRCREV = "47d927c130da97d140d1455103e3cacecef94807"
+SRCREV = "ea326ecb9fc05493c53e51832e447c157268e2ab"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.


### PR DESCRIPTION
Update the kernel version based on branch 6.6-2.1.x-imx to include the patch for Olimex iMX8MP-SOM-4GB-IND and iMX8MP-SOM-EVB-IND.

This patch is related to following two GitHub pull requests:
https://github.com/Freescale/meta-freescale-3rdparty/pull/307
https://github.com/Freescale/linux-fslc/pull/694