### PR TITLE
isp-imx: fix build against updated tinyxml2

### DIFF
--- a/recipes-bsp/isp-imx/isp-imx_4.2.2.24.4.bb
+++ b/recipes-bsp/isp-imx/isp-imx_4.2.2.24.4.bb
@@ -52,6 +52,9 @@ do_configure:prepend () {
     patchelf --replace-needed libjsoncpp.so.25 libjsoncpp.so.26 ${S}/mediacontrol/install/bin/isp_media_server
     patchelf --replace-needed libjsoncpp.so.25 libjsoncpp.so.26 ${S}/mediacontrol/install/lib/libmedia_server.so
     patchelf --replace-needed libjsoncpp.so.25 libjsoncpp.so.26 ${S}/tuningext/install/tuningext
+
+    # FIXME: Should be rebuild.
+    patchelf --replace-needed libtinyxml2.so.10 libtinyxml2.so.11 ${S}/appshell/shell_libs/ispcore/ARM64/libcam_device.so
 }
 
 do_install() {


### PR DESCRIPTION
Latest master meta-oe updated tinyxml2 to version 11.0.0. isp-imx packages a prebuilt library dynamically linked against tinyxml2.so.10 which is no longer provided, thus:

| ERROR: isp-imx-4.2.2.24.4-r0 do_package_qa: QA Issue: /usr/lib/libcam_device.so contained in package 
| isp-imx requires libtinyxml2.so.10()(64bit), but no providers found in RDEPENDS:isp-imx? [file-rdeps]

Fix the build by updating the dynamic section to require tinyxml2.so.11.

Note that I don't have a system to runtime test if that still works. The tinyxml2 API doesn't look like it changed from 10 to 11.

Note that the tinyxml2 version bump is only in meta-openembedded master. Styhead is providing tinxml2 10.0.0.
