### PR TITLE
kernel-module-nxp-wlan: Add Upstream-Status

### DIFF
--- a/recipes-kernel/kernel-modules/kernel-module-nxp-wlan/wlan_src_driver_patch_release_lf-6.6.52-2.2.0.patch
+++ b/recipes-kernel/kernel-modules/kernel-module-nxp-wlan/wlan_src_driver_patch_release_lf-6.6.52-2.2.0.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [platform specific]
+
 diff --git a/Makefile b/Makefile
 index 024e977..d61798e 100644
 --- a/Makefile


### PR DESCRIPTION
Add Upstream-Status to patch.

Fixes:
```
ERROR: kernel-module-nxp-wlan-git-r0 do_patch: QA Issue: Missing Upstream-Status in patch
/home/leon/poky-olimex-imx8mp/meta-freescale/recipes-kernel/kernel-modules/kernel-module-nxp-wlan/wlan_src_driver_patch_release_lf-6.6.52-2.2.0.patch
Please add according to https://docs.yoctoproject.org/contributor-guide/recipe-style-guide.html#patch-upstream-status . [patch-status]
ERROR: kernel-module-nxp-wlan-git-r0 do_patch: Fatal QA errors were found, failing task.
ERROR: Logfile of failure stored in: /home/leon/poky-olimex-imx8mp/build/tmp/work/olimex_imx8mp_evb-poky-linux/kernel-module-nxp-wlan/git/temp/log.do_patch.1878769
ERROR: Task (/home/leon/poky-olimex-imx8mp/meta-freescale/recipes-kernel/kernel-modules/kernel-module-nxp-wlan_git.bb:do_patch) failed with exit code '1'
```