### PR TITLE
wayland-protocols: Refresh alpha-compositing and hdr10 patches

### DIFF
--- a/recipes-graphics/wayland/wayland-protocols/0001-unstable-Add-alpha-compositing-protocol.patch
+++ b/recipes-graphics/wayland/wayland-protocols/0001-unstable-Add-alpha-compositing-protocol.patch
@@ -28,14 +28,14 @@ Conflicts:
  create mode 100644 unstable/alpha-compositing/alpha-compositing-unstable-v1.xml
 
 diff --git a/meson.build b/meson.build
-index a78d698a730b..99a555d53a09 100644
+index 25d42ce..4eb37f0 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -42,6 +42,7 @@ unstable_protocols = {
- 	'xdg-output': ['v1'],
- 	'xdg-shell': ['v5', 'v6'],
- 	'xwayland-keyboard-grab': ['v1'],
-+	'alpha-compositing': ['v1'],
+@@ -45,6 +45,7 @@ unstable_protocols = {
+ 	'xdg-output': {'v1': []},
+ 	'xdg-shell': {'v5': [], 'v6': []},
+ 	'xwayland-keyboard-grab': {'v1': []},
++	'alpha-compositing': {'v1': []},
  }
  
  staging_protocols = {

--- a/recipes-graphics/wayland/wayland-protocols/0002-unstable-Add-hdr10-metadata-protocol.patch
+++ b/recipes-graphics/wayland/wayland-protocols/0002-unstable-Add-hdr10-metadata-protocol.patch
@@ -19,14 +19,14 @@ Signed-off-by: Haihua Hu <jared.hu@nxp.com>
  create mode 100644 unstable/hdr10-metadata/hdr10-metadata-unstable-v1.xml
 
 diff --git a/meson.build b/meson.build
-index 99a555d53a09..70b594d3b89c 100644
+index 4eb37f0..c131e95 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -43,6 +43,7 @@ unstable_protocols = {
- 	'xdg-shell': ['v5', 'v6'],
- 	'xwayland-keyboard-grab': ['v1'],
- 	'alpha-compositing': ['v1'],
-+	'hdr10-metadata': ['v1'],
+@@ -46,6 +46,7 @@ unstable_protocols = {
+ 	'xdg-shell': {'v5': [], 'v6': []},
+ 	'xwayland-keyboard-grab': {'v1': []},
+ 	'alpha-compositing': {'v1': []},
++	'hdr10-metadata': {'v1': []},
  }
  
  staging_protocols = {


### PR DESCRIPTION
After upgrading to wayland-protocols 1.48, refresh 0001-unstable-Add-alpha-compositing-protocol.patch and 0002-unstable-Add-hdr10-metadata-protocol.patch so they apply cleanly after the meson.build protocol list schema changed.