### PR TITLE
mesa-demos: Add new patch for mesa-demos application

### DIFF
--- a/recipes-graphics/mesa/mesa-demos/0001-YOCIMX-8300-Fix-mesa-demos-build-break-on-GCC-14.patch
+++ b/recipes-graphics/mesa/mesa-demos/0001-YOCIMX-8300-Fix-mesa-demos-build-break-on-GCC-14.patch
@@ -1,0 +1,59 @@
+From 400c42cda81a859bd5950567eaffe394053ccc99 Mon Sep 17 00:00:00 2001
+From: Wujian Sun <wujian.sun_1@nxp.com>
+Date: Thu, 5 Dec 2024 10:32:05 +0800
+Subject: [PATCH] YOCIMX-8300 Fix mesa-demos build break on GCC 14
+
+| ../mesa-demos-8.5.0/src/egl/opengl/eglkms.c: In function 'main':
+| ../mesa-demos-8.5.0/src/egl/opengl/eglkms.c:190:24: error: passing
+argument 1 of 'eglGetDisplay' from incompatible pointer type
+[-Wincompatible-pointer-types]
+|   190 |    dpy = eglGetDisplay(gbm);
+|       |                        ^~~
+|       |                        |
+|       |                        struct gbm_device *
+| In file included from ../mesa-demos-8.5.0/src/egl/opengl/eglkms.c:33:
+
+Type' {aka 'struct wl_display *'} but argument is of type 'struct
+gbm_device *'
+|   143 | EGLAPI EGLDisplay EGLAPIENTRY eglGetDisplay
+(EGLNativeDisplayType display_id);
+|       |
+~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~
+| ../mesa-demos-8.5.0/src/egl/opengl/eglkms.c:229:50: error: passing
+argument 3 of 'eglCreateWindowSurface' from incompatible pointer type
+[-Wincompatible-pointer-types]
+|   229 |    surface = eglCreateWindowSurface(dpy, config, gs, NULL);
+|       |                                                  ^~
+|       |                                                  |
+|       |                                                  struct
+gbm_surface *
+
+Upstream-Status: Submitted [https://gitlab.freedesktop.org/mesa/demos/-/merge_requests/205]
+
+Signed-off-by: Wujian Sun <wujian.sun_1@nxp.com>
+---
+ src/egl/opengl/eglkms.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/egl/opengl/eglkms.c b/src/egl/opengl/eglkms.c
+index 832962b..57adc7b 100644
+--- a/src/egl/opengl/eglkms.c
++++ b/src/egl/opengl/eglkms.c
+@@ -187,7 +187,7 @@ int main(int argc, char *argv[])
+       goto close_fd;
+    }
+ 
+-   dpy = eglGetDisplay(gbm);
++   dpy = eglGetDisplay((EGLNativeDisplayType) gbm);
+    if (dpy == EGL_NO_DISPLAY) {
+       fprintf(stderr, "eglGetDisplay() failed\n");
+       ret = -1;
+@@ -226,7 +226,7 @@ int main(int argc, char *argv[])
+    gs = gbm_surface_create(gbm, kms.mode.hdisplay, kms.mode.vdisplay,
+ 			   GBM_BO_FORMAT_XRGB8888,
+ 			   GBM_BO_USE_SCANOUT | GBM_BO_USE_RENDERING);
+-   surface = eglCreateWindowSurface(dpy, config, gs, NULL);
++   surface = eglCreateWindowSurface(dpy, config, (EGLNativeWindowType) gs, NULL);
+ 
+    if (!eglMakeCurrent(dpy, surface, surface, ctx)) {
+       fprintf(stderr, "failed to make context current\n");

--- a/recipes-graphics/mesa/mesa-demos/0001-egl-clear-backgrounds-black.patch
+++ b/recipes-graphics/mesa/mesa-demos/0001-egl-clear-backgrounds-black.patch
@@ -1,4 +1,4 @@
-From cad7eb0f0487aea64c4460bd6ad95b5c9537d35a Mon Sep 17 00:00:00 2001
+From f5a6600ff8312a7c0f30273ab783c1d822749a73 Mon Sep 17 00:00:00 2001
 From: Jiyu Yang <jiyu.yang@nxp.com>
 Date: Thu, 11 Apr 2024 16:30:50 +0800
 Subject: [PATCH] egl: clear backgrounds black
@@ -13,18 +13,15 @@ Signed-off-by: Jiyu Yang <jiyu.yang@nxp.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/egl/opengles2/es2gears.c b/src/egl/opengles2/es2gears.c
-index db67f3a9..4e81afe7 100644
+index 9501f61..e421a8a 100644
 --- a/src/egl/opengles2/es2gears.c
 +++ b/src/egl/opengles2/es2gears.c
-@@ -515,7 +515,7 @@ gears_draw(void)
+@@ -350,7 +350,7 @@ gears_draw(void)
     GLfloat transform[16];
-    identity(transform);
+    mat4_identity(transform);
  
 -   glClearColor(0.0, 0.0, 0.0, 0.0);
 +   glClearColor(0.0, 0.0, 0.0, 1.0);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
  
     /* Translate and rotate the view */
--- 
-2.34.1
-

--- a/recipes-graphics/mesa/mesa-demos/Replace-glWindowPos2iARB-calls-with-glWindowPos2i.patch
+++ b/recipes-graphics/mesa/mesa-demos/Replace-glWindowPos2iARB-calls-with-glWindowPos2i.patch
@@ -1,4 +1,4 @@
-From 757649a766f90e745f24df1d191caeef15c71399 Mon Sep 17 00:00:00 2001
+From e453ac82b6ffd8f1d0de4c8ac8fd4bab6b924958 Mon Sep 17 00:00:00 2001
 From: Otavio Salvador <otavio@ossystems.com.br>
 Date: Tue, 4 Jun 2013 09:28:51 -0300
 Subject: [PATCH] Replace glWindowPos2iARB calls with glWindowPos2i
@@ -34,7 +34,7 @@ Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>
  20 files changed, 28 insertions(+), 28 deletions(-)
 
 diff --git a/src/demos/copypix.c b/src/demos/copypix.c
-index 286c5a9..041b567 100644
+index 164d8c0..2d062a7 100644
 --- a/src/demos/copypix.c
 +++ b/src/demos/copypix.c
 @@ -54,7 +54,7 @@ static void Display( void )
@@ -56,7 +56,7 @@ index 286c5a9..041b567 100644
     glPixelZoom(1, 1);
  
 diff --git a/src/demos/engine.c b/src/demos/engine.c
-index 928fcbb..beace4c 100644
+index 410d889..b24638a 100644
 --- a/src/demos/engine.c
 +++ b/src/demos/engine.c
 @@ -971,7 +971,7 @@ Draw(void)
@@ -69,7 +69,7 @@ index 928fcbb..beace4c 100644
        if (lit)
  	 glEnable(GL_LIGHTING);
 diff --git a/src/demos/fogcoord.c b/src/demos/fogcoord.c
-index 567eec0..e833009 100644
+index ea9a3ae..ed0483f 100644
 --- a/src/demos/fogcoord.c
 +++ b/src/demos/fogcoord.c
 @@ -68,14 +68,14 @@ PrintInfo(void)
@@ -90,7 +90,7 @@ index 567eec0..e833009 100644
  }
  
 diff --git a/src/glsl/shadow_sampler.c b/src/glsl/shadow_sampler.c
-index b830030..eb82d8b 100644
+index 5f0f192..16a2201 100644
 --- a/src/glsl/shadow_sampler.c
 +++ b/src/glsl/shadow_sampler.c
 @@ -85,7 +85,7 @@ Redisplay(void)
@@ -103,7 +103,7 @@ index b830030..eb82d8b 100644
  
     {
 diff --git a/src/tests/auxbuffer.c b/src/tests/auxbuffer.c
-index 5fa399a..0cd5f47 100644
+index d4f7c2d..5ff1785 100644
 --- a/src/tests/auxbuffer.c
 +++ b/src/tests/auxbuffer.c
 @@ -419,7 +419,7 @@ event_loop(Display *dpy, Window win)
@@ -116,7 +116,7 @@ index 5fa399a..0cd5f47 100644
        glCopyPixels(0, 0, WinWidth, WinHeight, GL_COLOR);
        glEnable(GL_DEPTH_TEST);
 diff --git a/src/tests/copypixrate.c b/src/tests/copypixrate.c
-index 2f64e0a..df1f9b0 100644
+index 4c12fbd..e80f3cb 100644
 --- a/src/tests/copypixrate.c
 +++ b/src/tests/copypixrate.c
 @@ -91,7 +91,7 @@ BlitOne(void)
@@ -129,7 +129,7 @@ index 2f64e0a..df1f9b0 100644
     }
  }
 diff --git a/src/tests/drawbuffers.c b/src/tests/drawbuffers.c
