### PR TITLE
pipewire: Simplify gstreamer package config override

### DIFF
--- a/dynamic-layers/multimedia-layer/recipes-multimedia/pipewire/pipewire_%.bbappend
+++ b/dynamic-layers/multimedia-layer/recipes-multimedia/pipewire/pipewire_%.bbappend
@@ -6,10 +6,13 @@ SYSTEMD_AUTO_ENABLE:imx-nxp-bsp = "disable"
 
 DEPENDS:append:mx95-nxp-bsp = " libdrm"
 
-PACKAGECONFIG:remove:mx6-nxp-bsp = "gstreamer"
-PACKAGECONFIG:remove:mx7-nxp-bsp = "gstreamer"
-PACKAGECONFIG:remove:mx8-nxp-bsp = "gstreamer"
-PACKAGECONFIG:remove:mx93-nxp-bsp = "gstreamer"
+PACKAGECONFIG:remove = "${PACKAGECONFIG_REMOVE}"
+PACKAGECONFIG_REMOVE              ?= ""
+PACKAGECONFIG_REMOVE:mx6-nxp-bsp  ?= "gstreamer"
+PACKAGECONFIG_REMOVE:mx7-nxp-bsp  ?= "gstreamer"
+PACKAGECONFIG_REMOVE:mx8-nxp-bsp  ?= "gstreamer"
+PACKAGECONFIG_REMOVE:mx93-nxp-bsp ?= "gstreamer"
+
 PACKAGECONFIG:class-target:append:imx-nxp-bsp = " ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'bluez-lc3', '', d)}"
 
 # FIXME: Needs to qualify on PACKAGECONFIG


### PR DESCRIPTION
Allow the user to more easily override the removal of the gstreamer PACKAGECONFIG.