### PR TITLE
kernel: replace tabs by spaces

### DIFF
--- a/classes/fsl-kernel-localversion.bbclass
+++ b/classes/fsl-kernel-localversion.bbclass
@@ -19,30 +19,30 @@ LINUX_VERSION_EXTENSION ?= \
 do_kernel_localversion[dirs] += "${S} ${B}"
 do_kernel_localversion() {
 
-	# Fallback for recipes not able to use LINUX_VERSION_EXTENSION
-	if [ "${@bb.data.inherits_class('kernel-yocto', d)}" = "False" ]; then
-		echo 'CONFIG_LOCALVERSION="${LOCALVERSION}"' >> ${B}/.config
-	fi
+    # Fallback for recipes not able to use LINUX_VERSION_EXTENSION
+    if [ "${@bb.data.inherits_class('kernel-yocto', d)}" = "False" ]; then
+        echo 'CONFIG_LOCALVERSION="${LOCALVERSION}"' >> ${B}/.config
+    fi
 
-	if [ "${SCMVERSION}" = "y" ]; then
-		# Add GIT revision to the local version
-		if [ "${SRCREV}" = "INVALID" ]; then
-			hash=${SRCREV_machine}
-		else
-			hash=${SRCREV}
-		fi
-		if [ "$hash" = "AUTOINC" ]; then
-			branch=`git --git-dir=${S}/.git  symbolic-ref --short -q HEAD`
-			head=`git --git-dir=${S}/.git rev-parse --verify --short origin/${branch} 2> /dev/null`
-		else
-			head=`git --git-dir=${S}/.git rev-parse --verify --short $hash 2> /dev/null`
-		fi
-		patches=`git --git-dir=${S}/.git rev-list --count $head..HEAD 2> /dev/null`
-		printf "%s%s%s%s" +g $head +p $patches > ${S}/.scmversion
+    if [ "${SCMVERSION}" = "y" ]; then
+        # Add GIT revision to the local version
+        if [ "${SRCREV}" = "INVALID" ]; then
+            hash=${SRCREV_machine}
+        else
+            hash=${SRCREV}
+        fi
+        if [ "$hash" = "AUTOINC" ]; then
+            branch=`git --git-dir=${S}/.git  symbolic-ref --short -q HEAD`
+            head=`git --git-dir=${S}/.git rev-parse --verify --short origin/${branch} 2> /dev/null`
+        else
+            head=`git --git-dir=${S}/.git rev-parse --verify --short $hash 2> /dev/null`
+        fi
+        patches=`git --git-dir=${S}/.git rev-list --count $head..HEAD 2> /dev/null`
+        printf "%s%s%s%s" +g $head +p $patches > ${S}/.scmversion
 
-		sed -i -e "/CONFIG_LOCALVERSION_AUTO[ =]/d" ${B}/.config
-		echo "CONFIG_LOCALVERSION_AUTO=y" >> ${B}/.config
-	fi
+        sed -i -e "/CONFIG_LOCALVERSION_AUTO[ =]/d" ${B}/.config
+        echo "CONFIG_LOCALVERSION_AUTO=y" >> ${B}/.config
+    fi
 }
 
 addtask kernel_localversion before do_configure after do_patch do_kernel_configme

