### PR TITLE
imx95-19x19-verdin: follow update to nxp bsp 6.12.3_1.0.0

### DIFF
--- a/conf/machine/imx95-19x19-verdin.conf
+++ b/conf/machine/imx95-19x19-verdin.conf
@@ -58,11 +58,12 @@ IMXBOOT_TARGETS_BASENAME = "flash"
 OEI_BOARD  = "mx95lp5"
 DDR_TYPE   = "lpddr5"
 
+LPDDR_FW_VERSION = "_v202409"
 DDR_FIRMWARE_NAME = " \
-    lpddr5_dmem_v202311.bin \
-    lpddr5_dmem_qb_v202311.bin \
-    lpddr5_imem_v202311.bin \
-    lpddr5_imem_qb_v202311.bin \
+    lpddr5_dmem${LPDDR_FW_VERSION}.bin \
+    lpddr5_dmem_qb${LPDDR_FW_VERSION}.bin \
+    lpddr5_imem${LPDDR_FW_VERSION}.bin \
+    lpddr5_imem_qb${LPDDR_FW_VERSION}.bin \
 "
 
 IMXBOOT_VARIANT = ""


### PR DESCRIPTION
Fixes building the machine as the deployed DDR FW files now are not the ones expected by imx-mkimage.