### PR TITLE
imx-sc-firmware: Always use BFD linker

### DIFF
--- a/recipes-bsp/imx-sc-firmware/imx-sc-firmware_1.18.0.bb
+++ b/recipes-bsp/imx-sc-firmware/imx-sc-firmware_1.18.0.bb
@@ -25,6 +25,9 @@ symlink_name = "scfw_tcm.bin"
 
 BOOT_TOOLS = "imx-boot-tools"
 
+LDFLAGS:remove = "-fuse-ld=lld"
+LDFLAGS:append = " -fuse-ld=bfd"
+
 do_compile[noexec] = "1"
 
 do_install[noexec] = "1"


### PR DESCRIPTION
Some distros e.g. yoe uses LLD linker as default, it does not work with prebuilt baremetal toolchain used for imx-sc-firmware