### PR TITLE
recipes-multimedia: libimxvpuapi: Use python-native instead the host one

### DIFF
--- a/recipes-multimedia/libimxvpuapi/libimxvpuapi2_2.3.1.bb
+++ b/recipes-multimedia/libimxvpuapi/libimxvpuapi2_2.3.1.bb
@@ -16,7 +16,7 @@ SRC_URI = "git://github.com/Freescale/libimxvpuapi.git;branch=${SRCBRANCH};proto
 
 S = "${WORKDIR}/git"
 
-inherit waf pkgconfig use-imx-headers
+inherit waf pkgconfig use-imx-headers python3native
 
 IMX_PLATFORM:mx6-nxp-bsp = "imx6"
 IMX_PLATFORM:mx8mq-nxp-bsp = "imx8m"

--- a/recipes-multimedia/libimxvpuapi/libimxvpuapi_git.bb
+++ b/recipes-multimedia/libimxvpuapi/libimxvpuapi_git.bb
@@ -14,7 +14,7 @@ SRC_URI = "git://github.com/Freescale/libimxvpuapi.git;branch=${SRCBRANCH};proto
 
 S = "${WORKDIR}/git"
 
-inherit waf pkgconfig
+inherit waf pkgconfig python3native
 
 COMPATIBLE_MACHINE = "(mx6q-nxp-bsp|mx6dl-nxp-bsp)"
 


### PR DESCRIPTION
The usage of the host native can break the build in depends of the container version you run and even let you depend on host tools. Make the dependency on yocto package