### PR TITLE
u-boot-imx: Bump to 6.6.52-2.2.0

### DIFF
--- a/recipes-bsp/u-boot/u-boot-imx-common_2024.04.inc
+++ b/recipes-bsp/u-boot/u-boot-imx-common_2024.04.inc
@@ -5,8 +5,8 @@ LIC_FILES_CHKSUM = "file://Licenses/gpl-2.0.txt;md5=b234ee4d69f5fce4486a80fdaf4a
 
 SRC_URI = "git://github.com/nxp-imx/uboot-imx.git;protocol=https;branch=${SRCBRANCH}"
 SRCBRANCH = "lf_v2024.04"
-LOCALVERSION ?= "-imx_v2024.04_6.6.36-2.1.0"
-SRCREV = "de16f4f17221b2ff72b8cb18c28cd8a29f3c2710"
+LOCALVERSION ?= "-imx_v2024.04_6.6.52-2.2.0"
+SRCREV = "6c4545203d123c246c5d7995f2893959506d28e0"
 
 DEPENDS += " \
     bc-native \


### PR DESCRIPTION
Relevant changes:
- 6c4545203d1 LF-13928 update key for capsule
- a6fbbc4830b LF-13892 imx8mp_evk: Fix kernel boot failure with DDR ECC enabled
- b2f3a82bb62 LFU-815 imx91: Update iMX9101 PN support to latest config
- dd06e11a237 LFU-813-3 imx95_15x15_evk: Turn on PCA9632 LED for LVDS backlight
- 3215ce8075b LFU-813-2 imx95_19x19_evk: Enable backlight for LVDS
- 063caa4957a LFU-813-1 gpio: adp5585: Reset alternate function pins to GPIO
- ca6436fb7e4 LFU-812 arm: dts: imx95: Assign PLL VCO as the parent of PLL
- 0688aa50da0 MA-23021 secretkeeper: return earlier if not initialized
- 0ee139a17eb MA-23003-2 android: populate the SecretKeeper identity
- e3b6dacd0ef MA-23003-1 trusty: add SecretKeeper client
- f63ddd9cb11 LFU-808-3 power: regulator: correct the LDO_SNVS name
- 5726a995b80 LFU-808-2 arm: dts: change LDO_SNVS voltage range
- 69d949bcd3e LFU-808-1 power: regulator: change LDO_SNVS voltage range
- b6d4dc9f627 LF-13712 video: nxp: imx_lcdifv3: Fix incorrect DISP_PARA register configuration
- 5f50707d7bb LFU-788 imx95_evk: Modify the size of memory visible to the kernel
- 86be8aa9268 LFU-807 imx: set enable_virt_at_load as false
- 94619f027ce LFU-805-7 verdin-imx95: Enable aqr-stby regulator
- 87f2e20bcb6 LFU-805-6 imx95_evk: Enable netc stby regulators
- 331d8ae9a43 LFU-805-5 arm: dts: imx95-19x19-verdin: Update enet1 and enet2 ports
- adf6ecb292f LFU-805-4 arm: dts: imx95-19x19-evk: Enable enet2 10Gbps port
- d04db3691af LFU-805-3 net: fsl_enetc: Add iMX95 enetc4 10Gbps port support
- 435f01c56e7 LFU-805-2 net: fsl_enetc_mdio: Add phy-supply property support
- b42dd7d9bf5 LFU-805-1 net: phy: aquantia: Increase timeout for out of reset
- 8461bbe8afa LFU-806 arm: dts: imx91: Update MEDIA_AXI clock to 333Mhz
- 18fbed49e2a LFU-804 mmc: fsl_esdhc_imx: Add workaround for errata ERR052357
- 4e4af7348e4 LFU-803-2 imx93_qsb: Switch to Tianma LCD panel
- fbc21190687 LFU-803-1 arm: dts: imx93_qsb: Add Tianma LCD panel DTS
- caa18774855 LFU-802 imx95: verdin: correct xen bootargs
- ba33b30784d LF-10293 imx8dxl_ddr3l_evk: Update default mtest range
- 713768fb3fb LFU-801 mtd: spi: mt35xu01g: Disable erase chip command
- 726021e921f LFU-796 imx91: Update iMX91 NIC clock to 250Mhz for low drive mode
- b3931582f67 LFU-800 ls1012afrdm: Fix wrong pointer cast used
- d601605d90a LFU-799 imx93_qsb: Fix build warning
- f296640286b LFU-790 imx8mp_evk: Modify the size of memory visible to the kernel
- ef5968f9050 MA-22915 Move ele buffer address to avoid Kernel image be overwrite
- 357a0faeb4f LFU-789 mtd: spi-nor: Fix chip erase timeout issue
- b9742cd668a LFU-793 imx95: Remove regions that AP does not have access from the memory map.
- e172c32c4c9 LFU-792 firmware: scmi: Fix SCMI_SENSOR_CONFIG_SET return parameter
- ae178324467 LFU-786-3: arm: dts: ls1088a-rdb: add bootph-all property
- 2b22a9f8595 LFU-786-2: board: freescale: ls1088a: check rtc chip and adjust the rtc node
- 69b7bfc391d LFU-786-1: configs: enable rtc pcf2131
- 161cb647c41 LFU-791 imx93_evk: enable XRST_STBY_EN function
- 33f5fc8ab17 LFU-784: imx8: fdt: fix fdt edma nodes check
- d1c05b18dd9 LFU-795 net: fec_mxc: correct fec clk