### PR TITLE
gst-example: downgrade to 1.26.6

### DIFF
--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -534,7 +534,7 @@ PREFERRED_VERSION_gstreamer1.0-plugins-good:imx-nxp-bsp ??= "1.26.6.imx"
 
 # GStreamer copied recipes
 PREFERRED_VERSION_gst-devtools:imx-nxp-bsp              ??= "1.26.6"
-PREFERRED_VERSION_gst-examples:imx-nxp-bsp              ??= "1.24.7.imx"
+PREFERRED_VERSION_gst-examples:imx-nxp-bsp              ??= "1.26.6"
 PREFERRED_VERSION_gstreamer1.0-libav:imx-nxp-bsp        ??= "1.26.6"
 PREFERRED_VERSION_gstreamer1.0-plugins-ugly:imx-nxp-bsp ??= "1.26.6"
 PREFERRED_VERSION_gstreamer1.0-python:imx-nxp-bsp       ??= "1.26.6"

--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -533,13 +533,13 @@ PREFERRED_VERSION_gstreamer1.0-plugins-good:imx-nxp-bsp ??= "1.26.6.imx"
 
 
 # GStreamer copied recipes
-PREFERRED_VERSION_gst-devtools:imx-nxp-bsp              ??= "1.26.6.imx"
+PREFERRED_VERSION_gst-devtools:imx-nxp-bsp              ??= "1.26.6"
 PREFERRED_VERSION_gst-examples:imx-nxp-bsp              ??= "1.24.7.imx"
-PREFERRED_VERSION_gstreamer1.0-libav:imx-nxp-bsp        ??= "1.26.6.imx"
-PREFERRED_VERSION_gstreamer1.0-plugins-ugly:imx-nxp-bsp ??= "1.26.6.imx"
-PREFERRED_VERSION_gstreamer1.0-python:imx-nxp-bsp       ??= "1.26.6.imx"
-PREFERRED_VERSION_gstreamer1.0-rtsp-server:imx-nxp-bsp  ??= "1.26.6.imx"
-PREFERRED_VERSION_gstreamer1.0-vaapi:imx-nxp-bsp        ??= "1.26.6.imx"
+PREFERRED_VERSION_gstreamer1.0-libav:imx-nxp-bsp        ??= "1.26.6"
+PREFERRED_VERSION_gstreamer1.0-plugins-ugly:imx-nxp-bsp ??= "1.26.6"
+PREFERRED_VERSION_gstreamer1.0-python:imx-nxp-bsp       ??= "1.26.6"
+PREFERRED_VERSION_gstreamer1.0-rtsp-server:imx-nxp-bsp  ??= "1.26.6"
+PREFERRED_VERSION_gstreamer1.0-vaapi:imx-nxp-bsp        ??= "1.26.6"
 
 # Use libcamera fork for certain SOCs
 PREFERRED_VERSION_libcamera ??= "${PREFERRED_VERSION_LIBCAMERA_IMX}"

--- a/recipes-multimedia/gstreamer/gst-examples/0001-Make-player-examples-installable.patch
+++ b/recipes-multimedia/gstreamer/gst-examples/0001-Make-player-examples-installable.patch
@@ -1,0 +1,37 @@
+From 7924016fce2d0b435891a335cdae52fc939c7e3b Mon Sep 17 00:00:00 2001
+From: Jussi Kukkonen <jussi.kukkonen@intel.com>
+Date: Thu, 17 Aug 2017 11:07:02 +0300
+Subject: [PATCH] Make player examples installable
+
+Signed-off-by: Jussi Kukkonen <jussi.kukkonen@intel.com>
+Upstream-Status: Denied [Upstream considers these code examples, for now a least]
+
+https://bugzilla.gnome.org/show_bug.cgi?id=777827
+
+---
+ playback/player/gst-play/meson.build | 1 +
+ playback/player/gtk/meson.build      | 1 +
+ 2 files changed, 2 insertions(+)
+
+Index: gst-examples/playback/player/gst-play/meson.build
+===================================================================
+--- gst-examples.orig/playback/player/gst-play/meson.build
++++ gst-examples/playback/player/gst-play/meson.build
+@@ -2,5 +2,6 @@ executable('gst-play',
+     ['gst-play.c',
+      'gst-play-kb.c',
+      'gst-play-kb.h'],
++    install: true,
+     dependencies : [gst_dep, dependency('gstreamer-play-1.0'), m_dep])
+ 
+Index: gst-examples/playback/player/gtk/meson.build
+===================================================================
+--- gst-examples.orig/playback/player/gtk/meson.build
++++ gst-examples/playback/player/gtk/meson.build
+@@ -20,5 +20,6 @@ if gtk_dep.found()
+        'gtk-video-renderer.h',
+        'gtk-video-renderer.c'],
+       c_args :  extra_c_args,
++      install: true,
+       dependencies : [gst_dep, gsttag_dep, gstplay_dep, gtk_dep, x11_dep])
+ endif

