### PR TITLE
uboot: Update to lf-6.18.2-1.0.0

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -28,6 +28,9 @@ ${IMX_MIRROR}   http://download.ossystems.com.br/bsp/freescale/source/ \n \
 # implemented in imx GL driver implementation
 COMPATIBLE_HOST:pn-xdg-desktop-portal-wlr:imxgpu = "(null)"
 
+# FIXME: Skip error if/when tools no softlink in ${TMPDIR}/hosttools
+HOSTTOOLS_NONFATAL:append = " cert-to-efi-sig-list"
+
 # For compatibility with layers before scarthgap
 PROVIDES:pn-bmap-tools-native = "bmaptool-native"
 RPROVIDES:pn-bmap-tools-native:bmap-tools-native = "bmaptool-native"

--- a/recipes-bsp/u-boot/u-boot-imx-common_2025.04.inc
+++ b/recipes-bsp/u-boot/u-boot-imx-common_2025.04.inc
@@ -4,10 +4,11 @@ LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://Licenses/gpl-2.0.txt;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 SRC_URI = "${UBOOT_SRC};branch=${SRCBRANCH}"
+
 UBOOT_SRC ?= "git://github.com/nxp-imx/uboot-imx.git;protocol=https"
 SRCBRANCH = "lf_v2025.04"
 LOCALVERSION ?= "-${SRCBRANCH}"
-SRCREV = "4ddbad60eff308a5b356fb9ab8734ac382ddd692"
+SRCREV = "99518e6b6f20cb6a2bf19115e355db9f58100af8"
 
 DEPENDS += " \
     bc-native \
@@ -15,6 +16,7 @@ DEPENDS += " \
     dtc-native \
     flex-native \
     gnutls-native \
+    python3-setuptools-native \
     xxd-native \
 "
 

--- a/recipes-bsp/u-boot/u-boot-imx-tools_2025.04.bb
+++ b/recipes-bsp/u-boot/u-boot-imx-tools_2025.04.bb
@@ -1,0 +1,9 @@
+require recipes-bsp/u-boot/u-boot-tools.inc
+require u-boot-imx-common_${PV}.inc
+
+PROVIDES:append:class-target = " ${MLPREFIX}u-boot-tools"
+PROVIDES:append:class-native = " u-boot-tools-native"
+PROVIDES:append:class-nativesdk = " nativesdk-u-boot-tools"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+COMPATIBLE_MACHINE:class-target = "(imx-generic-bsp)"

--- a/recipes-bsp/u-boot/u-boot-imx_2025.04.bb
+++ b/recipes-bsp/u-boot/u-boot-imx_2025.04.bb
@@ -1,6 +1,6 @@
 # Copyright (C) 2013-2016 Freescale Semiconductor
 # Copyright 2018 (C) O.S. Systems Software LTDA.
-# Copyright 2017-2024 NXP
+# Copyright 2017-2026 NXP
 
 require recipes-bsp/u-boot/u-boot.inc
 require u-boot-imx-common_${PV}.inc
@@ -23,7 +23,6 @@ do_deploy:append:mx8m-generic-bsp() {
         for config in ${UBOOT_MACHINE}; do
             i=$(expr $i + 1);
             for type in ${UBOOT_CONFIG}; do
-                builddir="${config}-${type}"
                 j=$(expr $j + 1);
                 if [ $j -eq $i ]
                 then
@@ -34,19 +33,28 @@ do_deploy:append:mx8m-generic-bsp() {
                     for key_value in ${UBOOT_DTB_NAME_FLAGS}; do
                         local type_key="${key_value%%:*}"
                         local dtb_name="${key_value#*:}"
+                        local dtb_path=""
                         if [ "$type_key" = "$type" ]
                         then
                             bbnote "UBOOT_CONFIG = $type, UBOOT_DTB_NAME = $dtb_name"
                             # There is only one ${dtb_name}, the first one. All the other are with the type appended
                             if [ ! -f "${DEPLOYDIR}/${BOOT_TOOLS}/${dtb_name}" ]; then
-                                install -m 0644 ${B}/${builddir}/arch/arm/dts/${dtb_name}  ${DEPLOYDIR}/${BOOT_TOOLS}/${dtb_name}
+                                if [ -f "${B}/${builddir}/dts/upstream/src/arm64/freescale/${dtb_name}" ];then
+                                    dtb_path="${B}/${builddir}/dts/upstream/src/arm64/freescale"
+                                elif [ -f "${B}/${builddir}/arch/arm/dts/${dtb_name}" ];then
+                                    dtb_path="${B}/${builddir}/arch/arm/dts/"
+                                else
+                                     bbfatal "no such ${dtb_name}"
+                                fi
+                                install -m 0644 ${dtb_path}/${dtb_name}  ${DEPLOYDIR}/${BOOT_TOOLS}/${dtb_name}
                             else
                                 bbwarn "Use custom wks.in for $dtb_name = $type"
                             fi
-                            install -m 0644 ${B}/${builddir}/arch/arm/dts/${dtb_name}  ${DEPLOYDIR}/${BOOT_TOOLS}/${dtb_name}-${type}
+                            install -m 0644 ${dtb_path}/${dtb_name}  ${DEPLOYDIR}/${BOOT_TOOLS}/${dtb_name}-${type}
                         fi
                         unset type_key
                         unset dtb_name
+                        unset dtb_path
                     done
 
                     unset UBOOT_DTB_NAME_FLAGS
@@ -62,6 +70,11 @@ do_deploy:append:mx8m-generic-bsp() {
 }
 
 do_deploy:append:mx93-generic-bsp() {
+    # Deploy CRT.* from u-boot for stmm
+    install -m 0644 ${S}/CRT.*     ${DEPLOYDIR}
+}
+
+do_deploy:append:mx95-generic-bsp() {
     # Deploy CRT.* from u-boot for stmm
     install -m 0644 ${S}/CRT.*     ${DEPLOYDIR}
 }


### PR DESCRIPTION
uboot: update to v25.04 latest commit 
- 8ULP depends on setuptools
-  Fix do_deploy failure as build path updated in uboot-sign.bbclass, ${B}/${config} -> ${B}/${config}-${type}.
- Need install efitools in host, `sudo apt install efitools



