### PR TITLE
imx-oei: provide virtual/imx-oei

### DIFF
--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -414,7 +414,8 @@ IMX_EXTRA_FIRMWARE:mx8ulp-generic-bsp = "firmware-upower firmware-ele-imx"
 IMX_EXTRA_FIRMWARE:mx91-generic-bsp   = "imx-boot-firmware-files firmware-ele-imx"
 IMX_EXTRA_FIRMWARE:mx93-generic-bsp   = "imx-boot-firmware-files firmware-ele-imx"
 PREFERRED_PROVIDER_virtual/imx-system-manager ??= "imx-system-manager"
-IMX_EXTRA_FIRMWARE:mx95-generic-bsp   = "imx-boot-firmware-files firmware-ele-imx virtual/imx-system-manager imx-oei"
+PREFERRED_PROVIDER_virtual/imx-oei ??= "imx-oei"
+IMX_EXTRA_FIRMWARE:mx95-generic-bsp   = "imx-boot-firmware-files firmware-ele-imx virtual/imx-system-manager virtual/imx-oei"
 
 # Firmware
 MACHINE_FIRMWARE ?= ""

--- a/dynamic-layers/arm-toolchain/recipes-bsp/imx-oei/imx-oei_1.0.0.bb
+++ b/dynamic-layers/arm-toolchain/recipes-bsp/imx-oei/imx-oei_1.0.0.bb
@@ -56,4 +56,6 @@ do_deploy() {
 FILES:${PN} = "/firmware"
 SYSROOT_DIRS += "/firmware"
 
+PROVIDES += "virtual/imx-oei"
+
 COMPATIBLE_MACHINE = "(mx95-generic-bsp)"

--- a/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
+++ b/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
@@ -38,7 +38,7 @@ do_compile[depends] += " \
 
 SC_FIRMWARE_NAME ?= "scfw_tcm.bin"
 
-OEI_ENABLE = "${@bb.utils.contains('DEPENDS', 'imx-oei', 'YES', 'NO', d)}"
+OEI_ENABLE = "${@bb.utils.contains('DEPENDS', 'virtual/imx-oei', 'YES', 'NO', d)}"
 OEI_NAME ?= "oei-${OEI_CORE}-*.bin"
 
 ATF_MACHINE_NAME ?= "bl31-${ATF_PLATFORM}.bin"


### PR DESCRIPTION
Some hardware vendors provide a customized Optional Executable Image (OEI) with changes specific to their boards (e.g. Toradex SMARC i.MX95).

Add a virtual provider to avoid conflicts between the OEI recipes from other layers. This follows the pattern used for the related imx-system-manager.