### PR TITLE
Wayland protocol and Weston: Updated to 1.37 and 14.0.1

### DIFF
--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -584,13 +584,13 @@ PREFERRED_PROVIDER_virtual/libg2d              ?= "imx-gpu-g2d"
 PREFERRED_PROVIDER_virtual/libg2d:imxdpu       ?= "imx-dpu-g2d"
 PREFERRED_PROVIDER_virtual/libg2d:mx93-nxp-bsp ?= "imx-pxp-g2d"
 
-PREFERRED_VERSION_weston:imx-nxp-bsp      ??= "12.0.4.imx"
+PREFERRED_VERSION_weston:imx-nxp-bsp      ??= "14.0.1.imx"
 # i.MX 6 & 7 stay on weston 10.0 for fbdev
 PREFERRED_VERSION_weston:mx6-nxp-bsp      ??= "10.0.5.imx"
 PREFERRED_VERSION_weston:mx7-nxp-bsp      ??= "10.0.5.imx"
 PREFERRED_VERSION_weston:imx-mainline-bsp   = ""
 
-PREFERRED_VERSION_wayland-protocols:imx-nxp-bsp  ??= "1.32.imx"
+PREFERRED_VERSION_wayland-protocols:imx-nxp-bsp  ??= "1.37.imx"
 
 PREFERRED_VERSION_xwayland:imx-nxp-bsp ??= "23.2.5.imx"
 

--- a/recipes-graphics/wayland/wayland-protocols_1.37.imx.bb
+++ b/recipes-graphics/wayland/wayland-protocols_1.37.imx.bb
@@ -12,7 +12,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=c7b12b6702da38ca028ace54aae3d484 \
 SRC_URI = "${WAYLAND_PROTOCOLS_SRC};branch=${SRCBRANCH}"
 WAYLAND_PROTOCOLS_SRC ?= "git://github.com/nxp-imx/wayland-protocols-imx.git;protocol=https"
 SRCBRANCH = "wayland-protocols-imx-${@oe.utils.trim_version("${PV}", 2)}"
-SRCREV = "7ece577d467f8afb2f5a2f7fff3761a1e0ee9dad"
+SRCREV = "831a5389062e56dcb1aac4a5419e55e3002aafaf"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Hi all,

Updated wayland protocol and weston to 1.37 and 14.01 based on LF6.12.3_1.1.0.  Tested with weston-* clients, works fine. The related libraries like xwayland and graphics libraries can be taken up in due course.

Regards,
Sathishkumar D