### PR TITLE
isp-imx: explicit coreutils dependency

### DIFF
--- a/recipes-bsp/isp-imx/isp-imx_4.2.2.26.1.bb
+++ b/recipes-bsp/isp-imx/isp-imx_4.2.2.26.1.bb
@@ -82,6 +82,6 @@ FILES_SOLIBS_VERSIONED = " \
 
 INSANE_SKIP:${PN} = "already-stripped"
 
-RDEPENDS:${PN} = "libdrm"
+RDEPENDS:${PN} = "libdrm coreutils"
 
 COMPATIBLE_MACHINE = "(mx8mp-nxp-bsp)"


### PR DESCRIPTION
The startup script does `realpath` / `head` with options that busybox doesn't support. 
<img width="1272" height="651" alt="image" src="https://github.com/user-attachments/assets/5f423918-83a4-459d-97a6-a66bdd7e57d9" />

I assume a lot of builds include `coreutils` elsewhere.