### PR TITLE
firmware-nxp-wifi: Allow use on non-i.MX machines

### DIFF
--- a/recipes-bsp/firmware-imx/firmware-nxp-wifi_1.1.bb
+++ b/recipes-bsp/firmware-imx/firmware-nxp-wifi_1.1.bb
@@ -13,8 +13,6 @@ SRC_URI = "git://github.com/nxp-imx/imx-firmware.git;protocol=https;branch=${SRC
 SRCBRANCH = "lf-6.18.2_1.0.0"
 SRCREV = "d7e4bb37b45bbf93faf888e0ca6763a29e28054a"
 
-COMPATIBLE_MACHINE = "(imx-generic-bsp)"
-
 inherit allarch
 
 CLEANBROKEN = "1"


### PR DESCRIPTION
The NXP Wi-Fi firmware packages are used by boards with NXP Wi-Fi modules even when the main SoC is not i.MX. Commit 8e7ebc0 removed the machine restriction for that reason, but it was later reintroduced while cleaning up BSP metadata.

Drop COMPATIBLE_MACHINE again so package dependencies decide whether the firmware is used.

Tested with git diff --check.