### PR TITLE
imx-base: mx8mq: fix SOC_ATF_BOOT_UART_BASE value

### DIFF
--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -130,6 +130,7 @@ IMX_DEFAULT_ATF_PROVIDER ??= "imx-atf"
 SOC_ATF_BOOT_UART_BASE                    = ""
 
 SOC_ATF_BOOT_UART_BASE:mx8m-generic-bsp   = "0x30890000"
+SOC_ATF_BOOT_UART_BASE:mx8mq-generic-bsp  = "0x30860000"
 ATF_BOOT_UART_BASE                       ?= "${SOC_ATF_BOOT_UART_BASE}"
 
 PREFERRED_PROVIDER_virtual/xserver      = "xserver-xorg"


### PR DESCRIPTION
mx8mq uses 0x30860000 as the base address for boot uart base.