### PR TITLE
[RFC] Distro to fragments

### DIFF
--- a/conf/fragments/bsp/fslc.conf
+++ b/conf/fragments/bsp/fslc.conf
@@ -1,0 +1,8 @@
+BB_CONF_FRAGMENT_SUMMARY = "Use FSLC BSP components (linux-fslc, u-boot-fslc)"
+BB_CONF_FRAGMENT_DESCRIPTION = "Sets IMX_DEFAULT_BSP = 'mainline' and selects the FSLC \
+linux-fslc kernel and u-boot-fslc bootloader as defaults for i.MX builds. \
+Note: DISTRO = 'poky' is used as-is; TARGET_VENDOR and DISTROOVERRIDES from \
+the legacy fslc-base.inc are not carried over."
+
+IMX_DEFAULT_BSP = "mainline"
+IMX_DEFAULT_BOOTLOADER = "u-boot-fslc"

--- a/conf/fragments/bsp/nxp.conf
+++ b/conf/fragments/bsp/nxp.conf
@@ -1,0 +1,32 @@
+BB_CONF_FRAGMENT_SUMMARY = "Use NXP downstream BSP components (linux-imx, u-boot-imx)"
+BB_CONF_FRAGMENT_DESCRIPTION = "Sets IMX_DEFAULT_BSP = 'nxp' and selects NXP downstream \
+providers for the kernel, bootloader, and GStreamer plugins on mx6/mx7/mx8/mx9 SoCs. \
+Requires a layer providing linux-imx and u-boot-imx (e.g. meta-imx). \
+Note: DISTRO = 'poky' is used as-is; TARGET_VENDOR and DISTROOVERRIDES from \
+the legacy fsl-base.inc are not carried over."
+
+IMX_DEFAULT_BSP = "nxp"
+IMX_DEFAULT_BOOTLOADER = "u-boot-imx"
+
+PREFERRED_PROVIDER_virtual/kernel:mx6-nxp-bsp = "linux-imx"
+PREFERRED_PROVIDER_virtual/kernel:mx7-nxp-bsp = "linux-imx"
+PREFERRED_PROVIDER_virtual/kernel:mx8-nxp-bsp = "linux-imx"
+PREFERRED_PROVIDER_virtual/kernel:mx9-nxp-bsp = "linux-imx"
+
+MACHINE_GSTREAMER_1_0_PLUGIN:mx6-nxp-bsp = "imx-gst1.0-plugin"
+MACHINE_GSTREAMER_1_0_PLUGIN:mx7-nxp-bsp = "imx-gst1.0-plugin"
+MACHINE_GSTREAMER_1_0_PLUGIN:mx8-nxp-bsp = "imx-gst1.0-plugin"
+MACHINE_GSTREAMER_1_0_PLUGIN:mx9-nxp-bsp = "imx-gst1.0-plugin"
+
+PREFERRED_VERSION_gstreamer1.0              ??= "1.24.7.imx"
+PREFERRED_VERSION_gstreamer1.0-plugins-bad  ??= "1.24.7.imx"
+PREFERRED_VERSION_gstreamer1.0-plugins-base ??= "1.24.7.imx"
+PREFERRED_VERSION_gstreamer1.0-plugins-good ??= "1.24.7.imx"
+PREFERRED_VERSION_gst-devtools              ??= "1.24.0.imx"
+PREFERRED_VERSION_gstreamer1.0-libav        ??= "1.24.0.imx"
+PREFERRED_VERSION_gstreamer1.0-plugins-ugly ??= "1.24.0.imx"
+PREFERRED_VERSION_gstreamer1.0-python       ??= "1.24.0.imx"
+PREFERRED_VERSION_gstreamer1.0-rtsp-server  ??= "1.24.0.imx"
+PREFERRED_VERSION_gstreamer1.0-vaapi        ??= "1.24.0.imx"
+
+PACKAGECONFIG:append:pn-pulseaudio = " autospawn-for-root"

--- a/conf/fragments/graphics/x11.conf
+++ b/conf/fragments/graphics/x11.conf
@@ -1,0 +1,5 @@
+BB_CONF_FRAGMENT_SUMMARY = "Enable X11 display backend"
+BB_CONF_FRAGMENT_DESCRIPTION = "Enables X11 display backend while removing Wayland support."
+
+DISTRO_FEATURES:remove = "wayland"
+DISTRO_FEATURES:append = " x11"