-index fa2f8a7..cd5033f 100644
+index f017d25..36b241f 100644
 --- a/src/tests/drawbuffers.c
 +++ b/src/tests/drawbuffers.c
 @@ -88,7 +88,7 @@ Display(void)
@@ -142,7 +142,7 @@ index fa2f8a7..cd5033f 100644
  
     free(buffer);
 diff --git a/src/tests/drawbuffers2.c b/src/tests/drawbuffers2.c
-index 5bcf0b2..84d444b 100644
+index 0cb8d47..ac1a5aa 100644
 --- a/src/tests/drawbuffers2.c
 +++ b/src/tests/drawbuffers2.c
 @@ -112,7 +112,7 @@ Display(void)
@@ -155,7 +155,7 @@ index 5bcf0b2..84d444b 100644
  
     free(buffer);
 diff --git a/src/tests/fbotest1.c b/src/tests/fbotest1.c
-index 161903c..5930a6d 100644
+index 322ea30..19082b6 100644
 --- a/src/tests/fbotest1.c
 +++ b/src/tests/fbotest1.c
 @@ -61,7 +61,7 @@ Display( void )
@@ -168,7 +168,7 @@ index 161903c..5930a6d 100644
  
     free(buffer);
 diff --git a/src/tests/fbotest2.c b/src/tests/fbotest2.c
