### PR TITLE
jailhouse-imx: Update branch from lf-6.6.52 -> lf-6.12.3

### DIFF
--- a/recipes-extended/jailhouse/files/0001-YOCIMX-9281-1-Fix-gcc15-errors.patch
+++ b/recipes-extended/jailhouse/files/0001-YOCIMX-9281-1-Fix-gcc15-errors.patch
@@ -1,0 +1,113 @@
+From 2be7793ca658015470fe0d60c0c973e12ce68d73 Mon Sep 17 00:00:00 2001
+From: Tom Hochstein <tom.hochstein@nxp.com>
+Date: Thu, 12 Jun 2025 06:49:58 -0700
+Subject: [PATCH 1/2] YOCIMX-9281-1: Fix gcc15 errors
+
+Fix several instances of the following errors:
+
+```
+| inmates/lib/include/inmate_common.h:87:16: error: cannot use keyword 'true' as enumeration constant
+|    87 | typedef enum { true = 1, false = 0 } bool;
+|       |                ^~~~
+```
+
+```
+| In file included from configs/arm64/hikey.c:16:
+| include/jailhouse/cell-config.h:318:41: error: initializer-string for array of 'char' truncates NUL terminator but destination lacks 'nonstring' attribute (6 chars into 5 available) [-Werror=unterminated-string-initialization]
+|   318 | #define JAILHOUSE_SYSTEM_SIGNATURE      "JHSYS"
+|       |                                         ^~~~~~~
+| configs/arm64/hikey.c:26:30: note: in expansion of macro 'JAILHOUSE_SYSTEM_SIGNATURE'
+|    26 |                 .signature = JAILHOUSE_SYSTEM_SIGNATURE,
+|       |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+Upstream-Status: Backport [Pending]
+Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>
+Signed-off-by: Peng Fan <peng.fan@nxp.com>
+---
+ hypervisor/include/jailhouse/header.h | 2 +-
+ hypervisor/include/jailhouse/types.h  | 2 ++
+ include/jailhouse/cell-config.h       | 4 ++--
+ include/jailhouse/hypercall.h         | 2 +-
+ inmates/lib/include/inmate_common.h   | 2 ++
+ 5 files changed, 8 insertions(+), 4 deletions(-)
+
+diff --git a/hypervisor/include/jailhouse/header.h b/hypervisor/include/jailhouse/header.h
+index 518bc5cb..324eb94b 100644
+--- a/hypervisor/include/jailhouse/header.h
++++ b/hypervisor/include/jailhouse/header.h
+@@ -55,7 +55,7 @@ struct jailhouse_header {
+ 	/** Signature "JAILHOUS" used for basic validity check of the
+ 	 * hypervisor image.
+ 	 * @note Filled at build time. */
+-	char signature[8];
++	char signature[8] __attribute__ ((nonstring));
+ 	/** Size of hypervisor core.
+ 	 * It starts with the hypervisor's header and ends after its bss
+ 	 * section. Rounded up to page boundary.
+diff --git a/hypervisor/include/jailhouse/types.h b/hypervisor/include/jailhouse/types.h
+index 6d78ad6d..f79d7428 100644
+--- a/hypervisor/include/jailhouse/types.h
++++ b/hypervisor/include/jailhouse/types.h
+@@ -19,7 +19,9 @@
+ 
+ #ifndef __ASSEMBLY__
+ 
++#if __GNUC__ < 15
+ typedef enum { true = 1, false = 0 } bool;
++#endif
+ 
+ /** Describes a CPU set. */
+ struct cpu_set {
+diff --git a/include/jailhouse/cell-config.h b/include/jailhouse/cell-config.h
+index 17d59306..affce1c2 100644
+--- a/include/jailhouse/cell-config.h
++++ b/include/jailhouse/cell-config.h
+@@ -91,7 +91,7 @@
+  * structure.
+  */
+ struct jailhouse_cell_desc {
+-	char signature[5];
++	char signature[5] __attribute__ ((nonstring));
+ 	__u8 architecture;
+ 	__u16 revision;
+ 
+@@ -330,7 +330,7 @@ struct jailhouse_pio {
+  * General descriptor of the system.
+  */
+ struct jailhouse_system {
+-	char signature[5];
++	char signature[5] __attribute__ ((nonstring));
+ 	__u8 architecture;
+ 	__u16 revision;
+ 
+diff --git a/include/jailhouse/hypercall.h b/include/jailhouse/hypercall.h
+index 07574d3d..cf58a4c9 100644
+--- a/include/jailhouse/hypercall.h
++++ b/include/jailhouse/hypercall.h
+@@ -107,7 +107,7 @@
+ 
+ #define COMM_REGION_GENERIC_HEADER					\
+ 	/** Communication region magic JHCOMM */			\
+-	char signature[6];						\
++	char signature[6] __attribute__ ((nonstring));						\
+ 	/** Communication region ABI revision */			\
+ 	__u16 revision;							\
+ 	/** Cell state, initialized by hypervisor, updated by cell. */	\
+diff --git a/inmates/lib/include/inmate_common.h b/inmates/lib/include/inmate_common.h
+index 1c20a0af..43cd7a20 100644
+--- a/inmates/lib/include/inmate_common.h
++++ b/inmates/lib/include/inmate_common.h
+@@ -84,7 +84,9 @@ typedef u32 __u32;
+ typedef s64 __s64;
+ typedef u64 __u64;
+ 
++#if __GNUC__ < 15
+ typedef enum { true = 1, false = 0 } bool;
++#endif
+ 
+ #include <jailhouse/hypercall.h>
+ 
+-- 
+2.34.1
+

--- a/recipes-extended/jailhouse/files/0002-YOCIMX-9281-2-hypervisor-arm64-fix-strh-usage.patch
+++ b/recipes-extended/jailhouse/files/0002-YOCIMX-9281-2-hypervisor-arm64-fix-strh-usage.patch
@@ -1,0 +1,34 @@
+From 98f6f8dc23d6b3d4fe5b15045ccb3d3ef36747be Mon Sep 17 00:00:00 2001
+From: Peng Fan <peng.fan@nxp.com>
+Date: Mon, 25 Aug 2025 09:48:05 +0800
+Subject: [PATCH 2/2] YOCIMX-9281-2: hypervisor: arm64: fix strh usage
+
+hypervisor/arch/arm64/entry.S:555: Error: immediate offset out of range
+
+Per ARM spec:
+STRH (immediate)
+<pimm> Is the optional positive immediate byte offset, a multiple of 2 in
+the range 0 to 8190, defaulting to 0 and encoded in the "imm12" field
+as <pimm>/2.
+
+So align sdei_event to 2 bytes aligned.
+
+Upstream-Status: Pending
+Signed-off-by: Peng Fan <peng.fan@nxp.com>
+---
+ hypervisor/arch/arm64/include/asm/percpu_fields.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/hypervisor/arch/arm64/include/asm/percpu_fields.h b/hypervisor/arch/arm64/include/asm/percpu_fields.h
+index 32f42a53..844a9417 100644
+--- a/hypervisor/arch/arm64/include/asm/percpu_fields.h
++++ b/hypervisor/arch/arm64/include/asm/percpu_fields.h
+@@ -18,4 +18,4 @@
+ 	bool suspended;							\
+ 	bool suspending;						\
+ 	bool resuming;							\
+-	bool sdei_event;
++	bool sdei_event __attribute__((aligned(2)));
+-- 
+2.34.1
+

--- a/recipes-extended/jailhouse/jailhouse-imx_git.bb
+++ b/recipes-extended/jailhouse/jailhouse-imx_git.bb
@@ -16,8 +16,10 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=9fa7f895f96bde2d47fd5b7d95b6ba4d \
 PROVIDES = "jailhouse"
 RPROVIDES:${PN} += "jailhouse"
 
-SRCBRANCH = "lf-6.6.52_2.2.0"
-SRCREV = "44dd492a745cd8b8313fb6c7c03fb45a36d70e8a"
+SRCBRANCH = "lf-6.12.3_1.0.0"
+SRCREV = "a68ba027402013ae444544d33ae676ddce9a6bbf"
+
+PV = "2023.03+git${SRCPV}"
 
 IMX_JAILHOUSE_SRC ?= "git://github.com/nxp-imx/imx-jailhouse.git;protocol=https"
 SRC_URI = "${IMX_JAILHOUSE_SRC};branch=${SRCBRANCH} \

--- a/recipes-extended/jailhouse/jailhouse-imx_git.bb
+++ b/recipes-extended/jailhouse/jailhouse-imx_git.bb
@@ -24,6 +24,8 @@ PV = "2023.03+git${SRCPV}"
 IMX_JAILHOUSE_SRC ?= "git://github.com/nxp-imx/imx-jailhouse.git;protocol=https"
 SRC_URI = "${IMX_JAILHOUSE_SRC};branch=${SRCBRANCH} \
            file://arm-arm64-Makefile-Remove-march-option-from-Makefile.patch \
+           file://0001-YOCIMX-9281-1-Fix-gcc15-errors.patch \
+           file://0002-YOCIMX-9281-2-hypervisor-arm64-fix-strh-usage.patch \
           "
 
 DEPENDS = " \
@@ -109,6 +111,12 @@ RDEPENDS:pyjailhouse = " \
     python3-shell \
 "
 
-INSANE_SKIP:${PN} = "ldflags"
+INSANE_SKIP:${PN} = "ldflags buildpaths"
+INSANE_SKIP:${PN}-dbg = "buildpaths"
+
+# The QA error in package kernel-module-${KERNEL_VERSION} cannot be skipped with
+# INSANE_SKIP, so adjust at the ERROR_QA level
+ERROR_QA:remove = "buildpaths"
+INSANE_SKIP:kernel-module-${KERNEL_VERSION} = "buildpaths"
 
 COMPATIBLE_MACHINE = "(mx8m-nxp-bsp|mx8ulp-nxp-bsp|mx9-nxp-bsp)"


### PR DESCRIPTION
This commit add the following source revisions:

    a68ba027 LF-14423 driver/pci: unbind device before remove overlay
    a41801ca only allow root cell to use Trusted SMC
    e4a40952 only allow root cell to use SIP
    ba9cf440 driver/pci: explicitly invoke pci_host_common_remove