### PR TITLE
imx-mkimage: Update to NXP BSP 6.12.3_1.0.0

### DIFF
--- a/recipes-bsp/imx-mkimage/imx-mkimage_git.inc
+++ b/recipes-bsp/imx-mkimage/imx-mkimage_git.inc
@@ -1,12 +1,12 @@
-# Copyright 2017-2023 NXP
+# Copyright 2017-2025 NXP
 
 DEPENDS = "zlib-native openssl-native"
 
 SRC_URI = "git://github.com/nxp-imx/imx-mkimage.git;protocol=https;branch=${SRCBRANCH} \
            file://0001-iMX8M-soc.mak-use-native-mkimage-from-sysroot.patch \
 "
-SRCBRANCH = "lf-6.6.52_2.2.0"
-SRCREV = "71b8c18af93a5eb972d80fbec290006066cff24f"
+SRCBRANCH = "lf-6.12.3_1.0.0"
+SRCREV = "9e60b1f7a87a6397cf8db10e07293075f489e974"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
9e60b1f i.MX94: change the fcb gen script for i.MX94 9bf51e8 iMX94: Add iMX94 soc makefilies
77dce74 iMX94: add v2 container support
c0c69cb imx95: upgrade Synopsys DDR PHY FW to v202409 64fcf1c Handled imx95 parse/extract functionality
55093c4 Add flash_all_ap target for non-Linux ap image.

Fixes: #2238