-index 6ef7f12..11c867e 100644
+index 05554e4..e6a6c29 100644
 --- a/src/tests/fbotest2.c
 +++ b/src/tests/fbotest2.c
 @@ -72,7 +72,7 @@ Display( void )
@@ -190,7 +190,7 @@ index 6ef7f12..11c867e 100644
  
        free(buffer);
 diff --git a/src/tests/fbotest3.c b/src/tests/fbotest3.c
-index 19f684d..e6d7710 100644
+index a3ac340..c320794 100644
 --- a/src/tests/fbotest3.c
 +++ b/src/tests/fbotest3.c
 @@ -79,7 +79,7 @@ Display( void )
@@ -203,7 +203,7 @@ index 19f684d..e6d7710 100644
  
     free(buffer);
 diff --git a/src/tests/readrate.c b/src/tests/readrate.c
-index 3859cf4..81eb8a3 100644
+index 8a9a02f..9709835 100644
 --- a/src/tests/readrate.c
 +++ b/src/tests/readrate.c
 @@ -85,7 +85,7 @@ MeasureFormat(struct format_type *fmt, GLint width, GLint height, GLuint pbo)
@@ -242,7 +242,7 @@ index 3859cf4..81eb8a3 100644
     }
  
 diff --git a/src/tests/viewmemory.c b/src/tests/viewmemory.c
-index 16044b9..3584c33 100644
+index 16054b6..ff7b4eb 100644
 --- a/src/tests/viewmemory.c
 +++ b/src/tests/viewmemory.c
 @@ -95,7 +95,7 @@ Draw(void)
@@ -255,7 +255,7 @@ index 16044b9..3584c33 100644
  
     glutSwapBuffers();
 diff --git a/src/trivial/clear-fbo-scissor.c b/src/trivial/clear-fbo-scissor.c
-index a30935c..5c15200 100644
+index 2d1ee4f..6d06330 100644
 --- a/src/trivial/clear-fbo-scissor.c
 +++ b/src/trivial/clear-fbo-scissor.c
 @@ -182,7 +182,7 @@ Draw(void)
@@ -268,7 +268,7 @@ index a30935c..5c15200 100644
  
        free(buffer);
 diff --git a/src/trivial/clear-fbo-tex.c b/src/trivial/clear-fbo-tex.c
