### PR TITLE
imx-mkimage: imx-boot: Specify build dependencies in DEPENDS

### DIFF
--- a/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
+++ b/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
@@ -14,15 +14,20 @@ DEPENDS:append:mx95-generic-bsp = " u-boot-mkeficapsule-native"
 
 # This package aggregates output deployed by other packages,
 # so set the appropriate dependencies
-do_compile[depends] += " \
-    virtual/bootloader:do_deploy \
-    ${@' '.join('%s:do_deploy' % r for r in '${IMX_EXTRA_FIRMWARE}'.split() )} \
-    imx-atf:do_deploy \
+DEPENDS += " \
+    virtual/bootloader \
+    ${IMX_EXTRA_FIRMWARE} \
+    imx-atf \
     ${@bb.utils.contains('UBOOT_CONFIG', 'crrm', '${CRRM_DEPLOY_DEPENDS}', '', d)} \
-    ${@bb.utils.contains('MACHINE_FEATURES', 'optee', 'optee-os:do_deploy', '', d)}"
+    ${@bb.utils.contains('MACHINE_FEATURES', 'optee', 'optee-os', '', d)} \
+"
+
+do_compile[deptask] = "do_deploy"
+do_compile[depends] += "${@bb.utils.contains('UBOOT_CONFIG', 'crrm', '${CRRM_INITRAMFS}:do_build', '', d)}"
+
 CRRM_DEPLOY_DEPENDS ?= " \
-    virtual/kernel:do_deploy \
-    ${CRRM_INITRAMFS}:do_build"
+    virtual/kernel \
+    ${CRRM_INITRAMFS}"
 CRRM_INITRAMFS ??= "imx-image-crrm-initramfs"
 
 inherit use-imx-security-controller-firmware uboot-config


### PR DESCRIPTION
Dependencies listed via do_compile[depends] are invisible to the SBOM script from OpenEmbedded. Since these components.

This patch lists the build-time dependencies for imx-boot in the DEPENDS variable instead, allowing these components to be automatically included in the imx-boot SBOM.

I used `do_compile[deptask] = "do_deploy"` to ensure that the `do_deploy` tasks of each dependency are still done before the recipe runs. The only particularity is the `${CRRM_INITRAMFS}:do_build`, is it really necessary that for this component that the entire `do_build` is done, instead of `do_deploy`?  I wasn't sure if it was important or not, so I preserved its precedence before the `imx-boot` recipe.