### PR TITLE
Set default UBOOT_ENTRYPOINT for mx93-generic-bsp

### DIFF
--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -94,6 +94,7 @@ UBOOT_ENTRYPOINT:mx6ulz-generic-bsp ?= "0x80008000"
 UBOOT_ENTRYPOINT:mx7-generic-bsp    ?= "0x80008000"
 UBOOT_ENTRYPOINT:mx7ulp-generic-bsp ?= "0x60008000"
 UBOOT_ENTRYPOINT:mx8m-generic-bsp   ?= "0x40480000"
+UBOOT_ENTRYPOINT:mx93-generic-bsp   ?= "0x80400000"
 UBOOT_ENTRYPOINT:vf-generic-bsp     ?= "0x80008000"
 
 # Some SoC can utilize the boot container provided by U-Boot,


### PR DESCRIPTION
It allows a  correct kernel load address when using FIT image with i.MX93. The value 0x80400000 has been retrieved from imx93_11x11_evk_defconfig in uboot-imx.

See issue #2100.