### PR TITLE
Bsp: upgrade to 6.18.2

### DIFF
--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -501,9 +501,12 @@ MACHINE_EXTRA_RRECOMMENDS += " \
     ${@bb.utils.filter('COMBINED_FEATURES', 'jailhouse', d)} \
 "
 
-# ELE extra Firmware
+# ELE extra Firmware,to be installed and accessed from userspace.
+# Note that multiple names can be given in order to install multiple versions
+# to a single rootfs.
 SECOEXT_FIRMWARE_NAME ?= "UNDEFINED"
 SECOEXT_FIRMWARE_NAME:mx8ulp-generic-bsp ?= "mx8ulp${IMX_SOC_REV_LOWER}ext-ahab-container.img"
+SECOEXT_FIRMWARE_NAME:mx95-generic-bsp   ?= "mx95a0runtime-ahab-container.img mx95b0runtime-ahab-container.img"
 SECOEXT_FIRMWARE_NAME:mx943-generic-bsp  ?= "mx943${IMX_SOC_REV_LOWER}runtime-ahab-container.img"
 
 # GStreamer 1.0 plugins

--- a/dynamic-layers/arm-toolchain/recipes-bsp/imx-oei/imx-oei.inc
+++ b/dynamic-layers/arm-toolchain/recipes-bsp/imx-oei/imx-oei.inc
@@ -11,40 +11,39 @@ PACKAGECONFIG[tcm] = ""
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
-OEI_CONFIGS ?= "ddr ${@bb.utils.filter('PACKAGECONFIG', 'tcm', d)}"
 OEI_CORE    ?= "UNDEFINED"
 OEI_SOC     ?= "UNDEFINED"
 OEI_BOARD   ?= "UNDEFINED"
-OEI_DDR_CONFIG  ?= ""
-OEI_DEBUG   ?= "0"
+OEI_CONFIGS ?= "ddr ${@bb.utils.filter('PACKAGECONFIG', 'tcm', d)}"
 
 LDFLAGS[unexport] = "1"
 
 EXTRA_OEMAKE = "\
     board=${OEI_BOARD} \
-    DEBUG=${OEI_DEBUG} \
+    DEBUG=1 \
     OEI_CROSS_COMPILE=arm-none-eabi-"
 
-EXTRA_OEMAKE:append:mx95-generic-bsp = " r=${IMX_SOC_REV}"
-
-python () {
-    if 'ecc' in d.getVar('PACKAGECONFIG'):
-        ddr_conf = d.getVar('OEI_DDR_CONFIG_ECC')
-    else:
-        ddr_conf = d.getVar('OEI_DDR_CONFIG')
-    if ddr_conf:
-        d.appendVar('EXTRA_OEMAKE', ' DDR_CONFIG='+ddr_conf)
-}
+EXTRA_OEMAKE:append:mx95-nxp-bsp = " r=${IMX_SOC_REV}"
 
 do_configure() {
+    if [ "${@bb.utils.filter('PACKAGECONFIG', 'ecc', d)}" ]; then
+        ddr_config=${OEI_DDR_CONFIG_ECC}
+    else
+        ddr_config=${OEI_DDR_CONFIG}
+    fi
     for oei_config in ${OEI_CONFIGS}; do
-        oe_runmake clean oei=$oei_config
+        oe_runmake clean oei=$oei_config DDR_CONFIG=$ddr_config
     done
 }
 
 do_compile() {
+    if [ "${@bb.utils.filter('PACKAGECONFIG', 'ecc', d)}" ]; then
+        ddr_config=${OEI_DDR_CONFIG_ECC}
+    else
+        ddr_config=${OEI_DDR_CONFIG}
+    fi
     for oei_config in ${OEI_CONFIGS}; do
-        oe_runmake oei=$oei_config
+        oe_runmake oei=$oei_config DDR_CONFIG=$ddr_config
     done
 }
 

--- a/dynamic-layers/arm-toolchain/recipes-bsp/imx-oei/imx-oei_1.0.0.bb
+++ b/dynamic-layers/arm-toolchain/recipes-bsp/imx-oei/imx-oei_1.0.0.bb
@@ -12,6 +12,6 @@ LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=b66f32a90f9577a5a3255c21d79bc619"
 SRC_URI = "${IMX_OEI_SRC};branch=${SRCBRANCH}"
 IMX_OEI_SRC ?= "git://github.com/nxp-imx/imx-oei.git;protocol=https"
 SRCBRANCH = "master"
-SRCREV = "49bfaa93e9d1fe213866bcb9507927a59a9ede5a"
+SRCREV = "fa9e9a29e8c8939cc360beafd01393ca393e439a"
 
 require imx-oei.inc

