### PR TITLE
imx-imx-boot-bootpart.wks.in: Set fixed size for /boot partition

### DIFF
--- a/wic/imx-imx-boot-bootpart.wks.in
+++ b/wic/imx-imx-boot-bootpart.wks.in
@@ -14,7 +14,7 @@
 #   ${IMX_BOOT_SEEK} 32 or 33kiB, see reference manual
 #
 part u-boot --source rawcopy --sourceparams="file=imx-boot.tagged" --ondisk mmcblk --no-table --align ${IMX_BOOT_SEEK}
-part /boot --source bootimg-partition --ondisk mmcblk --fstype=vfat --label boot --active --align 8192 --size 256
+part /boot --source bootimg-partition --ondisk mmcblk --fstype=vfat --label boot --active --align 8192 --fixed-size 256
 part / --source rootfs --ondisk mmcblk --fstype=ext4 --label root --align 8192
 
 bootloader --ptable msdos


### PR DESCRIPTION
Using --size in the imx-imx-boot-bootpart.wks.in to set size of /boot partition does not result in a 256MiB partition as expected but in a ~332MiB one.  Indeed, --size ensures --extra-space (default 10MiB) is added to actual data size and furthermore applies --overhead-factor (default 1.3) to the wanted size. This is exactly the case here as 256
* 1.3 = 332.8.

Use --fixed-size instead to force the /boot partition to be exactly 256MiB just as it is indicated in the comments of this file. Consequently, the `do_image_wic` task will also fail if data copied in this partition are too large at creation.

---

A [comment indicating the situation ](https://github.com/Freescale/meta-freescale/pull/1962#discussion_r1799936635) was also added to the previous commit on this file.