### PR TITLE
imx-vpuwrap: fix build error

### DIFF
--- a/recipes-multimedia/imx-vpuwrap/imx-vpuwrap/0001-vpu_wrapper_hantro_encoder-fix-missing-include.patch
+++ b/recipes-multimedia/imx-vpuwrap/imx-vpuwrap/0001-vpu_wrapper_hantro_encoder-fix-missing-include.patch
@@ -1,0 +1,32 @@
+From a3c2f61649afd05e4bab457370f0b32d7644505c Mon Sep 17 00:00:00 2001
+From: Max Krummenacher <max.krummenacher@toradex.com>
+Date: Mon, 3 Mar 2025 08:24:51 +0000
+Subject: [PATCH] vpu_wrapper_hantro_encoder: fix missing include
+
+gettimeofday is declared in sys/time.h. Add the include.
+
+Fixes the build error:
+| ../git/vpu_wrapper_hantro_encoder.c:953:3: error: implicit declaration of function 'gettimeofday' [-Wimplicit-function-declaration]
+|   953 |   gettimeofday (&pObj->tvEnd, NULL);
+
+Upstream-Status: Pending
+Signed-off-by: Max Krummenacher <max.krummenacher@toradex.com>
+---
+ vpu_wrapper_hantro_encoder.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/vpu_wrapper_hantro_encoder.c b/vpu_wrapper_hantro_encoder.c
+index 3819c389320c..a0bdb2f4f6c0 100755
+--- a/vpu_wrapper_hantro_encoder.c
++++ b/vpu_wrapper_hantro_encoder.c
+@@ -25,6 +25,7 @@
+ #include <string.h>
+ #include <time.h>
+ #include <semaphore.h>
++#include <sys/time.h>
+ 
+ #include "headers/OMX_Video.h"
+ #include "headers/OMX_VideoExt.h"
+-- 
+2.42.0
+

--- a/recipes-multimedia/imx-vpuwrap/imx-vpuwrap_git.bb
+++ b/recipes-multimedia/imx-vpuwrap/imx-vpuwrap_git.bb
@@ -12,6 +12,7 @@ DEPENDS:append:mx8mp-nxp-bsp = " imx-vpu-hantro-vc"
 
 SRC_URI = " \
     git://github.com/NXP/imx-vpuwrap.git;protocol=https;branch=${SRCBRANCH} \
+    file://0001-vpu_wrapper_hantro_encoder-fix-missing-include.patch \
 "
 SRCBRANCH = "MM_04.09.02_2410_L6.6.y"
 SRCREV = "378e33989cf72d6c2eb57a585072ba9abe87c6ff"


### PR DESCRIPTION
Add missing include file. Otherwise with latest master we see:  
| ../git/vpu_wrapper_hantro_encoder.c:953:3: error: implicit declaration of function 'gettimeofday' [-Wimplicit-function-declaration]
|   953 |   gettimeofday (&pObj->tvEnd, NULL);

@thochstein Can you report internally?