--- a/classes/kernel-imximage.bbclass
+++ b/classes/kernel-imximage.bbclass
@@ -22,39 +22,39 @@ DEPENDS:append = ' u-boot-mkimage-native'
 IMXIMAGE_ENTRYPOINT ?= "${UBOOT_ENTRYPOINT}"
 
 imx_mkimage() {
-	uboot-mkimage -n $1 -T imximage -e ${IMXIMAGE_ENTRYPOINT} -d $2 $2.imx
+    uboot-mkimage -n $1 -T imximage -e ${IMXIMAGE_ENTRYPOINT} -d $2 $2.imx
 }
 
 gen_imximage() {
-	if [ -z "${IMXIMAGE_ENTRYPOINT}" ]; then
-		bbfatal "IMXIMAGE_ENTRYPOINT must have a valid value"
-	fi
+    if [ -z "${IMXIMAGE_ENTRYPOINT}" ]; then
+        bbfatal "IMXIMAGE_ENTRYPOINT must have a valid value"
+    fi
 
-	for DTB in ${KERNEL_DEVICETREE}; do
-		DTB=`normalize_dtb "${DTB}"`
-		DTB_EXT=${DTB##*.}
-		DTB_BASE_NAME=`basename ${DTB} ."${DTB_EXT}"`
-		base_name="zImage-"${KERNEL_IMAGE_BASE_NAME}
-		symlink_name="zImage-"${KERNEL_IMAGE_SYMLINK_NAME}
-		DTB_NAME=`echo ${base_name} | sed "s/${MACHINE}/${DTB_BASE_NAME}/g"`
-		DTB_SYMLINK_NAME=`echo ${symlink_name} | sed "s/${MACHINE}/${DTB_BASE_NAME}/g"`
-		for DCD in dcd-${DTB}.cfg dcd.cfg; do
-			if [ -e "${WORKDIR}/${DCD}" ]; then
-				if [ -e ${DEPLOYDIR}/${DTB_NAME}.${DTB_EXT}.bin ]; then
-					imx_mkimage ${WORKDIR}/${DCD} ${DEPLOYDIR}/${DTB_NAME}.${DTB_EXT}.bin
-					ln -sf ${DTB_NAME}.${DTB_EXT}.bin.imx ${DEPLOYDIR}/$type-${DTB_BASE_NAME}.${DTB_EXT}.bin.imx
-				fi
+    for DTB in ${KERNEL_DEVICETREE}; do
+        DTB=`normalize_dtb "${DTB}"`
+        DTB_EXT=${DTB##*.}
+        DTB_BASE_NAME=`basename ${DTB} ."${DTB_EXT}"`
+        base_name="zImage-"${KERNEL_IMAGE_BASE_NAME}
+        symlink_name="zImage-"${KERNEL_IMAGE_SYMLINK_NAME}
+        DTB_NAME=`echo ${base_name} | sed "s/${MACHINE}/${DTB_BASE_NAME}/g"`
+        DTB_SYMLINK_NAME=`echo ${symlink_name} | sed "s/${MACHINE}/${DTB_BASE_NAME}/g"`
+        for DCD in dcd-${DTB}.cfg dcd.cfg; do
+            if [ -e "${WORKDIR}/${DCD}" ]; then
+                if [ -e ${DEPLOYDIR}/${DTB_NAME}.${DTB_EXT}.bin ]; then
+                    imx_mkimage ${WORKDIR}/${DCD} ${DEPLOYDIR}/${DTB_NAME}.${DTB_EXT}.bin
+                    ln -sf ${DTB_NAME}.${DTB_EXT}.bin.imx ${DEPLOYDIR}/$type-${DTB_BASE_NAME}.${DTB_EXT}.bin.imx
+                fi
 
-				if [ -e ${DEPLOYDIR}/zImage-${INITRAMFS_BASE_NAME}-${DTB_BASE_NAME}.${DTB_EXT}.bin ]; then
-					imx_mkimage ${WORKDIR}/${DCD} ${DEPLOYDIR}/zImage-${INITRAMFS_BASE_NAME}-${DTB_BASE_NAME}.${DTB_EXT}.bin
-					ln -sf zImage-${INITRAMFS_BASE_NAME}-${DTB_BASE_NAME}.${DTB_EXT}.bin.imx \
-					   ${DEPLOYDIR}/zImage-initramfs-${DTB_BASE_NAME}.${DTB_EXT}-${MACHINE}.bin.imx
-				fi
-			fi
-		done
-	done
+                if [ -e ${DEPLOYDIR}/zImage-${INITRAMFS_BASE_NAME}-${DTB_BASE_NAME}.${DTB_EXT}.bin ]; then
+                    imx_mkimage ${WORKDIR}/${DCD} ${DEPLOYDIR}/zImage-${INITRAMFS_BASE_NAME}-${DTB_BASE_NAME}.${DTB_EXT}.bin
+                    ln -sf zImage-${INITRAMFS_BASE_NAME}-${DTB_BASE_NAME}.${DTB_EXT}.bin.imx \
+                       ${DEPLOYDIR}/zImage-initramfs-${DTB_BASE_NAME}.${DTB_EXT}-${MACHINE}.bin.imx
+                fi
+            fi
+        done
+    done
 }
 
 do_deploy:append() {
-	gen_imximage
+    gen_imximage
 }

--- a/recipes-kernel/kernel-modules/kernel-module-ar_git.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-ar_git.bb
@@ -17,10 +17,10 @@ do_compile:prepend() {
 }
 
 do_install(){
-	install -d ${D}${nonarch_base_libdir}/modules/${KERNEL_VERSION}
-	install -d ${D}${bindir}
-	install -m 644 ${B}/bin/ar.ko ${D}${nonarch_base_libdir}/modules/${KERNEL_VERSION}/
-	cp -f ${S}/bin/ar_* ${D}${bindir}/ 
+    install -d ${D}${nonarch_base_libdir}/modules/${KERNEL_VERSION}
+    install -d ${D}${bindir}
+    install -m 644 ${B}/bin/ar.ko ${D}${nonarch_base_libdir}/modules/${KERNEL_VERSION}/
+    cp -f ${S}/bin/ar_* ${D}${bindir}/ 
 }
 
 FILES:${PN} += "${bindir}/"


### PR DESCRIPTION
Without this changes bitbake complains about
"TabError: inconsistent use of tabs and spaces in indentation" Because some included python code chunks use tab for indentation and others four spaces. So we convert to using 4 spaces as the recipes in openembedded-base do.