### PR TITLE
graphics: piglit and x11 update to lf-6.18.2

### DIFF
--- a/recipes-graphics/piglit/piglit_%.bbappend
+++ b/recipes-graphics/piglit/piglit_%.bbappend
@@ -15,9 +15,8 @@ PACKAGECONFIG_APPEND:imxgpu:mx7-nxp-bsp  = ""
 
 PACKAGECONFIG_REMOVE ?= ""
 PACKAGECONFIG_REMOVE:imxgpu              = "glx"
-PACKAGECONFIG_REMOVE:imxgpu:mx6-nxp-bsp  = "glx x11"
-PACKAGECONFIG_REMOVE:imxgpu:mx7-nxp-bsp  = "glx x11"
+PACKAGECONFIG_REMOVE:imxgpu:mx6-nxp-bsp  = "glx x11 opencl"
+PACKAGECONFIG_REMOVE:imxgpu:mx7-nxp-bsp  = "glx x11 opencl"
 
 PACKAGECONFIG[gbm] = "-DPIGLIT_USE_GBM=1,-DPIGLIT_USE_GBM=0,virtual/libgbm"
-
-CFLAGS:append:imxgpu:toolchain-clang = " -Wno-error=int-conversion"
+CFLAGS:append:imxgpu = " -Wno-error=int-conversion -Wno-error=incompatible-pointer-types"

--- a/recipes-graphics/xinput-calibrator/xinput-calibrator_%.bbappend
+++ b/recipes-graphics/xinput-calibrator/xinput-calibrator_%.bbappend
@@ -1,0 +1,7 @@
+# FIXME: Here it can avoid xinput_calibrator run under background
+#        when Desktop shows
+do_install:append() {
+     # Remove the xinput_calibrator.desktop from xdg/autostart
+     rm -rf ${D}${sysconfdir}/xdg/autostart
+}
+

--- a/recipes-graphics/xorg-xserver/xserver-xf86-config/imx-nxp-bsp/xorg.conf
+++ b/recipes-graphics/xorg-xserver/xserver-xf86-config/imx-nxp-bsp/xorg.conf
@@ -1,0 +1,12 @@
+Section "Device"
+    Identifier  "Kernel Framebuffer Device"
+    Driver      "fbdev"
+    Option      "fbdev" "/dev/fb0"
+EndSection
+
+Section "ServerFlags"
+    Option "BlankTime"  "0"
+    Option "StandbyTime"  "0"
+    Option "SuspendTime"  "0"
+    Option "OffTime"  "0"
+EndSection

--- a/recipes-graphics/xorg-xserver/xserver-xf86-config/imxdrm/xorg.conf
+++ b/recipes-graphics/xorg-xserver/xserver-xf86-config/imxdrm/xorg.conf
@@ -1,0 +1,11 @@
+Section "Module"
+  Load "dri2"
+  Load "glamoregl"
+EndSection
+
+Section "ServerFlags"
+    Option "BlankTime"  "0"
+    Option "StandbyTime"  "0"
+    Option "SuspendTime"  "0"
+    Option "OffTime"  "0"
+EndSection

--- a/recipes-graphics/xorg-xserver/xserver-xf86-config/imxfbdev/xorg.conf
+++ b/recipes-graphics/xorg-xserver/xserver-xf86-config/imxfbdev/xorg.conf
@@ -1,0 +1,13 @@
+    Identifier  "i.MX Accelerated Framebuffer Device"
+    Driver      "vivante"
+    Option      "fbdev"     "/dev/fb0"
+    Option      "vivante_fbdev" "/dev/fb0"
+    Option      "HWcursor"  "false"
+EndSection
+
+Section "ServerFlags"
+    Option "BlankTime"  "0"
+    Option "StandbyTime"  "0"
+    Option "SuspendTime"  "0"
+    Option "OffTime"  "0"
+EndSection


### PR DESCRIPTION
piglit: Remove opencl for 6 and 7
xinput-calibrator: Remove xinput_calibrator.desktop from xdg/autostart to avoid xinput_calibrator runs when Desktop shows
xserver-xf86-config: Add xorg.conf for imxdrm and imxfbdev
