### PR TITLE
meta-tq: dynamic-layers: imx-oei-tq: allow overwrite debug settings

### DIFF
--- a/dynamic-layers/arm-toolchain/recipes-bsp/imx-oei/imx-oei.inc
+++ b/dynamic-layers/arm-toolchain/recipes-bsp/imx-oei/imx-oei.inc
@@ -10,12 +10,13 @@ OEI_CORE    ?= "UNDEFINED"
 OEI_SOC     ?= "UNDEFINED"
 OEI_BOARD   ?= "UNDEFINED"
 OEI_DDRCONFIG  ?= ""
+OEI_DEBUG   ?= "0"
 
 LDFLAGS[unexport] = "1"
 
 EXTRA_OEMAKE = "\
     board=${OEI_BOARD} \
-    DEBUG=1 \
+    DEBUG=${OEI_DEBUG} \
     OEI_CROSS_COMPILE=arm-none-eabi-"
 
 EXTRA_OEMAKE:append:mx95-generic-bsp = " r=${IMX_SOC_REV}"


### PR DESCRIPTION
Prepare for production release while leave it up to local.conf or <machine>.conf to enable debug console output.