### PR TITLE
glmark: Simplify logic for DRM config

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-benchmark/glmark2/glmark2_%.bbappend
+++ b/dynamic-layers/openembedded-layer/recipes-benchmark/glmark2/glmark2_%.bbappend
@@ -1,5 +1,5 @@
-# Only _mx8 machine do provide virtual/libgbm required for any drm* flavour
-DRM-REMOVE:imxgpu = "drm-gl drm-gles2"
-DRM-REMOVE:imxgpu:mx8-nxp-bsp = ""
-DRM-REMOVE:imxgpu:mx95-nxp-bsp = ""
+# 6 and 7 Vivante do not provide virtual/libgbm required for any drm* flavour
+DRM-REMOVE                    = ""
+DRM-REMOVE:imxgpu:mx6-nxp-bsp = "drm-gl drm-gles2"
+DRM-REMOVE:imxgpu:mx7-nxp-bsp = "drm-gl drm-gles2"
 PACKAGECONFIG:remove = "${DRM-REMOVE}"


### PR DESCRIPTION
Since i.MX 8, DRM is supported by default by the i.MX GPU. Simplify the DRM config logic by reversing the default, making it clear that it is i.MX 6 and 7 that do not support DRM.