### PR TITLE
Update kernel and jailhouse to L6.6.52_2.0.0

### DIFF
--- a/conf/machine/imx8mp-lpddr4-evk.conf
+++ b/conf/machine/imx8mp-lpddr4-evk.conf
@@ -41,6 +41,7 @@ KERNEL_DEVICETREE:append:use-nxp-bsp = " \
     freescale/imx8mp-evk-root.dtb \
     freescale/imx8mp-evk-rpmsg.dtb \
     freescale/imx8mp-evk-rpmsg-lpv.dtb \
+    freescale/imx8mp-evk-sof-pdm.dtb \
     freescale/imx8mp-evk-sof-wm8960.dtb \
     freescale/imx8mp-evk-spdif-lb.dtb \
     freescale/imx8mp-evk-usdhc1-m2.dtb \

--- a/conf/machine/imx8qm-mek.conf
+++ b/conf/machine/imx8qm-mek.conf
@@ -38,11 +38,17 @@ KERNEL_DEVICETREE = " \
     freescale/imx8qm-mek-dsi-serdes-rpmsg.dtb \
     freescale/imx8qm-mek-enet2-tja1100.dtb \
     freescale/imx8qm-mek-hdmi.dtb \
-    freescale/imx8qm-mek-hdmi-rx.dtb \
-    freescale/imx8qm-mek-hdmi-rx-ov5640.dtb \
     freescale/imx8qm-mek-jdi-wuxga-lvds1-panel.dtb \
     freescale/imx8qm-mek-jdi-wuxga-lvds1-panel-rpmsg.dtb \
-    freescale/imx8qm-mek-ov5640.dtb \
+    freescale/imx8qm-mek-max9286-csi0.dtb \
+    freescale/imx8qm-mek-max9286-csi1.dtb \
+    freescale/imx8qm-mek-max9286-dual.dtb \
+    freescale/imx8qm-mek-ov5640-csi0.dtb \
+    freescale/imx8qm-mek-ov5640-csi0-rpmsg.dtb \
+    freescale/imx8qm-mek-ov5640-csi1.dtb \
+    freescale/imx8qm-mek-ov5640-csi1-rpmsg.dtb \
+    freescale/imx8qm-mek-ov5640-dual.dtb \
+    freescale/imx8qm-mek-ov5640-dual-rpmsg.dtb \
     freescale/imx8qm-mek-pcie-ep.dtb \
     freescale/imx8qm-mek-rpmsg.dtb \
     freescale/imx8qm-mek-sof.dtb \
@@ -50,6 +56,24 @@ KERNEL_DEVICETREE = " \
     freescale/imx8qm-mek-sof-wm8960.dtb \
     freescale/imx8qm-mek-usd-wifi.dtb \
     freescale/imx8qm-mek-usdhc3-m2.dtb \
+    freescale/imx8qm-mek-revd-ca53.dtb \
+    freescale/imx8qm-mek-revd-ca72.dtb \
+    freescale/imx8qm-mek-revd-dsi-rm67191.dtb \
+    freescale/imx8qm-mek-revd-dsi-rm67199.dtb \
+    freescale/imx8qm-mek-revd.dtb \
+    freescale/imx8qm-mek-revd-enet2-tja1100.dtb \
+    freescale/imx8qm-mek-revd-hdmi.dtb \
+    freescale/imx8qm-mek-revd-jdi-wuxga-lvds1-panel.dtb \
+    freescale/imx8qm-mek-revd-jdi-wuxga-lvds1-panel-rpmsg.dtb \
+    freescale/imx8qm-mek-revd-ov5640-csi0.dtb \
+    freescale/imx8qm-mek-revd-ov5640-csi1.dtb \
+    freescale/imx8qm-mek-revd-ov5640-dual.dtb \
+    freescale/imx8qm-mek-revd-pcie-ep.dtb \
+    freescale/imx8qm-mek-revd-root.dtb \
+    freescale/imx8qm-mek-revd-rpmsg.dtb \
+    freescale/imx8qm-mek-revd-sof-wm8962.dtb \
+    freescale/imx8qm-mek-revd-usdhc3-m2.dtb \
+    freescale/imx8qm-mek-revd-usd-wifi.dtb \
 "
 
 UBOOT_MAKE_TARGET = \

--- a/conf/machine/imx8qxp-mek.conf
+++ b/conf/machine/imx8qxp-mek.conf
@@ -20,6 +20,13 @@ KERNEL_DEVICETREE:append:use-nxp-bsp = " \
     freescale/${KERNEL_DEVICETREE_BASENAME}-enet2-tja1100.dtb \
     freescale/${KERNEL_DEVICETREE_BASENAME}-lcdif.dtb \
     freescale/${KERNEL_DEVICETREE_BASENAME}-lcdif-rpmsg.dtb \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-max9286.dtb \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-ov5640-csi.dtb \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-ov5640-csi-rpmsg.dtb \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-ov5640-dual.dtb \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-ov5640-dual-rpmsg.dtb \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-ov5640-parallel.dtb \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-ov5640-parallel-rpmsg.dtb \
     freescale/${KERNEL_DEVICETREE_BASENAME}-pcie-ep.dtb \
     freescale/${KERNEL_DEVICETREE_BASENAME}-sof.dtb \
     freescale/${KERNEL_DEVICETREE_BASENAME}-sof-cs42888.dtb \

