### PR TITLE
imx-atf: Bum to match 6.6.52-2.2.0

### DIFF
--- a/recipes-bsp/imx-atf/imx-atf_2.10.bb
+++ b/recipes-bsp/imx-atf/imx-atf_2.10.bb
@@ -9,7 +9,7 @@ PV .= "+git${SRCPV}"
 
 SRC_URI = "git://github.com/nxp-imx/imx-atf.git;protocol=https;branch=${SRCBRANCH}"
 SRCBRANCH = "lf_v2.10"
-SRCREV = "28affcae957cb8194917b5246276630f9e6343e1"
+SRCREV = "1b27ee3edbb40ef9432c69ccaa744d1ac5d54c5d"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Relevant changes:
```
- 1b27ee3ed Pull request #96: MA-23026 Fix bug: failed boot on LS platforms due caam driver
- 02b06d177 MA-23026 Fix bug: failed boot on LS platforms due caam driver
- afd50b207 LF-13734 fix(imx95): add missing license header
- 0efc2fff8 Pull request #95: MA-23009 Fix i.MX 8Q boot failed when trusty disabled
- 0728e974a MA-23009 Fix i.MX 8Q boot failed when trusty disabled
- f590c74e5 Pull request #94: MA-23007 Fix bug, i.MX 8MN ATF failed to build
- e9823459d MA-23007 Fix i.MX 8MN build break
- a53124bcd Pull request #92: ATF RNG
- 5b66f7321 MA-21916 Enable caam driver for i.MX
- 55f8854fc MA-21915 Make the CAAM driver compatible with i.MX devices
- 1d6489907 MA-22997 Fix bug: 8q failed to print any logs in ATF
- dfda4210e Pull request #88: Lf v2.10 LF-13160
- 8b770b71f MA-22946-2 Guard the FF-A functions
- b02708418 MA-22946 Enlarge the trusty stack
- 66b6ed7e1 trusty: delete the fp registers save&restore at init stage
- fea70c8d6 spd: trusty: Add FFA_PARTITION_INFO_GET
- 96c52d0c2 spd: trusty: Add FFA_RX_RELEASE
- afff18cea spd: trusty: add secure partition and non secure client descriptors
- 77ba0234d spd: trusty: use FFA specific macros from ffa_svc
- c80318969 trusty: generic-arm64-smcall: Add echo smcalls
- 42164a24c LF-13673 fix(imx93): correct the ecc en bit define
- 0e31b369c LF-13160-3: plat: imx8ulp: scmi sensor update temp return val
- f6f942d2e LF-13160-2: drivers: scmi-msg: sensor: follow return temp val with spec data types
- 3399b1786 LF-13160-1: plat: imx8ulp: scmi sensor: fix invalid temp error
- 5e2ae7751 LF-13235 feat(imx95): support LM boot and shutdown
- 7f72130b5 LF-13233 feat(imx95): support setting M7 reset address
- 7c4a94d42 LF-13603 fix(imx9): reduce the pmic stby off delay on imx93/91
- efbc6f46a LF-13319 feat(imx95): Implement a semaphore for GIC quiescing between SM and ATF
```