### PR TITLE
vulkan-wsi-layer: Fix build issue with GCC 16

### DIFF
--- a/recipes-graphics/vulkan/vulkan-wsi-layer/0001-wayland-Add-C-guard-before-__STDC_VERSION__-define.patch
+++ b/recipes-graphics/vulkan/vulkan-wsi-layer/0001-wayland-Add-C-guard-before-__STDC_VERSION__-define.patch
@@ -1,0 +1,106 @@
+From aa5d634a607d58f45cc9ccbdc1f80c94685a45a2 Mon Sep 17 00:00:00 2001
+From: Franz Schnyder <franz.schnyder@toradex.com>
+Date: Wed, 3 Jun 2026 10:00:55 +0200
+Subject: [PATCH] wayland: Add C++ guard before __STDC_VERSION__ define
+
+'__STDC_VERSION__' is predefined by the compiler in C++ mode. Redefining
+it triggers '-Wbuiltin-macro-redefined', which with '-Werror' fails the
+build under GCC 16.
+
+Upstream-Status: Submitted [https://gitlab.freedesktop.org/mesa/vulkan-wsi-layer/-/work_items/33]
+Signed-off-by: Franz Schnyder <franz.schnyder@toradex.com>
+---
+ wsi/wayland/surface.hpp            | 3 +++
+ wsi/wayland/surface_properties.cpp | 2 ++
+ wsi/wayland/swapchain.hpp          | 3 +++
+ wsi/wayland/wl_helpers.hpp         | 3 +++
+ wsi/wayland/wl_object_owner.hpp    | 3 +++
+ 5 files changed, 14 insertions(+)
+
+diff --git a/wsi/wayland/surface.hpp b/wsi/wayland/surface.hpp
+index f060f00..92aa598 100644
+--- a/wsi/wayland/surface.hpp
++++ b/wsi/wayland/surface.hpp
+@@ -28,9 +28,12 @@
+ 
+ #pragma once
+ 
++#ifndef __cplusplus
+ #ifndef __STDC_VERSION__
+ #define __STDC_VERSION__ 0
+ #endif
++#endif
++
+ #include <wayland-client.h>
+ 
+ #include "wsi/surface.hpp"
+diff --git a/wsi/wayland/surface_properties.cpp b/wsi/wayland/surface_properties.cpp
+index e6435b9..caf840d 100644
+--- a/wsi/wayland/surface_properties.cpp
++++ b/wsi/wayland/surface_properties.cpp
+@@ -24,9 +24,11 @@
+ 
+ #define VK_USE_PLATFORM_WAYLAND_KHR 1
+ 
++#ifndef __cplusplus
+ #ifndef __STDC_VERSION__
+ #define __STDC_VERSION__ 0
+ #endif
++#endif
+ 
+ #include <wayland-client.h>
+ #include <linux-dmabuf-unstable-v1-client-protocol.h>
+diff --git a/wsi/wayland/swapchain.hpp b/wsi/wayland/swapchain.hpp
+index 7667324..95096f8 100644
+--- a/wsi/wayland/swapchain.hpp
++++ b/wsi/wayland/swapchain.hpp
+@@ -31,9 +31,12 @@ extern "C" {
+ #include <vulkan/vk_icd.h>
+ }
+ 
++#ifndef __cplusplus
+ #ifndef __STDC_VERSION__
+ #define __STDC_VERSION__ 0
+ #endif
++#endif
++
+ #include <wayland-client.h>
+ #include <linux-dmabuf-unstable-v1-client-protocol.h>
+ #include "util/wsialloc/wsialloc.h"
+diff --git a/wsi/wayland/wl_helpers.hpp b/wsi/wayland/wl_helpers.hpp
+index 1f6bad6..2ca131b 100644
+--- a/wsi/wayland/wl_helpers.hpp
++++ b/wsi/wayland/wl_helpers.hpp
+@@ -26,9 +26,12 @@
+ 
+ #include <stdint.h>
+ 
++#ifndef __cplusplus
+ #ifndef __STDC_VERSION__
+ #define __STDC_VERSION__ 0
+ #endif
++#endif
++
+ #include <wayland-client.h>
+ 
+ #include "util/custom_allocator.hpp"
+diff --git a/wsi/wayland/wl_object_owner.hpp b/wsi/wayland/wl_object_owner.hpp
+index d317e28..564fd5a 100644
+--- a/wsi/wayland/wl_object_owner.hpp
++++ b/wsi/wayland/wl_object_owner.hpp
+@@ -24,9 +24,12 @@
+ 
+ #pragma once
+ 
++#ifndef __cplusplus
+ #ifndef __STDC_VERSION__
+ #define __STDC_VERSION__ 0
+ #endif
++#endif
++
+ #include <wayland-client.h>
+ #include <linux-dmabuf-unstable-v1-client-protocol.h>
+ #include <linux-explicit-synchronization-unstable-v1-protocol.h>
+-- 
+2.43.0
+

--- a/recipes-graphics/vulkan/vulkan-wsi-layer_git.bb
+++ b/recipes-graphics/vulkan/vulkan-wsi-layer_git.bb
@@ -8,7 +8,8 @@ PV = "0.0+git${SRCPV}"
 SRC_URI = "git://gitlab.freedesktop.org/mesa/vulkan-wsi-layer.git;protocol=https;branch=main \
            file://0001-MGS-6801-ccc-vkmark-on-wayland.patch \
            file://0002-MGS-6823-nxp-Add-support-of-VK_COMPOSITE_ALPHA_OPAQU.patch \
-           file://0003-Update-minimum-version-of-CMake.patch"
+           file://0003-Update-minimum-version-of-CMake.patch \
+           file://0001-wayland-Add-C-guard-before-__STDC_VERSION__-define.patch"
 SRCREV = "cb1a50cf7e640ad7306e673131ded98c0f133628"
 
 inherit cmake pkgconfig


### PR DESCRIPTION
'__STDC_VERSION__' is predefined by the compiler in C++ mode. Redefining it triggers '-Wbuiltin-macro-redefined', which with '-Werror' fails the build with GCC 16.

error: '__STDC_VERSION__' defined [-Werror]

As suggested in the Vulkan WSI Layer issue tracker, add a C++ guard before the __STDC_VERSION__ define.