### PR TITLE
scripts: avoid pointless LICENSE churn

### DIFF
--- a/scripts/generate-license-file
+++ b/scripts/generate-license-file
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+export LC_ALL=C
+
 # Create or clear the LICENSE file
 echo "# License Information" > LICENSE
 echo "" >> LICENSE
@@ -7,7 +9,7 @@ echo "This file lists all licenses used by recipes in the meta-freescale layer."
 echo "" >> LICENSE
 
 # Find all .bb and .inc files and extract license information
-find . -type f \( -name "*.bb" -o -name "*.inc" \) | while read -r file; do
+find . -type f \( -name "*.bb" -o -name "*.inc" \) | sort | while read -r file; do
     # Extract the license line from each recipe file, if it exists
     license_line=$(grep -i "^LICENSE" "$file")
     if [ -n "$license_line" ]; then


### PR DESCRIPTION
I was wondering why a bot decided to force-push a commit to a PR of mine. It turns out the script responsible for generating the LICENSE file is not deterministic, so depending on random file system layout we can end up regenerating the LICENSE without any actual change. For example:

$ diff -u <(git show baf20676~1:LICENSE | sort) <(git show baf20676:LICENSE | sort)

shows that baf20676 didn't provide any change at all in the actual contents, yet

$ git show --stat baf20676
commit baf20676bcd2b454577449dbf7b0346d7080b880
Author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
Date:   Wed Jan 22 21:42:44 2025 +0000

    Auto-update LICENSE file with current recipe licenses

 LICENSE | 256 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++--------------------------------------------------------------
 1 file changed, 128 insertions(+), 128 deletions(-)