### PR TITLE
imx-uuc: Don't inherit autotools

### DIFF
--- a/recipes-bsp/imx-uuc/imx-uuc_git.bb
+++ b/recipes-bsp/imx-uuc/imx-uuc_git.bb
@@ -6,8 +6,6 @@ DEPENDS = "virtual/kernel dosfstools-native"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
-inherit autotools-brokensep
-
 PR = "r1"
 PV = "0.5.1+git${SRCPV}"
 
@@ -15,6 +13,10 @@ SRC_URI = "git://github.com/NXPmicro/imx-uuc.git;protocol=https;branch=master"
 SRCREV = "9b4adc0cde346fbae743dc21fcf5115488307b83"
 
 S = "${WORKDIR}/git"
+
+do_install() {
+    oe_runmake 'DESTDIR=${D}' install
+}
 
 FILES:${PN} += "/linuxrc /fat"
 


### PR DESCRIPTION
The do_configure task is failing:
```
ERROR: imx-uuc-0.5.1+git-r1 do_configure: no configure script found at ./configure
```

It appears to be due to this OE-Core change:

    autotools: require that a configure script exists

    There's no point inheriting autotools if you're not actually going to
    run a configure script, so make a missing configure script fatal.

https://github.com/openembedded/openembedded-core/commit/6d327a39befae44a88a812bdf4acde800dcee57b

imx-uuc doesn't need autotools, just a simple do_install implementation.