### PR TITLE
imx-base.inc: set UBOOT_PROVIDES_BOOT_CONTAINER for mx95-mainline-bsp

### DIFF
--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -106,6 +106,9 @@ UBOOT_PROVIDES_BOOT_CONTAINER = "0"
 # IMX_DEFAULT_BOOTLOADER.
 UBOOT_PROVIDES_BOOT_CONTAINER:mx8m-generic-bsp = "${@oe.utils.ifelse(d.getVar('IMX_DEFAULT_BOOTLOADER') == 'u-boot-imx', '0', '1')}"
 
+# i.MX95 mainline U-Boot uses binman to assemble the boot container.
+UBOOT_PROVIDES_BOOT_CONTAINER:mx95-mainline-bsp = "1"
+
 # Trusted Firmware for Cortex-A (TF-A) can have different providers, either
 # from upstream or from NXP downstream fork. Below variable defines which TF-A
 # shall be taken into the build, and will be integrated into runtime image.


### PR DESCRIPTION
i.MX95 mainline U-Boot uses binman to assemble the boot container, so the imx-boot recipe is not needed on that path. Note that u-boot-fslc does not yet support i.MX95; this is currently only exercised by mainline U-Boot.