### PR TITLE
imx-boot: add LPDDR_FW_VERSION to mkimage arguments for iMX95

### DIFF
--- a/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
+++ b/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
@@ -78,6 +78,7 @@ MKIMAGE_EXTRA_ARGS ?= ""
 MKIMAGE_EXTRA_ARGS:mx95-nxp-bsp ?= " \
     OEI=${OEI_ENABLE} \
     LPDDR_TYPE=${DDR_TYPE} \
+    ${@'LPDDR_FW_VERSION='+d.getVar('LPDDR_FW_VERSION') if d.getVar('LPDDR_FW_VERSION') else ''} \
     ${@bb.utils.contains('SYSTEM_MANAGER_CONFIG', 'mx95alt', 'MSEL=1', '', d)}"
 MKIMAGE_EXTRA_ARGS:imx95-19x19-verdin ?= " \
     ${MKIMAGE_EXTRA_ARGS:mx95-nxp-bsp} \


### PR DESCRIPTION
For the iMX95 it can be necessary to use a different DDR FW version than the one selected by default by the mkimage build. You might need newer FW binaries while still supporting an older NXP BSP.

Pass LPDDR_FW_VERSION to make if it is set, otherwise do nothing such that the Makefile selects its default value just like before.

When using a different FW version without setting LPDDR_FW_VERSION accordingly you will get a build error similar to the below:
```
| DEBUG: Executing shell function do_compile
| NOTE: UBOOT_CONFIG = sd, UBOOT_DTB_NAME =
| NOTE: i.MX 95 boot binary build
| NOTE: i.MX 93 boot binary build
| NOTE: Copy ddr_firmware: lpddr4x_dmem_v202409.bin from $BUILD_PATH/deploy/images/verdin-imx95 -> $BUILD_PATH/tmp/work/verdin_imx95-tdx-linux/imx-boot/1.0/git/iMX95
[...]
| make[1]: *** No rule to make target 'lpddr4x_imem_v202311.bin', needed by 'm33-oei-ddrfw.bin'.  Stop.
```

Above we are using `lpddr4x_imem_v202409.bin` but mkimage is not aware without this fix and setting LPDDR_FW_VERSION (i.e.: in the machine conf).