### PR TITLE
imx-oei: Fix OEI_DEBUG, OEI_DDR_CONFIG and the conditional EXTRA_OEMAKE

### DIFF
--- a/dynamic-layers/arm-toolchain/recipes-bsp/imx-oei/imx-oei.inc
+++ b/dynamic-layers/arm-toolchain/recipes-bsp/imx-oei/imx-oei.inc
@@ -11,39 +11,40 @@ PACKAGECONFIG[tcm] = ""
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
+OEI_CONFIGS ?= "ddr ${@bb.utils.filter('PACKAGECONFIG', 'tcm', d)}"
 OEI_CORE    ?= "UNDEFINED"
 OEI_SOC     ?= "UNDEFINED"
 OEI_BOARD   ?= "UNDEFINED"
-OEI_CONFIGS ?= "ddr ${@bb.utils.filter('PACKAGECONFIG', 'tcm', d)}"
+OEI_DDR_CONFIG  ?= ""
+OEI_DEBUG   ?= "0"
 
 LDFLAGS[unexport] = "1"
 
 EXTRA_OEMAKE = "\
     board=${OEI_BOARD} \
-    DEBUG=1 \
+    DEBUG=${OEI_DEBUG} \
     OEI_CROSS_COMPILE=arm-none-eabi-"
 
-EXTRA_OEMAKE:append:mx95-nxp-bsp = " r=${IMX_SOC_REV}"
+EXTRA_OEMAKE:append:mx95-generic-bsp = " r=${IMX_SOC_REV}"
+
+python () {
+    if 'ecc' in d.getVar('PACKAGECONFIG'):
+        ddr_conf = d.getVar('OEI_DDR_CONFIG_ECC')
+    else:
+        ddr_conf = d.getVar('OEI_DDR_CONFIG')
+    if ddr_conf:
+        d.appendVar('EXTRA_OEMAKE', ' DDR_CONFIG='+ddr_conf)
+}
 
 do_configure() {
-    if [ "${@bb.utils.filter('PACKAGECONFIG', 'ecc', d)}" ]; then
-        ddr_config=${OEI_DDR_CONFIG_ECC}
-    else
-        ddr_config=${OEI_DDR_CONFIG}
-    fi
     for oei_config in ${OEI_CONFIGS}; do
-        oe_runmake clean oei=$oei_config DDR_CONFIG=$ddr_config
+        oe_runmake clean oei=$oei_config
     done
 }
 
 do_compile() {
-    if [ "${@bb.utils.filter('PACKAGECONFIG', 'ecc', d)}" ]; then
-        ddr_config=${OEI_DDR_CONFIG_ECC}
-    else
-        ddr_config=${OEI_DDR_CONFIG}
-    fi
     for oei_config in ${OEI_CONFIGS}; do
-        oe_runmake oei=$oei_config DDR_CONFIG=$ddr_config
+        oe_runmake oei=$oei_config
     done
 }
 


### PR DESCRIPTION
In commit 9de33fe48aae ("imx-oei: Update to lf6.18.2-1.0.0"), multiple issues were introduced to imx-oei.inc:
- DEBUG was hardcoded to 1, OEI_DEBUG is silently dropped completely
- DDR_CONFIG is always passed to make, even when no config is present
- The EXTRA_OEMAKE:append:mx95-generic-bsp was changed to mx95-nxp-bsp

All of these changes are unrelated to the desired update.

This reverts the changes to imx-oei.inc introduced by commit 9de33fe48aaec40f5648c5fa22a4a1782ac74c93.

@zelan-nxp: I would like NXP to be more careful in not overwriting meta-freescale logic with changes coming from meta-imx without a good reason. For the future I believe it would be good if we could split changes in recipe logic from version updates to ease the review. The reason for the anonymous python function that 9de33fe48aaec40f5648c5fa22a4a1782ac74c93 removed can be seen from a git blame or log for example. Let me know if this partial revert changes anything that is necessary for the update to 6.18 and I'll gladly change it. Thanks!