### PR TITLE
imx-gpu-viv: 6.4.11.p2.10 -> 6.4.11.p3-0

### DIFF
--- a/recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc
+++ b/recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc
@@ -254,7 +254,7 @@ do_install () {
     else
         # Install Vendor ICDs for OpenCL's installable client driver loader (ICDs Loader)
         install -d ${D}${sysconfdir}/OpenCL/vendors/
-        install -m 0644 ${S}/gpu-core/etc/Vivante.icd ${D}${sysconfdir}/OpenCL/vendors/Vivante.icd
+        install -m 0644 ${S}/gpu-core/etc/OpenCL/vendors/Vivante.icd ${D}${sysconfdir}/OpenCL/vendors/Vivante.icd
 
         if [ "${OPENCL_VX_INTRINSIC_EXTENSION_PACKAGES}" = "" ]; then
             rm -f ${D}${includedir}/CL/cl_viv_vx_ext.h

--- a/recipes-graphics/imx-gpu-viv/imx-gpu-viv_6.4.11.p2.10-aarch32.bb
+++ b/recipes-graphics/imx-gpu-viv/imx-gpu-viv_6.4.11.p2.10-aarch32.bb
@@ -1,9 +1,0 @@
-require imx-gpu-viv-6.inc
-
-LIC_FILES_CHKSUM = "file://COPYING;md5=ca53281cc0caa7e320d4945a896fb837" 
-
-IMX_SRCREV_ABBREV = "accdd64"
-
-SRC_URI[sha256sum] = "2242c7cbf1a2b07d40eefe5d1507747e477c54912f179ee0585a5d7965074ce0"
-
-COMPATIBLE_MACHINE = "(mx6q-nxp-bsp|mx6dl-nxp-bsp|mx6sx-nxp-bsp|mx6sl-nxp-bsp|mx7ulp-nxp-bsp)"

--- a/recipes-graphics/imx-gpu-viv/imx-gpu-viv_6.4.11.p2.10-aarch64.bb
+++ b/recipes-graphics/imx-gpu-viv/imx-gpu-viv_6.4.11.p2.10-aarch64.bb
@@ -1,9 +1,0 @@
-require imx-gpu-viv-6.inc
-
-LIC_FILES_CHKSUM = "file://COPYING;md5=ca53281cc0caa7e320d4945a896fb837" 
-
-IMX_SRCREV_ABBREV = "accdd64"
-
-SRC_URI[sha256sum] = "8108fd146de6986486f34860227511a5101b31072b99cd78ae38afba8939fd4e"
-
-COMPATIBLE_MACHINE = "(mx8-nxp-bsp)"

--- a/recipes-graphics/imx-gpu-viv/imx-gpu-viv_6.4.11.p3.0-aarch32.bb
+++ b/recipes-graphics/imx-gpu-viv/imx-gpu-viv_6.4.11.p3.0-aarch32.bb
@@ -1,0 +1,9 @@
+require imx-gpu-viv-6.inc
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=c0fb372b5d7f12181de23ef480f225f3"
+
+IMX_SRCREV_ABBREV = "c600d03"
+
+SRC_URI[sha256sum] = "fe8fc231f18047b9547a038e111c08e855760190d0e9848ead22b383d793499d"
+
+COMPATIBLE_MACHINE = "(mx6q-nxp-bsp|mx6dl-nxp-bsp|mx6sx-nxp-bsp|mx6sl-nxp-bsp|mx7ulp-nxp-bsp)"

--- a/recipes-graphics/imx-gpu-viv/imx-gpu-viv_6.4.11.p3.0-aarch64.bb
+++ b/recipes-graphics/imx-gpu-viv/imx-gpu-viv_6.4.11.p3.0-aarch64.bb
@@ -1,0 +1,9 @@
+require imx-gpu-viv-6.inc
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=c0fb372b5d7f12181de23ef480f225f3" 
+
+IMX_SRCREV_ABBREV = "c600d03"
+
+SRC_URI[sha256sum] = "82e1bb6304d2aac70c72b691239d1bb5f6738cadfa812d07196db2f580c63d29"
+
+COMPATIBLE_MACHINE = "(mx8-nxp-bsp)"


### PR DESCRIPTION
This commit update the recipes imx-gpu-viv for aarch32 and aarch64.