--- a/default-registry/configurations/fsl-community-bsp-master.conf.json
+++ b/default-registry/configurations/fsl-community-bsp-master.conf.json
@@ -176,63 +176,29 @@
             },
             "configurations": [
             {
-                "name": "fsl",
-                "description": "I will use the distro base configuration only (either FSL or FSLC)"
-            },
-            {
-                "name": "accept-fsl-eula",
-                "description": "Accept NXP EULA only",
+                "name": "fslc-framebuffer",
+                "description": "FSLC BSP with framebuffer backend",
                 "oe-fragments": [
-                    "freescale-layer/accept-fsl-eula"
-                ]
-            },
-            {
-                "name": "fsl-framebuffer",
-                "description": "Accept NXP EULA and configure FrameBuffer backend",
-                "oe-fragments": [
-                    "freescale-layer/eula/accept-fsl-eula",
+                    "freescale-layer/bsp/fslc",
                     "freescale-layer/graphics/framebuffer"
                 ]
             },
             {
-                "name": "fsl-wayland",
-                "description": "Accept NXP EULA and configure Wayland with systemd",
+                "name": "nxp-framebuffer",
+                "description": "Accept NXP EULA, NXP BSP with framebuffer backend",
                 "oe-fragments": [
                     "freescale-layer/eula/accept-fsl-eula",
-                    "freescale-layer/init/systemd",
-                    "freescale-layer/graphics/wayland"
-                ]
-            },
-            {
-                "name": "fsl-xwayland",
-                "description": "Accept NXP EULA and configure XWayland with systemd",
-                "oe-fragments": [
-                    "freescale-layer/eula/accept-fsl-eula",
-                    "freescale-layer/init/systemd",
-                    "freescale-layer/graphics/xwayland"
-                ]
-            },
-            {
-                "name": "framebuffer",
-                "description": "Configure FrameBuffer backend",
-                "oe-fragments": [
+                    "freescale-layer/bsp/nxp",
                     "freescale-layer/graphics/framebuffer"
                 ]
             },
             {
-                "name": "wayland",
-                "description": "Configure Wayland with systemd",
+                "name": "fslc-eula-framebuffer",
+                "description": "Accept NXP EULA, FSLC BSP with framebuffer backend",
                 "oe-fragments": [
-                    "freescale-layer/init/systemd",
-                    "freescale-layer/graphics/wayland"
-                ]
-            },
-            {
-                "name": "xwayland",
-                "description": "Configure XWayland with systemd",
-                "oe-fragments": [
-                    "freescale-layer/init/systemd",
-                    "freescale-layer/graphics/xwayland"
+                    "freescale-layer/eula/accept-fsl-eula",
+                    "freescale-layer/bsp/fslc",
+                    "freescale-layer/graphics/framebuffer"
                 ]
             }
             ]

--- a/default-registry/configurations/fsl-community-bsp-master.conf.json
+++ b/default-registry/configurations/fsl-community-bsp-master.conf.json
@@ -167,10 +167,10 @@
                     ]
                 },
                 "distro": {
-                    "description": "Target Distributions",
+                    "description": "Distribution",
                     "options": [
-                        {"name": "distro/fsl",  "description": "FSL NXP BSP base distribution"},
-                        {"name": "distro/fslc", "description": "FSLC Community BSP base distribution"}
+                        {"name": "distro/poky",    "description": "Poky reference distribution"},
+                        {"name": "distro/nodistro", "description": "No distribution policy"}
                     ]
                 }
             },


### PR DESCRIPTION
  Phase 1 of the distro-to-fragments migration (RFC: meta-freescale-distro deprecation)
  
  This series adds BitBake configuration fragments for BSP selection and the X11 display backend,
  registers the conf/fragments/ tree with bitbake-config-build, and updates the default-registry
  JSON to match.

  What changes:

  - conf/fragments/graphics/x11.conf: new fragment for the X11 display backend (wayland, xwayland,
  framebuffer already existed).
  - conf/fragments/bsp/fslc.conf: selects the FSLC mainline BSP (IMX_DEFAULT_BSP = "mainline",
  linux-fslc, u-boot-fslc).
  - conf/fragments/bsp/nxp.conf: selects the NXP downstream BSP (linux-imx, u-boot-imx) and carries
   the provider overrides and GStreamer version pins previously found in fsl-base.inc in
  meta-freescale-distro.
  - default-registry: replaces the old distro-bundled presets (which did not express a BSP choice)
  with fslc-framebuffer, nxp-framebuffer, and fslc-eula-framebuffer; replaces the phantom
  distro/fsl and distro/fslc one-of options with the real upstream fragments yocto/distro/poky and
  core/distro/nodistro.

  No breaking changes. Existing users of DISTRO = "fslc-wayland" (or any other distro from
  meta-freescale-distro) are not affected. A companion patch to meta-freescale-distro wires those
  distros through these fragments so they are validated by existing builds before the distros are
  deprecated.

---

* meta-freescale-distro/conf/distro/include/fsl-base.inc remains untouched and not linked
* provides 2 distro options `poky` and `nodistro`.  (bitbake configuration template requires a DISTRO)
* X11 fragment is there, but I'm not really sure we want that
* https://github.com/Freescale/meta-freescale-distro/pull/138 depends on this PR
* another point to remember is that if we decide to deprecate meta-freescale-distro and only use fragments, sstate-cache/sdk are impacted 