### PR TITLE
imx-seco_5.9.4.1.bb: Fix seco lib didn't install in rootfs

### DIFF
--- a/recipes-bsp/imx-seco/imx-seco_5.9.4.1.bb
+++ b/recipes-bsp/imx-seco/imx-seco_5.9.4.1.bb
@@ -17,7 +17,10 @@ S = "${UNPACKDIR}/${BPN}-${PV}-${IMX_SRCREV_ABBREV}"
 
 do_compile[noexec] = "1"
 
-do_install[noexec] = "1"
+do_install:append() {
+    install -d ${D}${base_libdir}/firmware/${PN}
+    install -m 0644 ${S}/firmware/seco/${SECO_FIRMWARE_NAME} ${D}${base_libdir}/firmware/${PN}
+}
 
 addtask deploy after do_install
 do_deploy () {
@@ -25,4 +28,5 @@ do_deploy () {
     install -m 0644 ${S}/firmware/seco/${SECO_FIRMWARE_NAME} ${DEPLOYDIR}
 }
 
+FILES:${PN} = "/"
 COMPATIBLE_MACHINE = "(mx8qm-generic-bsp|mx8qxp-generic-bsp|mx8dxl-generic-bsp|mx8dx-generic-bsp)"


### PR DESCRIPTION
Add machine's SECO_FIRMWARE_NAME to /usr/lib/firmware/imx-seco