### PR TITLE
linux-imx: Add '.git' suffix to SRC_URI

### DIFF
--- a/recipes-kernel/linux/linux-imx.inc
+++ b/recipes-kernel/linux/linux-imx.inc
@@ -17,7 +17,7 @@ PROVIDES += "linux-mfgtool"
 # Set the PV to the correct kernel version to satisfy the kernel version sanity check
 PV = "${LINUX_VERSION}+git${SRCPV}"
 
-SRC_URI = "git://github.com/nxp-imx/linux-imx;protocol=https;branch=${SRCBRANCH}"
+SRC_URI = "git://github.com/nxp-imx/linux-imx.git;protocol=https;branch=${SRCBRANCH}"
 
 # Tell to kernel class that we would like to use our defconfig to configure the kernel.
 # Otherwise, the --allnoconfig would be used per default which leads to mis-configured


### PR DESCRIPTION
This patch fixes the need to clone the same repo twice. The 'github.com/nxp-imx/linux-imx.git' repo is used in:
 - linux-imx-headers
 - linux-imx
 - kernel-module-imx-gpu-viv