### PR TITLE
imx-mkimage: Upgrade to NXP BSP 6.6.52_2.2.0

### DIFF
--- a/recipes-bsp/imx-mkimage/imx-mkimage_git.inc
+++ b/recipes-bsp/imx-mkimage/imx-mkimage_git.inc
@@ -5,8 +5,8 @@ DEPENDS = "zlib-native openssl-native"
 SRC_URI = "git://github.com/nxp-imx/imx-mkimage.git;protocol=https;branch=${SRCBRANCH} \
            file://0001-iMX8M-soc.mak-use-native-mkimage-from-sysroot.patch \
 "
-SRCBRANCH = "lf-6.6.36_2.1.0"
-SRCREV = "4622115cbc037f79039c4522faeced4aabea986b"
+SRCBRANCH = "lf-6.6.52_2.2.0"
+SRCREV = "71b8c18af93a5eb972d80fbec290006066cff24f"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
71b8c18 Add flash_all_ap target for non-Linux ap image.
b8f5454 For iMX95, change verdin M7 image name.
d97f0eb For iMX95, change 15x15 M7 image name.
0576197 M7 image names changed again.