### PR TITLE
gpu-viv: upgrade to 6.4.11.p4.4

### DIFF
--- a/recipes-graphics/imx-g2d/imx-gpu-g2d_6.4.11.p4.4.bb
+++ b/recipes-graphics/imx-g2d/imx-gpu-g2d_6.4.11.p4.4.bb
@@ -1,20 +1,19 @@
 # Copyright (C) 2016 Freescale Semiconductor
-# Copyright 2017-2022 NXP
+# Copyright 2017-2022,2026 NXP
 # Copyright 2018 (C) O.S. Systems Software LTDA.
 # Released under the MIT license (see COPYING.MIT for the terms)
 
 DESCRIPTION = "G2D library using i.MX GPU"
-HOMEPAGE = "https://www.nxp.com/"
 LICENSE = "Proprietary"
-LIC_FILES_CHKSUM = "file://COPYING;md5=a93b654673e1bc8398ed1f30e0813359" 
+LIC_FILES_CHKSUM = "file://COPYING;md5=bc649096ad3928ec06a8713b8d787eac"
 DEPENDS = "libgal-imx"
 PROVIDES = "virtual/libg2d"
 
 SRC_URI = "${FSL_MIRROR}/${IMX_BIN_NAME}.bin;name=${TARGET_ARCH};fsl-eula=true"
 IMX_BIN_NAME = "${BP}-${TARGET_ARCH}-${IMX_SRCREV_ABBREV}"
-IMX_SRCREV_ABBREV = "3c5e429"
-SRC_URI[aarch64.sha256sum] = "190bc9203e60e5de508e1dcf057b36d2c9bc3667c6972fd12f7df797e508a22d"
-SRC_URI[arm.sha256sum] = "aaf9a38fe446af579b16a836bf297f8cb1b2842ca3a784bedc21e32d37271ab4"
+IMX_SRCREV_ABBREV = "8626797"
+SRC_URI[aarch64.sha256sum] = "c2f68f79a6718f04f9df781925777ad6aec64edfdb4c35ca7e42f2b39d19fb4f"
+SRC_URI[arm.sha256sum] = "aa2b5525a3a58e2650d2594fdf2c7145cbf36ca99c5fe54111c39440069e0651"
 
 S = "${UNPACKDIR}/${IMX_BIN_NAME}"
 

--- a/recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc
+++ b/recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc
@@ -339,7 +339,8 @@ INSANE_SKIP:libgbm-imx += "dev-so"
 
 FILES:libvulkan-imx = "\
     ${libdir}/libvulkan_VSI${REALSOLIBS} \
-    ${sysconfdir}/vulkan"
+    ${libdir}/libvulkan_VSI${SOLIBS} \
+    ${datadir}/vulkan"
 FILES:libvulkan-imx-dev = "${includedir}/vulkan ${libdir}/libvulkan_VSI${SOLIBSDEV}"
 RPROVIDES:libvulkan-imx = "virtual-vulkan-icd"
 

--- a/recipes-graphics/imx-gpu-viv/imx-gpu-viv_6.4.11.p3.2-aarch32.bb
+++ b/recipes-graphics/imx-gpu-viv/imx-gpu-viv_6.4.11.p3.2-aarch32.bb
@@ -1,9 +1,0 @@
-require imx-gpu-viv-6.inc
-
-LIC_FILES_CHKSUM = "file://COPYING;md5=a93b654673e1bc8398ed1f30e0813359"
-
-IMX_SRCREV_ABBREV = "3c5e429"
-
-SRC_URI[sha256sum] = "ea7ffb01fd7cd88f2a308e5b12b40cc3c9553b8ff2941c4867943b4fee265d27"
-
-COMPATIBLE_MACHINE = "(mx6q-nxp-bsp|mx6dl-nxp-bsp|mx6sx-nxp-bsp|mx6sl-nxp-bsp|mx7ulp-nxp-bsp)"

