### PR TITLE
mesa: bbappend: drop kmsro packageconfig

### DIFF
--- a/recipes-graphics/mesa/mesa.bbappend
+++ b/recipes-graphics/mesa/mesa.bbappend
@@ -19,7 +19,7 @@ python () {
 }
 
 # Enable Etnaviv and Freedreno support
-PACKAGECONFIG:append:use-mainline-bsp = " gallium etnaviv kmsro freedreno"
+PACKAGECONFIG:append:use-mainline-bsp = " gallium etnaviv freedreno"
 
 # For NXP BSP, GPU drivers don't support dri
 PACKAGECONFIG:remove:imxgpu:use-nxp-bsp = "dri"


### PR DESCRIPTION
mesa is updated in oe-core to 25.0.2. That version dropped the configure option kmsro and unconditionally adds the code [1].

oe-core currently still has the packageconfig for it, however enabling results in a built time error. A fix is on the ML [2].

| ERROR: mesa-2_25.0.2-r0 do_recipe_qa: QA Issue: mesa: invalid PACKAGECONFIG(s): kmsro [invalid-packageconfig]

[1] https://gitlab.freedesktop.org/mesa/mesa/-/commit/70813c1c13b99cb029c8fa3537163650bdd17b6d
[2] https://lore.kernel.org/all/20250412-mesa-25-fixes-v1-1-791840391271@oss.qualcomm.com/