### PR TITLE
linux-imx-headers: fix ipu.h integer type macros

### DIFF
--- a/recipes-kernel/linux/linux-imx-headers/0001-ipu-uapi-Do-not-redefine-standard-integer-types.patch
+++ b/recipes-kernel/linux/linux-imx-headers/0001-ipu-uapi-Do-not-redefine-standard-integer-types.patch
@@ -1,0 +1,42 @@
+From 76a44c7b7913daf987a315f77f0c0b1e67a71aeb Mon Sep 17 00:00:00 2001
+From: Ernest Van Hoecke <ernest.vanhoecke@toradex.com>
+Date: Thu, 30 Apr 2026 10:52:00 +0200
+Subject: [PATCH] ipu: uapi: Do not redefine standard integer types
+
+The exported IPU UAPI header defines uint32_t, uint16_t and uint8_t as
+preprocessor macros. This breaks userspace builds when another header is
+included afterwards and uses the standard integer type names, because
+the macros rewrite those declarations.
+
+The header itself only needs the local u32 and u8 aliases. Keep those
+aliases mapped to the __u32 and __u8 types provided by linux/types.h,
+and leave the standard uint*_t namespace untouched.
+
+Upstream-Status: Submitted [https://community.nxp.com/t5/i-MX-Processors/linux-imx-include-uapi-linux-ipu-h-redefines-standard-integer/m-p/2359396]
+Signed-off-by: Ernest Van Hoecke <ernest.vanhoecke@toradex.com>
+---
+ include/uapi/linux/ipu.h | 8 ++------
+ 1 file changed, 2 insertions(+), 6 deletions(-)
+
+diff --git a/include/uapi/linux/ipu.h b/include/uapi/linux/ipu.h
+index 7bdac34bd1f0..e49430b0c938 100644
+--- a/include/uapi/linux/ipu.h
++++ b/include/uapi/linux/ipu.h
+@@ -38,12 +38,8 @@ typedef unsigned char bool;
+ #endif
+ #define irqreturn_t int
+ #define dma_addr_t int
+-#define uint32_t unsigned int
+-#define uint16_t unsigned short
+-#define uint8_t unsigned char
+-#define u32 unsigned int
+-#define u8 unsigned char
+-#define __u32 u32
++#define u32 __u32
++#define u8 __u8
+ #endif
+ 
+ /*!
+-- 
+2.43.0
+

--- a/recipes-kernel/linux/linux-imx-headers_6.18.bb
+++ b/recipes-kernel/linux/linux-imx-headers_6.18.bb
@@ -7,7 +7,9 @@ New headers are installed in ${includedir}/imx."
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-SRC_URI = "${LINUX_IMX_SRC}"
+SRC_URI = "${LINUX_IMX_SRC} \
+           file://0001-ipu-uapi-Do-not-redefine-standard-integer-types.patch \
+"
 LINUX_IMX_SRC ?= "git://github.com/nxp-imx/linux-imx.git;protocol=https;branch=${SRCBRANCH}"
 SRCBRANCH = "lf-6.18.y"
 LOCALVERSION = "-lts-${SRCBRANCH}"


### PR DESCRIPTION
Currently, for master meta-freescale+meta-toradex-bsp, `MACHINE=verdin-imx8mm bitbake imx-gst1.0-plugin` fails with the following error:

```
  | In file included from ../sources/imx-gst1.0-plugin-4.10.3+git/libs/v4l2_core/gstimxv4l2.c:29:
  | /workdir/oe/tmp/work/armv8a-mx8mm-tdx-linux/imx-gst1.0-plugin/4.10.3+git/recipe-sysroot/usr/include/imx/linux/ipu.h:42:17: error: two or more data types in declaration specifiers
  |    42 | #define uint8_t unsigned char
  |       |                 ^~~~~~~~
  | /workdir/oe/tmp/work/armv8a-mx8mm-tdx-linux/imx-gst1.0-plugin/4.10.3+git/recipe-sysroot/usr/include/imx/linux/ipu.h:42:26: error: two or more data types in declaration specifiers
  |    42 | #define uint8_t unsigned char
  |       |                          ^~~~
  | /workdir/oe/tmp/work/armv8a-mx8mm-tdx-linux/imx-gst1.0-plugin/4.10.3+git/recipe-sysroot/usr/include/imx/linux/ipu.h:41:18: error: two or more data types in declaration specifiers
  |    41 | #define uint16_t unsigned short
  |       |                  ^~~~~~~~
  | /workdir/oe/tmp/work/armv8a-mx8mm-tdx-linux/imx-gst1.0-plugin/4.10.3+git/recipe-sysroot/usr/include/imx/linux/ipu.h:41:27: error: two or more data types in declaration specifiers
  |    41 | #define uint16_t unsigned short
  |       |                           ^~~~~
  | /workdir/oe/tmp/work/armv8a-mx8mm-tdx-linux/imx-gst1.0-plugin/4.10.3+git/recipe-sysroot/usr/include/imx/linux/ipu.h:40:18: error: two or more data types in declaration specifiers
  |    40 | #define uint32_t unsigned int
  |       |                  ^~~~~~~~
  | /workdir/oe/tmp/work/armv8a-mx8mm-tdx-linux/imx-gst1.0-plugin/4.10.3+git/recipe-sysroot/usr/include/imx/linux/ipu.h:40:27: error: two or more data types in declaration specifiers
  |    40 | #define uint32_t unsigned int
  |       |                           ^~~

[...]

  | ninja: build stopped: subcommand failed.
  | INFO: autodetecting backend as ninja
  | INFO: calculating backend command to run: /workdir/oe/tmp/work/armv8a-mx8mm-tdx-linux/imx-gst1.0-plugin/4.10.3+git/recipe-sysroot-native/usr/bin/ninja -j 64 -v
  | WARNING: exit code 1 from a shell command.
  NOTE: recipe imx-gst1.0-plugin-4.10.3+git-r0: task do_compile: Failed
  ERROR: Task (/workdir/oe/build/../layers/meta-freescale/recipes-multimedia/gstreamer/imx-gst1.0-plugin_git.bb:do_compile) failed with exit code '1'
  NOTE: recipe gstreamer1.0-plugins-bad-1.26.6.imx-r0: task do_package: Succeeded
  NOTE: Tasks Summary: Attempted 10003 tasks of which 8796 didn't need to be rerun and 1 failed.
  NOTE: Writing buildhistory
  NOTE: Writing buildhistory took: 6 seconds
  
  Summary: 1 task failed:
    /workdir/oe/build/../layers/meta-freescale/recipes-multimedia/gstreamer/imx-gst1.0-plugin_git.bb:do_compile
      log: /workdir/oe/tmp/work/armv8a-mx8mm-tdx-linux/imx-gst1.0-plugin/4.10.3+git/temp/log.do_compile.827805
  Summary: There was 1 WARNING message.
  Summary: There was 1 ERROR message, returning a non-zero exit code.
 ```

---

The exported IPU UAPI header defines uint32_t, uint16_t and uint8_t as preprocessor macros. This breaks userspace builds when another header is included afterwards and uses the standard integer type names, because the macros rewrite those declarations.

This currently breaks imx-gst1.0-plugin with:

| recipe-sysroot/usr/include/imx/linux/ipu.h:42:17: error: two or more data types in declaration specifiers

The header itself only needs the local u32 and u8 aliases. Map those aliases to the __u32 and __u8 types provided by linux/types.h and leave the standard uint*_t namespace untouched.

---

I set Upstream-Status to submitted since I posted this patch on the NXP forum, but since there is no clear upstreaming process to linux-imx, please let me know if I should change this to Pending or something else. Thanks!