### PR TITLE
imx-boot-container: copy ${OPTEE_BOOT_IMAGE} to ${B}

### DIFF
--- a/classes/imx-boot-container.bbclass
+++ b/classes/imx-boot-container.bbclass
@@ -63,6 +63,9 @@ do_resolve_and_populate_binaries() {
                     else
                         bberror "ATF binary is undefined, result binary would be unusable!"
                     fi
+                    if [ "${@bb.utils.contains('MACHINE_FEATURES', 'optee', '1' , '0' , d)}" = "1" ] ; then
+                        cp ${DEPLOY_DIR_IMAGE}/${OPTEE_BOOT_IMAGE} ${B}/${config}/
+                    fi
                 fi
             done
             unset  j


### PR DESCRIPTION
After commit commit 015483904c52 ("arm: imx8m: add OP-TEE node") in upstream U-Boot, Binman complains if building imx8mp_evk with CONFIG_OPTEE=y because tee.bin is missing:

    Image 'image' is missing external blobs and is non-functional: tee-os

    /binman/section/nxp-imx8mcst@1/fit/images/tee/tee-os (tee.bin):
       See the documentation for your board. You may need to build Open Portable
       Trusted Execution Environment (OP-TEE) and build with TEE=/path/to/tee.bin

    Image 'image' has faked external blobs and is non-functional: tee.bin

    Some images are invalid
    make: *** [Makefile:1135: .binman_stamp] Error 103

This commit ensures that ${OPTEE_BOOT_IMAGE}, for example, tee.bin for imx8mp-evk, is copied to the build folder if the optee feature is enabled.