### PR TITLE
classes: add classes for uuu bundle generation

### DIFF
--- a/classes/uuu_bundle.bbclass
+++ b/classes/uuu_bundle.bbclass
@@ -1,0 +1,118 @@
+# Class to create a zip file suitable for flashing to NXP processors via the
+# uuu tool.
+#
+# Usage:
+#   Provide a `uuu.auto.in` flashing script via SRC_URI.
+#   In the recipe set the Variable `UUU_FILES` to a list of identifiers
+#     UUU_FILES = "bootloader whatever"
+#   and matching variable flags containing the file names or paths like
+#     UUU_FILE[bootloader] = "u-boot-${MACHINE}.${UBOOT_SUFFIX}-uuu"
+#     UUU_FILE[whatever] = "some-file.bin"
+#   Reference these files via `@@file_var@@`, e.g.
+#     @@file_bootloader@@
+#     @@file_whatever@@
+#   placeholders in your uuu script.
+#   The corresponding files will be searched in `${WORKDIR}/uuu` and
+#   DEPLOY_DIR_IMAGE (in that order) and added to the uuu bundle.
+#
+#   Specify needed dependencies via the UUU_DEPS variable, e.g.
+#     UUU_DEPS = "virtual/kernel:do_deploy"
+#
+#   In the recipe set the Variable `UUU_TEXTS` to a list of identifiers
+#     UUU_TEXTS = "bootargs whatever"
+#   and matching variable flags containing strings like
+#     UUU_TEXT[bootargs] = "init=/bin/sh"
+#     UUU_TEXT[whatever] = "some-string"
+#   Reference these strings via `@@text_var@@`, e.g.
+#     @@text_bootargs@@
+#     @@text_whatever@@
+#   placeholders in your uuu script.
+#
+# Copyright 2022-2026 (C) emlix GmbH, Daniel Wagenknecht <dwagenknecht@emlix.com>
+#
+# SPDX-License-Identifier: MIT
+
+inherit deploy image-artifact-names
+
+def get_uuu_workdir(d, var_suffix=None):
+    # the parameter can be specified with or without the _ prefix
+    var_suffix = "_" + var_suffix.lstrip("_") if var_suffix else ""
+    workdir = d.getVar('WORKDIR')
+    uuu_dir = os.path.join(workdir, 'uuu' + var_suffix)
+    return uuu_dir
+
+def create_uuuzip (d, \
+                   var_suffix=None, \
+                   output_file="${B}/${IMAGE_NAME}.uuu.zip", \
+                   file_searchpaths=None \
+                  ):
+    import shutil
+    from pathlib import Path
+
+    # the parameter can be specified with or without the _ prefix
+    var_suffix = "_" + var_suffix.lstrip("_") if var_suffix else ""
+
+    # the parameter can be specified with or without the .zip ending
+    output_file = d.expand(output_file.removesuffix(".zip"))
+
+    uuu_dir = get_uuu_workdir(d, var_suffix)
+
+    if not file_searchpaths:
+      file_searchpaths = "${DEPLOY_DIR_IMAGE}"
+
+    file_searchpaths = f'{uuu_dir}:{d.expand(file_searchpaths)}'
+
+    unpackdir = d.getVar('UNPACKDIR')
+    uuu_auto_file = f'{unpackdir}/uuu{var_suffix}.auto.in'
+    if not os.path.exists(uuu_auto_file):
+      bb.fatal(f'Missing uuu{var_suffix}.auto.in file.')
+    uuu_auto_content = Path(uuu_auto_file).read_text()
+
+    uuu_file_names = d.getVar('UUU_FILES' + var_suffix) or ""
+    for item in uuu_file_names.split():
+      if not item:
+        continue
+      filename = d.getVarFlag(f'UUU_FILE{var_suffix}', item) or d.getVarFlag('UUU_FILE', item)
+      file = bb.utils.which(file_searchpaths, filename)
+      if not file:
+        bb.fatal(f'File {filename} not found in {file_searchpaths}')
+
+      # Zip file should contain a flat directory structure containing
+      # actual files, no symlinks.
+      filename = os.path.basename(file)
+      file = os.path.realpath(file)
+      try:
+        shutil.copy(file, os.path.join(uuu_dir, filename))
+      except shutil.SameFileError:
+        pass
+
+      uuu_auto_content = uuu_auto_content.replace(f'@@file_{item}@@', filename)
+
+    uuu_text_names = d.getVar('UUU_TEXTS' + var_suffix) or ""
+    for item in uuu_text_names.split():
+      if not item:
+        continue
+      text = d.getVarFlag(f'UUU_TEXT{var_suffix}', item) or d.getVarFlag('UUU_TEXT', item)
+      uuu_auto_content = uuu_auto_content.replace(f'@@text_{item}@@', text)
+
+    Path(uuu_dir, 'uuu.auto.in').write_text(uuu_auto_content)
+
+    shutil.make_archive(output_file, 'zip', uuu_dir)
+
+python do_create_uuuzip () {
+    create_uuuzip(d)
+}
+addtask do_create_uuuzip after do_unpack
+do_create_uuuzip[depends] += 'zip-native:do_populate_sysroot ${UUU_DEPS}'
+do_create_uuuzip[cleandirs] += "${@get_uuu_workdir(d)}"
+
+do_deploy () {
+    install -d ${DEPLOYDIR}
+    install -m 0644 ${B}/${IMAGE_NAME}.uuu.zip ${DEPLOYDIR}
+    if [ -n "${IMAGE_LINK_NAME}" ] && [ "${IMAGE_NAME}" != "${IMAGE_LINK_NAME}" ]; then
+      ln -s ${IMAGE_NAME}.uuu.zip ${DEPLOYDIR}/${IMAGE_LINK_NAME}.uuu.zip
+    fi
+}
+addtask do_deploy after do_create_uuuzip
+
+

