### PR TITLE
Fail when build imx-boot adding flash_linux_m4 on IMXBOOT_TARGETS_SD

### DIFF
--- a/conf/machine/imx8qm-mek.conf
+++ b/conf/machine/imx8qm-mek.conf
@@ -75,8 +75,8 @@ IMAGE_BOOT_FILES += "hdmitxfw.bin hdmirxfw.bin dpfw.bin"
 ATF_PLATFORM = "imx8qm"
 
 IMXBOOT_TARGETS_SD = \
-    "${@bb.utils.contains('MACHINE_FEATURES', 'optee', 'flash_spl', \
-                                                       'flash flash_ca72', d)}"
+    "${@bb.utils.contains('MACHINE_FEATURES', 'optee', 'flash_linux_m4 flash_spl', \
+                                                       'flash_regression_linux_m4 flash flash_ca72', d)}"
 IMXBOOT_TARGETS_FSPI = \
     "${@bb.utils.contains('MACHINE_FEATURES', 'optee', 'flash_spl_flexspi', \
                                                        'flash_flexspi', d)}"


### PR DESCRIPTION
Hi @thochstein. Could you look at this?

Adding flash_linux_m4 to IMXBOOT_TARGETS_SD fails due to the missing changes in imx-boot. When building the imx-boot, the error below occurs.

MACHINE = imx8qm-mek

```
ERROR: imx-boot-1.0-r0 do_compile: Execution of '/home/rodrigo/src/oe/ossystems-demos/master/build/tmp/work/imx8qm_mek-ossystemsdemos-linux/imx-boot/1.0/temp/run.do_compile.314731' failed with exit code 2
ERROR: Logfile of failure stored in: /home/rodrigo/src/oe/ossystems-demos/master/build/tmp/work/imx8qm_mek-ossystemsdemos-linux/imx-boot/1.0/temp/log.do_compile.314731
Log data follows:
| DEBUG: Executing shell function do_compile
| NOTE: UBOOT_CONFIG = sd, UBOOT_DTB_NAME =
| NOTE: 8QM boot binary build
| NOTE: building iMX8QM - REV=B0  flash_linux_m4
| Compiling mkimage_imx8
| include misc.mak
| include m4.mak
| include android.mak
| include test.mak
| include autobuild.mak
| include alias.mak
| make[1]: *** No rule to make target 'm4_image.bin', needed by 'flash_linux_m4'.  Stop.
| make: *** [Makefile:26: flash_linux_m4] Error 2
| WARNING: exit code 2 from a shell command.
ERROR: Task (/home/rodrigo/src/oe/ossystems-demos/master/sources/meta-freescale/recipes-bsp/imx-mkimage/imx-boot_1.0.bb:do_compile) failed with exit code '1'
NOTE: Tasks Summary: Attempted 1443 tasks of which 1433 didn't need to be rerun and 1 failed.
NOTE: Writing buildhistory
NOTE: Writing buildhistory took: 2 seconds
```