### PR TITLE
libimxvpuapi2: Upgrade to version 2.3.1 to fix build of gstreamer-imx

### DIFF
--- a/recipes-multimedia/libimxvpuapi/libimxvpuapi2_2.3.1.bb
+++ b/recipes-multimedia/libimxvpuapi/libimxvpuapi2_2.3.1.bb
@@ -11,7 +11,7 @@ DEPENDS:append:mx8mp-nxp-bsp = " imx-vpu-hantro-vc"
 PV .= "+git${SRCPV}"
 
 SRCBRANCH ?= "master"
-SRCREV = "8639837a246f8d85fba8a707c130239aeabc0a19"
+SRCREV = "37095a854aa176bb763a25ce98ceb6a787501271"
 SRC_URI = "git://github.com/Freescale/libimxvpuapi.git;branch=${SRCBRANCH};protocol=https"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Fix build error of gstreamer-imx on Scarthgap. Applying patch 7926ba9bb65762002e2c0506b7e4bd4d950323a6 from Styhead.