### PR TITLE
imx-oei: only pass a non-empty DDR_CONFIG to EXTRA_OEMAKE

### DIFF
--- a/dynamic-layers/arm-toolchain/recipes-bsp/imx-oei/imx-oei.inc
+++ b/dynamic-layers/arm-toolchain/recipes-bsp/imx-oei/imx-oei.inc
@@ -22,11 +22,19 @@ LDFLAGS[unexport] = "1"
 
 EXTRA_OEMAKE = "\
     board=${OEI_BOARD} \
-    DDR_CONFIG=${@bb.utils.contains('PACKAGECONFIG', 'ecc', '${OEI_DDRCONFIG_ECC}', '${OEI_DDRCONFIG}', d)} \
     DEBUG=${OEI_DEBUG} \
     OEI_CROSS_COMPILE=arm-none-eabi-"
 
 EXTRA_OEMAKE:append:mx95-generic-bsp = " r=${IMX_SOC_REV}"
+
+python () {
+    if 'ecc' in d.getVar('PACKAGECONFIG'):
+        ddr_conf = d.getVar('OEI_DDRCONFIG_ECC')
+    else:
+        ddr_conf = d.getVar('OEI_DDRCONFIG')
+    if ddr_conf:
+        d.appendVar('EXTRA_OEMAKE', ' DDR_CONFIG='+ddr_conf)
+}
 
 do_configure() {
     for oei_config in ${OEI_CONFIGS}; do


### PR DESCRIPTION
Commit 6ff67d5c ("imx-oei.inc: Use PACKAGECONFIG support of ecc and tcm") started always passing DDR_CONFIG to EXTRA_OEMAKE. Its value depends on PACKAGECONFIG, either passing in OEI_DDRCONFIG_ECC or OEI_DDRCONFIG.

However, OEI_DDRCONFIG and/or OEI_DDRCONFIG_ECC are not necessarily present. When they are not, an empty DDR_CONFIG is passed to make, which prevents imx-oei from using its default value for this.

Make the passing of DDR_CONFIG conditional on the existence of OEI_DDRCONFIG(_ECC) again.

Fixes: 6ff67d5c ("imx-oei.inc: Use PACKAGECONFIG support of ecc and tcm")

----

https://github.com/Freescale/meta-freescale/pull/2456

@otavio @junzhuimx:

I'm not sure if my proposed fix here is the best. I wrote this to stay compatible with the functionality added in the mentioned PR while also allowing OEI_DDRCONFIG(_ECC) to not exist without issues, but I wonder if we cannot simplify:
- Why do we need OEI_DDRCONFIG_ECC, selected via PACKAGECONFIG? Why not use OEI_DDRCONFIG for the ECC use case as well? As I see it, instead of setting PACKAGECONFIG = "ecc" somewhere, you could just as well set OEI_DDRCONFIG to the desired value there. What am I missing, what else is this PACKAGECONFIG used for?

If this PACKAGECONFIG "ecc" is how we want to handle things, this PR hopefully fixes the use case for everyone, but I would personally prefer to simplify instead.

Without a fix, 6ff67d5c breaks our builds: `/workdir/oe/tmp/work/aquila_imx95-tdx-linux/imx-oei-toradex/1.0.0/temp/run.do_configure.165577: 150: Bad substitution`.