### PR TITLE
imx-system-manager: fix EXTRA_OEMAKE verbose parameter

### DIFF
--- a/dynamic-layers/arm-toolchain/recipes-bsp/imx-system-manager/imx-system-manager.inc
+++ b/dynamic-layers/arm-toolchain/recipes-bsp/imx-system-manager/imx-system-manager.inc
@@ -18,7 +18,7 @@ SYSTEM_MANAGER_CONFIG ?= "INVALID"
 LDFLAGS[unexport] = "1"
 
 EXTRA_OEMAKE = " \
-    V=y \
+    V=1 \
     SM_CROSS_COMPILE=arm-none-eabi- \
     ${PACKAGECONFIG_CONFARGS} \
 "


### PR DESCRIPTION
Change V=y to V=1 for proper verbose output in iMX System Manager builds.