--- a/classes/uuu_image_bundle.bbclass
+++ b/classes/uuu_image_bundle.bbclass
@@ -1,0 +1,115 @@
+# Class to create a zip file for an image suitable for flashing to NXP
+# processors via the uuu tool.
+#
+# Usage:
+#   For a basetype of an image, e.g. ext4.gz add
+#     `IMAGE_FSTYPES += "ext4.gz.uuu-zip"`
+#   to the image recipe and provide a
+#     `uuu_ext4.gz.auto.in`
+#   flashing script via the usual bitbake FILESPATH of the image recipe.
+#
+#   The base image (ext4.gz in this example) will be added to the uuu bundle.
+#   Reference the image as
+#     @@file_image@@
+#   in your uuu script.
+#
+#   Refer to the documentation for uuu_bundle.bbclass for the variables
+#     - `UUU_FILES`
+#     - `UUU_TEXTS`
+#   but suffix them with the basetype, e.g.
+#     - `UUU_FILES_ext4.gz` instead of `UUU_FILES`
+#     - `UUU_TEXTS_ext4.gz` instead of `UUU_TEXTS`
+#
+#   The variable flags with basetype suffix, e.g.
+#     - `UUU_FILE_ext4.gz[identifier]`
+#     - `UUU_TEXT_ext4.gz[identifier]`
+#   take presedence over the non-suffixed counterparts described in the
+#   documentation for uuu_bundle.bbclass but default to the values of those
+#   variables if not specified.
+#
+#   The variable
+#     - `UUU_DEPS`
+#   as described in the documentation for uuu_bundle.bbclass will be extended
+#   with the values of the variable suffixed with the basetype, e.g.
+#     - `UUU_DEPS_ext4.gz`
+#
+#   Note that `.uuu-zip` needs to be specified in IMAGE_FSTYPES, but the created
+#   file will have a `.uuu.zip` extension.
+#
+# Copyright 2022-2026 (C) emlix GmbH, Daniel Wagenknecht <dwagenknecht@emlix.com>
+#
+# SPDX-License-Identifier: MIT
+
+inherit image_types
+
+inherit uuu_bundle
+deltask do_create_uuuzip
+deltask do_deploy
+
+# We use CONVERSIONTYPES so any existing rootfs type can be converted to a
+# uuu.zip without having to deploy the possibly uncompressed intermediary
+# artifact. the CONVERSION_CMD just stages the file to the uuu working
+# directory, the creation of the uuu.zip file happens in the do_image_uuuzip
+# task.
+CONVERSIONTYPES += "uuu-zip"
+CONVERSION_CMD:uuu-zip = "cp ${IMAGE_NAME}.${type} ${@get_uuu_workdir(d, '${type}')}/${IMAGE_NAME}.${type} "
+
+python do_image_uuuzip () {
+    basetypes = d.getVar('UUU_IMAGE_BASETYPES').strip().split()
+
+    for type in basetypes:
+      output_file = os.path.join(d.getVar('IMGDEPLOYDIR'),d.getVar(f'UUU_IMAGE_{type}'))
+      create_uuuzip(d,
+        var_suffix=type,
+        output_file = output_file,
+        file_searchpaths="${IMGDEPLOYDIR}:${DEPLOY_DIR_IMAGE}"
+      )
+}
+do_image_uuuzip[depends] += 'zip-native:do_populate_sysroot ${UUU_DEPS}'
+do_image_uuuzip[postfuncs] += 'create_symlinks'
+addtask do_image_uuuzip before do_image_complete after do_unpack do_image
+
+
+do_image_prepare_uuuzip () {
+    # This task exists so the uuu working directory is clean before the individual image tasks run.
+    :
+}
+do_image_prepare_uuuzip[nostamp] = "1"
+addtask do_image_prepare_uuuzip
+
+python () {
+    pn = d.getVar("PN")
+    image_fstypes = d.getVar('IMAGE_FSTYPES') or ""
+    if 'uuu-zip' not in image_fstypes:
+      bb.warnonce(d.getVar('FILE') + " inherits uuu-image-bundle class but does not specify any uuu-zip image in IMAGE_FSTYPES")
+
+    # normally images don't provide any inputs via SRC_URI. We need a file per
+    # image type that should be converted to a uuu bundle, so we need to reactivate
+    # the relevant tasks. Assume file:// protocol only, so no do_fetch is needed.
+    d.delVarFlag('do_unpack', 'noexec')
+
+    for typestring in image_fstypes.split():
+      types = typestring.split(".")
+      if 'uuu-zip' not in types:
+        continue
+
+      imagetask = f'do_image_{types[0]}'
+
+      index = types.index('uuu-zip')
+      basetype = ".".join(types[:index])
+
+      image_name = d.expand('${IMAGE_NAME}')
+
+      d.setVarFlag(f'UUU_FILE_{basetype}', 'image', f'{image_name}.{basetype}')
+      d.appendVar(f'UUU_FILES_{basetype}', ' image')
+
+      d.appendVar('UUU_IMAGE_BASETYPES', f' {basetype}')
+      d.setVar(f'UUU_IMAGE_{basetype}', f'{image_name}.{basetype}.uuu.zip')
+      d.appendVar('SRC_URI', f' file://uuu_{basetype}.auto.in')
+
+      d.appendVarFlag(imagetask, 'depends', f' {pn}:do_image_prepare_uuuzip')
+      d.appendVarFlag('do_image_prepare_uuuzip', 'cleandirs', f' {get_uuu_workdir(d, basetype)}')
+
+      d.appendVarFlag('do_image_uuuzip', 'depends', f' {pn}:{imagetask}')
+      d.appendVarFlag('do_image_uuuzip', 'subimages', f' {basetype}.uuu.zip')
+}


