### PR TITLE
isp-imx: fix jsoncpp runtime dependency

### DIFF
--- a/recipes-bsp/isp-imx/isp-imx_4.2.2.26.1.bb
+++ b/recipes-bsp/isp-imx/isp-imx_4.2.2.26.1.bb
@@ -60,6 +60,13 @@ do_install() {
         rm ${D}/opt/imx8-isp/bin/tuningext
     fi
 
+    # The prebuilt ISP components were linked against jsoncpp 1.9.6
+    # (SONAME 26). jsoncpp 1.9.7 ships SONAME 27, so update the dynamic
+    # dependency.
+    patchelf --replace-needed libjsoncpp.so.26 libjsoncpp.so.27 \
+        ${D}${libdir}/libmedia_server.so \
+        ${D}/opt/imx8-isp/bin/isp_media_server
+
     if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
         install -d ${D}${systemd_system_unitdir}
         install -m 0644 ${S}/imx/imx8-isp.service ${D}${systemd_system_unitdir}


### PR DESCRIPTION
The prebuilt ISP media server binaries were linked against jsoncpp 1.9.6 and still require libjsoncpp.so.26. meta-openembedded now uses jsoncpp 1.9.7 which leads to libjsoncpp.so.27, but the runtime linker and OE shlib QA still match the exact SONAME from DT_NEEDED.

Patch the installed binaries to require libjsoncpp.so.27 so file-rdeps can resolve the dependency to the distro jsoncpp package.

---

Note: to actually get this to build, a patch to meta-openembedded is also required, I just sent that to the mailing list.
Right now, expect build failures on meta-openembedded with linking errors:
|  undefined reference to `Json::Value::operator[](char const*)'

This is a result of a bug in jsoncpp 1.9.7. A backport I submitted to meta-openembedded will solve that, but this patch is also needed for QA issues.