### PR TITLE
Weston/libdrm update to lf-6.18.2

### DIFF
--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -599,7 +599,7 @@ PREFERRED_VERSION_weston:imx-mainline-bsp   = ""
 PREFERRED_VERSION_xwayland:imx-nxp-bsp ??= "24.1.6.imx"
 
 # Use i.MX libdrm Version
-PREFERRED_VERSION_libdrm:imx-nxp-bsp ??= "2.4.123.imx"
+PREFERRED_VERSION_libdrm:imx-nxp-bsp ??= "2.4.127.imx"
 
 PREFERRED_VERSION_glslang:imxvulkan                  ??= "1.3.275.0.imx"
 PREFERRED_VERSION_spirv-headers:imxvulkan            ??= "1.3.275.0.imx"

--- a/recipes-graphics/drm/libdrm_2.4.127.imx.bb
+++ b/recipes-graphics/drm/libdrm_2.4.127.imx.bb
@@ -13,8 +13,8 @@ DEPENDS = "libpthread-stubs"
 
 SRC_URI = "${IMX_LIBDRM_SRC};branch=${SRCBRANCH}"
 IMX_LIBDRM_SRC ?= "git://github.com/nxp-imx/libdrm-imx.git;protocol=https"
-SRCBRANCH = "libdrm-imx-2.4.123"
-SRCREV = "c7c4953161a0f8f2cc7bee70284bf3263c9cfcf5"
+SRCBRANCH = "libdrm-imx-2.4.127"
+SRCREV = "ef5d39b51d2acfa66e165db89ba32ae32d55def5"
 
 DEFAULT_PREFERENCE = "-1"
 COMPATIBLE_MACHINE = "(imx-nxp-bsp)"

--- a/recipes-graphics/wayland/weston-init.bbappend
+++ b/recipes-graphics/wayland/weston-init.bbappend
@@ -45,6 +45,7 @@ PACKAGECONFIG_USE_G2D:mx8qm-nxp-bsp  ?= ""
 PACKAGECONFIG_USE_G2D:mx8qxp-nxp-bsp ?= ""
 PACKAGECONFIG_USE_G2D:mx8dx-nxp-bsp  ?= ""
 PACKAGECONFIG_USE_G2D:mx93-nxp-bsp   ?= "use-g2d"
+PACKAGECONFIG_USE_G2D:mx943-nxp-bsp   ?= "use-g2d"
 
 USE_G2D_VALUE             = "true"
 USE_G2D_VALUE:mx6-nxp-bsp = "1"
@@ -56,6 +57,18 @@ PACKAGECONFIG[repaint-window] = ",,"
 PACKAGECONFIG[size] = ",,"
 PACKAGECONFIG[use-g2d] = ",,"
 PACKAGECONFIG[xwayland] = ",,"