--- a/dynamic-layers/arm-toolchain/recipes-bsp/imx-system-manager/imx-system-manager_2026q1.bb
+++ b/dynamic-layers/arm-toolchain/recipes-bsp/imx-system-manager/imx-system-manager_2026q1.bb
@@ -14,7 +14,7 @@ LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=f2a70813bc08547f509361c08b718861"
 SRC_URI = "${IMX_SYSTEM_MANAGER_SRC};branch=${SRCBRANCH}"
 IMX_SYSTEM_MANAGER_SRC ?= "git://github.com/nxp-imx/imx-sm.git;protocol=https"
 SRCBRANCH = "master"
-SRCREV = "de30901b287e5c9a1e467d2d9a497b97bb6f7939"
+SRCREV = "c450f53974ea1df826970ad399cb338625b5638d"
 
 require imx-system-manager.inc
 

--- a/recipes-bsp/firmware-imx/firmware-ele-imx_2.0.5.bb
+++ b/recipes-bsp/firmware-imx/firmware-ele-imx_2.0.5.bb
@@ -1,15 +1,15 @@
-# Copyright 2021-2025 NXP
+# Copyright 2021-2026 NXP
 SUMMARY = "NXP i.MX ELE firmware"
 DESCRIPTION = "EdgeLock Secure Enclave firmware for i.MX series SoCs"
 SECTION = "base"
 LICENSE = "Proprietary"
-LIC_FILES_CHKSUM = "file://COPYING;md5=a93b654673e1bc8398ed1f30e0813359"
+LIC_FILES_CHKSUM = "file://COPYING;md5=bc649096ad3928ec06a8713b8d787eac"
 
 inherit fsl-eula-unpack use-imx-security-controller-firmware deploy
 
 SRC_URI = "${FSL_MIRROR}/${BP}-${IMX_SRCREV_ABBREV}.bin;fsl-eula=true"
-IMX_SRCREV_ABBREV = "89161a8"
-SRC_URI[sha256sum] = "2d29f0a4de3662ba15f6a7d9069702d4eaed415d96a17f29d5b127f2c6fdd634"
+IMX_SRCREV_ABBREV = "29313e0"
+SRC_URI[sha256sum] = "3af1a5e1336ae3379cf573ccdf34fd8adec99005c4abb70ea0f14af3ac5fb1ae"
 
 S = "${UNPACKDIR}/${BP}-${IMX_SRCREV_ABBREV}"
 
