### PR TITLE
alsa-lib: rework patches to apply on 1.2.13 and 1.2.14

### DIFF
--- a/recipes-multimedia/alsa/alsa-lib/0001-add-conf-for-multichannel-support-in-imx.patch
+++ b/recipes-multimedia/alsa/alsa-lib/0001-add-conf-for-multichannel-support-in-imx.patch
@@ -1,4 +1,4 @@
-From 365213e10b073c45d7bacf9c94e30e879bfa8255 Mon Sep 17 00:00:00 2001
+From 3fa81ebaf8bac6b167776888ae26c6c140d8aebc Mon Sep 17 00:00:00 2001
 From: Shengjiu Wang <b02247@freescale.com>
 Date: Thu, 5 Jun 2014 17:37:47 +0800
 Subject: [PATCH] add conf for multichannel support in imx
@@ -9,9 +9,9 @@ Signed-off-by: Shengjiu Wang <b02247@freescale.com>
 ---
  src/conf/cards/CS42888.conf  | 94 ++++++++++++++++++++++++++++++++++++
  src/conf/cards/IMX-HDMI.conf | 67 +++++++++++++++++++++++++
- src/conf/cards/Makefile.am   |  4 +-
+ src/conf/cards/Makefile.am   |  2 +
  src/conf/cards/aliases.conf  |  2 +
- 4 files changed, 166 insertions(+), 1 deletion(-)
+ 4 files changed, 165 insertions(+)
  create mode 100644 src/conf/cards/CS42888.conf
  create mode 100644 src/conf/cards/IMX-HDMI.conf
 
@@ -189,20 +189,18 @@ index 000000000000..a51509e8ad5a
 +
 +# vim: ft=alsaconf
 diff --git a/src/conf/cards/Makefile.am b/src/conf/cards/Makefile.am
-index f387cf4197da..fb7de95b194d 100644
+index f387cf4197da..cbd2cd04227d 100644
 --- a/src/conf/cards/Makefile.am
 +++ b/src/conf/cards/Makefile.am
-@@ -58,7 +58,9 @@ cfg_files = aliases.conf \
- 	VIA8237.conf \
- 	VX222.conf \
- 	VXPocket.conf \
--	VXPocket440.conf
-+	VXPocket440.conf \
+@@ -1,6 +1,8 @@
+ alsaconfigdir = @ALSA_CONFIG_DIR@
+ alsadir = $(alsaconfigdir)/cards
+ cfg_files = aliases.conf \
 +	CS42888.conf \
-+	IMX-HDMI.conf
- 
- alsa_DATA = $(cfg_files)
- 
++	IMX-HDMI.conf \
+ 	AACI.conf \
+ 	ATIIXP.conf \
+ 	ATIIXP-SPDMA.conf \
 diff --git a/src/conf/cards/aliases.conf b/src/conf/cards/aliases.conf
 index a54824ae636b..0aa874d7434f 100644
 --- a/src/conf/cards/aliases.conf

--- a/recipes-multimedia/alsa/alsa-lib/0005-add-ak4458-conf-for-multichannel-support.patch
+++ b/recipes-multimedia/alsa/alsa-lib/0005-add-ak4458-conf-for-multichannel-support.patch
@@ -1,4 +1,4 @@
-From eba3f36b6619d0794028f0880fbdfc2bb98df45e Mon Sep 17 00:00:00 2001
+From 92d2b7d91bc1ec4068ee9371753bb24ad1108827 Mon Sep 17 00:00:00 2001
 From: Shengjiu Wang <shengjiu.wang@nxp.com>
 Date: Wed, 31 Jan 2018 15:06:53 +0800
 Subject: [PATCH] add ak4458 conf for multichannel support
@@ -14,9 +14,9 @@ Upstream-Status: Inappropriate [i.MX specific]
 Signed-off-by: Shengjiu Wang <shengjiu.wang@nxp.com>
 ---
  src/conf/cards/AK4458.conf  | 74 +++++++++++++++++++++++++++++++++++++
- src/conf/cards/Makefile.am  |  3 +-
+ src/conf/cards/Makefile.am  |  1 +
  src/conf/cards/aliases.conf |  1 +
- 3 files changed, 77 insertions(+), 1 deletion(-)
+ 3 files changed, 76 insertions(+)
  create mode 100644 src/conf/cards/AK4458.conf
 
 diff --git a/src/conf/cards/AK4458.conf b/src/conf/cards/AK4458.conf
@@ -100,19 +100,17 @@ index 000000000000..3b5b195f2ca0
 +	slave.channels 8
 +}
 diff --git a/src/conf/cards/Makefile.am b/src/conf/cards/Makefile.am
-index fb7de95b194d..bdb1c2523d62 100644
+index cbd2cd04227d..3c29bd65d341 100644
 --- a/src/conf/cards/Makefile.am
 +++ b/src/conf/cards/Makefile.am
-@@ -60,7 +60,8 @@ cfg_files = aliases.conf \
- 	VXPocket.conf \
- 	VXPocket440.conf \
+@@ -3,6 +3,7 @@ alsadir = $(alsaconfigdir)/cards
+ cfg_files = aliases.conf \
  	CS42888.conf \
--	IMX-HDMI.conf
-+	IMX-HDMI.conf \
-+	AK4458.conf
- 
- alsa_DATA = $(cfg_files)
- 
+ 	IMX-HDMI.conf \
++	AK4458.conf \
+ 	AACI.conf \
+ 	ATIIXP.conf \
+ 	ATIIXP-SPDMA.conf \
 diff --git a/src/conf/cards/aliases.conf b/src/conf/cards/aliases.conf
 index 0aa874d7434f..dda71d99916e 100644
 --- a/src/conf/cards/aliases.conf

