### PR TITLE
linux-fslc-imx: Bump kernel to LF6.18.2_1.0.0 + stable up to v6.18.21

### DIFF
--- a/recipes-kernel/linux/linux-fslc-imx_6.18.bb
+++ b/recipes-kernel/linux/linux-fslc-imx_6.18.bb
@@ -28,12 +28,12 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # ------------------------------------------------------------------------------
 # 1. Stable (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: v6.12.3
+#    tag: v6.18.24
 #
 # ------------------------------------------------------------------------------
 # 2. NXP-specific (tag or SHA(s))
 # ------------------------------------------------------------------------------
-#    tag: lf-6.12.3-1.0.0
+#    tag: lf-6.18-1.0.x-imx
 #
 # ------------------------------------------------------------------------------
 # 3. Critical patches (SHA(s))
@@ -42,22 +42,15 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 # conflicts, prioritizing NXP BSP source code as the latest vendor updates.
 # Additional commits may exist to better acommodate yocto builds.
 #
-# $ git log --oneline  --no-merges v6.12.49.. ^mainline/linux-6.12.y ^NXP/lf-6.12.y
-# - bacd5504126bb imx8mp-olimex.dts: CSI GPIO pins
-# - 3a7012e991c98 hwrng: optee: support generic crypto
-# - 6c0a3377748eb arm64: dts: imx8mq: drop cpu-idle-states
-# - 7db0692d9ff5e of: enable using OF_DYNAMIC without OF_UNITTEST
-# - eff98b934385c gpu: drm: cadence: select hdmi helper
-# - be5e175e43d93 imx:dts:imx8mm-evkb: fix the pmic name to avoid duplicated label error
-# - 76e18f5a57b3e arm64: dts: imx8mm-evk-qca-wifi: enable support for bluetooth
-# - 06b99391f850c drm: of: Fix build without CONFIG_OF
-# - 17ac89e381a9d i2c: imx: Remove unnecessary clock reconfiguration
-# - 6d157e81ccc53 drm/imx: lcdifv3: Fix videomode settings
-# - 0a355239e2df3 clk: imx: imx8qm: add more resources to whitelist
-# - c5c4869899b1c arm64: dts: imx8: img: add #address-cells and #size-cells to I2C MIPI CSI nodes
-# - 3159e7d086295 arm64: dts: imx8qm: add missing imx8-ss-cm40.dtsi include
-# - ffea393034d48 arm64: imx_v8_defconfig: Enable CONFIG_GPIO_VF610
-# - a8762ad609202 imx8mp-olimex.dts: Olimex iMX8MP-SOM-EVB-IND
+# $ git log --oneline  --no-merges v6.18.24.. ^mainline/linux-6.18.y ^NXP/lf-6.18.y
+$ 6e811374f6340 drm/imx: lcdifv3: Fix videomode settings
+$ 40b594773feaf drm: of: Fix build without CONFIG_OF
+$ 40d5cc16c304a arm64: dts: imx8mm-evk-qca-wifi: enable support for bluetooth
+$ eff109d884f3b gpu: drm: cadence: select hdmi helper
+$ ddfe8741dab43 of: enable using OF_DYNAMIC without OF_UNITTEST
+$ 1b982f1a29bbc arm64: dts: imx8mq: drop cpu-idle-states
+$ de4b96e987407 hwrng: optee: support generic crypto
+
 #
 # NOTE to upgraders:
 # This recipe should NOT collect individual patches, they should be applied to
@@ -67,16 +60,16 @@ Latest stable Kernel patchlevel is applied and maintained by Community."
 
 require linux-imx.inc
 
-KBRANCH = "6.12-2.0.x-imx"
+KBRANCH = "6.18-1.0.x-imx"
 SRC_URI = "git://github.com/Freescale/linux-fslc.git;branch=${KBRANCH};protocol=https"
-SRCREV = "77b58422ab0fa4480a0b89a5f1ebfb9d1a900aef"
+SRCREV = "1d08c2fc5b376a84a3e7092651289fb8e8ffc1af"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
 # required by kernel-yocto.bbclass.
 #
 # LINUX_VERSION define should match to the kernel version referenced by SRC_URI and
 # should be updated once patchlevel is merged.
-LINUX_VERSION = "6.12.49"
+LINUX_VERSION = "6.18.24"
 
 KBUILD_DEFCONFIG:mx6-generic-bsp = "imx_v7_defconfig"
 KBUILD_DEFCONFIG:mx7-generic-bsp = "imx_v7_defconfig"
@@ -84,7 +77,7 @@ KBUILD_DEFCONFIG:mx8-generic-bsp = "imx_v8_defconfig"
 KBUILD_DEFCONFIG:mx9-generic-bsp = "imx_v8_defconfig"
 
 # Local version indicates the branch name in the NXP kernel tree where patches are collected from.
-LOCALVERSION = "-lf-6.12.y"
+LOCALVERSION = "-lf-6.18.y"
 
 DEFAULT_PREFERENCE = "1"
 


### PR DESCRIPTION
This is part of #2483