### PR TITLE
imx-secure-enclave: Bump to lf-6.6.52_2.2.0

### DIFF
--- a/recipes-bsp/imx-secure-enclave/imx-secure-enclave_git.bb
+++ b/recipes-bsp/imx-secure-enclave/imx-secure-enclave_git.bb
@@ -9,10 +9,10 @@ DEPENDS = "openssl"
 
 inherit systemd
 
-SRC_URI = "git://github.com/NXP/imx-secure-enclave.git;protocol=https;branch=lf-6.6.3_1.0.0"
-SRCREV = "964affa2cb3f9f7fc85a6a18db60f9213f744495"
+SRC_URI = "git://github.com/NXP/imx-secure-enclave.git;protocol=https;branch=lf-6.6.52_2.2.0"
+SRCREV = "dffbb844e86f4a49058ffbb40548474059969c27"
 
-PV = "lf-6.6.3_1.0.0"
+PV = "lf-6.6.52_2.2.0"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
bump the recipe to the LF6.6.52_2.2.0