@@ -17,10 +17,9 @@ do_compile[noexec] = "1"
 
 do_install() {
     install -d ${D}${nonarch_base_libdir}/firmware/imx/ele
-    install -m 0644 ${S}/${SECO_FIRMWARE_NAME} ${D}${nonarch_base_libdir}/firmware/imx/ele
-    if [ -e ${S}/${SECOEXT_FIRMWARE_NAME} ]; then
-        install -m 0644 ${S}/${SECOEXT_FIRMWARE_NAME} ${D}${nonarch_base_libdir}/firmware/imx/ele
-    fi
+    for fw in ${SECO_FIRMWARE_NAME} ${SECOEXT_FIRMWARE_NAME}; do
+        install -m 0644 ${S}/$fw ${D}${nonarch_base_libdir}/firmware/imx/ele
+    done
 }
 
 do_deploy () {
@@ -29,12 +28,7 @@ do_deploy () {
 }
 addtask deploy after do_install before do_build
 
-PACKAGES += "${PN}-ext"
-
-ALLOW_EMPTY:${PN}-ext = "1"
-
-FILES:${PN} += "${nonarch_base_libdir}/firmware/imx/ele/${SECO_FIRMWARE_NAME}"
-FILES:${PN}-ext += "${nonarch_base_libdir}/firmware/imx/ele/${SECOEXT_FIRMWARE_NAME}"
+FILES:${PN} = "${nonarch_base_libdir}/firmware"
 
 RREPLACES:${PN} = "firmware-sentinel"
 RPROVIDES:${PN} = "firmware-sentinel"

--- a/recipes-bsp/firmware-imx/firmware-imx-8.31.inc
+++ b/recipes-bsp/firmware-imx/firmware-imx-8.31.inc
@@ -1,16 +1,16 @@
 # Copyright (C) 2012-2016 Freescale Semiconductor
-# Copyright 2017-2025 NXP
+# Copyright 2017-2026 NXP
 # Copyright (C) 2018 O.S. Systems Software LTDA.
 HOMEPAGE = "https://www.nxp.com/"
 SECTION = "base"
 LICENSE = "Proprietary"
-LIC_FILES_CHKSUM = "file://COPYING;md5=a93b654673e1bc8398ed1f30e0813359"
+LIC_FILES_CHKSUM = "file://COPYING;md5=bc649096ad3928ec06a8713b8d787eac"
 
 # Note: This .inc file is used from differently named recipes, so the package
 # name must be hard-coded, i.e., ${BPN} cannot be used.
 SRC_URI = "${FSL_MIRROR}/firmware-imx-${PV}-${IMX_SRCREV_ABBREV}.bin;fsl-eula=true"
-IMX_SRCREV_ABBREV = "994fa14"
-SRC_URI[sha256sum] = "55996f340e87825685a00cd309901189066ec9545ee607734f942c3cde4d69dc"
+IMX_SRCREV_ABBREV = "4fa5b46"
+SRC_URI[sha256sum] = "7f83731cae7056ea4007bf8f0b19734cd76d53affb258405c85223ba7ade5354"
 
 S = "${UNPACKDIR}/firmware-imx-${PV}-${IMX_SRCREV_ABBREV}"
 

--- a/recipes-bsp/firmware-imx/firmware-imx_8.31.bb
+++ b/recipes-bsp/firmware-imx/firmware-imx_8.31.bb
@@ -1,5 +1,5 @@
 # Copyright (C) 2012-2016 Freescale Semiconductor
-# Copyright 2017-2021,2024-2025 NXP
+# Copyright 2017-2021,2024-2026 NXP
 # Copyright (C) 2018 O.S. Systems Software LTDA.
 SUMMARY = "Freescale i.MX firmware"
 DESCRIPTION = "Freescale i.MX firmware such as for the VPU"
@@ -65,6 +65,10 @@ do_install() {
     mv ${D}${nonarch_base_libdir}/firmware/vpu/vpu_fw_imx8* ${D}${nonarch_base_libdir}/firmware/amphion/vpu/
     # Install i.MX 95 VPU firmware
     install -m 0644 ${S}/firmware/vpu/wave633c_codec_fw.bin ${D}${nonarch_base_libdir}/firmware
+    # Install i.MX 952 VPU firmware
+    install -d ${D}${nonarch_base_libdir}/firmware/cnm
+    install -m 0644 ${S}/firmware/vpu/coda980_enc_fw.bin ${D}${nonarch_base_libdir}/firmware/cnm
+    install -m 0644 ${S}/firmware/vpu/wave511_dec_fw.bin ${D}${nonarch_base_libdir}/firmware/cnm
 }
 
 #
@@ -157,7 +161,7 @@ PACKAGES_DYNAMIC = "${PN}-vpu-* ${PN}-sdma-* ${PN}-easrc-* ${PN}-xcvr-* ${PN}-xu
 # is empty.
 # Therefore, we opt-out from producing -dev package here, since also for firmware
 # files it makes no sense.
-PACKAGES = "${PN} ${PN}-epdc ${PN}-hdmi ${PN}-vpu-amphion ${PN}-vpu-wave"
+PACKAGES = "${PN} ${PN}-epdc ${PN}-hdmi ${PN}-vpu-amphion ${PN}-vpu-coda980 ${PN}-vpu-wave511 ${PN}-vpu-wave"
 
 FILES:${PN}-epdc = "${nonarch_base_libdir}/firmware/imx/epdc/"
 FILES:${PN}-hdmi = " \
@@ -166,6 +170,8 @@ FILES:${PN}-hdmi = " \
     ${nonarch_base_libdir}/firmware/dpfw.bin \
 "
 FILES:${PN}-vpu-amphion = "${nonarch_base_libdir}/firmware/amphion/vpu/*"
+FILES:${PN}-vpu-coda980 = "${nonarch_base_libdir}/firmware/cnm/coda980_enc_fw.bin"
+FILES:${PN}-vpu-wave511 = "${nonarch_base_libdir}/firmware/cnm/wave511_dec_fw.bin"
 FILES:${PN}-vpu-wave = "${nonarch_base_libdir}/firmware/wave633c_codec_fw.bin"
 
 COMPATIBLE_MACHINE = "(imx-generic-bsp)"

--- a/recipes-bsp/firmware-imx/imx-boot-firmware-files_8.31.bb
+++ b/recipes-bsp/firmware-imx/imx-boot-firmware-files_8.31.bb
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2025 NXP
+# Copyright (C) 2018-2026 NXP
 SUMMARY = "Freescale i.MX Firmware files used for boot"
 
 require firmware-imx-${PV}.inc


### PR DESCRIPTION
firmware-ele: Bump 2.0.2 - > 2.0.5

- Don't deploy the extra/runtime firmware, it's not needed by imx-boot
- Don't create separate packages for the firmware, one package is sufficient

imx-oei: Update to lf-6.18.2-1.0.0

- Drop OEI_CONFIGS and use PACKAGECONFIG directly
- Add the UBOOT_CONFIG sd-ecc so a bootloader with DDR or ECC can be selected

imx-sm: Bump 2025q4 -> 2026q1

firmware-imx: Bump 8.28 -> 8.31
- install VPU firmware