--- a/conf/machine/imx8ulp-lpddr4-evk.conf
+++ b/conf/machine/imx8ulp-lpddr4-evk.conf
@@ -18,6 +18,7 @@ KERNEL_DEVICETREE:append:use-nxp-bsp = " \
     freescale/${KERNEL_DEVICETREE_BASENAME}-rk055hdmipi4m.dtb \
     freescale/${KERNEL_DEVICETREE_BASENAME}-rk055hdmipi4mv2.dtb \
     freescale/${KERNEL_DEVICETREE_BASENAME}-sof-btsco.dtb \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-tpm.dtb \
 "
 
 UBOOT_CONFIG_BASENAME = "imx8ulp_evk"

--- a/conf/machine/imx93-9x9-lpddr4-qsb.conf
+++ b/conf/machine/imx93-9x9-lpddr4-qsb.conf
@@ -18,6 +18,7 @@ KERNEL_DEVICETREE:append:use-nxp-bsp = " \
     freescale/${KERNEL_DEVICETREE_BASENAME}-ontat-wvga-panel.dtb \
     freescale/${KERNEL_DEVICETREE_BASENAME}-rpmsg.dtb \
     freescale/${KERNEL_DEVICETREE_BASENAME}-rpmsg-lpv.dtb \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-tianma-wvga-panel.dtb \
 "
 
 UBOOT_CONFIG_BASENAME = "imx93_9x9_qsb"

--- a/conf/machine/include/imx8x-mek.inc
+++ b/conf/machine/include/imx8x-mek.inc
@@ -33,8 +33,6 @@ KERNEL_DEVICETREE:append:use-nxp-bsp = " \
     freescale/${KERNEL_DEVICETREE_BASENAME}-jdi-wuxga-lvds0-panel-rpmsg.dtb \
     freescale/${KERNEL_DEVICETREE_BASENAME}-jdi-wuxga-lvds1-panel.dtb \
     freescale/${KERNEL_DEVICETREE_BASENAME}-jdi-wuxga-lvds1-panel-rpmsg.dtb \
-    freescale/${KERNEL_DEVICETREE_BASENAME}-ov5640.dtb \
-    freescale/${KERNEL_DEVICETREE_BASENAME}-ov5640-rpmsg.dtb \
     freescale/${KERNEL_DEVICETREE_BASENAME}-rpmsg.dtb \
 "
 

--- a/recipes-extended/jailhouse/jailhouse-imx_git.bb
+++ b/recipes-extended/jailhouse/jailhouse-imx_git.bb
@@ -16,8 +16,8 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=9fa7f895f96bde2d47fd5b7d95b6ba4d \
 PROVIDES = "jailhouse"
 RPROVIDES:${PN} += "jailhouse"
 
-SRCBRANCH = "lf-6.6.36_2.1.0"
-SRCREV = "327e56941e3e96ef9a291d2decb7add21078d8de"
+SRCBRANCH = "lf-6.6.52_2.2.0"
+SRCREV = "44dd492a745cd8b8313fb6c7c03fb45a36d70e8a"
 
 IMX_JAILHOUSE_SRC ?= "git://github.com/nxp-imx/imx-jailhouse.git;protocol=https"
 SRC_URI = "${IMX_JAILHOUSE_SRC};branch=${SRCBRANCH} \

--- a/recipes-kernel/linux/linux-imx-headers_6.6.bb
+++ b/recipes-kernel/linux/linux-imx-headers_6.6.bb
@@ -9,8 +9,8 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
 SRC_URI = "git://github.com/nxp-imx/linux-imx.git;protocol=https;branch=${SRCBRANCH}"
 SRCBRANCH = "lf-6.6.y"
-LOCALVERSION = "-6.6.36-2.1.0"
-SRCREV = "d23d64eea5111e1607efcce1d601834fceec92cb"
+LOCALVERSION = "-6.6.52-2.2.0"
+SRCREV = "e0f9e2afd4cff3f02d71891244b4aa5899dfc786"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-kernel/linux/linux-imx_6.6.bb
+++ b/recipes-kernel/linux/linux-imx_6.6.bb
@@ -13,8 +13,8 @@ i.MX Family Reference Boards. It includes support for many IPs such as GPU, VPU 
 require recipes-kernel/linux/linux-imx.inc
 
 SRCBRANCH = "lf-6.6.y"
-LOCALVERSION = "-6.6.36-2.1.0"
-SRCREV = "d23d64eea5111e1607efcce1d601834fceec92cb"
+LOCALVERSION = "-6.6.52-2.2.0"
+SRCREV = "e0f9e2afd4cff3f02d71891244b4aa5899dfc786"
 
 SRC_URI += " \
     file://0001-tty-vt-conmakehash-Don-t-mention-the-full-path-of-th.patch \
@@ -27,7 +27,7 @@ SRC_URI += " \
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "6.6.36"
+LINUX_VERSION = "6.6.52"
 
 KBUILD_DEFCONFIG:mx6-generic-bsp = "imx_v7_defconfig"
 KBUILD_DEFCONFIG:mx7-generic-bsp = "imx_v7_defconfig"


### PR DESCRIPTION
Base on L6.6.52-2.2.0 release:
1,Upgrade Jailhouse to L6.6.52_2.0.0
2,Upstream machine dtbs