### PR TITLE
imx8qm-mek,imx8qxp-mek: Fix SERIAL_CONSOLES

### DIFF
--- a/conf/machine/imx8qm-mek.conf
+++ b/conf/machine/imx8qm-mek.conf
@@ -20,7 +20,7 @@ RRECOMMENDS:${KERNEL_PACKAGE_NAME}-base = ""
 LOADADDR = ""
 
 # We have to disable SERIAL_CONSOLE due to auto-serial-console
-SERIAL_CONSOLES = "115200;ttyAMA0"
+SERIAL_CONSOLES = "115200;ttyLP0"
 
 # we do not want to have getty running on tty1 as we run
 # auto-serial-console there

--- a/conf/machine/include/imx8x-mek.inc
+++ b/conf/machine/include/imx8x-mek.inc
@@ -12,7 +12,7 @@ RRECOMMENDS:${KERNEL_PACKAGE_NAME}-base = ""
 LOADADDR = ""
 
 # We have to disable SERIAL_CONSOLE due to auto-serial-console
-SERIAL_CONSOLES = "115200;ttyAMA0"
+SERIAL_CONSOLES = "115200;ttyLP0"
 
 # we do not want to have getty running on tty1 as we run
 # auto-serial-console there


### PR DESCRIPTION
On Walnascar, 8QM and 8QXP MEK fail to boot. One difference in the log compared with Styhead is the getty on ttyAMA0 instead of ttyLP0 and a failure:
```
[ TIME ] Timed out waiting for device /dev/ttyAMA0.
```

It seems SERIAL_CONSOLES for these two boards has been wrong all along but masked until recently:

https://git.yoctoproject.org/poky/commit/meta/recipes-core/systemd?id=d1eaffbd6bde845c3fcd81660b694e1ea1f46ab2