-index de84f98..f0fbdf6 100644
+index 94534bd..6a38c4b 100644
 --- a/src/trivial/clear-fbo-tex.c
 +++ b/src/trivial/clear-fbo-tex.c
 @@ -140,7 +140,7 @@ static void Draw( void )
@@ -281,7 +281,7 @@ index de84f98..f0fbdf6 100644
        
        free(buffer);
 diff --git a/src/trivial/clear-fbo.c b/src/trivial/clear-fbo.c
-index 10d830b..3fee3e3 100644
+index 2065836..ad39401 100644
 --- a/src/trivial/clear-fbo.c
 +++ b/src/trivial/clear-fbo.c
 @@ -116,7 +116,7 @@ Draw(void)
@@ -294,7 +294,7 @@ index 10d830b..3fee3e3 100644
        
        free(buffer);
 diff --git a/src/trivial/readpixels.c b/src/trivial/readpixels.c
-index ccce4ed..74e0546 100644
+index fb88570..da9030e 100644
 --- a/src/trivial/readpixels.c
 +++ b/src/trivial/readpixels.c
 @@ -71,7 +71,7 @@ static void Draw(void)
@@ -307,7 +307,7 @@ index ccce4ed..74e0546 100644
     glDrawPixels(Width, Height, GL_RGBA, GL_FLOAT, image);
     free(image);
 diff --git a/src/trivial/tri-fbo.c b/src/trivial/tri-fbo.c
-index d5800b2..dd1f21a 100644
+index 76985a9..21c0ec0 100644
 --- a/src/trivial/tri-fbo.c
 +++ b/src/trivial/tri-fbo.c
 @@ -119,7 +119,7 @@ static void Draw( void )
@@ -320,7 +320,7 @@ index d5800b2..dd1f21a 100644
        
        
 diff --git a/src/xdemos/glxsnoop.c b/src/xdemos/glxsnoop.c
-index 2215cfd..13d2b2d 100644
+index 294297a..abb32a8 100644
 --- a/src/xdemos/glxsnoop.c
 +++ b/src/xdemos/glxsnoop.c
 @@ -91,7 +91,7 @@ redraw(Display *dpy, Window srcWin, Window dstWin )
@@ -350,6 +350,3 @@ index f670983..d010085 100644
        glCopyPixels(0, 0, Width[0], Height[0], GL_COLOR);
     }
  
--- 
-1.8.1
-

--- a/recipes-graphics/mesa/mesa-demos/fix-clear-build-break.patch
+++ b/recipes-graphics/mesa/mesa-demos/fix-clear-build-break.patch
@@ -1,10 +1,18 @@
-mesa-demos:  Add extension header to fix build break now that gl1 is removed
+From d152655a1421f0cdf7ce22c35a36c367c07af587 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Tue, 26 Aug 2014 14:44:17 -0500
+Subject: [PATCH] mesa-demos:  Add extension header to fix build break now that
+ gl1 is removed
 
 Upstream-Status: Pending
 
 Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ src/egl/opengles1/clear.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
 diff --git a/src/egl/opengles1/clear.c b/src/egl/opengles1/clear.c
-index 9fe1b5291e1905fd6fe572063ed707d59ce45a81..ca9954a21b5f475709dbdef07f90b900962fcbc7 100644
+index 9fe1b52..ca9954a 100644
 --- a/src/egl/opengles1/clear.c
 +++ b/src/egl/opengles1/clear.c
 @@ -34,7 +34,7 @@

--- a/recipes-graphics/mesa/mesa-demos_%.bbappend
+++ b/recipes-graphics/mesa/mesa-demos_%.bbappend
@@ -3,7 +3,9 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 SRC_URI:append:imxgpu = " \
     file://Replace-glWindowPos2iARB-calls-with-glWindowPos2i.patch \
     file://fix-clear-build-break.patch \
-    file://0001-egl-clear-backgrounds-black.patch"
+    file://0001-egl-clear-backgrounds-black.patch \
+    file://0001-YOCIMX-8300-Fix-mesa-demos-build-break-on-GCC-14.patch \
+"
 
 REQUIRED_DISTRO_FEATURES:remove:imxgpu = "x11"
 


### PR DESCRIPTION
This commit fix the old patchs and add the following new patch:
    0001-YOCIMX-8300-Fix-mesa-demos-build-break-on-GCC-14.patch