### PR TITLE
weston-init: Fix install error for sysvinit case

### DIFF
--- a/recipes-graphics/wayland/weston-init.bbappend
+++ b/recipes-graphics/wayland/weston-init.bbappend
@@ -120,7 +120,7 @@ do_install:append() {
         insert_line_after "ExecStart=" "Restart=on-failure" ${D}${systemd_system_unitdir}/weston.service
     else
         # Install weston-socket.sh for sysvinit as well
-        install -D -p -m0644 ${WORKDIR}/weston-socket.sh ${D}${sysconfdir}/profile.d/weston-socket.sh
+        install -D -p -m0644 ${S}/weston-socket.sh ${D}${sysconfdir}/profile.d/weston-socket.sh
     fi
 
     # Include commented gbm-format


### PR DESCRIPTION
The weston-init recipe fails to install properly when using sysvinit.
```
| install: cannot stat '/.../weston-init/1.0/weston-socket.sh': No such file or directory
```

The install uses the wrong path variable `WORKDIR` where `S` is correct.