### PR TITLE
asound.conf: default sample rate to 48000

### DIFF
--- a/recipes-bsp/alsa-state/alsa-state/imx-mainline-bsp/asound.conf
+++ b/recipes-bsp/alsa-state/alsa-state/imx-mainline-bsp/asound.conf
@@ -218,8 +218,8 @@ rate 8000
 
 pcm.asymed{
 type asym
-playback.pcm "dmix_44100"
-capture.pcm "dsnoop_44100"
+playback.pcm "dmix_48000"
+capture.pcm "dsnoop_48000"
 }
 
 pcm.dsp0{

--- a/recipes-bsp/alsa-state/alsa-state/imx-nxp-bsp/asound.conf
+++ b/recipes-bsp/alsa-state/alsa-state/imx-nxp-bsp/asound.conf
@@ -218,8 +218,8 @@ rate 8000
 
 pcm.asymed{
 type asym
-playback.pcm "dmix_44100"
-capture.pcm "dsnoop_44100"
+playback.pcm "dmix_48000"
+capture.pcm "dsnoop_48000"
 }
 
 pcm.dsp0{


### PR DESCRIPTION
Change the default sample rate as used with ALSA to 48000 instead of
44100. Most newer content, videos, and web-based content uses 48 kHz sampling rate, especially with modern codecs like Opus.

Normally applications request ALSA to use a PCM sample rate which matches the input content when starting playback. However, more complex applications such as Chromium will internally resample audio to match the default output. This can result in high CPU usage for resampling, so having ALSA's default rate match the majority of content is preferred.

See also #2217.