### PR TITLE
global recipes: Fix whinlatter updates for source code lacation

### DIFF
--- a/recipes-bsp/atf/qoriq-atf_2.12.bb
+++ b/recipes-bsp/atf/qoriq-atf_2.12.bb
@@ -7,8 +7,8 @@ do_compile[depends] += "u-boot:do_deploy rcw:do_deploy uefi:do_deploy"
 
 PV:append = "+${SRCPV}"
 
-SRC_URI += "git://github.com/ARMmbed/mbedtls;protocol=https;nobranch=1;destsuffix=git/mbedtls;name=mbedtls \
-    git://github.com/nxp/ddr-phy-binary;protocol=https;nobranch=1;destsuffix=git/ddr-phy-binary;name=ddr \
+SRC_URI += "git://github.com/ARMmbed/mbedtls;protocol=https;nobranch=1;destsuffix=${S}/mbedtls;name=mbedtls \
+    git://github.com/nxp/ddr-phy-binary;protocol=https;nobranch=1;destsuffix=${S}/ddr-phy-binary;name=ddr \
 "
 SRCREV_mbedtls = "0795874acdf887290b2571b193cafd3c4041a708"
 SRCREV_ddr = "fbc036b88acb6c06ffed02c898cbae9856ec75ba"

--- a/recipes-dpaa2/dce/dce_git.bb
+++ b/recipes-dpaa2/dce/dce_git.bb
@@ -4,7 +4,7 @@ LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=956df5ea6cfe0a1dcf2dee7ca37c0cdf"
 
 SRC_URI = "git://github.com/nxp-qoriq/dce;protocol=https;nobranch=1 \
-      git://github.com/nxp-qoriq/qbman_userspace;protocol=https;nobranch=1;name=qbman;destsuffix=git/lib/qbman_userspace \
+      git://github.com/nxp-qoriq/qbman_userspace;protocol=https;nobranch=1;name=qbman;destsuffix=${S}/lib/qbman_userspace \
       file://0001-support-user-merge.patch \
 "
 SRCREV = "88ef2e8c3845532ee64cea4349fd38fb2bd5f807"

--- a/recipes-extended/odp/odp.inc
+++ b/recipes-extended/odp/odp.inc
@@ -10,8 +10,8 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/odp:"
 
 SRC_URI = " \
 git://github.com/nxp-qoriq/odp;protocol=https;nobranch=1 \
-git://github.com/nxp-qoriq/qbman_userspace;protocol=https;nobranch=1;name=qbman;destsuffix=git/platform/linux-dpaa2/flib/qbman \
-git://github.com/nxp-qoriq/flib;protocol=https;nobranch=1;name=rta;destsuffix=git/platform/linux-dpaa2/flib/rta \
+git://github.com/nxp-qoriq/qbman_userspace;protocol=https;nobranch=1;name=qbman;destsuffix=${S}/platform/linux-dpaa2/flib/qbman \
+git://github.com/nxp-qoriq/flib;protocol=https;nobranch=1;name=rta;destsuffix=${S}/platform/linux-dpaa2/flib/rta \
 "
 
 SRC_URI += "file://0001-Fix-this-build-error.patch"


### PR DESCRIPTION
${WORKDIR}/git or  ${UNPACKDIR}/git no longer supported in whinlatter