### PR TITLE
Consolidate recipe content from meta-freescale-distro

### DIFF
--- a/recipes-devtools/half/half_2.1.0.bb
+++ b/recipes-devtools/half/half_2.1.0.bb
@@ -1,0 +1,19 @@
+SUMMARY = "C++ library for half precision floating point arithmetics"
+DESCRIPTION = "half is a C++ header-only library to provide an IEEE-754 conformant \ 
+half-precision floating point type along with corresponding arithmetic operators, \
+type conversions and common mathematical functions."
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=813a6278831975d26c115ed6f9c21831"
+
+SRC_URI = "https://sourceforge.net/projects/half/files/half/${PV}/${BP}.zip"
+SRC_URI[sha256sum] = "ad1788afe0300fa2b02b0d1df128d857f021f92ccf7c8bddd07812685fa07a25"
+
+S = "${UNPACKDIR}"
+
+do_install () {
+    install -d ${D}${includedir}
+    cp -r ${S}/include/* ${D}${includedir}
+}
+
+ALLOW_EMPTY:${PN} = "1"

--- a/recipes-devtools/stb/stb_git.bb
+++ b/recipes-devtools/stb/stb_git.bb
@@ -1,0 +1,18 @@
+SUMMARY = "single-file public domain (or MIT licensed) libraries for C/C++"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://stb.h;beginline=14418;endline=14433;md5=b10975d4c8155af1811ab611586f01d2"
+
+PV = "0.0+git${SRCPV}"
+
+SRCREV = "f67165c2bb2af3060ecae7d20d6f731173485ad0"
+SRC_URI = "git://github.com/nothings/stb.git;protocol=https;branch=master"
+
+do_install() {
+    install -d ${D}${includedir}
+    for hdr in ${S}/*.h; do
+        install -m 0644 $hdr ${D}${includedir}
+    done
+}
+
+# This is a header-only library, so the main package will be empty.
+ALLOW_EMPTY:${PN} = "1"

--- a/recipes-fsl/fsl-rc-local/fsl-rc-local.bb
+++ b/recipes-fsl/fsl-rc-local/fsl-rc-local.bb
@@ -1,0 +1,23 @@
+# Copyright (C) 2012 O.S. Systems Software LTDA.
+
+DESCRIPTION = "Extra files for fsl-gui-image"
+LICENSE = "LGPL-2.0-only"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=39ec502560ab2755c4555ee8416dfe42"
+
+SRC_URI = "file://rc.local.etc \
+           file://rc.local.init \
+           file://LICENSE"
+
+S = "${UNPACKDIR}"
+
+inherit update-rc.d
+
+INITSCRIPT_NAME = "rc.local"
+INITSCRIPT_PARAMS = "start 99 2 3 4 5 ."
+
+do_install () {
+    install -d ${D}/${sysconfdir}/init.d
+    install -m 755 ${S}/rc.local.etc ${D}/${sysconfdir}/rc.local
+    install -m 755 ${S}/rc.local.init ${D}/${sysconfdir}/init.d/rc.local
+
+}

--- a/recipes-fsl/fsl-rc-local/fsl-rc-local/LICENSE
+++ b/recipes-fsl/fsl-rc-local/fsl-rc-local/LICENSE
@@ -1,0 +1,1 @@
+All content inside fsl-rc-local package are distributed under GPLv2 license

--- a/recipes-fsl/fsl-rc-local/fsl-rc-local/rc.local.etc
+++ b/recipes-fsl/fsl-rc-local/fsl-rc-local/rc.local.etc
@@ -1,0 +1,14 @@
+#!/bin/sh -e
+#
+# rc.local
+#
+# This script is executed at the end of each multiuser runlevel.
+# Make sure that the script will "exit 0" on success or any other
+# value on error.
+#
+# In order to enable or disable this script just change the execution
+# bits.
+#
+# By default this script does nothing.
+
+exit 0

--- a/recipes-fsl/fsl-rc-local/fsl-rc-local/rc.local.init
+++ b/recipes-fsl/fsl-rc-local/fsl-rc-local/rc.local.init
@@ -1,0 +1,36 @@
+#! /bin/sh
+### BEGIN INIT INFO
+# Provides:          rc.local
+# Required-Start:    $all
+# Required-Stop:
+# Default-Start:     2 3 4 5
+# Default-Stop:
+# Short-Description: Run /etc/rc.local if it exist
+### END INIT INFO
+
+PATH=/sbin:/usr/sbin:/bin:/usr/bin
+
+do_start() {
+	if [ -x /etc/rc.local ]; then
+		echo -n "Running local boot scripts (/etc/rc.local)"
+		/etc/rc.local
+		[ $? = 0 ] && echo "." || echo "error"
+		return $ES
+	fi
+}
+
+case "$1" in
+    start)
+	do_start
+        ;;
+    restart|reload|force-reload)
+        echo "Error: argument '$1' not supported" >&2
+        exit 3
+        ;;
+    stop)
+        ;;
+    *)
+        echo "Usage: $0 start|stop" >&2
+        exit 3
+        ;;
+esac

--- a/recipes-fsl/images/fsl-image-machine-test.bb
+++ b/recipes-fsl/images/fsl-image-machine-test.bb
@@ -1,0 +1,31 @@
+DESCRIPTION = "A console-only image that includes gstreamer packages, \
+Freescale's multimedia packages (VPU and GPU) when available, and \
+test and benchmark applications."
+
+IMAGE_FEATURES += " \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', '', \
+       bb.utils.contains('DISTRO_FEATURES',     'x11', 'x11-base', \
+                                                       '', d), d)} \
+    debug-tweaks \
+    tools-testapps \
+    tools-profile \
+"
+
+LICENSE = "MIT"
+
+inherit core-image
+
+CORE_IMAGE_EXTRA_INSTALL += " \
+    packagegroup-fsl-gstreamer1.0 \
+    packagegroup-fsl-gstreamer1.0-full \
+    packagegroup-fsl-tools-gpu \
+    packagegroup-fsl-tools-gpu-external \
+    packagegroup-fsl-tools-testapps \
+    packagegroup-fsl-tools-benchmark \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', \
+                         'firmwared', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', \
+                         'weston weston-init', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'x11 wayland', \
+                         'weston-xwayland xterm', '', d)} \
+"

--- a/recipes-fsl/images/fsl-image-multimedia-full.bb
+++ b/recipes-fsl/images/fsl-image-multimedia-full.bb
@@ -1,0 +1,8 @@
+# This image extends fsl-image-multimedia with additional
+# gstreamer plugins
+
+require fsl-image-multimedia.bb
+
+CORE_IMAGE_EXTRA_INSTALL += " \
+    packagegroup-fsl-gstreamer1.0-full \
+"

--- a/recipes-fsl/images/fsl-image-multimedia.bb
+++ b/recipes-fsl/images/fsl-image-multimedia.bb
@@ -1,0 +1,30 @@
+DESCRIPTION = "A console-only image that includes gstreamer packages and \
+Freescale's multimedia packages (VPU and GPU) when available for the specific \
+machine."
+
+IMAGE_FEATURES += "\
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'weston', \
+       bb.utils.contains('DISTRO_FEATURES',     'x11', 'x11-base', \
+                                                       '', d), d)} \
+"
+
+LICENSE = "MIT"
+
+inherit core-image
+
+CORE_IMAGE_EXTRA_INSTALL += " \
+    packagegroup-fsl-tools-gpu \
+    packagegroup-fsl-gstreamer1.0 \
+    packagegroup-imx-tools-audio \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', \
+                         'weston weston-init weston-examples \
+                          gtk+3-demo', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'x11 wayland', \
+                         'weston-xwayland xterm', '', d)} \
+"
+
+PACKAGE_IMX_TO_REMOVE = ""
+PACKAGE_IMX_TO_REMOVE:imxgpu2d = "gtk+3-demo"
+PACKAGE_IMX_TO_REMOVE:imxgpu3d = ""
+
+CORE_IMAGE_EXTRA_INSTALL:remove = "${PACKAGE_IMX_TO_REMOVE}"

--- a/recipes-fsl/images/fsl-image-network-full-cmdline.bb
+++ b/recipes-fsl/images/fsl-image-network-full-cmdline.bb
@@ -1,0 +1,22 @@
+DESCRIPTION = "A console-only image that includes full cmdline and \
+Freescale's networking packages (QorIQ DPAA/DPAA2) when available."
+
+IMAGE_FEATURES += " \
+    debug-tweaks \
+    tools-profile \
+"
+
+LICENSE = "MIT"
+
+CORE_IMAGE_EXTRA_INSTALL:append = "\
+    packagegroup-core-boot \
+    packagegroup-core-full-cmdline \
+    packagegroup-fsl-network \
+"
+
+# SPI Nor-Flash
+NETWORK_TOOLS:append:fsl-lsch3 = "\
+    mtd-utils \
+"
+
+inherit core-image

--- a/recipes-fsl/packagegroups/packagegroup-fsl-gstreamer1.0-commercial.bb
+++ b/recipes-fsl/packagegroups/packagegroup-fsl-gstreamer1.0-commercial.bb
@@ -1,0 +1,17 @@
+DESCRIPTION = "Package group used by FSL Community to provide audio and video plugins \
+that are subject to restricted licensing and/or royalties and thus require \
+the 'commercial' license whitelist flag"
+SUMMARY = "FSL Community package group - set of GStreamer 1.0 plugins with commercial licence flag"
+LICENSE_FLAGS = "commercial"
+
+inherit packagegroup
+
+RDEPENDS:${PN} = " \
+    packagegroup-fsl-gstreamer1.0 \
+"
+
+# Plugins from the -ugly collection which require the "commercial" flag in LICENSE_FLAGS_ACCEPTED to be set
+RDEPENDS:${PN} = " \
+    gstreamer1.0-plugins-ugly-asf \
+    gstreamer1.0-libav \
+"

--- a/recipes-fsl/packagegroups/packagegroup-fsl-gstreamer1.0-full.bb
+++ b/recipes-fsl/packagegroups/packagegroup-fsl-gstreamer1.0-full.bb
@@ -1,0 +1,15 @@
+DESCRIPTION = "Package group used by FSL Community to provide all GStreamer plugins from the \
+base, good, and bad packages, as well as the ugly and libav ones if commercial packages \
+are whitelisted, and plugins for the required hardware acceleration (if supported by the SoC)."
+SUMMARY = "FSL Community package group - full set of all GStreamer 1.0 plugins"
+
+inherit packagegroup
+
+RDEPENDS:${PN} = " \
+    packagegroup-fsl-gstreamer1.0 \
+    ${@bb.utils.contains('LICENSE_FLAGS_ACCEPTED', 'commercial', 'packagegroup-fsl-gstreamer1.0-commercial', '', d)} \
+    gstreamer1.0-plugins-base-meta \
+    gstreamer1.0-plugins-good-meta \
+    gstreamer1.0-plugins-bad-meta \
+    ${@bb.utils.contains('LICENSE_FLAGS_ACCEPTED', 'commercial', 'gstreamer1.0-plugins-ugly-meta', '', d)} \
+"

--- a/recipes-fsl/packagegroups/packagegroup-fsl-gstreamer1.0.bb
+++ b/recipes-fsl/packagegroups/packagegroup-fsl-gstreamer1.0.bb
@@ -1,0 +1,118 @@
+DESCRIPTION = "Package group used by FSL Community to provide audio, video, networking and debug \
+GStreamer plugins with the required hardware acceleration (if supported by the SoC)."
+SUMMARY = "FSL Community package group - set of commonly used GStreamer 1.0 plugins"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit packagegroup
+
+PACKAGES += " \
+    ${PN}-base \
+    ${PN}-audio \
+    ${PN}-video \
+    ${PN}-video-bad \
+    ${PN}-debug \
+    ${PN}-network-base \
+    ${PN}-network \
+"
+
+MACHINE_GSTREAMER_1_0_PLUGIN ?= ""
+
+RDEPENDS:${PN} = " \
+    ${PN}-audio \
+    ${PN}-video \
+    ${PN}-network-base \
+    ${PN}-debug \
+"
+
+# List of X11 specific plugins
+GST_X11_PACKAGES = " \
+    gstreamer1.0-plugins-base-ximagesink \
+    gstreamer1.0-plugins-base-xvimagesink \
+"
+
+# List of Wayland specific plugins
+GST_WAYLAND_PACKAGES = " \
+    gstreamer1.0-plugins-bad-waylandsink \
+"
+
+# basic plugins required in virtually every pipeline
+RDEPENDS:${PN}-base = " \
+    gstreamer1.0 \
+    gstreamer1.0-plugins-base-playback \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'alsa', 'gstreamer1.0-plugins-base-alsa', '', d)} \
+    gstreamer1.0-plugins-base-audioconvert \
+    gstreamer1.0-plugins-base-audioresample \
+    gstreamer1.0-plugins-base-gio \
+    gstreamer1.0-plugins-base-typefindfunctions \
+    gstreamer1.0-plugins-base-videoconvertscale \
+    gstreamer1.0-plugins-base-volume \
+    gstreamer1.0-plugins-good-autodetect \
+    ${MACHINE_GSTREAMER_1_0_PLUGIN} \
+    ${@bb.utils.contains("MACHINE_GSTREAMER_1_0_PLUGIN", "imx-gst1.0-plugin", "imx-gst1.0-plugin-tools", "", d)} \
+"
+
+RRECOMMENDS:${PN}-base = " \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'x11', '${GST_X11_PACKAGES}', \
+                          bb.utils.contains('DISTRO_FEATURES', 'wayland', \
+                                            '${GST_WAYLAND_PACKAGES}', '', d), d)} \
+"
+
+# Basic audio plugins: parsers, demuxers, decoders
+RDEPENDS:${PN}-audio = " \
+    ${PN}-base \
+    gstreamer1.0-plugins-base-ogg \
+    gstreamer1.0-plugins-good-audioparsers \
+    gstreamer1.0-plugins-good-flac \
+    gstreamer1.0-plugins-good-icydemux \
+    gstreamer1.0-plugins-good-id3demux \
+    gstreamer1.0-plugins-good-speex \
+    gstreamer1.0-plugins-good-wavparse \
+"
+
+# Basic video plugins: parsers, demuxers
+RDEPENDS:${PN}-video = " \
+    ${PN}-base \
+    gstreamer1.0-plugins-base-subparse \
+    gstreamer1.0-plugins-base-theora \
+    gstreamer1.0-plugins-good-avi \
+    gstreamer1.0-plugins-good-flv \
+    gstreamer1.0-plugins-good-isomp4 \
+    gstreamer1.0-plugins-good-matroska \
+"
+
+RRECOMMENDS:${PN}-video = " \
+    ${PN}-audio \
+"
+
+# Additional video plugins from the -bad collection
+RDEPENDS:${PN}-video-bad = " \
+    ${PN}-video \
+    gstreamer1.0-plugins-bad-mpegpsdemux \
+    gstreamer1.0-plugins-bad-mpegtsdemux \
+    gstreamer1.0-plugins-bad-videoparsersbad \
+"
+
+# Plugins used for diagnostics and debugging of pipelines
+RDEPENDS:${PN}-debug = " \
+    ${PN}-base \
+    gstreamer1.0-plugins-base-audiotestsrc \
+    gstreamer1.0-plugins-base-videotestsrc \
+    gstreamer1.0-plugins-good-debug \
+    gstreamer1.0-plugins-good-navigationtest \
+"
+
+# Basic networking plugins required by most pipelines that receive and/or send data
+RDEPENDS:${PN}-network-base = " \
+    gstreamer1.0-plugins-base-tcp \
+    gstreamer1.0-plugins-good-soup \
+    gstreamer1.0-plugins-good-udp \
+"
+
+# Additional networking plugins
+RDEPENDS:${PN}-network = " \
+    ${PN}-network-base \
+    gstreamer1.0-plugins-good-rtp \
+    gstreamer1.0-plugins-good-rtpmanager \
+    gstreamer1.0-plugins-good-rtsp \
+"

--- a/recipes-fsl/packagegroups/packagegroup-fsl-network.bb
+++ b/recipes-fsl/packagegroups/packagegroup-fsl-network.bb
@@ -1,0 +1,50 @@
+# Copyright (C) 2020 Jens Rehsack <sno@netbsd.org>
+# Released under the MIT license (see COPYING.MIT for the terms)
+
+DESCRIPTION = "Package group used by FSL Community to add the packages which provide (QorIQ) networking support."
+SUMMARY = "FSL Community package group - networking"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit packagegroup
+
+NETWORK_TOOLS = "\
+	ethtool \
+	tcpdump \
+"
+
+NETWORK_TOOLS:append:qoriq = " \
+	ceetm \
+	dpdk \
+	ovs-dpdk \
+	pktgen-dpdk \
+	tsntool \
+"
+
+# Data Place Acceleration Architecture
+NETWORK_TOOLS:append:fsl-lsch2 = "\
+	eth-config \
+"
+
+# 2nd generation Data Place Acceleration Architecture
+NETWORK_TOOLS:append:ls1088a = "\
+	aiopsl \
+	gpp-aioptool \
+	ofp \
+"
+
+NETWORK_TOOLS:append:ls2088a = "\
+	aiopsl \
+	gpp-aioptool \
+	ofp \
+"
+
+NETWORK_TOOLS:append:fsl-lsch3 = "\
+	dce \
+	restool \
+	spc \
+"
+
+RDEPENDS:${PN} = " \
+    ${NETWORK_TOOLS} \
+"

--- a/recipes-fsl/packagegroups/packagegroup-fsl-tools-benchmark.bb
+++ b/recipes-fsl/packagegroups/packagegroup-fsl-tools-benchmark.bb
@@ -1,0 +1,23 @@
+# Copyright (C) 2012-2016 Freescale Semiconductor
+# Released under the MIT license (see COPYING.MIT for the terms)
+
+DESCRIPTION = "Package group used by FSL Community to provide a set of benchmark applications."
+SUMMARY = "FSL Communtiy package group - tools/benchmark"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit packagegroup
+
+RDEPENDS:${PN} = " \
+    lmbench \
+    bonnie++ \
+    dbench \
+    fio \
+    iozone3 \
+    iperf3 \
+    nbench-byte \
+    tiobench \
+    ${@bb.utils.contains('TUNE_FEATURES', 'neon',             'cpuburn-neon', \
+       bb.utils.contains('TUNE_FEATURES', 'cortexa53 crypto', 'cpuburn-neon', \
+                                                              '', d), d)} \
+"

--- a/recipes-fsl/packagegroups/packagegroup-fsl-tools-gpu-external.bb
+++ b/recipes-fsl/packagegroups/packagegroup-fsl-tools-gpu-external.bb
@@ -1,0 +1,28 @@
+# Copyright (C) 2014, 2016 Freescale Semiconductor
+# Copyright (C) 2015, 2016 O.S. Systems Software LTDA.
+# Released under the MIT license (see COPYING.MIT for the terms)
+DESCRIPTION = "Package group used by FSL Community to provide graphic packages used \
+to test the several hardware accelerated graphics APIs including packages not \
+provided by Freescale."
+SUMMARY = "FSL Community Package group - tools/gpu/external"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit packagegroup
+
+SOC_TOOLS_GPU_X11 = ""
+SOC_TOOLS_GPU_X11:imxgpu2d = " mesa-demos glmark2 gtkperf"
+
+SOC_TOOLS_GPU_FB = ""
+
+SOC_TOOLS_GPU_WAYLAND = ""
+
+SOC_TOOLS_GPU_XWAYLAND = ""
+SOC_TOOLS_GPU_XWAYLAND:imxgpu2d = "mesa-demos gtkperf"
+
+RDEPENDS:${PN} = " \
+    ${@bb.utils.contains("DISTRO_FEATURES", "x11 wayland", "${SOC_TOOLS_GPU_XWAYLAND}", \
+       bb.utils.contains("DISTRO_FEATURES",     "wayland", "${SOC_TOOLS_GPU_WAYLAND}", \
+       bb.utils.contains("DISTRO_FEATURES",         "x11", "${SOC_TOOLS_GPU_X11}", \
+                                                           "${SOC_TOOLS_GPU_FB}", d), d), d)} \
+"

--- a/recipes-fsl/packagegroups/packagegroup-fsl-tools-gpu.bb
+++ b/recipes-fsl/packagegroups/packagegroup-fsl-tools-gpu.bb
@@ -1,0 +1,32 @@
+# Copyright (C) 2012-2014, 2016 Freescale Semiconductor
+# Copyright (C) 2015, 2016 O.S. Systems Software LTDA.
+# Released under the MIT license (see COPYING.MIT for the terms)
+
+DESCRIPTION = "Package group used by FSL Community to add the packages which provide GPU support."
+SUMMARY = "FSL Community package group - tools/gpu"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit packagegroup
+
+SOC_TOOLS_GPU = ""
+
+# i.MX6 SoloLite does not support apitrace because of its dependency on gles2.
+SOC_TOOLS_GPU:imxgpu2d = " \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', '', \
+       bb.utils.contains('DISTRO_FEATURES',     'x11', 'xserver-xorg-extension-viv-autohdmi', \
+                                                       '', d), d)} \
+"
+
+SOC_TOOLS_GPU:append:imxgpu3d = " \
+    imx-gpu-apitrace \
+"
+
+SOC_TOOLS_GPU:append:imxgpu = " \
+    imx-gpu-sdk \
+    imx-gpu-viv-tools \
+"
+
+RDEPENDS:${PN} = " \
+    ${SOC_TOOLS_GPU} \
+"

--- a/recipes-fsl/packagegroups/packagegroup-fsl-tools-testapps.bb
+++ b/recipes-fsl/packagegroups/packagegroup-fsl-tools-testapps.bb
@@ -1,0 +1,45 @@
+# Copyright (C) 2012-2014, 2016 Freescale Semiconductor
+# Copyright (C) 2015, 2016 O.S. Systems Software LTDA.
+# Released under the MIT license (see COPYING.MIT for the terms)
+
+DESCRIPTION = "Packagegroup used by FSL Community to provide a set of packages and utilities \
+for hardware test."
+SUMMARY = "FSL Community packagegroup - tools/testapps"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit packagegroup
+
+SOC_TOOLS_TEST = ""
+SOC_TOOLS_TEST:imx-nxp-bsp = "imx-test"
+SOC_TOOLS_TEST:imxgpu  = "imx-test imx-gpu-viv-demos"
+SOC_TOOLS_TEST:qoriq = "ceetm optee-test-qoriq"
+
+RDEPENDS:${PN} = " \
+    alsa-utils \
+    alsa-tools \
+    dosfstools \
+    evtest \
+    e2fsprogs-mke2fs \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'sysvinit', 'fsl-rc-local', '', d)} \
+    fbset \
+    i2c-tools \
+    iproute2 \
+    memtester \
+    python3-core \
+    python3-json \
+    python3-datetime \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'v4l-utils', '', d)} \
+    ethtool \
+    mtd-utils \
+    mtd-utils-ubifs \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'gtk+3-demo', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', \
+                         'weston-examples', '', d)} \
+    ${SOC_TOOLS_TEST} \
+"
+
+RDEPENDS_IMX_TO_REMOVE = ""
+RDEPENDS_IMX_TO_REMOVE:imxgpu3d = ""
+
+RDEPENDS:${PN}:remove = "${RDEPENDS_IMX_TO_REMOVE}"

--- a/recipes-fsl/packagegroups/packagegroup-imx-tools-audio.bb
+++ b/recipes-fsl/packagegroups/packagegroup-imx-tools-audio.bb
@@ -1,0 +1,33 @@
+# Copyright (C) 2015 Freescale Semiconductor
+# Copyright (C) 2015 O.S. Systems Software LTDA.
+# Released under the MIT license (see COPYING.MIT for the terms)
+
+SUMMARY = "Set of audio tools for inclusion on images"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302 \
+                    file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
+
+inherit packagegroup
+
+ALSA_INSTALL = " \
+    alsa-utils \
+    alsa-tools \
+"
+
+PULSEAUDIO_INSTALL = " \
+    pulseaudio-server \
+    pulseaudio-module-cli \
+    pulseaudio-misc \
+    pulseaudio-module-device-manager \
+    ${@bb.utils.contains('DISTRO_FEATURES',"x11", "pulseaudio-module-x11-xsmp \
+                                                   pulseaudio-module-x11-publish \
+                                                   pulseaudio-module-x11-cork-request \
+                                                   pulseaudio-module-x11-bell \
+                                                   consolekit", \
+                                           "", d)} \
+"
+
+RDEPENDS:${PN} = " \
+    ${@bb.utils.contains("DISTRO_FEATURES", "alsa",  "${ALSA_INSTALL}", "", d)} \
+    ${@bb.utils.contains("DISTRO_FEATURES", "pulseaudio",  "${PULSEAUDIO_INSTALL}", "", d)} \
+"

--- a/recipes-graphics/devil/devil_1.8.0.bb
+++ b/recipes-graphics/devil/devil_1.8.0.bb
@@ -1,0 +1,21 @@
+DESCRIPTION = "A full featured cross-platform image library"
+SECTION = "libs"
+LICENSE = "LGPL-2.1-only"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/LGPL-2.1-only;md5=1a6d268fd218675ffea8be556788b780"
+PR = "r0"
+
+DEPENDS = "libpng jpeg tiff xz"
+
+SRC_URI = "http://sourceforge.net/projects/openil/files/DevIL/${PV}/DevIL-${PV}.zip"
+SRC_URI[sha256sum] = "451337f392c65bfb83698a781370534dc63d7bafca21e9b37178df0518f7e895"
+
+S = "${UNPACKDIR}/DevIL/DevIL"
+
+inherit cmake
+
+TARGET_CFLAGS += "-Dpng_set_gray_1_2_4_to_8=png_set_expand_gray_1_2_4_to_8"
+
+SOLIBS = ".so"
+FILES_SOLIBSDEV = ""
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"

--- a/recipes-graphics/gli/gli_0.8.4.0.bb
+++ b/recipes-graphics/gli/gli_0.8.4.0.bb
@@ -1,0 +1,22 @@
+SUMMARY = "OpenGL Image Library"
+DESCRIPTION = "OpenGL Image (GLI) is a header only C++ \
+image library for graphics software."
+HOMEPAGE = "http://gli.g-truc.net"
+BUGTRACKER = "https://github.com/g-truc/gli/issues"
+
+SECTION = "libs"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://readme.md;beginline=19;endline=20;md5=ab03b667ee630c1abb1add70365a50fb"
+
+SRC_URI = " \
+    git://github.com/g-truc/gli;protocol=https;branch=master \
+"
+SRCREV = "0c171ee87fcfe35a7e0e0445adef06f92e0b6a91"
+
+inherit cmake
+
+# This is a header-only library, so the main package will be empty.
+ALLOW_EMPTY:${PN} = "1"
+
+BBCLASSEXTEND = "native"

--- a/recipes-graphics/glm/glm_%.bbappend
+++ b/recipes-graphics/glm/glm_%.bbappend
@@ -1,0 +1,2 @@
+# This is a header-only library, so the main package will be empty.
+ALLOW_EMPTY:${PN} = "1"

--- a/recipes-graphics/imx-gpu-sdk/imx-gpu-sdk-src.inc
+++ b/recipes-graphics/imx-gpu-sdk/imx-gpu-sdk-src.inc
@@ -1,0 +1,4 @@
+SRC_URI = "${GPU_SDK_SRC};branch=${GPU_SDK_SRC_BRANCH}"
+GPU_SDK_SRC ?= "git://github.com/nxp-imx/gtec-demo-framework.git;protocol=https"
+GPU_SDK_SRC_BRANCH ?= "master"
+SRCREV = "35bbd45ed6eac169a778bd154283771b9bf39be7"

--- a/recipes-graphics/imx-gpu-sdk/imx-gpu-sdk_6.1.1.bb
+++ b/recipes-graphics/imx-gpu-sdk/imx-gpu-sdk_6.1.1.bb
@@ -1,0 +1,145 @@
+SUMMARY = "i.MX GPU SDK Samples"
+DESCRIPTION = "Set of sample applications for i.MX GPU"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://License.md;md5=9d58a2573275ce8c35d79576835dbeb8"
+
+DEPENDS_BACKEND = \
+    "${@bb.utils.contains('DISTRO_FEATURES', 'wayland', ' libxdg-shell wayland', \
+        bb.utils.contains('DISTRO_FEATURES',     'x11',               ' xrandr', \
+                                                                             '', d), d)}"
+DEPENDS_MX8       = ""
+DEPENDS_MX8:mx8-nxp-bsp   = " \
+    glslang-native \
+    opencv \
+    rapidopencl \
+    rapidopenvx \
+    rapidvulkan \
+    vulkan-headers \
+    vulkan-loader \
+"
+DEPENDS_MX8:mx8mm-nxp-bsp = " \
+    opencv \
+"
+DEPENDS = " \
+    assimp \
+    cmake-native \
+    devil \
+    fmt \
+    gli \
+    glm \
+    gstreamer1.0 \
+    gstreamer1.0-plugins-base \
+    gtest \
+    half \
+    ninja-native \
+    nlohmann-json \
+    rapidjson \
+    stb \
+    zlib \
+    ${DEPENDS_BACKEND} \
+    ${DEPENDS_MX8} \
+"
+DEPENDS:append:imxgpu2d = " virtual/libg2d virtual/libopenvg"
+DEPENDS:append:imxgpu3d = " virtual/libgles2"
+
+require imx-gpu-sdk-src.inc
+
+
+WINDOW_SYSTEM = \
+    "${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'Wayland_XDG', \
+        bb.utils.contains('DISTRO_FEATURES',     'x11',         'X11', \
+                                                                 'FB', d), d)}"
+
+FEATURES                  = "ConsoleHost,EarlyAccess,EGL,GoogleUnitTest,Lib_NlohmannJson,OpenVG,Test_RequireUserInputToExit,WindowHost"
+FEATURES:append:imxgpu    = ",HW_GPU_VIVANTE"
+FEATURES:append:imxgpu2d  = ",G2D"
+FEATURES:append:imxgpu3d  = ",OpenGLES2"
+FEATURES:append           = "${FEATURES_SOC}"
+
+FEATURES_SOC              = ""
+FEATURES_SOC:mx6q-nxp-bsp         = ",OpenGLES3"
+FEATURES_SOC:mx6dl-nxp-bsp        = ",OpenGLES3"
+FEATURES_SOC:mx8-nxp-bsp          = ",OpenCV4,Vulkan1.2,OpenGLES3.2,OpenCL1.2,OpenVX1.2"
+FEATURES_SOC:mx8mm-nxp-bsp        = ",OpenCV4"
+
+EXTENSIONS               = "*"
+EXTENSIONS:mx6q-nxp-bsp  = "OpenGLES:GL_VIV_direct_texture,OpenGLES3:GL_EXT_geometry_shader,OpenGLES3:GL_EXT_tessellation_shader"
+EXTENSIONS:mx6dl-nxp-bsp = "OpenGLES:GL_VIV_direct_texture,OpenGLES3:GL_EXT_geometry_shader,OpenGLES3:GL_EXT_tessellation_shader"
+EXTENSIONS:mx8m-nxp-bsp  = "OpenGLES:GL_VIV_direct_texture,OpenGLES3:GL_EXT_color_buffer_float"
+EXTENSIONS:mx8mm-nxp-bsp = "*"
+
+do_compile () {
+    export FSL_PLATFORM_NAME=Yocto
+    export ROOTFS=${STAGING_DIR_HOST}
+    . ./prepare.sh
+    FslBuild.py -vvvvv -t sdk --UseFeatures [${FEATURES}] --UseExtensions [${EXTENSIONS}] --Variants [WindowSystem=${WINDOW_SYSTEM}] --BuildThreads ${@oe.utils.parallel_make(d)} -c install --CMakeInstallPrefix ${S}
+}
+
+REMOVALS = " \
+    GLES2/DeBayer \
+    GLES2/DirectMultiSamplingVideoYUV \
+    GLES3/DirectMultiSamplingVideoYUV \
+"
+REMOVALS:append:imxdpu = " \
+    G2D/EightLayers \
+"
+REMOVALS:append:mx6q-nxp-bsp = " \
+    GLES3/HDR02_FBBasicToneMapping \
+    GLES3/HDR03_SkyboxTonemapping \
+    GLES3/HDR04_HDRFramebuffer \
+"
+REMOVALS:append:mx6dl-nxp-bsp = " \
+    GLES3/HDR02_FBBasicToneMapping \
+    GLES3/HDR03_SkyboxTonemapping \
+    GLES3/HDR04_HDRFramebuffer \
+"
+
+do_install () {
+    install -d "${D}/opt/${PN}"
+    cp -r ${S}/bin/* ${D}/opt/${PN}
+    for removal in ${REMOVALS}; do
+        rm -rf ${D}/opt/${PN}/$removal
+    done
+}
+
+FILES:${PN} += "/opt/${PN}"
+FILES:${PN}-dbg += "/opt/${PN}/*/*/.debug /usr/src/debug"
+INSANE_SKIP:${PN} += "already-stripped rpaths"
+
+# Unfortunately recipes with an empty main package, like header-only libraries,
+# are not included in the SDK. Use RDEPENDS as a workaround.
+RDEPENDS_EMPTY_MAIN_PACKAGE = " \
+    fmt \
+    gli \
+    glm \
+    googletest \
+    half \
+    nlohmann-json \
+    rapidjson \
+    stb \
+"
+RDEPENDS_EMPTY_MAIN_PACKAGE_MX8       = ""
+RDEPENDS_EMPTY_MAIN_PACKAGE_MX8:mx8-nxp-bsp   = " \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'libxdg-shell', '', d)} \
+    rapidopencl \
+    rapidopenvx \
+    rapidvulkan \
+"
+RDEPENDS_EMPTY_MAIN_PACKAGE_MX8:mx8mm-nxp-bsp = ""
+# vulkan-loader is dynamically loaded, so need to add an explicit
+# dependency
+RDEPENDS_VULKAN_LOADER       = ""
+RDEPENDS_VULKAN_LOADER:mx8-nxp-bsp   = "vulkan-validation-layers vulkan-loader"
+RDEPENDS_VULKAN_LOADER:mx8mm-nxp-bsp = ""
+RDEPENDS:${PN} += " \
+    ${RDEPENDS_EMPTY_MAIN_PACKAGE} \
+    ${RDEPENDS_EMPTY_MAIN_PACKAGE_MX8} \
+    ${RDEPENDS_VULKAN_LOADER} \
+"
+
+# For backwards compatibility
+RPROVIDES:${PN} = "fsl-gpu-sdk"
+RREPLACES:${PN} = "fsl-gpu-sdk"
+RCONFLICTS:${PN} = "fsl-gpu-sdk"
+
+COMPATIBLE_MACHINE = "(imxgpu)"

--- a/recipes-graphics/imx-gpu-sdk/libxdg-shell.bb
+++ b/recipes-graphics/imx-gpu-sdk/libxdg-shell.bb
@@ -1,0 +1,21 @@
+SUMMARY = "Provides XDG shell header and glue code library"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://${UNPACKDIR}/${BP}/License.md;md5=9d58a2573275ce8c35d79576835dbeb8"
+
+DEPENDS = "wayland-native wayland wayland-protocols"
+
+require imx-gpu-sdk-src.inc
+
+SRC_URI += "file://0001-xdg-shell-Add-CMake-minimum.patch"
+
+S = "${UNPACKDIR}/${BP}/ThirdParty/Recipe/xdg-shell"
+
+inherit cmake pkgconfig
+
+EXTRA_OECMAKE = " \
+    -DWAYLAND_SCANNER=${STAGING_BINDIR_NATIVE}/wayland-scanner \
+    -DWAYLAND_PROTOCOLS_DIR=${STAGING_DATADIR}/wayland-protocols \
+"
+
+ALLOW_EMPTY:${PN} = "1"
+RDEPENDS:${PN}-dev = "${PN}-staticdev"

--- a/recipes-graphics/imx-gpu-sdk/libxdg-shell/0001-xdg-shell-Add-CMake-minimum.patch
+++ b/recipes-graphics/imx-gpu-sdk/libxdg-shell/0001-xdg-shell-Add-CMake-minimum.patch
@@ -1,0 +1,38 @@
+From 6e38ee09378bfa7edc97528967f0dd0bd810f2c6 Mon Sep 17 00:00:00 2001
+From: Tom Hochstein <tom.hochstein@nxp.com>
+Date: Thu, 9 Oct 2025 08:29:44 -0500
+Subject: [PATCH] xdg-shell: Add CMake minimum
+
+The build is broken:
+```
+| CMake Error in CMakeLists.txt:
+|   No cmake_minimum_required command is present.  A line of code such as
+|
+|     cmake_minimum_required(VERSION 4.1)
+|
+|   should be added at the top of the file.  The version specified may be lower
+|   if you wish to support older CMake versions for this project.  For more
+|   information run "cmake --help-policy CMP0000".
+```
+
+Upstream-Status: Pending
+Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>
+---
+ CMakeLists.txt | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8d39c6c5..5cb52e32 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,5 +1,7 @@
+ # Generate the client header and glue library from xdg-shell.xml
+ 
++cmake_minimum_required(VERSION 3.5)
++
+ include(FindPkgConfig)
+ 
+ if (NOT DEFINED WAYLAND_PROTOCOLS_DIR)
+-- 
+2.34.1
+

--- a/recipes-graphics/rapidopencl/rapidopencl_1.1.0.1.bb
+++ b/recipes-graphics/rapidopencl/rapidopencl_1.1.0.1.bb
@@ -1,0 +1,16 @@
+SUMMARY = "Experimental low level header only C++11 RAII wrapper classes for the OpenCL API"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=b98f636daed34d12d11e25f3185c0204"
+
+SRC_URI = "git://github.com/Unarmed1000/RapidOpenCL;protocol=https;branch=master \
+"
+SRCREV = "21254804a56ae96e8385c2652733c338d62da04f"
+
+# RapidOpenCL is a header-only C++11 RAII wrapper class, so the main package will be empty.
+
+do_install () {
+    install -d ${D}${includedir}
+    cp -r ${S}/include/* ${D}${includedir}
+}
+
+ALLOW_EMPTY:${PN} = "1"

--- a/recipes-graphics/rapidopenvx/rapidopenvx_1.1.0.bb
+++ b/recipes-graphics/rapidopenvx/rapidopenvx_1.1.0.bb
@@ -1,0 +1,14 @@
+SUMMARY = "Low level header only C++11 RAII wrapper classes for the OpenVX API"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=b98f636daed34d12d11e25f3185c0204"
+
+SRC_URI = "git://github.com/Unarmed1000/RapidOpenVX;protocol=https;branch=master \
+"
+SRCREV = "909c7abbff0ee35610f07f6fadeaf3a2eadce36e"
+
+do_install () {
+    install -d ${D}${includedir}
+    cp -r ${S}/include/* ${D}${includedir}
+}
+
+ALLOW_EMPTY:${PN} = "1"

--- a/recipes-graphics/rapidvulkan/rapidvulkan_1.2.162.0.bb
+++ b/recipes-graphics/rapidvulkan/rapidvulkan_1.2.162.0.bb
@@ -1,0 +1,13 @@
+SUMMARY = "Low level header only C++11 RAII wrapper classes for the Vulkan API"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=b98f636daed34d12d11e25f3185c0204"
+
+DEPENDS = "vulkan-loader"
+
+SRC_URI = "git://github.com/Unarmed1000/RapidVulkan;protocol=https;branch=master"
+SRCREV = "e39a407c5ae880792d8843ada65a19dd26b3dca7"
+
+
+inherit cmake
+
+ALLOW_EMPTY:${PN} = "1"

--- a/recipes-graphics/vulkan/assimp/0001-X3D-Fix-invalid-vector-back-usage-6283.patch
+++ b/recipes-graphics/vulkan/assimp/0001-X3D-Fix-invalid-vector-back-usage-6283.patch
@@ -1,0 +1,52 @@
+From 59bc03d931270b6354690512d0c881eec8b97678 Mon Sep 17 00:00:00 2001
+From: Kim Kulling <kimkulling@users.noreply.github.com>
+Date: Fri, 25 Jul 2025 15:01:16 +0200
+Subject: [PATCH] X3D: Fix invalid vector::back usage (#6283)
+
+* X3D: Fix invalid vector::back usage
+
+Upstream-Status: Backport [https://github.com/assimp/assimp/commit/59bc03d931270b6354690512d0c881eec8b97678]
+---
+ code/AssetLib/X3D/X3DGeoHelper.cpp | 14 ++++++++++----
+ 1 file changed, 10 insertions(+), 4 deletions(-)
+
+diff --git a/code/AssetLib/X3D/X3DGeoHelper.cpp b/code/AssetLib/X3D/X3DGeoHelper.cpp
+index 1c962a460..b90956d2c 100644
+--- a/code/AssetLib/X3D/X3DGeoHelper.cpp
++++ b/code/AssetLib/X3D/X3DGeoHelper.cpp
+@@ -128,13 +128,17 @@ void X3DGeoHelper::rect_parallel_epiped(const aiVector3D &pSize, std::list<aiVec
+ 
+ #undef MESH_RectParallelepiped_CREATE_VERT
+ 
++static constexpr int InvalidIndex = -1;
++
+ void X3DGeoHelper::coordIdx_str2faces_arr(const std::vector<int32_t> &pCoordIdx, std::vector<aiFace> &pFaces, unsigned int &pPrimitiveTypes) {
+     std::vector<int32_t> f_data(pCoordIdx);
+     std::vector<unsigned int> inds;
+     unsigned int prim_type = 0;
+ 
+-    if (f_data.back() != (-1)) {
+-        f_data.push_back(-1);
++    if (!f_data.empty()) {
++        if (f_data.back() != InvalidIndex) {
++            f_data.push_back(InvalidIndex);
++        }
+     }
+ 
+     // reserve average size.
+@@ -191,8 +195,10 @@ mg_m_err:
+ void X3DGeoHelper::coordIdx_str2lines_arr(const std::vector<int32_t> &pCoordIdx, std::vector<aiFace> &pFaces) {
+     std::vector<int32_t> f_data(pCoordIdx);
+ 
+-    if (f_data.back() != (-1)) {
+-        f_data.push_back(-1);
++    if (!f_data.empty()) {
++        if (f_data.back() != InvalidIndex) {
++            f_data.push_back(InvalidIndex);
++        }
+     }
+ 
+     // reserve average size.
+-- 
+2.34.1
+

--- a/recipes-graphics/vulkan/assimp_5.4.3.bb
+++ b/recipes-graphics/vulkan/assimp_5.4.3.bb
@@ -1,0 +1,34 @@
+DESCRIPTION = "Open Asset Import Library is a portable Open Source library to import \
+               various well-known 3D model formats in a uniform manner."
+HOMEPAGE = "http://www.assimp.org/"
+SECTION = "devel"
+
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=d9d5275cab4fb13ae624d42ce64865de"
+
+DEPENDS = "zlib"
+
+SRC_URI = "git://github.com/assimp/assimp.git;protocol=https;branch=master \
+           file://0001-X3D-Fix-invalid-vector-back-usage-6283.patch"
+UPSTREAM_CHECK_GITTAGREGEX = "v(?P<pver>(\d+(\.\d+)+))"
+
+SRCREV = "c35200e38ea8f058812b83de2ef32c6093b0ece2"
+
+inherit cmake
+
+do_unpack:append() {
+    bb.build.exec_func('remove_non_compliant_source', d)
+}
+
+remove_non_compliant_source() {
+    # Remove non-compliant files manually. A patch file cannot be used
+    # since many of the files are binary.
+    rm -rf ${S}/test/models-nonbsd ${S}/scripts/StepImporter/schema_ifc2x3.exp
+}
+
+EXTRA_OECMAKE = "-DASSIMP_BUILD_ASSIMP_TOOLS=OFF -DASSIMP_BUILD_TESTS=OFF -DASSIMP_LIB_INSTALL_DIR=${baselib}"
+
+BBCLASSEXTEND = "native nativesdk"
+
+# Work around do_package_qa error
+INSANE_SKIP:${PN}-dev += "buildpaths"

--- a/recipes-multimedia/gstreamer/gst-variable-rtsp-server_1.0.bb
+++ b/recipes-multimedia/gstreamer/gst-variable-rtsp-server_1.0.bb
@@ -1,0 +1,25 @@
+# Copyright (C) 2017 NXP Semiconductor
+
+SUMMARY = "RTSP server for live-stream from a v4l2 video source"
+HOMEPAGE = "https://github.com/Gateworks/gst-gateworks-apps"
+SECTION = "multimedia"
+
+LICENSE = "GPL-3.0-only"
+
+inherit pkgconfig
+
+DEPENDS = "gstreamer1.0 gstreamer1.0-rtsp-server glib-2.0"
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
+
+SRC_URI = " \
+    git://github.com/Gateworks/gst-gateworks-apps;branch=master;protocol=https \
+"
+
+SRCREV = "490564815d8049dbdd79087f546835b673ba6e88"
+
+
+do_install() {
+    install -m 0755 -D ${S}/bin/gst-variable-rtsp-server \
+        ${D}/${bindir}/gst-variable-rtsp-server
+}


### PR DESCRIPTION
## Consolidate recipe content from meta-freescale-distro

This is the first step of consolidating all recipe content into a single
layer. Every recipe, packagegroup and demo image under
`meta-freescale-distro/recipes-*/` is moved into `meta-freescale`, one
commit per recipe.

Going forward `meta-freescale` becomes the single home for recipe content.
`meta-freescale-distro` shrinks into a thin backward-compatibility layer
that only keeps the distro definitions (`conf/distro/fsl-*`, `fslc-*`) for
the wrynose LTS lifetime and is no longer used for recipe development.

### What moves (25 recipes)
- **recipes-devtools:** half, stb
- **recipes-fsl:** fsl-rc-local, 4 demo images (fsl-image-*), 9 packagegroups
- **recipes-graphics:** devil, gli, glm (bbappend), imx-gpu-sdk (+ libxdg-shell), rapidopencl, rapidopenvx, rapidvulkan, assimp
- **recipes-multimedia:** gst-variable-rtsp-server

### Notes
- The distro `.conf`/`.inc` files intentionally stay in meta-freescale-distro.
- No filename collisions with existing meta-freescale recipes; all
  destination directories already exist.
- The distro configs only `require conf/fragments/...`, all of which already
  live in meta-freescale, so nothing breaks for the layers that consume them.
- Plain move (no git-history replay); each commit notes the origin.

Paired with the removal PR: Freescale/meta-freescale-distro#140
