### PR TITLE
imx-uuc: Update upsteam URI to nxp-imx

### DIFF
--- a/recipes-bsp/imx-uuc/imx-uuc_git.bb
+++ b/recipes-bsp/imx-uuc/imx-uuc_git.bb
@@ -1,5 +1,5 @@
 # Copyright (C) 2016 Freescale Semiconductor
-# Copyright (C) 2017-2019,2024 NXP
+# Copyright (C) 2017-2019,2024-2025 NXP
 SUMMARY = "A Daemon wait for NXP mfgtools host's command"
 SECTION = "base"
 DEPENDS = "virtual/kernel dosfstools-native"
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 PR = "r1"
 PV = "0.5.1+git${SRCPV}"
 
-SRC_URI = "git://github.com/NXPmicro/imx-uuc.git;protocol=https;branch=master"
+SRC_URI = "git://github.com/nxp-imx/imx-uuc.git;protocol=https;branch=master"
 SRCREV = "25f65e10368aa07056f9536e88ed911ac7f38f99"
 
 do_install() {


### PR DESCRIPTION
As NXP moves imx-uuc.git to project github.com/nxp-imx, the original github.com/NXPmicro/imx-uuc.git will be redircting to this new location.