### PR TITLE
kernel-module-isp-vvcam: 4.2.2.24.2 -> 4.2.2.25.1

### DIFF
--- a/recipes-kernel/kernel-modules/kernel-module-isp-vvcam_4.2.2.25.1.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-isp-vvcam_4.2.2.25.1.bb
@@ -1,4 +1,4 @@
-# Copyright 2020-2023 NXP
+# Copyright (C) 2020-2023 NXP
 
 DESCRIPTION = "Kernel loadable module for ISP"
 LICENSE = "GPL-2.0-only"
@@ -6,8 +6,8 @@ LIC_FILES_CHKSUM = "file://${S}/../LICENSE;md5=64381a6ea83b48c39fe524c85f65fb44"
 
 SRC_URI = "${ISP_KERNEL_SRC};branch=${SRCBRANCH}"
 ISP_KERNEL_SRC ?= "git://github.com/nxp-imx/isp-vvcam.git;protocol=https"
-SRCBRANCH = "lf-6.6.y_2.0.0"
-SRCREV = "ab77b0521615d3f279263ba67439aed887d525d7"
+SRCBRANCH = "lf-6.12.y_1.0.0"
+SRCREV = "78d717bb22819df9d988ef1b4e3cca1acf61095d"
 
 S = "${WORKDIR}/git/vvcam/v4l2"
 


### PR DESCRIPTION
This commit add the following source revisions:

    78d717b MA-23208 Fix undeclared "vmalloc" build error in vvcam
    2ac9f12 CL1041202 M865SW-1317: vvcam: isp framerate statistic is not accurate
    ad07139 MA-21928-1 Fix update symbol list build error
    f4d9818 CL982766 M865SW-1297: vvcam: Modify license for vvfocus headfile
    aba15ee CL981700 M865SW-1272: vvcam: Add little endian support for raw10/raw12 capture in tuning tool
    72c5955 CL950364 M865SW-1248: vvcam: ISP service random crash and can't be recovered.
    4fabcb6 LF-12838: vvcam: Fix the os08a20 sensor capture failed issue
    b5a4eaf LF-12820-3: vvcam: video: Fix build issue on rebase kernel next-20240618
    c2cf5b7 LF-12820-2: vvcam: isp: Fix build issue on rebase kernel next-20240618
    e470f21 LF-12820-1: vvcam: dwe: Fix build issue on rebase kernel next-20240618
    93fa173 LF-12303: vvcam: Stop direct calls to queue num_buffers field
    7f4c263 CL863724 M865SW-1231: vvcam: add two build warning options
    9c58fe4 CL883206 M865SW-1188: vvcam: fix CTS capture failed on some resolutions
    bc67534 CL865138 M865SW-1233: vvcam : fix isp_ioc_g_feature_veresion spell error