### PR TITLE
treewide: Sort DEPENDS/RDEPENDS and drop double blank lines

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-devtools/uuu/uuu_git.bb
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/uuu/uuu_git.bb
@@ -11,6 +11,6 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=38ec0c18112e9a92cffc4951661e85a5"
 
 inherit cmake pkgconfig
 
-DEPENDS = "libusb zlib bzip2 openssl zstd libtinyxml2"
+DEPENDS = "bzip2 libtinyxml2 libusb openssl zlib zstd"
 
 BBCLASSEXTEND = "native nativesdk"

--- a/dynamic-layers/openembedded-layer/recipes-dpaa/fmc/fmc_git.bb
+++ b/dynamic-layers/openembedded-layer/recipes-dpaa/fmc/fmc_git.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=a504ab5a8ff235e67c7301214749346c"
 
 PR = "r2"
 
-DEPENDS = "libxml2 fmlib tclap"
+DEPENDS = "fmlib libxml2 tclap"
 
 SRC_URI = "git://github.com/nxp-qoriq/fmc;protocol=https;nobranch=1"
 SRCREV = "5b9f4b16a864e9dfa58cdcc860be278a7f66ac18"
@@ -27,7 +27,6 @@ EXTRA_OEMAKE_PLATFORM:p2041 = "p4080ds"
 EXTRA_OEMAKE_PLATFORM:p3041 = "p4080ds"
 EXTRA_OEMAKE_PLATFORM:p4080 = "p4080ds"
 EXTRA_OEMAKE_PLATFORM:p5040 = "p4080ds"
