### PR TITLE
libimxdmabuffer: be explicit about dwl compatibility

### DIFF
--- a/recipes-bsp/libimxdmabuffer/libimxdmabuffer_1.1.3.bb
+++ b/recipes-bsp/libimxdmabuffer/libimxdmabuffer_1.1.3.bb
@@ -61,7 +61,9 @@ PACKAGECONFIG:append:imxpxp           = " pxp"
 # former is not available pre-5.6. Out of the dma-heaps, we
 # pick the uncached one by default (see above).
 PACKAGECONFIG:append:mx8-nxp-bsp      = " dma-heap-uncached"
-PACKAGECONFIG:append:mx8m-nxp-bsp     = " dwl"
+PACKAGECONFIG:append:mx8mq-nxp-bsp     = " dwl"
+PACKAGECONFIG:append:mx8mm-nxp-bsp     = " dwl"
+PACKAGECONFIG:append:mx8mp-nxp-bsp     = " dwl"
 
 HANTRO_CONF = "--hantro-headers-path=${STAGING_INCDIR}/hantro_dec --hantro-decoder-version=G2"
 


### PR DESCRIPTION
PACKAGECONFIG[dwl] injects a direct dependency on imx-vpu-hantro which in itself is only compatible with (mx8mq-nxp-bsp|mx8mm-nxp-bsp|mx8mp-nxp-bsp)

When configuring a mx8mn based machine (e.g. imx8mn EVK) the imx-vpu-hantro is skipped as not compatible, but a world build fails with

ERROR: Nothing PROVIDES 'imx-vpu-hantro'
(but /build/meta-freescale/recipes-bsp/libimxdmabuffer/libimxdmabuffer_1.1.2.bb DEPENDS on or otherwise requires it) imx-vpu-hantro was skipped: incompatible with machine imx8mn-ddr4-evk (not in COMPATIBLE_MACHINE) imx-vpu-hantro was skipped: incompatible with machine imx8mn-ddr4-evk (not in COMPATIBLE_MACHINE) ERROR: Required build target 'meta-world-pkgdata' has no buildable providers. Missing or unbuildable dependency chain was: ['meta-world-pkgdata', 'gstreamer1.0-plugins-imx', 'libimxdmabuffer', 'imx-vpu-hantro']

Fix that by enabling dwl only for the same COMPATIBLE_MACHINE settings as in the imx-vpu-hantro recipe