### PR TITLE
vulkan-loader: Configure virtual-vulkan-icd for i.MX GPU

### DIFF
--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -577,6 +577,11 @@ PREFERRED_PROVIDER_virtual/libg2d              ?= "imx-gpu-g2d"
 PREFERRED_PROVIDER_virtual/libg2d:imxdpu       ?= "imx-dpu-g2d"
 PREFERRED_PROVIDER_virtual/libg2d:mx93-nxp-bsp ?= "imx-pxp-g2d"
 
+# Set preferred Vulkan ICD runtime
+PREFERRED_RPROVIDER_virtual-vulkan-icd         ?= "mesa"
+PREFERRED_RPROVIDER_virtual-vulkan-icd:imxviv  ?= "libvulkan-imx"
+PREFERRED_RPROVIDER_virtual-vulkan-icd:imxmali ?= "mali-imx-libvulkan"
+
 PREFERRED_VERSION_weston:imx-nxp-bsp      ??= "14.0.2.imx"
 # i.MX 6 & 7 stay on weston 10.0 for fbdev
 PREFERRED_VERSION_weston:mx6-nxp-bsp      ??= "10.0.5.imx"

--- a/recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc
+++ b/recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc
@@ -346,6 +346,7 @@ FILES:libvulkan-imx = "\
     ${libdir}/libvulkan_VSI${REALSOLIBS} \
     ${sysconfdir}/vulkan"
 FILES:libvulkan-imx-dev = "${includedir}/vulkan ${libdir}/libvulkan_VSI${SOLIBSDEV}"
+RPROVIDES:libvulkan-imx = "virtual-vulkan-icd"
 
 FILES:libspirv-imx = " \
     ${libdir}/libSPIRV_viv${SOLIBS} \

--- a/recipes-graphics/mali/mali-imx.inc
+++ b/recipes-graphics/mali/mali-imx.inc
@@ -46,6 +46,7 @@ FILES:${PN}-opencl-icd = " \
 FILES:${PN}-libvulkan = " \
     ${sysconfdir}/vulkan"
 RDEPENDS:${PN}-libvulkan = "vulkan-wsi-layer"
+RPROVIDES:${PN}-libvulkan = "virtual-vulkan-icd"
 
 FILES:${PN}-dev = " \
     ${bindir}/malisc"

--- a/recipes-graphics/vulkan/vulkan-loader_%.bbappend
+++ b/recipes-graphics/vulkan/vulkan-loader_%.bbappend
@@ -8,7 +8,3 @@ PACKAGE_ARCH:imx-nxp-bsp = "${MACHINE_SOCARCH}"
 SOLIBS:imx-nxp-bsp          = ".so*"
 FILES_SOLIBSDEV:imx-nxp-bsp = ""
 INSANE_SKIP:${PN}:imx-nxp-bsp += "dev-so"
-
-# Override default mesa drivers with i.MX GPU drivers
-RRECOMMENDS:${PN}:imxviv  = "libvulkan-imx"
-RRECOMMENDS:${PN}:imxmali = "mali-imx-libvulkan"


### PR DESCRIPTION
Use the new virtual runtime provider to configure the ICD for i.MX GPU.