### PR TITLE
feat(regex):  use explicitly regex mark for regexs

### DIFF
--- a/recipes-bsp/firmware-imx/firmware-imx_8.26.bb
+++ b/recipes-bsp/firmware-imx/firmware-imx_8.26.bb
@@ -102,14 +102,14 @@ python populate_packages:prepend() {
 
 
     easrcdir = bb.data.expand('${nonarch_base_libdir}/firmware/imx/easrc', d)
-    do_split_packages(d, easrcdir, '^easrc-([^_]*).*\.bin',
+    do_split_packages(d, easrcdir, r'^easrc-([^_]*).*\.bin',
                       output_pattern='firmware-imx-easrc-%s',
                       description='Freescale IMX EASRC Firmware [%s]',
                       extra_depends='',
                       prepend=True)
 
     vpudir = bb.data.expand('${nonarch_base_libdir}/firmware/vpu', d)
-    do_split_packages(d, vpudir, '^vpu_fw_([^_]*).*\.bin',
+    do_split_packages(d, vpudir, r'^vpu_fw_([^_]*).*\.bin',
                       output_pattern='firmware-imx-vpu-%s',
                       description='Freescale IMX VPU Firmware [%s]',
                       hook=coda_vpu_links,
@@ -117,21 +117,21 @@ python populate_packages:prepend() {
                       prepend=True)
 
     sdmadir = bb.data.expand('${nonarch_base_libdir}/firmware/imx/sdma', d)
-    do_split_packages(d, sdmadir, '^sdma-([^-]*).*\.bin',
+    do_split_packages(d, sdmadir, r'^sdma-([^-]*).*\.bin',
                       output_pattern='firmware-imx-sdma-%s',
                       description='Freescale IMX SDMA Firmware [%s]',
                       extra_depends='',
                       prepend=True)
 
     xcvrdir = bb.data.expand('${nonarch_base_libdir}/firmware/imx/xcvr', d)
-    do_split_packages(d, xcvrdir, '^xcvr-([^_]*).*\.bin',
+    do_split_packages(d, xcvrdir, r'^xcvr-([^_]*).*\.bin',
                       output_pattern='firmware-imx-xcvr-%s',
                       description='Freescale IMX XCVR Firmware [%s]',
                       extra_depends='',
                       prepend=True)
 
     xuvidir = bb.data.expand('${nonarch_base_libdir}/firmware/imx/xuvi', d)
-    do_split_packages(d, xuvidir, '^vpu_fw_([^_]*).*\.bin',
+    do_split_packages(d, xuvidir, r'^vpu_fw_([^_]*).*\.bin',
                       output_pattern='firmware-imx-xuvi-%s',
                       description='Freescale IMX XUVI Firmware [%s]',
                       extra_depends='',

--- a/recipes-multimedia/imx-codec/imx-codec_4.9.0.bb
+++ b/recipes-multimedia/imx-codec/imx-codec_4.9.0.bb
@@ -60,7 +60,7 @@ do_package_qa[prefuncs] += "__set_insane_skip"
 
 python __split_libfslcodec_plugins() {
     codecdir = bb.data.expand('${libdir}', d)
-    do_split_packages(d, codecdir, '^lib_([^_]*).*_arm.*_elinux\.so\..*',
+    do_split_packages(d, codecdir, r'^lib_([^_]*).*_arm.*_elinux\.so\..*',
                       aux_files_pattern='${libdir}/imx-mm/audio-codec/wrap/lib_%sd_wrap_arm*_elinux.so.*',
                       output_pattern='imx-codec-%s',
                       description='Freescale i.MX Codec (%s)',


### PR DESCRIPTION
- regex should be marked with `r`
- this should fix errors like this
```
Parsing recipes...WARNING: /home/project/build/../meta-freescale/recipes-multimedia/imx-codec/imx-codec_4.8.3.bb: /home/project/build/../meta-freescale/recipes-multimedia/imx-codec/imx-codec_4.8.3.bb:63: SyntaxWarning: invalid escape sequence '\.'
do_split_packages(d, codecdir, '^lib_([^_]*).*_arm.*_elinux\.so\..*',
```