### PR TITLE
[SCARTHGAP] bump imx-gpu-viv/imx-gpu-g2d to align with NXP BSP LF6.6.52-2.2.1

### DIFF
--- a/recipes-graphics/imx-g2d/imx-gpu-g2d_6.4.11.p2.12.bb
+++ b/recipes-graphics/imx-g2d/imx-gpu-g2d_6.4.11.p2.12.bb
@@ -1,19 +1,19 @@
 # Copyright (C) 2016 Freescale Semiconductor
-# Copyright 2017-2024 NXP
+# Copyright 2017-2022 NXP
 # Copyright 2018 (C) O.S. Systems Software LTDA.
 # Released under the MIT license (see COPYING.MIT for the terms)
 
 DESCRIPTION = "G2D library using i.MX GPU"
 LICENSE = "Proprietary"
-LIC_FILES_CHKSUM = "file://COPYING;md5=ca53281cc0caa7e320d4945a896fb837" 
+LIC_FILES_CHKSUM = "file://COPYING;md5=bc649096ad3928ec06a8713b8d787eac"
 DEPENDS = "libgal-imx"
 PROVIDES = "virtual/libg2d"
 
 SRC_URI = "${FSL_MIRROR}/${IMX_BIN_NAME}.bin;name=${TARGET_ARCH};fsl-eula=true"
 IMX_BIN_NAME = "${BP}-${TARGET_ARCH}-${IMX_SRCREV_ABBREV}"
-IMX_SRCREV_ABBREV = "accdd64"
-SRC_URI[aarch64.sha256sum] = "780479f19142126ed58e12222b80f8f3b882ad3d223ff61b7ea02001f517ff03"
-SRC_URI[arm.sha256sum] = "cd4fd05dd6f6880edc3255c85fe08094a07ea4cd3eee947df004dcb8f37bc8fa"
+IMX_SRCREV_ABBREV = "4402ac2"
+SRC_URI[aarch64.sha256sum] = "f82208abc84453c94fdc737ed6267cd689e68c23af9e4154bee6ce0651c075b1"
+SRC_URI[arm.sha256sum] = "bdfe4d48da0239d264b766ad46b89982f78af04ca4d5051aaf7615473b4de86a"
 
 S = "${WORKDIR}/${IMX_BIN_NAME}"
 

--- a/recipes-graphics/imx-gpu-viv/imx-gpu-viv_6.4.11.p2.10-aarch32.bb
+++ b/recipes-graphics/imx-gpu-viv/imx-gpu-viv_6.4.11.p2.10-aarch32.bb
@@ -1,9 +1,0 @@
-require imx-gpu-viv-6.inc
-
-LIC_FILES_CHKSUM = "file://COPYING;md5=ca53281cc0caa7e320d4945a896fb837" 
-
-IMX_SRCREV_ABBREV = "accdd64"
-
-SRC_URI[sha256sum] = "2242c7cbf1a2b07d40eefe5d1507747e477c54912f179ee0585a5d7965074ce0"
-
-COMPATIBLE_MACHINE = "(mx6q-nxp-bsp|mx6dl-nxp-bsp|mx6sx-nxp-bsp|mx6sl-nxp-bsp|mx7ulp-nxp-bsp)"

--- a/recipes-graphics/imx-gpu-viv/imx-gpu-viv_6.4.11.p2.10-aarch64.bb
+++ b/recipes-graphics/imx-gpu-viv/imx-gpu-viv_6.4.11.p2.10-aarch64.bb
@@ -1,9 +1,0 @@
-require imx-gpu-viv-6.inc
-
-LIC_FILES_CHKSUM = "file://COPYING;md5=ca53281cc0caa7e320d4945a896fb837" 
-
-IMX_SRCREV_ABBREV = "accdd64"
-
-SRC_URI[sha256sum] = "8108fd146de6986486f34860227511a5101b31072b99cd78ae38afba8939fd4e"
-
-COMPATIBLE_MACHINE = "(mx8-nxp-bsp)"

--- a/recipes-graphics/imx-gpu-viv/imx-gpu-viv_6.4.11.p2.12-aarch32.bb
+++ b/recipes-graphics/imx-gpu-viv/imx-gpu-viv_6.4.11.p2.12-aarch32.bb
@@ -1,0 +1,9 @@
+require imx-gpu-viv-6.inc
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=bc649096ad3928ec06a8713b8d787eac"
+
+IMX_SRCREV_ABBREV = "4402ac2"
+
+SRC_URI[sha256sum] = "06617e2569144edbe5dd585be18c6b89bdf2da6ab56e04149c4c076e73f7884d"
+
+COMPATIBLE_MACHINE = "(mx6q-nxp-bsp|mx6dl-nxp-bsp|mx6sx-nxp-bsp|mx6sl-nxp-bsp|mx7ulp-nxp-bsp)"

--- a/recipes-graphics/imx-gpu-viv/imx-gpu-viv_6.4.11.p2.12-aarch64.bb
+++ b/recipes-graphics/imx-gpu-viv/imx-gpu-viv_6.4.11.p2.12-aarch64.bb
@@ -1,0 +1,9 @@
+require imx-gpu-viv-6.inc
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=bc649096ad3928ec06a8713b8d787eac"
+
+IMX_SRCREV_ABBREV = "4402ac2"
+
+SRC_URI[sha256sum] = "869c45f15fc3c93f9dd179410b9ee0e65e152c0e59b595a37ac1d55409e2c51d"
+
+COMPATIBLE_MACHINE = "(mx8-nxp-bsp)"


### PR DESCRIPTION
This is part of #2326

Did a quick test on a Verdin iMX8MP and did not spot any obvious regressions around the GPU