### PR TITLE
bump imx-vpu-hantro to latest of rel_6.6.52_2.2.0

### DIFF
--- a/recipes-bsp/imx-vpu-hantro-vc/imx-vpu-hantro-vc_1.10.1.bb
+++ b/recipes-bsp/imx-vpu-hantro-vc/imx-vpu-hantro-vc_1.10.1.bb
@@ -2,15 +2,16 @@
 
 DESCRIPTION = "i.MX VC8000E Encoder library"
 LICENSE = "Proprietary"
-LIC_FILES_CHKSUM = "file://COPYING;md5=db4762b09b6bda63da103963e6e081de"
+LIC_FILES_CHKSUM = "file://COPYING;md5=ca53281cc0caa7e320d4945a896fb837"
 
 inherit fsl-eula-unpack
 
-SRC_URI = "${FSL_MIRROR}/${BP}.bin;fsl-eula=true"
+SRC_URI = "${FSL_MIRROR}/${BP}-${IMX_SRCREV_ABBREV}.bin;fsl-eula=true"
+IMX_SRCREV_ABBREV = "c0244a1"
 
-S = "${WORKDIR}/${BPN}-${PV}"
+SRC_URI[sha256sum] = "713ba375f25490727fcc62bab5d5508f74de03204b4c153464b696b652c5c7df"
 
-SRC_URI[sha256sum] = "84fcefa0619def2f009ca6651c5cffcda57fed29cd7060ef68be48c5d0d7814b"
+S = "${WORKDIR}/${BP}-${IMX_SRCREV_ABBREV}"
 
 # SCR is the location and name of the Software Content Register file
 # relative to ${D}${D_SUBDIR}.

--- a/recipes-bsp/imx-vpu-hantro/imx-vpu-hantro-daemon_1.4.0.bb
+++ b/recipes-bsp/imx-vpu-hantro/imx-vpu-hantro-daemon_1.4.0.bb
@@ -6,8 +6,12 @@ LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=cd8bc2a79509c22fc9c1782a151210b1"
 DEPENDS = "imx-vpu-hantro"
 DEPENDS:append:mx8mp-nxp-bsp = " imx-vpu-hantro-vc"
 
-SRC_URI = "${FSL_MIRROR}/${BP}.tar.gz"
-SRC_URI[sha256sum] = "80d6620063fd5e5506b05c907677b579d471a9b6daa8b26ffb963110cc680bf9"
+SRC_URI = "${FSL_MIRROR}/${BP}-${IMX_SRCREV_ABBREV}.tar.gz"
+IMX_SRCREV_ABBREV = "75d9dd9"
+
+SRC_URI[sha256sum] = "c3ac36c203fef44ef21c98a90b3fff73af9f328f16b4d85157308848f6c34823"
+
+S = "${WORKDIR}/${BP}-${IMX_SRCREV_ABBREV}"
 
 PLATFORM:mx8mm-nxp-bsp = "IMX8MM"
 PLATFORM:mx8mq-nxp-bsp = "IMX8MQ"

--- a/recipes-bsp/imx-vpu-hantro/imx-vpu-hantro_1.35.0.bb
+++ b/recipes-bsp/imx-vpu-hantro/imx-vpu-hantro_1.35.0.bb
@@ -2,12 +2,16 @@
 
 DESCRIPTION = "i.MX Hantro VPU library"
 LICENSE = "Proprietary"
-LIC_FILES_CHKSUM = "file://COPYING;md5=44a8052c384584ba09077e85a3d1654f"
+LIC_FILES_CHKSUM = "file://COPYING;md5=ca53281cc0caa7e320d4945a896fb837"
 
 PROVIDES = "virtual/imxvpu"
 
-SRC_URI = "${FSL_MIRROR}/${BP}.bin;fsl-eula=true"
-SRC_URI[sha256sum] = "f751ab7369d48e610ea3b6b0dc5a885c70a510861d6b46296ffc063fed370003"
+SRC_URI = "${FSL_MIRROR}/${BP}-${IMX_SRCREV_ABBREV}.bin;fsl-eula=true"
+IMX_SRCREV_ABBREV = "98ff183"
+
+SRC_URI[sha256sum] = "c4730cb996a3eafbc06ed0765cd509caa63cdeecdc0c4958efbc91383e0501fd"
+
+S = "${WORKDIR}/${BP}-${IMX_SRCREV_ABBREV}"
 
 inherit fsl-eula-unpack use-imx-headers
 


### PR DESCRIPTION
Hello,

The video encoding wasn’t working on i.MX8MM. The change from https://github.com/nxp-imx/linux-imx/commit/08d3e59a62a7dec30a6401e050b88a260f085580 broke compatibility between the kernel driver and the current version of  userspace VPU libraries on `meta-freescale` . While this was fixed on the userspace libraries in `meta-imx`, we still need to bump `meta-freescale`.

I bumped to the latest version of rel_6.6.52_2.2.0 since we'll need the backport for scarthgap too. The i.MX8MP doesn't seem to be affected (at least by this same issue), but it was more practical to bump `imx-vpu-hantro-vc` as well.

The bump was tested on both i.MX8MM and i.MX8MP using latest Toradex BSP . 

Maybe, this also fix https://github.com/Freescale/meta-freescale/issues/2208. 