### PR TITLE
fsl-kernel-localversion: Fix duplicate LOCALVERSION

### DIFF
--- a/classes/fsl-kernel-localversion.bbclass
+++ b/classes/fsl-kernel-localversion.bbclass
@@ -13,7 +13,8 @@ SCMVERSION ??= "y"
 LOCALVERSION ??= "+fslc"
 
 # LINUX_VERSION_EXTENSION is used as CONFIG_LOCALVERSION by kernel-yocto class
-LINUX_VERSION_EXTENSION ?= "${LOCALVERSION}"
+LINUX_VERSION_EXTENSION ?= \
+    "${@bb.utils.contains('SCMVERSION', 'y', '', '${LOCALVERSION}', d)}"
 
 do_kernel_localversion[dirs] += "${S} ${B}"
 do_kernel_localversion() {


### PR DESCRIPTION
The kernel version contains LOCALVERSION twice. For example, for LOCALVERSION=nxp-next:
```
$ cat tmp/work/imx95evk-poky-linux/linux-imx/6.18.y+git/build/include/generated/utsrelease.h
#define UTS_RELEASE "6.18.0-nxp-next-nxp-next-06195-gb61baedaf5d5"
```

The problem is kernel-yocto.bbclass adds LOCALVERSION via .config if LINUX_VERSION_EXTENSION is not empty, and the build itself adds it because fsl-kernel-localversion.bbclass sets CONFIG_LOCALVERSION_AUTO=y whenever SCMVERSION is enabled.

Fix by clearing LINUX_VERSION_EXTENSION if SCMVERSION is enabled.