### PR TITLE
wayland-protocols: fix non target builds

### DIFF
--- a/recipes-graphics/wayland/wayland-protocols_%.bbappend
+++ b/recipes-graphics/wayland/wayland-protocols_%.bbappend
@@ -6,11 +6,11 @@ NXP_PATCHES = " \
     file://0003-linux-dmabuf-support-passing-buffer-DTRC-meta-to-com.patch \
 "
 
-SRC_URI:append:imx-nxp-bsp = " ${NXP_PATCHES}"
+SRC_URI:append:imx-nxp-bsp:class-target = " ${NXP_PATCHES}"
 
 # override the effect of "inherit allarch"
-python allarch_package_arch_handler:prepend:imx-nxp-bsp () {
+python allarch_package_arch_handler:prepend:imx-nxp-bsp:class-target () {
     return
 }
 
-PACKAGE_ARCH:imx-nxp-bsp = "${MACHINE_SOCARCH}"
+PACKAGE_ARCH:imx-nxp-bsp:class-target = "${MACHINE_SOCARCH}"


### PR DESCRIPTION
[@sandy-lcq](https://github.com/sandy-lcq)

It was found that at least in some configurations a nativesdk (and likely a native) build failed as the wayland-protocols artefacts weren't found.

Don't apply the patches or change the PACKAGE_ARCH if not building for target.

See also meta-freescale issue #2525.

Fixes: 48dfc5f5f33c ("wayland-protocols: use upstream repo with NXP downstream patches")