### PR TITLE
drop styhead compatibility

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -8,7 +8,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 BBFILE_COLLECTIONS += "freescale-layer"
 BBFILE_PATTERN_freescale-layer := "^${LAYERDIR}/"
 BBFILE_PRIORITY_freescale-layer = "5"
-LAYERSERIES_COMPAT_freescale-layer = "styhead walnascar"
+LAYERSERIES_COMPAT_freescale-layer = "walnascar"
 LAYERDEPENDS_freescale-layer = "core"
 
 # Add the Freescale-specific licenses into the metadata


### PR DESCRIPTION
Due to commit 1e3228f1 (imx-atf: Adjust for compiler virtual renames in oe-core), which was required due to oe-core commit 4ccc3bc, this is no longer compatible with styhead.