### PR TITLE
[SCARTHGAP] Update imx-oei to NXP BSP LF6.6.52-2.2.1, support B0 silicon

### DIFF
--- a/conf/machine/imx95-19x19-verdin.conf
+++ b/conf/machine/imx95-19x19-verdin.conf
@@ -9,6 +9,12 @@ MACHINEOVERRIDES =. "mx95:"
 require conf/machine/include/imx95-evk.inc
 IMX_DEFAULT_BSP = "nxp"
 
+# iMX95 Verdin EVK V1.1E is the first revision with a B0 SoC,
+# older versions require A0/A1 support, set with the below variable
+#IMX_SOC_REV:${MACHINE} = "A0"
+# When building for A0/A1 iMX95 SoCs, set OEI_DDRCONFIG accordingly
+OEI_DDRCONFIG = "${@'XIMX95LPD5EVK19_6400mbps_train_timing_a1' if d.getVar('IMX_SOC_REV')[0] == 'A' else ''}"
+
 KERNEL_DEVICETREE_BASENAME = "imx95-19x19-verdin"
 
 KERNEL_DEVICETREE:append:use-nxp-bsp = " \

--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -185,6 +185,7 @@ IMX_SOC_REV:mx8ulp-generic-bsp ??= \
     "${@bb.utils.contains('MACHINE_FEATURES', 'soc-reva0', 'A0', \
                                                            'A2', d)}"
 IMX_SOC_REV:mx93-generic-bsp   ??= "A1"
+IMX_SOC_REV:mx95-generic-bsp   ??= "B0"
 
 IMX_SOC_REV_LOWER   = "${@d.getVar('IMX_SOC_REV').lower()}"
 IMX_SOC_REV_UPPER   = "${@d.getVar('IMX_SOC_REV').upper()}"

--- a/dynamic-layers/arm-toolchain/recipes-bsp/imx-oei/imx-oei_1.0.0.bb
+++ b/dynamic-layers/arm-toolchain/recipes-bsp/imx-oei/imx-oei_1.0.0.bb
@@ -1,7 +1,7 @@
 SUMMARY = "i.MX Optional Execution Image"
 
-LICENSE = "GPL-2.0-only"
-LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=59530bdf33659b29e73d4adb9f9f6552"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=b66f32a90f9577a5a3255c21d79bc619"
 
 INHIBIT_DEFAULT_DEPS = "1"
 DEPENDS = "gcc-arm-none-eabi-native"
@@ -9,7 +9,7 @@ DEPENDS = "gcc-arm-none-eabi-native"
 SRC_URI = "${IMX_OEI_SRC};branch=${SRCBRANCH}"
 IMX_OEI_SRC ?= "git://github.com/nxp-imx/imx-oei.git;protocol=https"
 SRCBRANCH = "master"
-SRCREV = "1a572a640ef8d6883e8ca39744cd6d2d5dbed678"
+SRCREV = "ca91ce798b2f3a2a0bab8c0f835f4bea88c9b080"
 
 S = "${WORKDIR}/git"
 

--- a/dynamic-layers/arm-toolchain/recipes-bsp/imx-oei/imx-oei_1.0.0.bb
+++ b/dynamic-layers/arm-toolchain/recipes-bsp/imx-oei/imx-oei_1.0.0.bb
@@ -29,6 +29,8 @@ EXTRA_OEMAKE = "\
     DEBUG=1 \
     OEI_CROSS_COMPILE=arm-none-eabi-"
 
+EXTRA_OEMAKE:append:mx95-generic-bsp = " r=${IMX_SOC_REV}"
+
 do_configure() {
     for oei_config in ${OEI_CONFIGS}; do
         oe_runmake clean oei=$oei_config

--- a/dynamic-layers/arm-toolchain/recipes-bsp/imx-oei/imx-oei_1.0.0.bb
+++ b/dynamic-layers/arm-toolchain/recipes-bsp/imx-oei/imx-oei_1.0.0.bb
@@ -21,6 +21,7 @@ OEI_CONFIGS ?= "UNDEFINED"
 OEI_CORE    ?= "UNDEFINED"
 OEI_SOC     ?= "UNDEFINED"
 OEI_BOARD   ?= "UNDEFINED"
+OEI_DDRCONFIG  ?= ""
 
 LDFLAGS[unexport] = "1"
 
@@ -30,6 +31,7 @@ EXTRA_OEMAKE = "\
     OEI_CROSS_COMPILE=arm-none-eabi-"
 
 EXTRA_OEMAKE:append:mx95-generic-bsp = " r=${IMX_SOC_REV}"
+EXTRA_OEMAKE:append = " ${@' DDR_CONFIG=${OEI_DDRCONFIG}' if d.getVar('OEI_DDRCONFIG') else ''}"
 
 do_configure() {
     for oei_config in ${OEI_CONFIGS}; do


### PR DESCRIPTION
This is part of issue #2326

Took the changes from `meta-imx` to update to BSP 6.6.52-2.2.1, but with one notable difference in `imx95-a1-19x19-verdin.conf`:

Add the "imx95-19x19-verdin" machine override such that all
conditional overrides for the base machine are also executed for this A1
machine.
    
In practice this override was only used in `imx-boot_1.0.bb` for
MKIMAGE_EXTRA_ARGS. meta-imx added a `imx95-a1-19x19-verdin` override
there that does the same as the `imx95-19x19-verdin` override, this
commit solves it differently by adding the `imx95-19x19-verdin` override
to the A1 machine.