### PR TITLE
linux-fslc-imx: Use 6.6-2.2.0.x from NXP BSP LF6.6.52_2.2.0

### DIFF
--- a/recipes-kernel/linux/linux-fslc-imx_6.6.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_6.6.bb
@@ -38,14 +38,19 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 3. Critical patches (SHA(s))
 # ------------------------------------------------------------------------------
-
-# $ git log --oneline  --no-merges v6.6.34.. ^mainline/linux-6.6.y ^NXP/lf-6.6.y
-# - a10c64e35a24 tty: vt: conmakehash: cope with abs_srctree no longer in env
-# - 3fb57e773e55 tty: vt: conmakehash: Don't mention the full path of the input in output
-# - d1198b88bc1b Revert "dmaengine: fsl-edma: add address for channel mux register in fsl_edma_chan"
-# - 717fee4a9cf7 Revert "dmaengine: fsl-edma: add i.MX8ULP edma support"
-# - 74ef72069927 Revert "dmaengine: fsl-edma: clean up unused "fsl,imx8qm-adma" compatible string"
-# - b54c6ea17058 Revert "dmaengine: fsl-edma: change the memory access from local into remote mode in i.MX 8QM"
+# The list includes well-known commits not yet upstreamed. Reverts address merge
+# conflicts, prioritizing NXP BSP source code as the latest vendor updates.
+# Additional commits may exist to better acommodate yocto builds.
+#
+# $ git log --oneline  --no-merges v6.6.52.. ^mainline/linux-6.6.y ^NXP/lf-6.6.y
+# - 090d101928fc tty: vt: conmakehash: Don't mention the full path of the input in output
+# - d16eb5ced32f arm64: dts: imx8mm-evk-qca-wifi: enable support for bluetooth
+# - d39502c0dea9 imx:dts:imx8mm-evkb: fix the pmic name to avoid duplicated label error
+# - 58181fb0ff67 media: imx8: select v4l2_* for mxc-mipi-csi2_yav
+# - 930431e0d1d5 gpu: drm: cadence: select hdmi helper
+# - da675fd29502 of: enable using OF_DYNAMIC without OF_UNITTEST
+# - 7c5f3cbb180c arm64: dts: imx8mq: drop cpu-idle-states
+# - a9920ce3e197 hwrng: optee: support generic crypto
 #
 # NOTE to upgraders:
 # This recipe should NOT collect individual patches, they should be applied to
@@ -55,16 +60,16 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 
 require linux-imx.inc
 
-KBRANCH = "6.6-2.1.x-imx"
+KBRANCH = "6.6-2.2.x-imx"
 SRC_URI = "git://github.com/Freescale/linux-fslc.git;branch=${KBRANCH};protocol=https"
-SRCREV = "6605f549a71ef3af9c65609cba985086ac4edf2b"
+SRCREV = "113a097d3614e3dce802828ae439be23c5e4c931"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "6.6.54"
+LINUX_VERSION = "6.6.69"
 
 KBUILD_DEFCONFIG:mx6-generic-bsp = "imx_v7_defconfig"
 KBUILD_DEFCONFIG:mx7-generic-bsp = "imx_v7_defconfig"


### PR DESCRIPTION
It also updates the stable kernel tags up to version v6.6.69, and include some LmP commits