### PR DESCRIPTION
> **NOTE** This is meant for discussion. This implementation evolved over the past few years and I've used it in multiple projects. The image_populate_mfgtool class did not exist when I first used this class. Are you interested in integrating this into meta-freescale?

The uuu_bundle.bbclass can be used to create uuu zip files containing arbitrary files collected from DEPLOY_DIR_IMAGE and a uuu.auto script. A user provided uuu.auto.in script is processed to replace file placeholders and text placeholders.

The uuu_image_bundle.bbclass does the same for image recipes when inheriting the class and specifying a basetype with `uuu-zip` extension in IMAGE_FSTYPE, e.g. `ext4.gz.uuu-zip`. This can be done for multiple basetypes, so the same image recipe can provide different uuu-bundles, e.g. for booting the image from ramdisk for test purposes or flashing it to internal storage.

The provided classes differ from the image_populate_mfgtool.bbclass by:
- not being limited to image recipes
- allowing creation of uuu bundles for multiple types from IMAGE_FSTYPES
- not bundling the uuu binaries
- creating a name.uuu.zip file that can be directly used with the uuu tool, e.g. uuu path/to/name.uuu.zip
- more flexible variable replacement, e.g. not assuming `UBOOT_BINARY` is used as bootloader in uuu.auto script
- properly integrating with the Openembedded deploy and image deploy mechanisms
- different semantics