### PR TITLE
linux-fslc-imx: Bump to v5.15.201

### DIFF
--- a/recipes-kernel/linux/linux-fslc-imx_5.15.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_5.15.bb
@@ -28,7 +28,7 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v5.15.157
+#    tag: v5.15.201
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
@@ -51,17 +51,17 @@ LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
 KBRANCH = "5.15-2.2.x-imx"
-SRCREV = "5134e031114e613cb04858e248af5e65fe1e112f"
+SRCREV = "5f2b61f91866c72e259bb164f7d0553908586ac1"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "5.15.157"
+LINUX_VERSION = "5.15.201"
 
 # Local version indicates the branch name in the NXP kernel tree where patches are collected from.
-LOCALVERSION = "-5.15.157-2.2.0"
+LOCALVERSION = "-5.15.201-2.2.0"
 
 DEFAULT_PREFERENCE = "1"
 


### PR DESCRIPTION
Use kernel with merged 5.15.201 stable patches.