### PR TITLE
xwayland: add missing libtirpc dependency

### DIFF
--- a/recipes-graphics/xwayland/xwayland_24.1.6.imx.bb
+++ b/recipes-graphics/xwayland/xwayland_24.1.6.imx.bb
@@ -25,7 +25,7 @@ UPSTREAM_CHECK_REGEX = "xwayland-(?P<pver>\d+(\.(?!90\d)\d+)+)\.tar"
 inherit meson features_check pkgconfig
 REQUIRED_DISTRO_FEATURES = "x11 opengl"
 
-DEPENDS += "xorgproto xtrans pixman libxkbfile libxfont2 wayland wayland-native wayland-protocols libdrm libepoxy libxcvt"
+DEPENDS += "xorgproto xtrans pixman libxkbfile libxfont2 wayland wayland-native wayland-protocols libdrm libepoxy libxcvt libtirpc"
 
 OPENGL_PKGCONFIGS = "glx glamor dri3"
 PACKAGECONFIG ??= "${XORG_CRYPTO} ${XWAYLAND_EI} \


### PR DESCRIPTION
Current recipe is failing with the following error:

| ../xwayland-24.1.6/os/meson.build:66:8: ERROR: Problem encountered: secure-rpc requested, but neither libtirpc or libc RPC support were found

Fix it by adding libtirpc as dependency. This aligns with the xwayland recipe from oe-core layer [1].

[1] https://github.com/openembedded/openembedded-core/commit/6334fac0a0b0783298957e2ccbe3a27490f7da09

Fixes: 2a1583a69cf6 ("xwayland: 23.2.5.imx -> 24.1.6-imx")