--- a/recipes-graphics/imx-gpu-viv/imx-gpu-viv_6.4.11.p3.2-aarch64.bb
+++ b/recipes-graphics/imx-gpu-viv/imx-gpu-viv_6.4.11.p3.2-aarch64.bb
@@ -1,9 +1,0 @@
-require imx-gpu-viv-6.inc
-
-LIC_FILES_CHKSUM = "file://COPYING;md5=a93b654673e1bc8398ed1f30e0813359"
-
-IMX_SRCREV_ABBREV = "3c5e429"
-
-SRC_URI[sha256sum] = "bf6fe102e8aa7a16373392efcf6ac45d705bbb95f5c39501da8aaa30957c554f"
-
-COMPATIBLE_MACHINE = "(mx8-nxp-bsp)"

--- a/recipes-graphics/imx-gpu-viv/imx-gpu-viv_6.4.11.p4.4-aarch32.bb
+++ b/recipes-graphics/imx-gpu-viv/imx-gpu-viv_6.4.11.p4.4-aarch32.bb
@@ -1,0 +1,9 @@
+require imx-gpu-viv-6.inc
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=bc649096ad3928ec06a8713b8d787eac"
+
+IMX_SRCREV_ABBREV = "8626797"
+
+SRC_URI[sha256sum] = "db361e1f9db45f498fd669e1f58823d937d436e6fc797da6c710cf35609b47a9"
+
+COMPATIBLE_MACHINE = "(mx6q-nxp-bsp|mx6dl-nxp-bsp|mx6sx-nxp-bsp|mx6sl-nxp-bsp|mx7ulp-nxp-bsp)"

--- a/recipes-graphics/imx-gpu-viv/imx-gpu-viv_6.4.11.p4.4-aarch64.bb
+++ b/recipes-graphics/imx-gpu-viv/imx-gpu-viv_6.4.11.p4.4-aarch64.bb
@@ -1,0 +1,9 @@
+require imx-gpu-viv-6.inc
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=bc649096ad3928ec06a8713b8d787eac"
+
+IMX_SRCREV_ABBREV = "8626797"
+
+SRC_URI[sha256sum] = "8cc97005a7469c0e83139cf1b9a8106fa6f0a84fb6f87d0f6bb9808408305c28"
+
+COMPATIBLE_MACHINE = "(mx8-nxp-bsp)"

--- a/recipes-kernel/kernel-modules/kernel-module-imx-gpu-viv_6.4.11.p4.4.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-imx-gpu-viv_6.4.11.p4.4.bb
@@ -1,5 +1,5 @@
 # Copyright (C) 2015-2016 Freescale Semiconductor
-# Copyright (C) 2017-2025 NXP
+# Copyright (C) 2017-2026 NXP
 
 SUMMARY = "Kernel loadable module for Vivante GPU"
 DESCRIPTION = "Builds the Vivante GPU kernel driver as a loadable kernel module, \
@@ -7,15 +7,12 @@ allowing flexibility to use a newer graphics release with an older kernel."
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6"
 
-SRC_URI = "${LINUX_IMX_SRC};subpath=drivers/mxc/gpu-viv;destsuffix=${BP}/src \
+SRC_URI = "${LINUX_IMX_SRC};subpath=drivers/mxc/gpu-viv;destsuffix=${BB_GIT_DEFAULT_DESTSUFFIX}/src \
            file://Add-makefile.patch"
-
 LINUX_IMX_SRC ?= "git://github.com/nxp-imx/linux-imx.git;protocol=https;branch=${SRCBRANCH}"
-SRCBRANCH = "lf-6.12.y"
+SRCBRANCH = "lf-6.18.y"
 LOCALVERSION = "-lts-${SRCBRANCH}"
-SRCREV = "807e28f65f46b131a698a4c62e2cc0b6b4682731"
-
-S = "${UNPACKDIR}/${BP}"
+SRCREV = "b9ab260bee4d15d079e39a373162eb6201c1cb4a"
 
 inherit module
 


### PR DESCRIPTION
imx-gpu-g2d: Bump 6.4.11.p3.2 -> 6.4.11.p4.4/
imx-gpu-viv: Bump to 6.4.11.p4.4
- Normalize OpenCL ICD implementation
kernel-module-gpu-viv: Bump to 6.4.11.p4.4