### PR TITLE
imx-mcore-demos: Fix 7D

### DIFF
--- a/recipes-fsl/mcore-demos/imx-mcore-demos.inc
+++ b/recipes-fsl/mcore-demos/imx-mcore-demos.inc
@@ -44,7 +44,9 @@ MCORE_DEMO_FILE_EXTENSION:mx7ulp-nxp-bsp = "img"
 
 do_install () {
     install -d ${D}${nonarch_base_libdir}/firmware
-    install -m 0644 ${S}/*.elf ${D}${nonarch_base_libdir}/firmware
+    if ls ${S}/*.elf > /dev/null 2>&1; then
+        install -m 0644 ${S}/*.elf ${D}${nonarch_base_libdir}/firmware
+    fi
     install -m 0644 ${S}/*.${MCORE_DEMO_FILE_EXTENSION} ${D}${nonarch_base_libdir}/firmware
 }
 


### PR DESCRIPTION
For 7D there are no .elf files and there is a build break:
```
| install: cannot stat '.../imx7d-sabresd-m4-freertos-1.0.1/*.elf': No such file or directory
```

Fixes #2056.