--- a/recipes-multimedia/alsa/alsa-lib/0006-add-conf-for-iMX-XCVR-sound-card.patch
+++ b/recipes-multimedia/alsa/alsa-lib/0006-add-conf-for-iMX-XCVR-sound-card.patch
@@ -1,4 +1,4 @@
-From 812399f89e01239ca88b905451a55ba996a88e1a Mon Sep 17 00:00:00 2001
+From faa9791070520f8d5e7060e5668efd1302c86c66 Mon Sep 17 00:00:00 2001
 From: Viorel Suman <viorel.suman@nxp.com>
 Date: Mon, 9 Mar 2020 14:25:46 +0200
 Subject: [PATCH] add conf for iMX XCVR sound card
@@ -8,9 +8,9 @@ Upstream-Status: Pending
 Signed-off-by: Viorel Suman <viorel.suman@nxp.com>
 ---
  src/conf/cards/IMX-XCVR.conf | 39 ++++++++++++++++++++++++++++++++++++
- src/conf/cards/Makefile.am   |  3 ++-
+ src/conf/cards/Makefile.am   |  1 +
  src/conf/cards/aliases.conf  |  1 +
- 3 files changed, 42 insertions(+), 1 deletion(-)
+ 3 files changed, 41 insertions(+)
  create mode 100755 src/conf/cards/IMX-XCVR.conf
 
 diff --git a/src/conf/cards/IMX-XCVR.conf b/src/conf/cards/IMX-XCVR.conf
@@ -59,19 +59,17 @@ index 000000000000..009000c63a19
 +	preamble.y 0x3
 +}
 diff --git a/src/conf/cards/Makefile.am b/src/conf/cards/Makefile.am
-index bdb1c2523d62..044d2581f8bd 100644
+index 3c29bd65d341..4502919e3bec 100644
 --- a/src/conf/cards/Makefile.am
 +++ b/src/conf/cards/Makefile.am
-@@ -61,7 +61,8 @@ cfg_files = aliases.conf \
- 	VXPocket440.conf \
+@@ -4,6 +4,7 @@ cfg_files = aliases.conf \
  	CS42888.conf \
  	IMX-HDMI.conf \
--	AK4458.conf
-+	AK4458.conf \
-+	IMX-XCVR.conf
- 
- alsa_DATA = $(cfg_files)
- 
+ 	AK4458.conf \
++	IMX-XCVR.conf \
+ 	AACI.conf \
+ 	ATIIXP.conf \
+ 	ATIIXP-SPDMA.conf \
 diff --git a/src/conf/cards/aliases.conf b/src/conf/cards/aliases.conf
 index dda71d99916e..6dab14855f25 100644
 --- a/src/conf/cards/aliases.conf

--- a/recipes-multimedia/alsa/alsa-lib/0007-add-conf-for-imx-cs42448-sound-card.patch
+++ b/recipes-multimedia/alsa/alsa-lib/0007-add-conf-for-imx-cs42448-sound-card.patch
@@ -1,4 +1,4 @@
-From 2f87ea5afa137dfa2f7a096e9c8518be43920ed9 Mon Sep 17 00:00:00 2001
+From 38d84440a7bec9e26380f08f050b2ada772b822e Mon Sep 17 00:00:00 2001
 From: Chancel Liu <chancel.liu@nxp.com>
 Date: Fri, 29 Jul 2022 16:12:37 +0800
 Subject: [PATCH] add conf for imx-cs42448 sound card
@@ -11,9 +11,9 @@ Upstream-Status: Inappropriate [i.MX specific]
 Signed-off-by: Chancel Liu <chancel.liu@nxp.com>
 ---
  src/conf/cards/CS42448.conf | 58 +++++++++++++++++++++++++++++++++++++
- src/conf/cards/Makefile.am  |  3 +-
+ src/conf/cards/Makefile.am  |  1 +
  src/conf/cards/aliases.conf |  1 +
- 3 files changed, 61 insertions(+), 1 deletion(-)
+ 3 files changed, 60 insertions(+)
  create mode 100644 src/conf/cards/CS42448.conf
 
 diff --git a/src/conf/cards/CS42448.conf b/src/conf/cards/CS42448.conf
@@ -81,19 +81,17 @@ index 000000000000..28ba5c485837
 +
 +# vim: ft=alsaconf
 diff --git a/src/conf/cards/Makefile.am b/src/conf/cards/Makefile.am
-index 044d2581f8bd..b08962cf3ba3 100644
+index 4502919e3bec..da2def3a9498 100644
 --- a/src/conf/cards/Makefile.am
 +++ b/src/conf/cards/Makefile.am
-@@ -62,7 +62,8 @@ cfg_files = aliases.conf \
- 	CS42888.conf \
+@@ -5,6 +5,7 @@ cfg_files = aliases.conf \
  	IMX-HDMI.conf \
  	AK4458.conf \
--	IMX-XCVR.conf
-+	IMX-XCVR.conf \
-+	CS42448.conf
- 
- alsa_DATA = $(cfg_files)
- 
+ 	IMX-XCVR.conf \
++	CS42448.conf \
+ 	AACI.conf \
+ 	ATIIXP.conf \
+ 	ATIIXP-SPDMA.conf \
 diff --git a/src/conf/cards/aliases.conf b/src/conf/cards/aliases.conf
 index 6dab14855f25..554db846f8e5 100644
 --- a/src/conf/cards/aliases.conf


### PR DESCRIPTION
This PR makes the alsa-lib patches compatible with 1.2.13 (walnascar) and 1.2.14 (latest master).

Feel free to close if branching off walnascar looks like the better solution.