### PR TITLE
conf/machine: Drop non-existent image type sdcard

### DIFF
--- a/conf/machine/include/imx93-evk.inc
+++ b/conf/machine/include/imx93-evk.inc
@@ -26,7 +26,6 @@ UBOOT_CONFIG ??= "sd"
 UBOOT_CONFIG[sd]   = "${UBOOT_CONFIG_BASENAME}_defconfig"
 UBOOT_CONFIG[ecc]  = "${UBOOT_CONFIG_BASENAME}_inline_ecc_defconfig"
 UBOOT_CONFIG[fspi] = "${UBOOT_CONFIG_BASENAME}_defconfig"
-UBOOT_CONFIG_IMAGE_FSTYPES[sd] = "sdcard"
 
 # Set ATF platform name
 ATF_PLATFORM = "imx93"

--- a/conf/machine/include/imx943-evk.inc
+++ b/conf/machine/include/imx943-evk.inc
@@ -36,8 +36,6 @@ UBOOT_CONFIG[sd]     = "${UBOOT_CONFIG_BASENAME}_defconfig"
 UBOOT_CONFIG[sd-ecc] = "${UBOOT_CONFIG_BASENAME}_defconfig"
 UBOOT_CONFIG[crrm]   = "${UBOOT_CONFIG_BASENAME}_xspi_crrm_defconfig"
 UBOOT_CONFIG[xspi]   = "${UBOOT_CONFIG_BASENAME}_xspi_defconfig"
-UBOOT_CONFIG_IMAGE_FSTYPES[sd]     = "sdcard"
-UBOOT_CONFIG_IMAGE_FSTYPES[sd-ecc] = "sdcard"
 
 ATF_PLATFORM = "imx94"
 OEI_CORE = "m33"

--- a/conf/machine/include/imx95-evk.inc
+++ b/conf/machine/include/imx95-evk.inc
@@ -21,7 +21,6 @@ UBOOT_CONFIG ??= "sd"
 UBOOT_CONFIG[sd] = "${UBOOT_CONFIG_BASENAME}_defconfig"
 UBOOT_CONFIG[sd-ecc] = "${UBOOT_CONFIG_BASENAME}_defconfig"
 UBOOT_CONFIG[fspi] = "${UBOOT_CONFIG_BASENAME}_fspi_defconfig"
-UBOOT_CONFIG_IMAGE_FSTYPES[sd] = "sdcard"
 
 ATF_PLATFORM = "imx95"
 OEI_CORE   = "m33"


### PR DESCRIPTION
This is a follow-up to commit 777cb1b05ba7 ("conf/machine: Drop non-existent image type sdcard")

Original commit message:

The machine configuration files specify an image type `sdcard` via `UBOOT_CONFIG`. This type is not listed in `IMAGE_TYPES`, and the specification appears to have no effect on the build. It appears to be historical only and of no use, so drop it.