### PR TITLE
Revert "mesa: Drop patches as no longer needed"

### DIFF
--- a/recipes-graphics/mesa/mesa.bbappend
+++ b/recipes-graphics/mesa/mesa.bbappend
@@ -1,6 +1,10 @@
 PROVIDES:remove:imxgpu   = "virtual/egl"
 PROVIDES:remove:imxgpu3d = "virtual/libgl virtual/libgles1 virtual/libgles2"
 
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+SRC_URI:append:mx93-nxp-bsp = " file://0001-MGS-7673-egl-dri2-fix-video-showing-wrong-frame.patch"
+SRC_URI:append:imx-nxp-bsp  = " file://0001-MGS-7599-cso-fix-virgl-driver-assert-issue.patch"
+
 PACKAGECONFIG:remove:imxgpu   = "egl gbm"
 PACKAGECONFIG:remove:imxgpu3d = "gles"
 

--- a/recipes-graphics/mesa/mesa/0001-MGS-7599-cso-fix-virgl-driver-assert-issue.patch
+++ b/recipes-graphics/mesa/mesa/0001-MGS-7599-cso-fix-virgl-driver-assert-issue.patch
@@ -1,0 +1,47 @@
+From 612c3dc98d5d050b9cfee16ec77ca3c8358caa0d Mon Sep 17 00:00:00 2001
+From: Wujian Sun <wujian.sun_1@nxp.com>
+Date: Mon, 29 Apr 2024 17:29:16 +0800
+Subject: [PATCH] MGS-7599 cso: fix virgl driver assert issue
+
+A workaround that remove PIPE_MAX_SAMPLERS and
+PIPE_MAX_CONSTANT_BUFFERS assert.
+
+Upstream-Status: Inappropriate [i.MX-specific]
+
+Signed-off-by: Wujian Sun <wujian.sun_1@nxp.com>
+---
+ src/gallium/auxiliary/cso_cache/cso_context.c | 2 --
+ src/gallium/drivers/virgl/virgl_screen.c      | 2 +-
+ 2 files changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/src/gallium/auxiliary/cso_cache/cso_context.c b/src/gallium/auxiliary/cso_cache/cso_context.c
+index 3e86def31c5..ffc6d22da9c 100644
+--- a/src/gallium/auxiliary/cso_cache/cso_context.c
++++ b/src/gallium/auxiliary/cso_cache/cso_context.c
+@@ -403,10 +403,8 @@ cso_unbind_context(struct cso_context *ctx)
+                                               PIPE_SHADER_CAP_MAX_CONST_BUFFERS);
+             int maximg = scr->get_shader_param(scr, sh,
+                                               PIPE_SHADER_CAP_MAX_SHADER_IMAGES);
+-            assert(maxsam <= PIPE_MAX_SAMPLERS);
+             assert(maxview <= PIPE_MAX_SHADER_SAMPLER_VIEWS);
+             assert(maxssbo <= PIPE_MAX_SHADER_BUFFERS);
+-            assert(maxcb <= PIPE_MAX_CONSTANT_BUFFERS);
+             assert(maximg <= PIPE_MAX_SHADER_IMAGES);
+             if (maxsam > 0) {
+                ctx->base.pipe->bind_sampler_states(ctx->base.pipe, sh, 0, maxsam, zeros);
+diff --git a/src/gallium/drivers/virgl/virgl_screen.c b/src/gallium/drivers/virgl/virgl_screen.c
+index 389a1935cc3..7c7f8ba576b 100644
+--- a/src/gallium/drivers/virgl/virgl_screen.c
++++ b/src/gallium/drivers/virgl/virgl_screen.c
+@@ -435,7 +435,7 @@ virgl_get_shader_param(struct pipe_screen *screen,
+          return 1;
+       case PIPE_SHADER_CAP_MAX_TEXTURE_SAMPLERS:
+          return MIN2(vscreen->caps.caps.v2.max_shader_sampler_views,
+-                     PIPE_MAX_SHADER_SAMPLER_VIEWS);
++                     PIPE_MAX_SAMPLERS);
+       case PIPE_SHADER_CAP_INTEGERS:
+          return vscreen->caps.caps.v1.glsl_level >= 130;
+       case PIPE_SHADER_CAP_MAX_CONTROL_FLOW_DEPTH:
+-- 
+2.17.1
+

--- a/recipes-graphics/mesa/mesa/0001-MGS-7673-egl-dri2-fix-video-showing-wrong-frame.patch
+++ b/recipes-graphics/mesa/mesa/0001-MGS-7673-egl-dri2-fix-video-showing-wrong-frame.patch
@@ -1,0 +1,33 @@
+From 188d7b01037e5a0249e63c2600cf15a288a9ff3f Mon Sep 17 00:00:00 2001
+From: Wujian Sun <wujian.sun_1@nxp.com>
+Date: Fri, 19 Apr 2024 18:38:17 +0800
+Subject: [PATCH] MGS-7673 egl/dri2: fix video showing wrong frame
+
+Softpipe driver doesn't support EGL_EXT_image_dma_buf_import_modifiers
+extension.
+Should not report the extension.
+
+Upstream-Status: Pending
+
+Signed-off-by: Wujian Sun <wujian.sun_1@nxp.com>
+---
+ src/egl/drivers/dri2/egl_dri2.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/egl/drivers/dri2/egl_dri2.c b/src/egl/drivers/dri2/egl_dri2.c
+index 992f0e3d46d..6ee209d4b47 100644
+--- a/src/egl/drivers/dri2/egl_dri2.c
++++ b/src/egl/drivers/dri2/egl_dri2.c
+@@ -942,7 +942,8 @@ dri2_setup_screen(_EGLDisplay *disp)
+ 
+ #ifdef HAVE_LIBDRM
+       if (dri2_dpy->image->base.version >= 8 &&
+-          dri2_dpy->image->createImageFromDmaBufs) {
++          dri2_dpy->image->createImageFromDmaBufs &&
++          strcmp("softpipe", pscreen->get_name(pscreen))) {
+          disp->Extensions.EXT_image_dma_buf_import = EGL_TRUE;
+          disp->Extensions.EXT_image_dma_buf_import_modifiers = EGL_TRUE;
+       }
+-- 
+2.17.1
+


### PR DESCRIPTION
These patches are still needed on Walnascar, so revert the backport from master that removed them.

This reverts commit 1d23556d3f94aafa6c2df995df3ea8773835f823.