### PR TITLE
firmware-ele-imx: Use generic-bsp compatible

### DIFF
--- a/recipes-bsp/firmware-imx/firmware-ele-imx_1.3.0.bb
+++ b/recipes-bsp/firmware-imx/firmware-ele-imx_1.3.0.bb
@@ -39,4 +39,4 @@ FILES:${PN}-ext += "${nonarch_base_libdir}/firmware/imx/ele/${SECOEXT_FIRMWARE_N
 RREPLACES:${PN} = "firmware-sentinel"
 RPROVIDES:${PN} = "firmware-sentinel"
 
-COMPATIBLE_MACHINE = "(mx8ulp-nxp-bsp|mx9-nxp-bsp)"
+COMPATIBLE_MACHINE = "(mx8ulp-generic-bsp|mx9-generic-bsp)"


### PR DESCRIPTION
There is no need to limit this to NXP BSPs. This should also be backported to scartgap