### PR TITLE
imx-boot-container.bbclass: follow builddir change

### DIFF
--- a/classes/imx-boot-container.bbclass
+++ b/classes/imx-boot-container.bbclass
@@ -52,19 +52,20 @@ do_resolve_and_populate_binaries() {
         for config in ${UBOOT_MACHINE}; do
             i=$(expr $i + 1);
             for type in ${UBOOT_CONFIG}; do
+                builddir="${config}-${type}"
                 j=$(expr $j + 1);
                 if [ $j -eq $i ]; then
                     for firmware in ${IMX_BOOT_CONTAINER_FIRMWARE}; do
-                        bbnote "Copy firmware: ${firmware} from ${DEPLOY_DIR_IMAGE} -> ${B}/${config}/"
-                        cp ${DEPLOY_DIR_IMAGE}/${firmware} ${B}/${config}/
+                        bbnote "Copy firmware: ${firmware} from ${DEPLOY_DIR_IMAGE} -> ${B}/${builddir}/"
+                        cp ${DEPLOY_DIR_IMAGE}/${firmware} ${B}/${builddir}/
                     done
                     if [ -n "${ATF_MACHINE_NAME}" ]; then
-                        cp ${DEPLOY_DIR_IMAGE}/${ATF_MACHINE_NAME} ${B}/${config}/bl31.bin
+                        cp ${DEPLOY_DIR_IMAGE}/${ATF_MACHINE_NAME} ${B}/${builddir}/bl31.bin
                     else
                         bberror "ATF binary is undefined, result binary would be unusable!"
                     fi
                     if [ "${@bb.utils.contains('MACHINE_FEATURES', 'optee', '1' , '0' , d)}" = "1" ] ; then
-                        cp ${DEPLOY_DIR_IMAGE}/${OPTEE_BOOT_IMAGE} ${B}/${config}/
+                        cp ${DEPLOY_DIR_IMAGE}/${OPTEE_BOOT_IMAGE} ${B}/${builddir}/
                     fi
                 fi
             done
@@ -90,10 +91,11 @@ do_deploy:append() {
         for config in ${UBOOT_MACHINE}; do
             i=$(expr $i + 1);
             for type in ${UBOOT_CONFIG}; do
+                builddir="${config}-${type}"
                 j=$(expr $j + 1);
                 if [ $j -eq $i ]
                 then
-                    install -m 0644 ${B}/${config}/flash.bin  ${DEPLOYDIR}/flash.bin-${MACHINE}-${type}
+                    install -m 0644 ${B}/${builddir}/flash.bin  ${DEPLOYDIR}/flash.bin-${MACHINE}-${type}
                     # When there's more than one word in UBOOT_CONFIG,
                     # the first UBOOT_CONFIG listed will be the imx-boot binary
                     if [ ! -f "${DEPLOYDIR}/imx-boot" ]; then

--- a/recipes-bsp/u-boot/u-boot-imx_2024.04.bb
+++ b/recipes-bsp/u-boot/u-boot-imx_2024.04.bb
@@ -23,11 +23,13 @@ do_deploy:append:mx8m-generic-bsp() {
         for config in ${UBOOT_MACHINE}; do
             i=$(expr $i + 1);
             for type in ${UBOOT_CONFIG}; do
+                builddir="${config}-${type}"
                 j=$(expr $j + 1);
                 if [ $j -eq $i ]
                 then
+                    builddir="${config}-${type}"
                     install -d ${DEPLOYDIR}/${BOOT_TOOLS}
-                    install -m 0644 ${B}/${config}/u-boot-nodtb.bin ${DEPLOYDIR}/${BOOT_TOOLS}/u-boot-nodtb.bin-${MACHINE}-${type}
+                    install -m 0644 ${B}/${builddir}/u-boot-nodtb.bin ${DEPLOYDIR}/${BOOT_TOOLS}/u-boot-nodtb.bin-${MACHINE}-${type}
                     UBOOT_DTB_NAME_FLAGS="${type}:${UBOOT_DTB_NAME}"
                     for key_value in ${UBOOT_DTB_NAME_FLAGS}; do
                         local type_key="${key_value%%:*}"
@@ -37,11 +39,11 @@ do_deploy:append:mx8m-generic-bsp() {
                             bbnote "UBOOT_CONFIG = $type, UBOOT_DTB_NAME = $dtb_name"
                             # There is only one ${dtb_name}, the first one. All the other are with the type appended
                             if [ ! -f "${DEPLOYDIR}/${BOOT_TOOLS}/${dtb_name}" ]; then
-                                install -m 0644 ${B}/${config}/arch/arm/dts/${dtb_name}  ${DEPLOYDIR}/${BOOT_TOOLS}/${dtb_name}
+                                install -m 0644 ${B}/${builddir}/arch/arm/dts/${dtb_name}  ${DEPLOYDIR}/${BOOT_TOOLS}/${dtb_name}
                             else
                                 bbwarn "Use custom wks.in for $dtb_name = $type"
                             fi
-                            install -m 0644 ${B}/${config}/arch/arm/dts/${dtb_name}  ${DEPLOYDIR}/${BOOT_TOOLS}/${dtb_name}-${type}
+                            install -m 0644 ${B}/${builddir}/arch/arm/dts/${dtb_name}  ${DEPLOYDIR}/${BOOT_TOOLS}/${dtb_name}-${type}
                         fi
                         unset type_key
                         unset dtb_name


### PR DESCRIPTION
openembedded core renamed the build directory to include the build type. commit 22e96b32b0be ("u-boot: Make sure the build dir is unique for each UBOOT_CONFIG")

Follow that.