-
 
 do_compile () {
     oe_runmake MACHINE=${EXTRA_OEMAKE_PLATFORM} -C source

--- a/dynamic-layers/openembedded-layer/recipes-support/opencv/opencv_4.6.0.imx.bb
+++ b/dynamic-layers/openembedded-layer/recipes-support/opencv/opencv_4.6.0.imx.bb
@@ -16,7 +16,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 ARM_INSTRUCTION_SET:armv4 = "arm"
 ARM_INSTRUCTION_SET:armv5 = "arm"
 
-DEPENDS = "libtool swig-native bzip2 zlib glib-2.0 libwebp"
+DEPENDS = "bzip2 glib-2.0 libtool libwebp swig-native zlib"
 
 SRCREV_opencv = "b0dc474160e389b9c9045da5db49d03ae17c6a6b"
 SRCREV_contrib = "7b77c355a8fdc97667b3fa1e7a0d37e4973fc868"

--- a/recipes-bsp/atf/qoriq-atf_2.12.bb
+++ b/recipes-bsp/atf/qoriq-atf_2.12.bb
@@ -2,7 +2,7 @@ require qoriq-atf-${PV}.inc
 
 inherit deploy
 
-DEPENDS += "u-boot-mkimage-native u-boot openssl openssl-native rcw qoriq-cst-native bc-native"
+DEPENDS += "bc-native openssl openssl-native qoriq-cst-native rcw u-boot u-boot-mkimage-native"
 do_compile[depends] += "u-boot:do_deploy rcw:do_deploy uefi:do_deploy"
 
 PV:append = "+${SRCPV}"

--- a/recipes-bsp/firmware-imx/imx-boot-firmware-files_8.31.bb
+++ b/recipes-bsp/firmware-imx/imx-boot-firmware-files_8.31.bb
@@ -30,7 +30,6 @@ deploy_for_mx8m() {
     install -m 0644 ${S}/firmware/hdmi/cadence/signed_hdmi_imx8m.bin ${DEPLOYDIR}
 }
 
-
 deploy_for_mx9() {
     # Synopsys DDR
     for ddr_firmware in ${DDR_FIRMWARE_NAME}; do

--- a/recipes-bsp/imx-mkimage/imx-mkimage_git.inc
+++ b/recipes-bsp/imx-mkimage/imx-mkimage_git.inc
@@ -1,6 +1,6 @@
 # Copyright 2017-2026 NXP
 
-DEPENDS = "zlib-native openssl-native"
+DEPENDS = "openssl-native zlib-native"
 
 SRC_URI = "${IMX_MKIMAGE_SRC};branch=${SRCBRANCH} \
            file://0001-iMX8M-soc.mak-use-native-mkimage-from-sysroot.patch \

--- a/recipes-bsp/imx-uuc/imx-uuc_git.bb
+++ b/recipes-bsp/imx-uuc/imx-uuc_git.bb
@@ -3,7 +3,7 @@
 SUMMARY = "A Daemon wait for NXP mfgtools host's command"
 HOMEPAGE = "https://github.com/nxp-imx/imx-uuc"
 SECTION = "base"
-DEPENDS = "virtual/kernel dosfstools-native"
+DEPENDS = "dosfstools-native virtual/kernel"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 

--- a/recipes-bsp/isp-imx/basler-camera_4.2.2.26.1.bb
+++ b/recipes-bsp/isp-imx/basler-camera_4.2.2.26.1.bb
@@ -25,5 +25,4 @@ FILES:${PN} = "${libdir} /opt"
 INSANE_SKIP:${PN} = "already-stripped"
 RDEPENDS:${PN} += "isp-imx"
 
-
 COMPATIBLE_MACHINE = "(mx8mp-nxp-bsp)"

--- a/recipes-bsp/isp-imx/isp-imx_4.2.2.26.1.bb
+++ b/recipes-bsp/isp-imx/isp-imx_4.2.2.26.1.bb
@@ -4,7 +4,7 @@ DESCRIPTION = "i.MX Verisilicon Software ISP"
 LICENSE = "Proprietary"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bc649096ad3928ec06a8713b8d787eac"
 
-DEPENDS = "boost libdrm virtual/libg2d libtinyxml2 jsoncpp patchelf-native"
+DEPENDS = "boost jsoncpp libdrm libtinyxml2 patchelf-native virtual/libg2d"
 
 SRC_URI = "${FSL_MIRROR}/${BP}-${IMX_SRCREV_ABBREV}.bin;fsl-eula=true"
 SRC_URI += "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', '${ISP_SYSTEMD_PATCH}', '', d)}"

--- a/recipes-bsp/ppfe-firmware/ppfe-firmware_git.bb
+++ b/recipes-bsp/ppfe-firmware/ppfe-firmware_git.bb
@@ -3,7 +3,6 @@ HOMEPAGE = "https://github.com/NXP/qoriq-engine-pfe-bin"
 LICENSE = "NXP-Binary-EULA"
 LIC_FILES_CHKSUM = "file://NXP-Binary-EULA.txt;md5=92723670f432558b9e2494ed177d2a85"
 
-
 INHIBIT_DEFAULT_DEPS = "1"
 
 inherit deploy

--- a/recipes-bsp/u-boot/u-boot-qoriq_2025.04.bb
+++ b/recipes-bsp/u-boot/u-boot-qoriq_2025.04.bb
@@ -27,7 +27,7 @@ PV:append = "+fslgit"
 LOCALVERSION = "+fsl"
 
 INHIBIT_DEFAULT_DEPS = "1"
-DEPENDS = "libgcc virtual/cross-cc bison-native bc-native gnutls-native swig-native python3-native"
+DEPENDS = "bc-native bison-native gnutls-native libgcc python3-native swig-native virtual/cross-cc"
 DEPENDS:append:qoriq-arm64 = " dtc-native"
 DEPENDS:append:qoriq-arm = " dtc-native"
 DEPENDS:append:qoriq-ppc = " boot-format-native"

--- a/recipes-devtools/qemu/qemu-qoriq_4.2.bb
+++ b/recipes-devtools/qemu/qemu-qoriq_4.2.bb
@@ -4,7 +4,7 @@ require qemu-qoriq.inc
 
 COMPATIBLE_MACHINE = "(qoriq)"
 
-DEPENDS = "glib-2.0 zlib pixman bison-native"
+DEPENDS = "bison-native glib-2.0 pixman zlib"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=441c28d2cf86e15a37fa47e15a72fbac \
                     file://COPYING.LIB;endline=24;md5=8c5efda6cf1e1b03dcfd0e6c0d271c7f"

--- a/recipes-downgrade/vulkan/vulkan-validation-layers_1.3.275.0.imx.bb
+++ b/recipes-downgrade/vulkan/vulkan-validation-layers_1.3.275.0.imx.bb
@@ -13,7 +13,7 @@ SRCREV = "780c65337e111c7385109c7b720d757a778e4fe2"
 
 REQUIRED_DISTRO_FEATURES = "vulkan"
 
-DEPENDS = "vulkan-headers vulkan-loader spirv-headers spirv-tools glslang vulkan-utility-libraries"
+DEPENDS = "glslang spirv-headers spirv-tools vulkan-headers vulkan-loader vulkan-utility-libraries"
 
 # BUILD_TESTS            - Not required for OE builds
 # USE_ROBIN_HOOD_HASHING - Provides substantial performance improvements on all platforms.

--- a/recipes-dpaa2/spc/spc_git.bb
+++ b/recipes-dpaa2/spc/spc_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/nxp-qoriq/spc"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=163b09a1c249a6ff2b28da1ceca2e0a8"
 
-DEPENDS = "libxml2 fmlib tclap"
+DEPENDS = "fmlib libxml2 tclap"
 
 SRC_URI = "git://github.com/nxp-qoriq/spc;protocol=https;nobranch=1"
 SRCREV = "b8d69580e5c6aeeb9f1354ee2faed6e0134eaef4"

--- a/recipes-extended/odp/odp_git.bb
+++ b/recipes-extended/odp/odp_git.bb
@@ -4,9 +4,9 @@ inherit autotools-brokensep
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
-DEPENDS = "openssl cunit libxml2"
+DEPENDS = "cunit libxml2 openssl"
 
-RDEPENDS:${PN} = "bash libcrypto libssl odp-module odp-counters"
+RDEPENDS:${PN} = "bash libcrypto libssl odp-counters odp-module"
 
 ODP_SOC ?= ""
 ODP_SOC:ls1043ardb = "LS1043"

--- a/recipes-extended/ovs-dpdk/ovs-dpdk_3.1.bb
+++ b/recipes-extended/ovs-dpdk/ovs-dpdk_3.1.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/nxp-qoriq/ovs-dpdk"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=1ce5d23a6429dff345518758f13aaeab"
 
-DEPENDS = "dpdk python3-six-native coreutils-native autoconf-native automake-native"
+DEPENDS = "autoconf-native automake-native coreutils-native dpdk python3-six-native"
 RDEPENDS:${PN} = "bash libcrypto libssl python3"
 
 inherit python3native pkgconfig

--- a/recipes-extended/pktgen-dpdk/pktgen-dpdk_21.05.0.bb
+++ b/recipes-extended/pktgen-dpdk/pktgen-dpdk_21.05.0.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://git.dpdk.org/apps/pktgen-dpdk/"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=0245ceedaef59ae0129500b0ce1e8a45"
 
-DEPENDS += "libpcap dpdk lua lua-native"
+DEPENDS += "dpdk libpcap lua lua-native"
 
 SRC_URI = "git://dpdk.org/git/apps/pktgen-dpdk;protocol=https;nobranch=1 \
            file://fix-gcc11-mismatched-dealloc-error.patch \

--- a/recipes-extended/secure-obj/secure-obj.inc
+++ b/recipes-extended/secure-obj/secure-obj.inc
@@ -2,7 +2,7 @@ DESCRIPTION = "Secure Object"
 HOMEPAGE = "https://github.com/nxp-qoriq/secure_obj"
 LICENSE = "BSD-3-Clause"
 
-DEPENDS = "openssl optee-os-qoriq optee-client-qoriq"
+DEPENDS = "openssl optee-client-qoriq optee-os-qoriq"
 RDEPENDS:${PN} = "bash libcrypto libssl"
 
 DEPENDS += "python3-pycryptodomex-native"

--- a/recipes-fsl/packagegroups/packagegroup-fsl-gstreamer1.0.bb
+++ b/recipes-fsl/packagegroups/packagegroup-fsl-gstreamer1.0.bb
@@ -20,9 +20,9 @@ MACHINE_GSTREAMER_1_0_PLUGIN ?= ""
 
 RDEPENDS:${PN} = "\
     ${PN}-audio \
-    ${PN}-video \
-    ${PN}-network-base \
     ${PN}-debug \
+    ${PN}-network-base \
+    ${PN}-video \
 "
 
 # List of X11 specific plugins

--- a/recipes-fsl/packagegroups/packagegroup-fsl-mfgtool.bb
+++ b/recipes-fsl/packagegroups/packagegroup-fsl-mfgtool.bb
@@ -43,7 +43,7 @@ RDEPENDS:${PN}-mtd = "\
 
 RDEPENDS:${PN}-extfs = "\
     ${PN}-base \
-    e2fsprogs-mke2fs \
     e2fsprogs-e2fsck \
+    e2fsprogs-mke2fs \
 "
 COMPATIBLE_MACHINE = "(imx-generic-bsp)"

--- a/recipes-graphics/devil/devil_1.8.0.bb
+++ b/recipes-graphics/devil/devil_1.8.0.bb
@@ -5,7 +5,7 @@ LICENSE = "LGPL-2.1-only"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/LGPL-2.1-only;md5=1a6d268fd218675ffea8be556788b780"
 PR = "r0"
 
-DEPENDS = "libpng jpeg tiff xz"
+DEPENDS = "jpeg libpng tiff xz"
 
 SRC_URI = "http://sourceforge.net/projects/openil/files/DevIL/${PV}/DevIL-${PV}.zip"
 SRC_URI[sha256sum] = "451337f392c65bfb83698a781370534dc63d7bafca21e9b37178df0518f7e895"

--- a/recipes-graphics/drm/libdrm_2.4.127.imx.bb
+++ b/recipes-graphics/drm/libdrm_2.4.127.imx.bb
@@ -8,8 +8,8 @@ SECTION = "x11/base"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=9eb1f4831351ab42d762c40b3ebb7add \
             file://xf86drm.c;beginline=9;endline=32;md5=c8a3b961af7667c530816761e949dc71"
-PROVIDES = "drm"
 DEPENDS = "libpthread-stubs"
+PROVIDES = "drm"
 
 SRC_URI = "${IMX_LIBDRM_SRC};branch=${SRCBRANCH}"
 IMX_LIBDRM_SRC ?= "git://github.com/nxp-imx/libdrm-imx.git;protocol=https"
@@ -46,10 +46,6 @@ PACKAGES =+ "${PN}-tests ${PN}-drivers ${PN}-radeon ${PN}-nouveau ${PN}-omap \
              ${PN}-intel ${PN}-exynos ${PN}-freedreno ${PN}-amdgpu \
              ${PN}-etnaviv"
 
-RRECOMMENDS:${PN}-drivers = "${PN}-radeon ${PN}-nouveau ${PN}-omap ${PN}-intel \
-                             ${PN}-exynos ${PN}-freedreno ${PN}-amdgpu \
-                             ${PN}-etnaviv"
-
 FILES:${PN}-tests = "${bindir}/*"
 FILES:${PN}-radeon = "${libdir}/libdrm_radeon.so.*"
 FILES:${PN}-nouveau = "${libdir}/libdrm_nouveau.so.*"
@@ -59,6 +55,10 @@ FILES:${PN}-exynos = "${libdir}/libdrm_exynos.so.*"
 FILES:${PN}-freedreno = "${libdir}/libdrm_freedreno.so.*"
 FILES:${PN}-amdgpu = "${libdir}/libdrm_amdgpu.so.* ${datadir}/${PN}/amdgpu.ids"
 FILES:${PN}-etnaviv = "${libdir}/libdrm_etnaviv.so.*"
+
+RRECOMMENDS:${PN}-drivers = "${PN}-radeon ${PN}-nouveau ${PN}-omap ${PN}-intel \
+                             ${PN}-exynos ${PN}-freedreno ${PN}-amdgpu \
+                             ${PN}-etnaviv"
 
 BBCLASSEXTEND = "native nativesdk"
 

--- a/recipes-graphics/imx-gpu-apitrace/imx-gpu-apitrace_10.0.0.bb
+++ b/recipes-graphics/imx-gpu-apitrace/imx-gpu-apitrace_10.0.0.bb
@@ -3,7 +3,7 @@ SUMMARY = "Samples for OpenGL ES"
 HOMEPAGE = "https://github.com/nxp-imx/apitrace-imx"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=aeb969185a143c3c25130bc2c3ef9a50"
-DEPENDS = "zlib libpng procps"
+DEPENDS = "libpng procps zlib"
 
 SRC_URI = "git://github.com/nxp-imx/apitrace-imx.git;protocol=https;branch=imx_10.0 \
            file://0001-dlsym-workaround-glibc-2.34-build-failure.patch \

--- a/recipes-graphics/imx-gpu-sdk/imx-gpu-sdk_6.1.1.bb
+++ b/recipes-graphics/imx-gpu-sdk/imx-gpu-sdk_6.1.1.bb
@@ -45,7 +45,6 @@ DEPENDS:append:imxgpu3d = " virtual/libgles2"
 
 require imx-gpu-sdk-src.inc
 
-
 WINDOW_SYSTEM = \
     "${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'Wayland_XDG', \
         bb.utils.contains('DISTRO_FEATURES',     'x11',         'X11', \
@@ -130,7 +129,7 @@ RDEPENDS_EMPTY_MAIN_PACKAGE_MX8:mx8mm-nxp-bsp = ""
 # vulkan-loader is dynamically loaded, so need to add an explicit
 # dependency
 RDEPENDS_VULKAN_LOADER = ""
-RDEPENDS_VULKAN_LOADER:mx8-nxp-bsp = "vulkan-validation-layers vulkan-loader"
+RDEPENDS_VULKAN_LOADER:mx8-nxp-bsp = "vulkan-loader vulkan-validation-layers"
 RDEPENDS_VULKAN_LOADER:mx8mm-nxp-bsp = ""
 RDEPENDS:${PN} += "\
     ${RDEPENDS_EMPTY_MAIN_PACKAGE} \

--- a/recipes-graphics/imx-gpu-sdk/libxdg-shell.bb
+++ b/recipes-graphics/imx-gpu-sdk/libxdg-shell.bb
@@ -2,7 +2,7 @@ SUMMARY = "Provides XDG shell header and glue code library"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://${UNPACKDIR}/${BP}/License.md;md5=9d58a2573275ce8c35d79576835dbeb8"
 
-DEPENDS = "wayland-native wayland wayland-protocols"
+DEPENDS = "wayland wayland-native wayland-protocols"
 
 require imx-gpu-sdk-src.inc
 

--- a/recipes-graphics/rapidvulkan/rapidvulkan_1.2.162.0.bb
+++ b/recipes-graphics/rapidvulkan/rapidvulkan_1.2.162.0.bb
@@ -8,7 +8,6 @@ DEPENDS = "vulkan-loader"
 SRC_URI = "git://github.com/Unarmed1000/RapidVulkan;protocol=https;branch=master"
 SRCREV = "e39a407c5ae880792d8843ada65a19dd26b3dca7"
 
-
 REQUIRED_DISTRO_FEATURES = "vulkan"
 
 inherit cmake features_check

--- a/recipes-graphics/wayland/weston_10.0.5.imx.bb
+++ b/recipes-graphics/wayland/weston_10.0.5.imx.bb
@@ -31,8 +31,8 @@ inherit meson pkgconfig useradd
 #
 require ${THISDIR}/required-distro-features.inc
 
-DEPENDS = "libxkbcommon gdk-pixbuf pixman cairo glib-2.0"
-DEPENDS += "wayland wayland-protocols libinput virtual/egl pango wayland-native"
+DEPENDS = "cairo gdk-pixbuf glib-2.0 libinput libxkbcommon pango pixman \
+           virtual/egl wayland wayland-native wayland-protocols"
 
 LDFLAGS += "${@bb.utils.contains('DISTRO_FEATURES', 'lto', '-Wl,-z,undefs', '', d)}"
 

--- a/recipes-graphics/wayland/weston_14.0.2.imx.bb
+++ b/recipes-graphics/wayland/weston_14.0.2.imx.bb
@@ -32,8 +32,8 @@ inherit meson pkgconfig useradd
 #
 require ${THISDIR}/required-distro-features.inc
 
-DEPENDS = "libxkbcommon gdk-pixbuf pixman cairo glib-2.0"
-DEPENDS += "wayland wayland-protocols libinput virtual/egl pango wayland-native libdisplay-info"
+DEPENDS = "cairo gdk-pixbuf glib-2.0 libdisplay-info libinput libxkbcommon \
+           pango pixman virtual/egl wayland wayland-native wayland-protocols"
 
 LDFLAGS += "${@bb.utils.contains('DISTRO_FEATURES', 'lto', '-Wl,-z,undefs', '', d)}"
 

--- a/recipes-kernel/linux/linux-imx-headers_6.18.bb
+++ b/recipes-kernel/linux/linux-imx-headers_6.18.bb
@@ -17,7 +17,6 @@ LOCALVERSION = "-lts-${SRCBRANCH}"
 KBRANCH = "${SRCBRANCH}"
 SRCREV = "f49f45233f7b10006ce7e9c826ee882bb14ac8b5"
 
-
 do_configure[noexec] = "1"
 
 do_compile[noexec] = "1"
@@ -81,7 +80,7 @@ do_install() {
 ALLOW_EMPTY:${PN} = "1"
 
 INHIBIT_DEFAULT_DEPS = "1"
-DEPENDS += "unifdef-native bison-native rsync-native"
+DEPENDS += "bison-native rsync-native unifdef-native"
 
 PACKAGE_ARCH = "${MACHINE_SOCARCH}"
 

--- a/recipes-multimedia/gstreamer/gst-devtools_1.26.6.bb
+++ b/recipes-multimedia/gstreamer/gst-devtools_1.26.6.bb
@@ -14,7 +14,7 @@ SRC_URI = "https://gstreamer.freedesktop.org/src/gst-devtools/gst-devtools-${PV}
 
 SRC_URI[sha256sum] = "dec8fc56d578d65c498e65e56efe44994c5d3f4e85dbbdff0242b441b32e19b2"
 
-DEPENDS = "json-glib glib-2.0 glib-2.0-native gstreamer1.0 gstreamer1.0-plugins-base"
+DEPENDS = "glib-2.0 glib-2.0-native gstreamer1.0 gstreamer1.0-plugins-base json-glib"
 RRECOMMENDS:${PN} = "git"
 
 FILES:${PN} += "${datadir}/gstreamer-1.0/* ${libdir}/gst-validate-launcher/* ${libdir}/gstreamer-1.0/*"

--- a/recipes-multimedia/gstreamer/gst-examples_1.26.6.bb
+++ b/recipes-multimedia/gstreamer/gst-examples_1.26.6.bb
@@ -8,7 +8,7 @@ BUGTRACKER = "https://gitlab.freedesktop.org/gstreamer/gst-examples/-/issues"
 LICENSE = "LGPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://playback/player/gtk/gtk-play.c;beginline=1;endline=20;md5=f8c72dae3d36823ec716a9ebcae593b9"
 
-DEPENDS = "glib-2.0 gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-bad gtk+3 json-glib glib-2.0-native"
+DEPENDS = "glib-2.0 glib-2.0-native gstreamer1.0 gstreamer1.0-plugins-bad gstreamer1.0-plugins-base gtk+3 json-glib"
 
 SRC_URI = "git://gitlab.freedesktop.org/gstreamer/gstreamer.git;protocol=https;branch=1.26 \
            file://0001-Make-player-examples-installable.patch \

--- a/recipes-multimedia/gstreamer/gst-variable-rtsp-server_1.0.bb
+++ b/recipes-multimedia/gstreamer/gst-variable-rtsp-server_1.0.bb
@@ -8,7 +8,7 @@ LICENSE = "GPL-3.0-only"
 
 inherit pkgconfig
 
-DEPENDS = "gstreamer1.0 gstreamer1.0-rtsp-server glib-2.0"
+DEPENDS = "glib-2.0 gstreamer1.0 gstreamer1.0-rtsp-server"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
 

--- a/recipes-multimedia/gstreamer/gst-variable-rtsp-server_1.0.bb
+++ b/recipes-multimedia/gstreamer/gst-variable-rtsp-server_1.0.bb
@@ -18,7 +18,6 @@ SRC_URI = "\
 
 SRCREV = "490564815d8049dbdd79087f546835b673ba6e88"
 
-
 do_install() {
     install -m 0755 -D ${S}/bin/gst-variable-rtsp-server \
         ${D}/${bindir}/gst-variable-rtsp-server

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.26.6.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.26.6.imx.bb
@@ -11,6 +11,7 @@ require recipes-multimedia/gstreamer/gstreamer1.0-plugins-license.inc
 SUMMARY = "'Bad' GStreamer plugins and helper libraries "
 HOMEPAGE = "https://gstreamer.freedesktop.org/"
 BUGTRACKER = "https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad/-/issues"
+CVE_PRODUCT = "gst-plugins-bad"
 
 SRC_URI = "https://gstreamer.freedesktop.org/src/gst-plugins-bad/gst-plugins-bad-${PV}.tar.xz \
            file://0001-fix-maybe-uninitialized-warnings-when-compiling-with.patch \

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.26.6.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.26.6.imx.bb
@@ -170,7 +170,6 @@ FILES:${PN}-opencv += "${datadir}/gst-plugins-bad/1.0/opencv*"
 FILES:${PN}-transcode += "${datadir}/gstreamer-1.0/encoding-profiles"
 FILES:${PN}-voamrwbenc += "${datadir}/gstreamer-1.0/presets/GstVoAmrwbEnc.prs"
 
-
 ########### End of OE-core copy ###########
 
 ########### i.MX overrides ################

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-imx_2.2.0.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-imx_2.2.0.bb
@@ -9,7 +9,7 @@ DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base libimxdmabuffer"
 # for the uniaudio decoder, videoparsersbad for the VPU video decoder
 # the gstreamer1.0-plugins-imx RDEPENDS is necessary to ensure the -good recipe is
 # built (it is not a compile-time dependency however, hence RDEPENDS and not DEPENDS)
-RDEPENDS:gstreamer1.0-plugins-imx = "gstreamer1.0-plugins-good gstreamer1.0-plugins-bad"
+RDEPENDS:gstreamer1.0-plugins-imx = "gstreamer1.0-plugins-bad gstreamer1.0-plugins-good"
 RDEPENDS:gstreamer1.0-plugins-imx-imxaudio = "gstreamer1.0-plugins-good-audioparsers"
 RDEPENDS:gstreamer1.0-plugins-imx-imxvpu = "gstreamer1.0-plugins-bad-videoparsersbad"
 

--- a/recipes-multimedia/gstreamer/gstreamer1.0-vaapi_1.26.6.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-vaapi_1.26.6.bb
@@ -14,7 +14,7 @@ SRC_URI = "https://gstreamer.freedesktop.org/src/${REALPN}/${REALPN}-${PV}.tar.x
 SRC_URI[sha256sum] = "d87c57244cecbd17bb030b698dcb67a66225de639f7c5b837391c4a8e5477667"
 
 S = "${UNPACKDIR}/${REALPN}-${PV}"
-DEPENDS = "libva gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-bad"
+DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-bad gstreamer1.0-plugins-base libva"
 
 inherit meson pkgconfig features_check upstream-version-is-even
 

--- a/recipes-multimedia/gstreamer/gstreamer1.0_1.26.6.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0_1.26.6.imx.bb
@@ -13,7 +13,7 @@ BUGTRACKER = "https://bugzilla.gnome.org/enter_bug.cgi?product=Gstreamer"
 SECTION = "multimedia"
 LICENSE = "LGPL-2.1-or-later"
 
-DEPENDS = "glib-2.0 glib-2.0-native libxml2 bison-native flex-native"
+DEPENDS = "bison-native flex-native glib-2.0 glib-2.0-native libxml2"
 
 inherit meson pkgconfig gettext upstream-version-is-even gobject-introspection ptest-gnome
 

--- a/recipes-multimedia/gstreamer/imx-gst1.0-plugin_git.bb
+++ b/recipes-multimedia/gstreamer/imx-gst1.0-plugin_git.bb
@@ -43,7 +43,6 @@ IMXGST_SRC ?= "git://github.com/nxp-imx/imx-gst1.0-plugin.git;protocol=https"
 SRCBRANCH = "MM_04.10.03_2512_L6.18.2"
 SRCREV = "0565fc515612908a353e8378e24f97de17cc56a6"
 
-
 inherit meson pkgconfig use-imx-headers
 
 PLATFORM:mx6-nxp-bsp = "MX6"

--- a/recipes-multimedia/libcamera/neo-ipa-uguzzi_0.2.6.bb
+++ b/recipes-multimedia/libcamera/neo-ipa-uguzzi_0.2.6.bb
@@ -21,7 +21,6 @@ NEO_IPA_UGUZZI_SRC ?= "git://github.com/nxp-imx/neo-ipa-uguzzi;protocol=https"
 SRCBRANCH = "lf-6.18.2_1.0.0"
 SRCREV = "3c3b18e397a81fac2babe14dca01f4ada1ecc8b2"
 
-
 inherit meson pkgconfig
 
 FILES:${PN} += "${libdir}/libcamera ${datadir}/libcamera"

--- a/recipes-multimedia/libimxvpuapi/libimxvpuapi2_2.3.1.bb
+++ b/recipes-multimedia/libimxvpuapi/libimxvpuapi2_2.3.1.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/Freescale/libimxvpuapi"
 LICENSE = "LGPL-2.1-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=38fa42a5a6425b26d2919b17b1527324"
 SECTION = "multimedia"
-DEPENDS = "virtual/imxvpu libimxdmabuffer"
+DEPENDS = "libimxdmabuffer virtual/imxvpu"
 # Add imx-vpu-hantro-vc as dependency for being
 # able to encode video using the VC8000E encoder
 DEPENDS:append:mx8mp-nxp-bsp = " imx-vpu-hantro-vc"

--- a/recipes-security/optee-imx/optee-os-fslc.inc
+++ b/recipes-security/optee-imx/optee-os-fslc.inc
@@ -13,7 +13,7 @@ require optee-fslc.inc
 
 CVE_PRODUCT = "linaro:op-tee op-tee:op-tee_os"
 
-DEPENDS = "python3-pyelftools-native python3-cryptography-native"
+DEPENDS = "python3-cryptography-native python3-pyelftools-native"
 
 DEPENDS:append:toolchain-clang = " lld-native compiler-rt"
 
@@ -73,7 +73,6 @@ SYSROOT_DIRS += "${nonarch_base_libdir}/firmware"
 PACKAGES += "${PN}-ta"
 FILES:${PN} = "${nonarch_base_libdir}/firmware/"
 FILES:${PN}-ta = "${nonarch_base_libdir}/optee_armtz/*"
-
 
 # note: "textrel" is not triggered on all archs
 INSANE_SKIP:${PN} = "textrel"

--- a/recipes-security/optee-imx/optee-test-fslc.inc
+++ b/recipes-security/optee-imx/optee-test-fslc.inc
@@ -11,7 +11,7 @@ inherit python3native ptest
 inherit deploy
 require optee-fslc.inc
 
-DEPENDS = "optee-client optee-os-tadevkit python3-cryptography-native openssl"
+DEPENDS = "openssl optee-client optee-os-tadevkit python3-cryptography-native"
 DEPENDS:append:toolchain-clang = " lld-native"
 
 SRC_URI = "git://github.com/OP-TEE/optee_test.git;branch=master;protocol=https \

--- a/recipes-security/optee-imx/optee-test_4.8.0.imx.bb
+++ b/recipes-security/optee-imx/optee-test_4.8.0.imx.bb
@@ -8,6 +8,5 @@ LIC_FILES_CHKSUM = "file://LICENSE.md;md5=a8fa504109e4cd7ea575bc49ea4be560 \
                     file://LICENSE-BSD;md5=dca16d6efa93b55d0fd662ae5cd6feeb \
                     file://LICENSE-GPL;md5=10e86b5d2a6cb0e2b9dcfdd26a9ac58d"
 
-
 SRCBRANCH = "lf-6.18.2_1.0.0"
 SRCREV = "3383a744a5997fdb3457b3cbe95aea3ce27879b3"

--- a/recipes-security/smw/smw_5.3.bb
+++ b/recipes-security/smw/smw_5.3.bb
@@ -11,10 +11,10 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=ff20c8e51b28869d9cdec70a818d163f \
                     file://${PSA_ARCH_TESTS_SRC_PATH}/LICENSE.md;md5=2a944942e1496af1886903d274dedb13"
 
 DEPENDS = "\
-    python3-cryptography-native \
     json-c \
     optee-client \
     optee-os-tadevkit \
+    python3-cryptography-native \
     sqlite3 \
 "
 


### PR DESCRIPTION
Part **3 of 5** of the stacked oelint-adv remediation series.
Based on #2552 (PR 2).

## What

Per-recipe mechanical cleanups (one commit per recipe / PN):

- Sort DEPENDS / RDEPENDS entries alphabetically and consolidate
- Order DEPENDS and package variables per oelint
- Drop double blank lines
- gstreamer1.0-plugins-bad: restore CVE_PRODUCT from OE-core

45 commits, each scoped to one recipe so any single one reverts in isolation.
The diffs are small and homogeneous (dependency reordering / blank-line
removal); they change ordering only, not the dependency sets themselves.

## Why

Mechanical but per-recipe, so grouped separately from the treewide sweeps
and from the semantic metadata work.

## Testing

Parse-level; dependency ordering does not change build output. Spot-checking
a few gstreamer / vulkan / optee recipes is enough.

## Stack

1. #2551 — treewide: Normalize whitespace and add .editorconfig
2. #2552 — treewide: Set HOMEPAGE and lowercase SECTION
3. **treewide: Sort DEPENDS/RDEPENDS and drop double blank lines** ← this PR
4. oelint: Suppress layer-inapplicable rules
5. treewide: Set mandatory SUMMARY/DESCRIPTION/HOMEPAGE and SECTION