### PR TITLE
vulkan-loader: Backport virtual-vulkan-icd to 1.3.275.0.imx

### DIFF
--- a/recipes-downgrade/vulkan/vulkan-loader_1.3.275.0.imx.bb
+++ b/recipes-downgrade/vulkan/vulkan-loader_1.3.275.0.imx.bb
@@ -31,7 +31,7 @@ PACKAGECONFIG ??= "${@bb.utils.filter('DISTRO_FEATURES', 'wayland x11', d)}"
 PACKAGECONFIG[x11] = "-DBUILD_WSI_XLIB_SUPPORT=ON -DBUILD_WSI_XCB_SUPPORT=ON, -DBUILD_WSI_XLIB_SUPPORT=OFF -DBUILD_WSI_XCB_SUPPORT=OFF, libxcb libx11 libxrandr"
 PACKAGECONFIG[wayland] = "-DBUILD_WSI_WAYLAND_SUPPORT=ON, -DBUILD_WSI_WAYLAND_SUPPORT=OFF, wayland"
 
-RRECOMMENDS:${PN} = "mesa-vulkan-drivers"
+RRECOMMENDS:${PN} = "virtual-vulkan-icd"
 
 # These recipes need to be updated in lockstep with each other:
 # glslang, vulkan-headers, vulkan-loader, vulkan-tools, spirv-headers, spirv-tools,


### PR DESCRIPTION
The virtual-vulkan-icd package provided by imx-gpu-viv is missing from the image. The problem is the downgraded vulkan-loader needed for imx-gpu-viv does not have the virtual-vulkan-icd feature. Add it.