### PR TITLE
firmware-nxp-wifi: Enable nullglob

### DIFF
--- a/recipes-bsp/firmware-imx/firmware-nxp-wifi_1.1.bb
+++ b/recipes-bsp/firmware-imx/firmware-nxp-wifi_1.1.bb
@@ -30,6 +30,8 @@ do_install() {
     install -d ${D}${nonarch_base_libdir}/firmware/nxp
     install -d ${D}${nonarch_base_libdir}/firmware/brcm/
 
+    shopt -s nullglob
+
     # Install bcm4359-pcie
     for f in cyw-wifi-bt/*_CYW*/brcmfmac4359-pcie*; do
         install -D -m 0644 $f ${D}${nonarch_base_libdir}/firmware/brcm/$(basename $f)
@@ -42,6 +44,8 @@ do_install() {
     for f in nxp/FwImage_IW612_SD/*; do
         install -D -m 0644 $f ${D}${nonarch_base_libdir}/firmware/nxp/IW612_SD_RFTest/$(basename $f)
     done
+
+    shopt -u nullglob
 
     oe_runmake install INSTALLDIR=${D}${nonarch_base_libdir}/firmware/nxp
 


### PR DESCRIPTION
makes the glob expand to nothing when there are no matches, so the loop body never executes.

Fixes
| install: cannot stat 'cyw-wifi-bt/*_CYW*/brcmfmac4359-pcie*': No such file or directory