### PR TITLE
imx-atf: upgrade to NXP 6.12.20-2.0.0 release

### DIFF
--- a/recipes-bsp/imx-atf/imx-atf_2.12.bb
+++ b/recipes-bsp/imx-atf/imx-atf_2.12.bb
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2024 NXP
+# Copyright (C) 2017-2025 NXP
 
 DESCRIPTION = "i.MX ARM Trusted Firmware"
 SECTION = "BSP"
@@ -9,8 +9,8 @@ PV .= "+git${SRCPV}"
 
 SRC_URI = "git://github.com/nxp-imx/imx-atf.git;protocol=https;branch=${SRCBRANCH} \
            file://0001-imx93-trdc-Fix-header-guard.patch"
-SRCBRANCH = "lf_v2.10"
-SRCREV = "78a14c75a06dea39036c44ae0f9d23acc7bcaef2"
+SRCBRANCH = "lf_v2.12"
+SRCREV = "6ddd57019494cabfca5065368349109c37f2cc9f"
 
 inherit deploy
 


### PR DESCRIPTION
Upgrade version to 2.12, from new 6.12.20-2.0.0 NXP release.