### PR TITLE
alsa-state: Use i:MX-specific configuration to support QorIQ platforms

### DIFF
--- a/conf/machine/include/qoriq-base.inc
+++ b/conf/machine/include/qoriq-base.inc
@@ -43,6 +43,8 @@ EXTRA_IMAGEDEPENDS += "u-boot qoriq-cst-native"
 
 MACHINEOVERRIDES =. "qoriq:"
 
+INHERIT += "machine-overrides-extender"
+
 # Machines or distros can define which BSP it should use by default. We are
 # intending to default for nxp BSP by default and specific machines or
 # DISTROs might change it if need.
@@ -51,6 +53,8 @@ MACHINEOVERRIDES =. "qoriq:"
 QORIQ_DEFAULT_BSP ?= "nxp"
 
 MACHINEOVERRIDES =. "use-${QORIQ_DEFAULT_BSP}-bsp:"
+MACHINEOVERRIDES_EXTENDER:use-mainline-bsp = "qoriq-generic-bsp:qoriq-mainline-bsp"
+MACHINEOVERRIDES_EXTENDER:use-nxp-bsp = "qoriq-generic-bsp:qoriq-nxp-bsp"
 
 # Sub-architecture support
 MACHINE_SOCARCH_SUFFIX ?= ""

--- a/recipes-bsp/alsa-state/alsa-state.bbappend
+++ b/recipes-bsp/alsa-state/alsa-state.bbappend
@@ -2,3 +2,4 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 PACKAGE_ARCH:imx-generic-bsp = "${MACHINE_ARCH}"
+PACKAGE_ARCH:qoriq-generic-bsp = "${MACHINE_ARCH}"

--- a/recipes-bsp/alsa-state/alsa-state/qoriq-generic-bsp
+++ b/recipes-bsp/alsa-state/alsa-state/qoriq-generic-bsp
@@ -1,0 +1,1 @@
+imx-generic-bsp

--- a/recipes-bsp/alsa-state/alsa-state/qoriq-mainline-bsp
+++ b/recipes-bsp/alsa-state/alsa-state/qoriq-mainline-bsp
@@ -1,0 +1,1 @@
+imx-mainline-bsp

--- a/recipes-bsp/alsa-state/alsa-state/qoriq-nxp-bsp
+++ b/recipes-bsp/alsa-state/alsa-state/qoriq-nxp-bsp
@@ -1,0 +1,1 @@
+imx-nxp-bsp


### PR DESCRIPTION
This asound.conf can be used for both i.MX and Layerscale platforms. But the latter don't have `imx-<default>-bsp` in their overrides. Use the common `use-<default>-bsp` instead.