### PR TITLE
vulkan-wsi-layer: add S assignment

### DIFF
--- a/recipes-graphics/vulkan/vulkan-wsi-layer_git.bb
+++ b/recipes-graphics/vulkan/vulkan-wsi-layer_git.bb
@@ -11,6 +11,8 @@ SRC_URI = "git://gitlab.freedesktop.org/mesa/vulkan-wsi-layer.git;protocol=https
            file://0003-Update-minimum-version-of-CMake.patch"
 SRCREV = "cb1a50cf7e640ad7306e673131ded98c0f133628"
 
+S = "${WORKDIR}/git"
+
 inherit cmake pkgconfig
 
 PACKAGECONFIG ??= "${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'wayland', 'headless', d)}"


### PR DESCRIPTION
Add missing S assignment for walnascar. Fixes build issue:

WARNING: vulkan-wsi-layer-0.0+git-r0 do_unpack: vulkan-wsi-layer: the directory ${WORKDIR}/${BP} (/home/qt/work/build/tmp/work/cortexa55-mx95-poky-linux/vulkan-wsi-layer/0.0+git/vulkan-wsi-layer-0.0+git) pointed to by the S variable doesn't exist - please set S within the recipe to point to where the source has been unpacked t ERROR: vulkan-wsi-layer-0.0+git-r0 do_patch: Applying patch '0001-MGS-6801-ccc-vkmark-on-wayland.patch' on target directory '/home/qt/work/build/tmp/work/cortexa55-mx95-poky-linux/vulkan-wsi-layer/0.0+git/vulkan-wsi-layer-0.0+git' CmdError('quilt --quiltrc /home/qt/work/build/tmp/work/cortexa55-mx95-poky-linux/vulkan-wsi-layer/0.0+git/recipe-sysroot-native/etc/quiltrc push', 0, "stdout: Applying patch 0001-MGS-6801-ccc-vkmark-on-wayland.patch can't find file to patch at input line 19