### PR TITLE
imx-oei: split recipe

### DIFF
--- a/dynamic-layers/arm-toolchain/recipes-bsp/imx-oei/imx-oei.inc
+++ b/dynamic-layers/arm-toolchain/recipes-bsp/imx-oei/imx-oei.inc
@@ -1,0 +1,55 @@
+INHIBIT_DEFAULT_DEPS = "1"
+DEPENDS = "gcc-arm-none-eabi-native"
+
+S = "${WORKDIR}/git"
+
+inherit deploy
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+OEI_CONFIGS ?= "UNDEFINED"
+OEI_CORE    ?= "UNDEFINED"
+OEI_SOC     ?= "UNDEFINED"
+OEI_BOARD   ?= "UNDEFINED"
+OEI_DDRCONFIG  ?= ""
+
+LDFLAGS[unexport] = "1"
+
+EXTRA_OEMAKE = "\
+    board=${OEI_BOARD} \
+    DEBUG=1 \
+    OEI_CROSS_COMPILE=arm-none-eabi-"
+
+EXTRA_OEMAKE:append:mx95-generic-bsp = " r=${IMX_SOC_REV}"
+EXTRA_OEMAKE:append = " ${@' DDR_CONFIG=${OEI_DDRCONFIG}' if d.getVar('OEI_DDRCONFIG') else ''}"
+
+do_configure() {
+    for oei_config in ${OEI_CONFIGS}; do
+        oe_runmake clean oei=$oei_config
+    done
+}
+
+do_compile() {
+    for oei_config in ${OEI_CONFIGS}; do
+        oe_runmake oei=$oei_config
+    done
+}
+
+do_install() {
+    install -d ${D}/firmware
+    for oei_config in ${OEI_CONFIGS}; do
+        install -m 0644 ${B}/build/${OEI_BOARD}/$oei_config/oei-*.bin ${D}/firmware
+    done
+}
+
+addtask deploy after do_install
+do_deploy() {
+    cp -rf ${D}/firmware/* ${DEPLOYDIR}/
+}
+
+FILES:${PN} = "/firmware"
+SYSROOT_DIRS += "/firmware"
+
+PROVIDES += "virtual/imx-oei"
+
+COMPATIBLE_MACHINE = "(mx95-generic-bsp)"

--- a/dynamic-layers/arm-toolchain/recipes-bsp/imx-oei/imx-oei_1.0.0.bb
+++ b/dynamic-layers/arm-toolchain/recipes-bsp/imx-oei/imx-oei_1.0.0.bb
@@ -1,65 +1,17 @@
 SUMMARY = "i.MX Optional Execution Image"
-
+DESCRIPTION = "\
+The Optional Executable Image (OEI) is an optional plugin loaded and executed \
+by Cortex-M processor ROM on many NXP i.MX processors. The Cortex-M is the \
+boot core, runs the boot ROM which loads the OEI, and then branches to the \
+OEI. The OEI then configures some aspects of the hardware such as DDR config, \
+init TCM ECC, etc. There could be multiple OEI images in the boot container. \
+After execution of OEI, the processor returns to ROM execution."
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=b66f32a90f9577a5a3255c21d79bc619"
-
-INHIBIT_DEFAULT_DEPS = "1"
-DEPENDS = "gcc-arm-none-eabi-native"
 
 SRC_URI = "${IMX_OEI_SRC};branch=${SRCBRANCH}"
 IMX_OEI_SRC ?= "git://github.com/nxp-imx/imx-oei.git;protocol=https"
 SRCBRANCH = "master"
 SRCREV = "ca91ce798b2f3a2a0bab8c0f835f4bea88c9b080"
 
-S = "${WORKDIR}/git"
-
-inherit deploy
-
-PACKAGE_ARCH = "${MACHINE_ARCH}"
-
-OEI_CONFIGS ?= "UNDEFINED"
-OEI_CORE    ?= "UNDEFINED"
-OEI_SOC     ?= "UNDEFINED"
-OEI_BOARD   ?= "UNDEFINED"
-OEI_DDRCONFIG  ?= ""
-
-LDFLAGS[unexport] = "1"
-
-EXTRA_OEMAKE = "\
-    board=${OEI_BOARD} \
-    DEBUG=1 \
-    OEI_CROSS_COMPILE=arm-none-eabi-"
-
-EXTRA_OEMAKE:append:mx95-generic-bsp = " r=${IMX_SOC_REV}"
-EXTRA_OEMAKE:append = " ${@' DDR_CONFIG=${OEI_DDRCONFIG}' if d.getVar('OEI_DDRCONFIG') else ''}"
-
-do_configure() {
-    for oei_config in ${OEI_CONFIGS}; do
-        oe_runmake clean oei=$oei_config
-    done
-}
-
-do_compile() {
-    for oei_config in ${OEI_CONFIGS}; do
-        oe_runmake oei=$oei_config
-    done
-}
-
-do_install() {
-    install -d ${D}/firmware
-    for oei_config in ${OEI_CONFIGS}; do
-        install -m 0644 ${B}/build/${OEI_BOARD}/$oei_config/oei-*.bin ${D}/firmware
-    done
-}
-
-addtask deploy after do_install
-do_deploy() {
-    cp -rf ${D}/firmware/* ${DEPLOYDIR}/
-}
-
-FILES:${PN} = "/firmware"
-SYSROOT_DIRS += "/firmware"
-
-PROVIDES += "virtual/imx-oei"
-
-COMPATIBLE_MACHINE = "(mx95-generic-bsp)"
+require imx-oei.inc


### PR DESCRIPTION
Similar the recipe into version configuration and build instructions, similar to imx-system-manager.


(cherry picked from commit a13010303ee97d9534e65ac98c025b74e2a8aba9)