### PR TITLE
imx-base.inc: set SECOEXT_FIRMWARE_NAME to empty by default

### DIFF
--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -504,7 +504,7 @@ MACHINE_EXTRA_RRECOMMENDS += " \
 # ELE extra Firmware,to be installed and accessed from userspace.
 # Note that multiple names can be given in order to install multiple versions
 # to a single rootfs.
-SECOEXT_FIRMWARE_NAME ?= "UNDEFINED"
+SECOEXT_FIRMWARE_NAME ?= ""
 SECOEXT_FIRMWARE_NAME:mx8ulp-generic-bsp ?= "mx8ulp${IMX_SOC_REV_LOWER}ext-ahab-container.img"
 SECOEXT_FIRMWARE_NAME:mx95-generic-bsp   ?= "mx95a0runtime-ahab-container.img mx95b0runtime-ahab-container.img"
 SECOEXT_FIRMWARE_NAME:mx943-generic-bsp  ?= "mx943${IMX_SOC_REV_LOWER}runtime-ahab-container.img"


### PR DESCRIPTION
SECOEXT_FIRMWARE_NAME is set to 'UNDEFINED' by default. Since commit d7930c6e ("firmware-ele-imx: Bump 2.0.2 -> 2.0.5"), the firmware-ele-imx recipe fails during do_install if this variable is not overridden.

The install step tries to access a non-existent path named 'UNDEFINED', resulting in:
  install: cannot stat '.../UNDEFINED': No such file or directory

Set SECOEXT_FIRMWARE_NAME to an empty value to prevent build failures when the parameter is not explicitly defined.