### PR TITLE
imx-test: Update SRCBRANCH lf-6.6.3_1.0.0 -> lf-6.12.3_1.0.0

### DIFF
--- a/recipes-bsp/imx-test/imx-test_git.bb
+++ b/recipes-bsp/imx-test/imx-test_git.bb
@@ -20,8 +20,8 @@ PV = "7.0+${SRCPV}"
 
 SRC_URI = "git://github.com/nxp-imx/imx-test.git;protocol=https;branch=${SRCBRANCH} \
            file://memtool_profile"
-SRCBRANCH = "lf-6.6.3_1.0.0"
-SRCREV = "8a1fa37664a1e470cf86f1185c08e265e4602a9b"
+SRCBRANCH = "lf-6.12.3_1.0.0"
+SRCREV = "92a497313016bfa536d561e13fcbad2d273ded4c"
 
 S = "${WORKDIR}/git"
 
@@ -40,6 +40,7 @@ PLATFORM:mx7d-nxp-bsp  = "IMX7D"
 PLATFORM:mx7ulp-nxp-bsp = "IMX7D"
 PLATFORM:mx8-nxp-bsp = "IMX8"
 PLATFORM:mx8ulp-nxp-bsp = "IMX8ULP"
+PLATFORM:mx91-nxp-bsp = "IMX8"
 PLATFORM:mx93-nxp-bsp = "IMX8ULP"
 PLATFORM:mx95-nxp-bsp = "IMX8"
 


### PR DESCRIPTION
This commit update source branch and add the following source revisions:

    92a4973 MLK-26263 mxc_v4l2_capture: add verbose mode to output realtime status
    4838c5a LF-14230: mxc_asrc_test: switch to upstreamed API
    5eedc57 LF-14501: vpu: solve dqbuf return error
    81bf1cc LF-14501: vpu : solve camera node enum fail
    3ee0114 MLK-26240-10: mxc_v4l2_vpu_test: support to set colorimetry for encoder
    3034abb MLK-26240-9: mxc_v4l2_vpu_test: drop incomplete avcc nalu
    30f2b13 MLK-26240-8: mxc_v4l2_vpu_test: remove the buffer count check in waylandsink
    be8275f MLK-26240-7: mxc_v4l2_vpu_test: support to handle YUV4MPEG2
    92ca890 MLK-26240-6: mxc_v4l2_vpu_test: parser support to init format from the postfix
    8c9a466 MLK-26240-5: mxc_v4l2_vpu_test: ofile support to append format postfix
    05b0181 MLK-26240-4: mxc_v4l2_vpu_test: init all nodes context firstly
    ab0ef14 MLK-26240-3: mxc_v4l2_vpu_test: filter support to append some extra data at the end
    3d97b28 MLK-26240-2: mxc_v4l2_vpu_test: support to push codec header in a separate buffer
    f3adaeb MLK-26240-1: mxc_v4l2_vpu_test: avoid overwrite the input buffer in media parse
    26925d3 mxc_pdm_test: Fix compile error for imcompatible pointer type [YOCIMX-8276]
    6944645 LF-11976: mxc_v4l2_vpu_test: fix NULL pointer error if v4l2 driver only support single plane
    b1b4f9e LF-11976: mxc_v4l2_vpu_test: don't return error for set fps fail.
    9247368 LF-11976: mxc_v4l2_vpu_test: zeroize fmtdesc
    4d08cb3 LF-11976: vpu: add statistic info in vpu v4l2 unit test
    7695a1c LF-11459: vpu: integrate network node into filter node
    8e7c7ca LF-11608-3: mxc_v4l2_vpu_test: add corrupt filter
    99c546c LF-11608-2: mxc_v4l2_vpu_test: support fps test
    fc0b0b3 LF-11608-1: mxc_v4l2_vpu_test: encoder support dmabuf input
    7c2a567 LF-11459: vpu: new node to simulate package drop in v4l2 unit test
    4d095a0 MLK-26178: mxc_v4l2_vpu_test: set default crop for ofile output
    27323f7 LF-11496: mxc_jpeg_test: Initialize format before S_FMT