+
+update_file() {
+    sed -i -e "s,$1,$2," $3
+}
+
+insert_line_before() {
+    sed -i -e "/$1/i $2" $3
+}
+
+insert_line_after() {
+    sed -i -e "/$1/a $2" $3
+}
 
 do_install:append() {
     # Replace the template variables
@@ -91,4 +104,35 @@ do_install:append() {
     if [ "${@bb.utils.contains('PACKAGECONFIG', 'xwayland', 'yes', 'no', d)}" = "no" ]; then
         sed -i -e "s/^xwayland=true/#xwayland=true/g" ${D}${sysconfdir}/xdg/weston/weston.ini
     fi
+
+    if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
+        # Add weston.log back, used by NXP for testing
+        update_file "ExecStart=/usr/bin/weston " "ExecStart=/usr/bin/weston --log=\$\{XDG_RUNTIME_DIR\}/weston.log " ${D}${systemd_system_unitdir}/weston.service
+
+        # FIXME: weston should be run as weston, not as root
+        update_file "User=weston" "User=root" ${D}${systemd_system_unitdir}/weston.service
+        update_file "Group=weston" "Group=root" ${D}${systemd_system_unitdir}/weston.service
+
+        # FIXME: Upstream this change
+        insert_line_before "ExecStart=" "ExecStartPre=+chvt 7" ${D}${systemd_system_unitdir}/weston.service
+
+        # FIXME: fix the underlying problem and drop this workaround
+        insert_line_after "ExecStart=" "Restart=on-failure" ${D}${systemd_system_unitdir}/weston.service
+    else
+        # Install weston-socket.sh for sysvinit as well
+        install -D -p -m0644 ${WORKDIR}/weston-socket.sh ${D}${sysconfdir}/profile.d/weston-socket.sh
+    fi
+
+    # Include commented gbm-format
+    if ! [ "${@bb.utils.contains('PACKAGECONFIG', 'gbm-format', 'yes', 'no', d)}" = "yes" ]; then
+        sed -i -e "/^\[core\]/a #gbm-format=${GBM_FORMAT_VALUE}" ${D}${sysconfdir}/xdg/weston/weston.ini
+    fi
+}
+
+do_install:append:mx6-nxp-bsp() {
+    update_file "--no-resizeable" "--no-clients-resize" ${D}${sysconfdir}/xdg/weston/weston.ini
+}
+
+do_install:append:mx7-nxp-bsp() {
+    update_file "--no-resizeable" "--no-clients-resize" ${D}${sysconfdir}/xdg/weston/weston.ini
 }

--- a/recipes-graphics/wayland/weston-init/imx-nxp-bsp/weston.ini
+++ b/recipes-graphics/wayland/weston-init/imx-nxp-bsp/weston.ini
@@ -21,5 +21,5 @@ touchscreen_calibrator=true
 #transform=rotate-90
 
 [screen-share]
-command=@bindir@/weston --backend=rdp-backend.so --shell=fullscreen-shell.so --no-clients-resize
+command=@bindir@/weston --backend=rdp-backend.so --shell=fullscreen-shell.so --no-resizeable
 #start-on-startup=true

--- a/recipes-graphics/wayland/weston_10.0.5.imx.bb
+++ b/recipes-graphics/wayland/weston_10.0.5.imx.bb
@@ -161,11 +161,12 @@ LIC_FILES_CHKSUM:append = "file://LICENSE;md5=d79ee9e66bb0f95d3386a7acae780b70"
 DEFAULT_PREFERENCE = "-1"
 
 SRC_URI:remove = "https://gitlab.freedesktop.org/wayland/weston/-/releases/${PV}/downloads/${BPN}-${PV}.tar.xz"
-SRC_URI:prepend = "git://github.com/nxp-imx/weston-imx.git;protocol=https;branch=${SRCBRANCH} "
+SRC_URI:prepend = "${WESTON_SRC};branch=${SRCBRANCH} "
+WESTON_SRC ?= "git://github.com/nxp-imx/weston-imx.git;protocol=https"
 SRC_URI += "file://0001-Revert-protocol-no-found-wayland-scanner-with-Yocto-.patch \
             file://0001-g2d-renderer.c-Include-sys-stat.h.patch"
 SRCBRANCH = "weston-imx-10.0.5"
-SRCREV = "7129417ae04de57f9596ccf27f74ef967660a64f"
+SRCREV = "5223a3c86177709d25f86a96622c0829da955a0e"
 
 # Disable OpenGL for parts with GPU support for 2D but not 3D
 REQUIRED_DISTRO_FEATURES          = "opengl"

--- a/recipes-graphics/wayland/weston_14.0.2.imx.bb
+++ b/recipes-graphics/wayland/weston_14.0.2.imx.bb
@@ -163,16 +163,20 @@ SRC_URI:remove = "https://gitlab.freedesktop.org/wayland/weston/-/releases/${PV}
 SRC_URI:prepend = "${WESTON_SRC};branch=${SRCBRANCH} "
 WESTON_SRC ?= "git://github.com/nxp-imx/weston-imx.git;protocol=https"
 SRCBRANCH = "weston-imx-14.0.2"
-SRCREV = "c267ba8e6eed3a824e042a200bcc1b4c370ba88f"
+SRCREV = "be99fd1adad7e77c8c31926b09520ade5cdaca35"
 
 PACKAGECONFIG:remove = "${PACKAGECONFIG_IMX_REMOVALS}"
 PACKAGECONFIG_IMX_REMOVALS ?= "wayland x11"
 
-PACKAGECONFIG:append = " ${PACKAGECONFIG_G2D}"
+PACKAGECONFIG:append = " ${PACKAGECONFIG_G2D} ${PACKAGECONFIG_PIPEWIRE}"
 PACKAGECONFIG_G2D               ??= ""
 PACKAGECONFIG_G2D:imxgpu2d      ??= "imxg2d"
 PACKAGECONFIG_G2D:mx93-nxp-bsp  ??= "imxg2d"
 PACKAGECONFIG_G2D:mx943-nxp-bsp ??= "imxg2d"
+
+PACKAGECONFIG_PIPEWIRE             ??= ""
+PACKAGECONFIG_PIPEWIRE:mx8-nxp-bsp ??= "pipewire"
+PACKAGECONFIG_PIPEWIRE:mx9-nxp-bsp ??= "pipewire"
 
 # Weston with i.MX G2D renderer
 PACKAGECONFIG[imxg2d] = "-Drenderer-g2d=true,-Drenderer-g2d=false,virtual/libg2d"


### PR DESCRIPTION
libdrm: Bump 2.4.123 -> 2.4.127
weston: Upgrade to latest commit
- Enable pipewire backend for weston 14
- weston-init: Fix arg rename --no-clients-resize -> --no-resizeable,
      The command line argument --no-clients-resize is renamed for Weston 14
      to --no-resizeable.
