### PR TITLE
firmware-ele-imx: upgrade 2.0.2.1 -> 2.0.5

### DIFF
--- a/recipes-bsp/firmware-imx/firmware-ele-imx_2.0.5.bb
+++ b/recipes-bsp/firmware-imx/firmware-ele-imx_2.0.5.bb
@@ -3,13 +3,13 @@ SUMMARY = "NXP i.MX ELE firmware"
 DESCRIPTION = "EdgeLock Secure Enclave firmware for i.MX series SoCs"
 SECTION = "base"
 LICENSE = "Proprietary"
-LIC_FILES_CHKSUM = "file://COPYING;md5=a93b654673e1bc8398ed1f30e0813359"
+LIC_FILES_CHKSUM = "file://COPYING;md5=bc649096ad3928ec06a8713b8d787eac"
 
 inherit fsl-eula-unpack use-imx-security-controller-firmware deploy
 
 SRC_URI = "${FSL_MIRROR}/${BP}-${IMX_SRCREV_ABBREV}.bin;fsl-eula=true"
-IMX_SRCREV_ABBREV = "d30b14a"
-SRC_URI[sha256sum] = "293a0e7957ca2a24c6c2edbc87b237141a4b7ef19b35257edce65a026d7cbc0a"
+IMX_SRCREV_ABBREV = "29313e0"
+SRC_URI[sha256sum] = "3af1a5e1336ae3379cf573ccdf34fd8adec99005c4abb70ea0f14af3ac5fb1ae"
 
 S = "${WORKDIR}/${BP}-${IMX_SRCREV_ABBREV}"
 


### PR DESCRIPTION
firmware-ele-imx: upgrade 2.0.2.1 -> 2.0.5

Fix an early boot reset on i.MX95 (MIMX9596C specifically) by upgrading
the ELE firmware to version 2.0.5.

Version 2.0.2.1 of the firmware works with SoCs such as MIMX9596X but
not with MIMX9596C: the only difference between the two parts is the
supported temperature range.

The ELE driver code in newer NXP releases (Linux 6.18, imx-sm and
U-Boot) was reviewed for changes in the communication protocol
compared to the previous firmware version: no incompatibilities were
found, so the new firmware is considered safe for the lf-6.6.52-2.2.1
release.

Tested on Toradex i.MX95 SoMs with no regressions observed.