### PR TITLE
oelint: Suppress layer-inapplicable rules

### DIFF
--- a/.oelint.cfg
+++ b/.oelint.cfg
@@ -2,8 +2,15 @@
 # directory as the working directory (see contrib/oelint/run-oelint.sh).
 #
 # Layer-specific parser hints live in oelint.constants.json and are passed by
-# contrib/oelint/run-oelint.sh. Rule exceptions should stay inline as
+# contrib/oelint/run-oelint.sh. Per-recipe exceptions should stay inline as
 # '# nooelint: <rule.id>' comments next to the finding, so new recipes are fully
-# linted and each exception is documented in place.
+# linted and each exception is documented in place. Only rules that provably
+# never apply to the whole layer are suppressed here.
 [oelint]
 release = wrynose
+# meta-freescale is a BSP layer: the bulk of its recipes package machine-specific
+# firmware and prebuilt binaries that are not cross-compilable libraries, so
+# BBCLASSEXTEND (native/nativesdk) does not apply. Suppress it layer-wide rather
+# than annotating every such recipe.
+suppress =
+    oelint.var.bbclassextend

--- a/.oelint.cfg
+++ b/.oelint.cfg
@@ -5,12 +5,20 @@
 # contrib/oelint/run-oelint.sh. Per-recipe exceptions should stay inline as
 # '# nooelint: <rule.id>' comments next to the finding, so new recipes are fully
 # linted and each exception is documented in place. Only rules that provably
-# never apply to the whole layer are suppressed here.
+# never apply to the whole layer are suppressed here:
+#
+#   * oelint.var.bbclassextend - meta-freescale is a BSP layer; the bulk of its
+#     recipes package machine-specific firmware and prebuilt binaries that are
+#     not cross-compilable libraries, so BBCLASSEXTEND (native/nativesdk) does
+#     not apply.
+#   * oelint.var.suggestedvar.CVE_PRODUCT / .BUGTRACKER - advisory 'suggested'
+#     variables. Most recipes here package NXP firmware/BSP components with no
+#     upstream bug tracker and no meaningful NVD CPE product; guessing a
+#     CVE_PRODUCT would create false or missed CVE matches, which is worse than
+#     leaving it unset. Set them inline on the rare recipe that has a real value.
 [oelint]
 release = wrynose
-# meta-freescale is a BSP layer: the bulk of its recipes package machine-specific
-# firmware and prebuilt binaries that are not cross-compilable libraries, so
-# BBCLASSEXTEND (native/nativesdk) does not apply. Suppress it layer-wide rather
-# than annotating every such recipe.
 suppress =
     oelint.var.bbclassextend
+    oelint.var.suggestedvar.CVE_PRODUCT
+    oelint.var.suggestedvar.BUGTRACKER


### PR DESCRIPTION
Part **4 of 5** of the stacked oelint-adv remediation series.
Based on #2553 (PR 3).

## What

Two layer-wide suppressions in `.oelint.cfg`, each with rationale in the config
and its own commit:

- `oelint.var.bbclassextend` — meta-freescale is a BSP layer; most recipes
  package machine-specific firmware / prebuilt binaries that are not
  cross-compilable libraries, so BBCLASSEXTEND (native/nativesdk) does not
  apply. (~168 findings.)
- `oelint.var.suggestedvar.CVE_PRODUCT` and `.BUGTRACKER` — advisory
  "suggested" variables. Most recipes here have no upstream tracker and no
  meaningful NVD CPE; a guessed CVE_PRODUCT would make cve-check match the
  wrong CPE (false positives + masked advisories), so leaving it unset is the
  correct default. Real values can still be set inline per recipe. (~370
  findings.)

## Why

Config-only, no recipe changes. Isolated so the policy decision is reviewed on
its own and clears ~538 non-actionable findings from the survey before the
per-recipe metadata PR.

## Testing

None needed — linter configuration only.

## Stack

1. #2551 — treewide: Normalize whitespace and add .editorconfig
2. #2552 — treewide: Set HOMEPAGE and lowercase SECTION
3. #2553 — treewide: Sort DEPENDS/RDEPENDS and drop double blank lines
4. **oelint: Suppress layer-inapplicable rules** ← this PR
5. treewide: Set mandatory SUMMARY/DESCRIPTION/HOMEPAGE and SECTION