### PR TITLE
Update libimxvpuapi2 to 90d3a52 version to incorporate skipped-frame-info fix

### DIFF
--- a/recipes-multimedia/libimxvpuapi/libimxvpuapi2_2.3.0.bb
+++ b/recipes-multimedia/libimxvpuapi/libimxvpuapi2_2.3.0.bb
@@ -11,7 +11,7 @@ DEPENDS:append:mx8mp-nxp-bsp = " imx-vpu-hantro-vc"
 PV .= "+git${SRCPV}"
 
 SRCBRANCH ?= "master"
-SRCREV = "8639837a246f8d85fba8a707c130239aeabc0a19"
+SRCREV = "90d3a52106d0b704a064ddb58d1226a60ce2c6e8"
 SRC_URI = "git://github.com/Freescale/libimxvpuapi.git;branch=${SRCBRANCH};protocol=https"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Updated libimxvpuapi2_2.3.0.bb to includ fix from:
https://github.com/Freescale/libimxvpuapi/pull/62
into meta-freescale.