### PR TITLE
Update imx8mm-ddr4-evk.conf

### DIFF
--- a/conf/machine/imx8mm-ddr4-evk.conf
+++ b/conf/machine/imx8mm-ddr4-evk.conf
@@ -6,7 +6,7 @@
 
 require include/imx8mm-evk.inc
 
-KERNEL_DEVICETREE_BASENAME = "${MACHINE}"
+KERNEL_DEVICETREE_BASENAME = "imx8mm-ddr4-evk"
 KERNEL_DEVICETREE:append:use-nxp-bsp = " \
     freescale/${KERNEL_DEVICETREE_BASENAME}-revb.dtb \
     freescale/${KERNEL_DEVICETREE_BASENAME}-revb-rm67191.dtb \


### PR DESCRIPTION
When changing LPDDR4 to DDR4 in imx8mmevk.conf the build fails.

For example:

MACHINEOVERRIDES =. "imx8mm-lpddr4-evk:"
require conf/machine/imx8mm-lpddr4-evk.conf

to

MACHINEOVERRIDES =. "imx8mm-ddr4-evk:"
require conf/machine/imx8mm-ddr4-evk.conf