### PR TITLE
Revert "Replace kernel-fitimage KERNER_CLASSES with kernel-fit-extra-…

### DIFF
--- a/conf/machine/ls1012afrwy.conf
+++ b/conf/machine/ls1012afrwy.conf
@@ -12,7 +12,8 @@ require conf/machine/include/arm/arch-arm64.inc
 
 MACHINE_FEATURES += "optee"
 
-KERNEL_CLASSES += "kernel-fit-extra-artifacts"
+KERNEL_CLASSES  = " kernel-fitimage "
+KERNEL_IMAGETYPES = "fitImage"
 
 UBOOT_DTB_LOADADDRESS = "0x90000000"
 UBOOT_ENTRYPOINT = "0x80080000"

--- a/conf/machine/ls1012ardb.conf
+++ b/conf/machine/ls1012ardb.conf
@@ -12,7 +12,8 @@ require conf/machine/include/arm/arch-arm64.inc
 
 MACHINE_FEATURES += "optee"
 
-KERNEL_CLASSES += "kernel-fit-extra-artifacts"
+KERNEL_CLASSES  = " kernel-fitimage "
+KERNEL_IMAGETYPES = "fitImage"
 
 UBOOT_DTB_LOADADDRESS = "0x90000000"
 UBOOT_ENTRYPOINT = "0x80080000"

--- a/conf/machine/ls1028ardb.conf
+++ b/conf/machine/ls1028ardb.conf
@@ -11,7 +11,8 @@ require conf/machine/include/arm/arch-arm64.inc
 
 MACHINE_FEATURES += "optee"
 
-KERNEL_CLASSES += "kernel-fit-extra-artifacts"
+KERNEL_CLASSES  = " kernel-fitimage "
+KERNEL_IMAGETYPES = "fitImage"
 
 UBOOT_DTB_LOADADDRESS = "0x90000000"
 UBOOT_ENTRYPOINT = "0x80080000"

--- a/conf/machine/ls1043ardb.conf
+++ b/conf/machine/ls1043ardb.conf
@@ -12,7 +12,8 @@ require conf/machine/include/arm/arch-arm64.inc
 
 MACHINE_FEATURES += "optee"
 
-KERNEL_CLASSES += "kernel-fit-extra-artifacts"
+KERNEL_CLASSES  = " kernel-fitimage "
+KERNEL_IMAGETYPES = "fitImage"
 
 UBOOT_DTB_LOADADDRESS = "0x90000000"
 UBOOT_ENTRYPOINT = "0x80080000"

--- a/conf/machine/ls1046afrwy.conf
+++ b/conf/machine/ls1046afrwy.conf
@@ -11,7 +11,8 @@ require conf/machine/include/arm/arch-arm64.inc
 
 MACHINE_FEATURES += "optee"
 
-KERNEL_CLASSES += "kernel-fit-extra-artifacts"
+KERNEL_CLASSES  = " kernel-fitimage "
+KERNEL_IMAGETYPES = "fitImage"
 
 UBOOT_DTB_LOADADDRESS = "0x90000000"
 UBOOT_ENTRYPOINT = "0x80080000"

--- a/conf/machine/ls1046ardb.conf
+++ b/conf/machine/ls1046ardb.conf
@@ -11,7 +11,8 @@ require conf/machine/include/arm/arch-arm64.inc
 
 MACHINE_FEATURES += "optee"
 
-KERNEL_CLASSES += "kernel-fit-extra-artifacts"
+KERNEL_CLASSES  = " kernel-fitimage "
+KERNEL_IMAGETYPES = "fitImage"
 
 UBOOT_DTB_LOADADDRESS = "0x90000000"
 UBOOT_ENTRYPOINT = "0x80080000"

--- a/conf/machine/ls1088ardb-pb.conf
+++ b/conf/machine/ls1088ardb-pb.conf
@@ -11,7 +11,8 @@ require conf/machine/include/arm/arch-arm64.inc
 
 MACHINE_FEATURES += "optee"
 
-KERNEL_CLASSES += "kernel-fit-extra-artifacts"
+KERNEL_CLASSES  = " kernel-fitimage "
+KERNEL_IMAGETYPES = "fitImage"
 
 UBOOT_DTB_LOADADDRESS = "0x90000000"
 UBOOT_ENTRYPOINT = "0x80080000"

--- a/conf/machine/ls1088ardb.conf
+++ b/conf/machine/ls1088ardb.conf
@@ -11,7 +11,8 @@ require conf/machine/include/arm/arch-arm64.inc
 
 MACHINE_FEATURES += "optee"
 
-KERNEL_CLASSES += "kernel-fit-extra-artifacts"
+KERNEL_CLASSES  = " kernel-fitimage "
+KERNEL_IMAGETYPES = "fitImage"
 
 UBOOT_DTB_LOADADDRESS = "0x90000000"
 UBOOT_ENTRYPOINT = "0x80080000"

--- a/conf/machine/ls2088ardb.conf
+++ b/conf/machine/ls2088ardb.conf
@@ -11,7 +11,8 @@ MACHINEOVERRIDES =. "fsl-lsch3:ls2088a:"
 
 MACHINE_FEATURES += "optee"
 
-KERNEL_CLASSES += "kernel-fit-extra-artifacts"
+KERNEL_CLASSES  = " kernel-fitimage "
+KERNEL_IMAGETYPES = "fitImage"
 
 UBOOT_DTB_LOADADDRESS = "0x90000000"
 UBOOT_ENTRYPOINT = "0x80080000"

--- a/conf/machine/lx2160ardb.conf
+++ b/conf/machine/lx2160ardb.conf
@@ -11,7 +11,8 @@ MACHINEOVERRIDES =. "fsl-lsch3:lx2160a:"
 
 MACHINE_FEATURES += "optee"
 
-KERNEL_CLASSES += "kernel-fit-extra-artifacts"
+KERNEL_CLASSES  = " kernel-fitimage "
+KERNEL_IMAGETYPES = "fitImage"
 
 DTB_LOAD = "0x90000000"
 UBOOT_ENTRYPOINT = "0x80080000"

--- a/conf/machine/lx2162aqds.conf
+++ b/conf/machine/lx2162aqds.conf
@@ -11,7 +11,8 @@ MACHINEOVERRIDES =. "fsl-lsch3:lx2162a:"
 
 MACHINE_FEATURES += "optee"
 
-KERNEL_CLASSES += "kernel-fit-extra-artifacts"
+KERNEL_CLASSES  = " kernel-fitimage "
+KERNEL_IMAGETYPES = "fitImage"
 
 DTB_LOAD = "0x90000000"
 UBOOT_ENTRYPOINT = "0x80080000"


### PR DESCRIPTION
…artifacts"

This reverts commit f515d8537234e85ddc612a32459808641b774ba5.

This commit was cherry-picked to walnascar, but this is wrong. This kernel class does not exist on walnascar.