--- a/recipes-multimedia/gstreamer/gst-examples/gst-player.desktop
+++ b/recipes-multimedia/gstreamer/gst-examples/gst-player.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Name=Media Player
+Comment=Basic media player
+Icon=video-player
+TryExec=gtk-play
+Exec=gtk-play
+StartupNotify=true
+Terminal=false
+Type=Application
+Categories=GTK;AudioVideo;

--- a/recipes-multimedia/gstreamer/gst-examples_1.26.6.bb
+++ b/recipes-multimedia/gstreamer/gst-examples_1.26.6.bb
@@ -1,0 +1,41 @@
+#copy from openembedded-core layer: https://github.com/openembedded/openembedded-core/blob/whinlatter/meta/recipes-multimedia/gstreamer
+# downgrade version to compatible imx gstreamer version
+
+SUMMARY = "GStreamer examples (including gtk-play, gst-play)"
+DESCRIPTION = "GStreamer example applications"
+HOMEPAGE = "https://gitlab.freedesktop.org/gstreamer/gst-examples"
+BUGTRACKER = "https://gitlab.freedesktop.org/gstreamer/gst-examples/-/issues"
+LICENSE = "LGPL-2.0-or-later"
+LIC_FILES_CHKSUM = "file://playback/player/gtk/gtk-play.c;beginline=1;endline=20;md5=f8c72dae3d36823ec716a9ebcae593b9"
+
+DEPENDS = "glib-2.0 gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-bad gtk+3 json-glib glib-2.0-native"
+
+SRC_URI = "git://gitlab.freedesktop.org/gstreamer/gstreamer.git;protocol=https;branch=1.26;tag=${PV} \
+           file://0001-Make-player-examples-installable.patch \
+           file://gst-player.desktop \
+           "
+
+SRCREV = "6cbdcfaca66dd52cdc4670d6f5122c68b9161170"
+
+S = "${UNPACKDIR}/${BP}/subprojects/gst-examples"
+
+inherit meson pkgconfig features_check
+
+# gtk-play has runtime errors otherwise
+TARGET_LDFLAGS += "-rdynamic"
+
+UPSTREAM_CHECK_GITTAGREGEX = "^(?P<pver>\d+\.(\d*[02468])+(\.\d+)+)"
+
+ANY_OF_DISTRO_FEATURES = "${GTK3DISTROFEATURES}"
+
+do_install:append() {
+	install -m 0644 -D ${UNPACKDIR}/gst-player.desktop ${D}${datadir}/applications/gst-player.desktop
+}
+
+RDEPENDS:${PN} = "gstreamer1.0-plugins-base-playback"
+RRECOMMENDS:${PN} = "gstreamer1.0-plugins-base-meta \
+                     gstreamer1.0-plugins-good-meta \
+                     gstreamer1.0-plugins-bad-meta \
+                      ${@bb.utils.contains("LICENSE_FLAGS_ACCEPTED", "commercial", "gstreamer1.0-libav", "", d)} \
+                     ${@bb.utils.contains("LICENSE_FLAGS_ACCEPTED", "commercial", "gstreamer1.0-plugins-ugly-meta", "", d)}"
+RPROVIDES:${PN} += "gst-player gst-player-bin"


### PR DESCRIPTION
1.24.7.imx version was removed ,follow the OE core version, now is 1.28.2