### PR TITLE
firmware-nxp-wifi: create symbolic links to firmware/mrvl folder

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -11,7 +11,7 @@ This file lists all licenses used by recipes in the meta-freescale layer.
 ./recipes-bsp/dp-firmware-cadence/dp-firmware-cadence_22.04.bb: LICENSE = "Proprietary"
 ./recipes-bsp/firmware-imx/firmware-ele-imx_1.3.0.bb: LICENSE = "Proprietary"
 ./recipes-bsp/firmware-imx/firmware-imx-8.26.inc: LICENSE = "Proprietary"
-./recipes-bsp/firmware-imx/firmware-nxp-wifi_1.0.bb: LICENSE = "Proprietary"
+./recipes-bsp/firmware-imx/firmware-nxp-wifi_1.1.bb: LICENSE = "Proprietary"
 ./recipes-bsp/firmware-imx/firmware-sof-imx_2.3.0.bb: LICENSE = "BSD-3-Clause"
 ./recipes-bsp/firmware-upower/firmware-upower_1.3.1.bb: LICENSE = "Proprietary"
 ./recipes-bsp/fsl-tlu/fsl-tlu_1.0.0.bb: LICENSE = "GPL-2.0-only"

--- a/recipes-bsp/firmware-imx/firmware-nxp-wifi_1.1.bb
+++ b/recipes-bsp/firmware-imx/firmware-nxp-wifi_1.1.bb
@@ -44,7 +44,10 @@ do_install() {
 
     oe_runmake install INSTALLDIR=${D}${nonarch_base_libdir}/firmware/nxp
 
-
+    # Upstream SDIO8997 and IW416 driver firmwares are located on mrvl folder
+    install -d ${D}${nonarch_base_libdir}/firmware/mrvl
+    ln -frs ${D}${nonarch_base_libdir}/firmware/nxp/sdiouart8997_combo_v4.bin ${D}${nonarch_base_libdir}/firmware/mrvl/sdiouart8997_combo_v4.bin
+    ln -frs ${D}${nonarch_base_libdir}/firmware/nxp/sdiouartiw416_combo_v0.bin ${D}${nonarch_base_libdir}/firmware/mrvl/sdiouartiw416_combo_v0.bin
 }
 
 PACKAGES =+ " \
@@ -105,6 +108,7 @@ RREPLACES:${PN}-nxp8997-pcie = "linux-firmware-nxp8997-pcie"
 RCONFLICTS:${PN}-nxp8997-pcie = "linux-firmware-nxp8997-pcie"
 
 FILES:${PN}-nxp8997-sdio = " \
+    ${nonarch_base_libdir}/firmware/mrvl/sdiouart8997_combo_v4.bin \
     ${nonarch_base_libdir}/firmware/nxp/sdio*8997* \
 "
 RDEPENDS:${PN}-nxp8997-sdio += "${PN}-nxp8997-common"
@@ -139,6 +143,7 @@ RREPLACES:${PN}-nxp9098-sdio = "linux-firmware-nxp9098-sdio"
 RCONFLICTS:${PN}-nxp9098-sdio = "linux-firmware-nxp9098-sdio"
 
 FILES:${PN}-nxpiw416-sdio = " \
+    ${nonarch_base_libdir}/firmware/mrvl/sdiouartiw416_combo_v0.bin \
     ${nonarch_base_libdir}/firmware/nxp/*iw416* \
 "
 RDEPENDS:${PN}-nxpiw416-sdio += "${PN}-nxp-common"

--- a/recipes-bsp/firmware-imx/firmware-nxp-wifi_1.1.bb
+++ b/recipes-bsp/firmware-imx/firmware-nxp-wifi_1.1.bb
@@ -173,5 +173,3 @@ RDEPENDS:${PN}-nxpiw612-sdio += "${PN}-nxp-common"
 RPROVIDES:${PN}-nxpiw612-sdio = "linux-firmware-nxpiw612-sdio"
 RREPLACES:${PN}-nxpiw612-sdio = "linux-firmware-nxpiw612-sdio"
 RCONFLICTS:${PN}-nxpiw612-sdio = "linux-firmware-nxpiw612-sdio"
-
-COMPATIBLE_MACHINE = "(imx-generic-bsp)"


### PR DESCRIPTION
The upstream kernel Wi-Fi driver expects the sdiouart8997_combo_v4 and sdiouartiw416_combo_v0 binaries to be located under firmware/mrvl [1], different from the out-of-tree driver, which places them under firmware/nxp. Create symbolic links to deploy these binaries in the correct location for the upstream driver.

Due to this change, bump the recipe version to 1.1.

[1] https://github.com/torvalds/linux/blob/master/drivers/net/wireless/marvell/mwifiex/sdio.h#L31