### PR TITLE
u-boot-imx: handle efitools dependency for i.mx9 platforms

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,6 +10,7 @@ BBFILE_PATTERN_freescale-layer := "^${LAYERDIR}/"
 BBFILE_PRIORITY_freescale-layer = "5"
 LAYERSERIES_COMPAT_freescale-layer = "whinlatter wrynose"
 LAYERDEPENDS_freescale-layer = "core"
+LAYERDEPENDS_freescale-layer:append:mx9-nxp-bsp = " efi-secure-boot"
 
 # Add the Freescale-specific licenses into the metadata
 LICENSE_PATH += "${LAYERDIR}/custom-licenses"

--- a/recipes-bsp/u-boot/u-boot-imx-common_2025.04.inc
+++ b/recipes-bsp/u-boot/u-boot-imx-common_2025.04.inc
@@ -18,6 +18,8 @@ DEPENDS += " \
     xxd-native \
 "
 
+DEPENDS:append:mx9-nxp-bsp = " efitools-native"
+
 B = "${WORKDIR}/build"
 
 inherit fsl-u-boot-localversion


### PR DESCRIPTION
A missing dependency is causing the error below in u-boot-imx, when the target is an i.MX9* platform:

|   cert-to-efi-sig-list /src/build/tmp/work/(...)/u-boot-imx/2025.04/git/CRT.crt arch/arm/dts/capsule_esl_file
| /bin/sh: 1: cert-to-efi-sig-list: not found
| make[3]: *** [scripts/Makefile.lib:392: arch/arm/dts/capsule_esl_file] Error 127

cert-to-efi-sig-list is provided by efitools-native, and this recipe is provided by meta-efi-secure-boot.

Declare this dependency on two levels: u-boot-imx's recipe and meta-freescale's layer configuration. It is conditional to i.MX9* in both places, so this shouldn't affect other platforms.