### PR TITLE
imx-boot: remove uboot-sign inheritance

### DIFF
--- a/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
+++ b/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
@@ -7,7 +7,7 @@ LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6"
 SECTION = "BSP"
 
-inherit use-imx-security-controller-firmware uboot-sign
+inherit use-imx-security-controller-firmware
 
 DEPENDS += " \
     u-boot \


### PR DESCRIPTION
Remove the uboot-sign inheritance from imx-boot recipe, otherwise the following issue occurs when "UBOOT_SIGN_ENABLE = 1" because the "uboot-sign.bbclass" is also deploying the same files; at least on imx93:

ERROR: imx-boot-1.0-r0 do_deploy: Recipe imx-boot is trying to install files into a shared area when those files already exist. The files and the manifests listing them are:
      build/tmp/deploy/images/edge-pro/u-boot.dtb
          (matched in manifest-edge_pro-u-boot-imx.deploy)
      build/tmp/deploy/images/edge-pro/u-boot-edge-pro.dtb
          (matched in manifest-edge_pro-u-boot-imx.deploy)
      build/tmp/deploy/images/edge-pro/u-boot-nodtb-edge-pro.bin
          (matched in manifest-edge_pro-u-boot-imx.deploy)
      build/tmp/deploy/images/edge-pro/u-boot-nodtb.bin
         (matched in manifest-edge_pro-u-boot-imx.deploy)
      Please adjust the recipes so only one recipe provides a given file.

This issue occurs because the imx-boot and u-boot recipes inherit from the uboot-sign bbclass, and in the Kirkstone branch, the deploy prepend callback was defined as "do_deploy:prepend:pn-${UBOOT_PN}", whereas in the Scarthgap branch, it was defined as "do_deploy:prepend", which prevented the issue.