### PR TITLE
vulkan-loader: Fix version-specific patching

### DIFF
--- a/recipes-graphics/vulkan/vulkan-loader_%.bbappend
+++ b/recipes-graphics/vulkan/vulkan-loader_%.bbappend
@@ -1,5 +1,3 @@
-FILESEXTRAPATHS:prepend:imx-nxp-bsp := "${THISDIR}/${PN}:"
-
 SRC_URI:append:imx-nxp-bsp = " \
     file://0001-LF-11869-change-mali-wsi-layer-activating-order.patch \
 "

--- a/recipes-graphics/vulkan/vulkan-loader_1.3.275.0.imx.bbappend
+++ b/recipes-graphics/vulkan/vulkan-loader_1.3.275.0.imx.bbappend
@@ -1,0 +1,1 @@
+FILESEXTRAPATHS:prepend:imx-nxp-bsp := "${THISDIR}/vulkan-loader-1.3.275.0.imx:"

--- a/recipes-graphics/vulkan/vulkan-loader_1.4.321.0.bbappend
+++ b/recipes-graphics/vulkan/vulkan-loader_1.4.321.0.bbappend
@@ -1,0 +1,1 @@
+FILESEXTRAPATHS:prepend:imx-nxp-bsp := "${THISDIR}/vulkan-loader-1.4.321.0:"


### PR DESCRIPTION
The build fails because it cannot find the patch files in the version- specific folder. The problem is the bbappend uses `PN`. However, it turns out that `BP` doesn't work either:

```
ERROR: /.../poky/meta/recipes-graphics/vulkan/vulkan-loader_1.4.321.0.bb: Unable to get checksum for vulkan-loader SRC_URI entry 0001-LF-11869-change-mali-wsi-layer-activating-order.patch: file could not be found
The following paths were searched:
/.../meta-freescale/recipes-graphics/vulkan/defaultpkgname-1.0/fsl/0001-LF-11869-change-mali-wsi-layer-activating-order.patch
[ %< SNIP %< ]
```

When `FILESEXTRAPATHS` is prepended, `BP` is not ready since the immediate expansion operator `:=` is used, hence the folder name `defaultpkgname-1.0` shown in the error log.

Fix the problem with hard-coded values.

Fixes #2365.