### PR TITLE
[Backport scarthgap] imx95-19x19-verdin: follow update to nxp bsp 6.12.3_1.0.0

### DIFF
--- a/conf/machine/imx95-19x19-verdin.conf
+++ b/conf/machine/imx95-19x19-verdin.conf
@@ -53,11 +53,12 @@ IMXBOOT_TARGETS = "flash_a55"
 OEI_BOARD  = "mx95lp5"
 DDR_TYPE   = "lpddr5"
 
+LPDDR_FW_VERSION = "_v202409"
 DDR_FIRMWARE_NAME = " \
-    lpddr5_dmem_v202311.bin \
-    lpddr5_dmem_qb_v202311.bin \
-    lpddr5_imem_v202311.bin \
-    lpddr5_imem_qb_v202311.bin \
+    lpddr5_dmem${LPDDR_FW_VERSION}.bin \
+    lpddr5_dmem_qb${LPDDR_FW_VERSION}.bin \
+    lpddr5_imem${LPDDR_FW_VERSION}.bin \
+    lpddr5_imem_qb${LPDDR_FW_VERSION}.bin \
 "
 
 IMXBOOT_VARIANT = ""


### PR DESCRIPTION
With commit 992ad9c5b4b9 ("imx-mkimage: Upgrade to NXP BSP 6.6.52_2.2.1") in scarthgap we now get build errors for the imx95-19x19-verdin machine.
The DDR FW files are not found.
Backport the fix already done for master and walnascar.