### PR TITLE
qe-ucode: replace NXP-Binary-EULA with LICENSE to calculate checksum  (cherry-picked from master)

### DIFF
--- a/recipes-bsp/qe-ucode/qe-ucode_git.bb
+++ b/recipes-bsp/qe-ucode/qe-ucode_git.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "qe microcode binary"
 SECTION = "qe-ucode"
 LICENSE = "NXP-Binary-EULA"
-LIC_FILES_CHKSUM = "file://NXP-Binary-EULA;md5=c62f8109b4df15ca37ceeb5e4943626c"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=c62f8109b4df15ca37ceeb5e4943626c"
 
 inherit deploy
 


### PR DESCRIPTION
According to the commit c89d7843943f("Move License File from NXP-Binary-EULA to LICENSE") of repo https://github.com/nxp-qoriq/qoriq-qe-ucode. NXP-Binary-EULA is renamed to LICENSE, so replace NXP-Binary-EULA with LICENSE in recipe file.