### PR TITLE
conf/layer.conf: Add wrynose to LAYERSERIES_COMPAT

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -8,7 +8,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 BBFILE_COLLECTIONS += "freescale-layer"
 BBFILE_PATTERN_freescale-layer := "^${LAYERDIR}/"
 BBFILE_PRIORITY_freescale-layer = "5"
-LAYERSERIES_COMPAT_freescale-layer = "whinlatter"
+LAYERSERIES_COMPAT_freescale-layer = "whinlatter wrynose"
 LAYERDEPENDS_freescale-layer = "core"
 
 # Add the Freescale-specific licenses into the metadata


### PR DESCRIPTION
Wrynose is now the version compatible on openembedded-core.

Test OK on board i.MX93