### PR TITLE
treewide: Set mandatory SUMMARY/DESCRIPTION/HOMEPAGE and SECTION

### DIFF
--- a/recipes-bsp/atf/qoriq-atf-2.12.inc
+++ b/recipes-bsp/atf/qoriq-atf-2.12.inc
@@ -1,6 +1,8 @@
-DESCRIPTION = "ARM Trusted Firmware"
+SUMMARY = "ARM Trusted Firmware for QorIQ"
+DESCRIPTION = "ARM Trusted Firmware (TF-A) for NXP QorIQ Layerscape SoCs."
 HOMEPAGE = "https://github.com/nxp-qoriq/atf"
 
+SECTION = "bsp"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://license.rst;md5=1dd070c98a281d18d9eefd938729b031"
 

--- a/recipes-bsp/dp-firmware-cadence/dp-firmware-cadence_22.04.bb
+++ b/recipes-bsp/dp-firmware-cadence/dp-firmware-cadence_22.04.bb
@@ -1,4 +1,7 @@
 SUMMARY = "DP firmware"
+DESCRIPTION = "Cadence DisplayPort (HDP) firmware for i.MX8 SoCs."
+HOMEPAGE = "https://www.nxp.com/"
+SECTION = "bsp"
 LICENSE = "Proprietary"
 LIC_FILES_CHKSUM = "file://COPYING;md5=d3c315c6eaa43e07d8c130dc3a04a011"
 
@@ -21,8 +24,9 @@ do_deploy () {
 }
 addtask deploy before do_build after do_install
 
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
 PACKAGES += "${PN}-image"
 FILES:${PN}-image += "/boot"
 
 COMPATIBLE_MACHINE = "(qoriq-arm64)"
-PACKAGE_ARCH = "${MACHINE_ARCH}"

--- a/recipes-bsp/firmware-imx/firmware-ele-imx_2.0.5.bb
+++ b/recipes-bsp/firmware-imx/firmware-ele-imx_2.0.5.bb
@@ -1,6 +1,7 @@
 # Copyright 2021-2026 NXP
 SUMMARY = "NXP i.MX ELE firmware"
 DESCRIPTION = "EdgeLock Secure Enclave firmware for i.MX series SoCs"
+HOMEPAGE = "https://www.nxp.com/"
 SECTION = "base"
 LICENSE = "Proprietary"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bc649096ad3928ec06a8713b8d787eac"

--- a/recipes-bsp/firmware-imx/firmware-sof-imx_2.3.0.bb
+++ b/recipes-bsp/firmware-imx/firmware-sof-imx_2.3.0.bb
@@ -1,7 +1,8 @@
 # Copyright (C) 2020-2022 NXP
 # Released under the MIT license (see COPYING.MIT for the terms)
 
-DESCRIPTION = "Sound Open Firmware"
+SUMMARY = "Sound Open Firmware for i.MX"
+DESCRIPTION = "Sound Open Firmware (SOF) audio DSP firmware for i.MX SoCs."
 HOMEPAGE = "https://www.sofproject.org"
 SECTION = "base"
 LICENSE = "BSD-3-Clause"

--- a/recipes-bsp/firmware-imx/imx-boot-firmware-files_8.31.bb
+++ b/recipes-bsp/firmware-imx/imx-boot-firmware-files_8.31.bb
@@ -1,5 +1,6 @@
 # Copyright (C) 2018-2026 NXP
 SUMMARY = "Freescale i.MX Firmware files used for boot"
+DESCRIPTION = "Prebuilt i.MX firmware blobs (HDMI, SECO and related) used during boot."
 
 require firmware-imx-${PV}.inc
 

--- a/recipes-bsp/firmware-upower/firmware-upower_1.3.1.bb
+++ b/recipes-bsp/firmware-upower/firmware-upower_1.3.1.bb
@@ -1,7 +1,9 @@
 # Copyright 2021-2022 NXP
-DESCRIPTION = "NXP i.MX uPower firmware"
-LICENSE = "Proprietary"
+SUMMARY = "i.MX uPower firmware"
+DESCRIPTION = "Firmware for the uPower microcontroller found on i.MX SoCs."
+HOMEPAGE = "https://www.nxp.com/"
 SECTION = "bsp"
+LICENSE = "Proprietary"
 LIC_FILES_CHKSUM = "file://COPYING;md5=db4762b09b6bda63da103963e6e081de"
 
 SRC_URI = "${FSL_MIRROR}/${BPN}-${PV}.bin;fsl-eula=true"

--- a/recipes-bsp/imx-atf/imx-atf_2.12.bb
+++ b/recipes-bsp/imx-atf/imx-atf_2.12.bb
@@ -1,6 +1,7 @@
 # Copyright (C) 2017-2026 NXP
 
-DESCRIPTION = "i.MX ARM Trusted Firmware"
+SUMMARY = "ARM Trusted Firmware for i.MX"
+DESCRIPTION = "ARM Trusted Firmware (TF-A) for NXP i.MX SoCs."
 HOMEPAGE = "https://github.com/nxp-imx/imx-atf"
 SECTION = "bsp"
 LICENSE = "BSD-3-Clause"

--- a/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
+++ b/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
@@ -2,11 +2,12 @@
 
 require imx-mkimage_git.inc
 
+SUMMARY = "Boot loader image for i.MX 8 devices"
 DESCRIPTION = "Generate Boot Loader for i.MX 8 device"
 HOMEPAGE = "https://github.com/nxp-imx/imx-mkimage"
+SECTION = "bsp"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6"
-SECTION = "bsp"
 
 DEPENDS += "xxd-native"
 DEPENDS:append:mx8m-generic-bsp = " u-boot-mkimage-native dtc-native u-boot-mkeficapsule-native"

--- a/recipes-bsp/imx-mkimage/imx-mkimage_git.bb
+++ b/recipes-bsp/imx-mkimage/imx-mkimage_git.bb
@@ -3,11 +3,12 @@
 
 require imx-mkimage_git.inc
 
-DESCRIPTION = "i.MX make image"
+SUMMARY = "i.MX boot image generation tool"
+DESCRIPTION = "Tooling to assemble i.MX boot images (mkimage_imx8 and related)."
 HOMEPAGE = "https://github.com/nxp-imx/imx-mkimage"
+SECTION = "bsp"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6"
-SECTION = "bsp"
 
 inherit deploy native
 

--- a/recipes-bsp/imx-sc-firmware/imx-sc-firmware_1.18.0.bb
+++ b/recipes-bsp/imx-sc-firmware/imx-sc-firmware_1.18.0.bb
@@ -1,10 +1,12 @@
 # Copyright (C) 2016 Freescale Semiconductor
 # Copyright (C) 2017-2024 NXP
 
-DESCRIPTION = "i.MX System Controller Firmware"
+SUMMARY = "i.MX System Controller firmware"
+DESCRIPTION = "System Controller Unit (SCU) firmware for i.MX8 QuadMax/QuadXPlus SoCs."
+HOMEPAGE = "https://www.nxp.com/"
+SECTION = "bsp"
 LICENSE = "Proprietary"
 LIC_FILES_CHKSUM = "file://COPYING;md5=c0fb372b5d7f12181de23ef480f225f3"
-SECTION = "bsp"
 
 inherit fsl-eula-unpack pkgconfig deploy
 

--- a/recipes-bsp/imx-vpu-hantro-vc/imx-vpu-hantro-vc_1.11.0.bb
+++ b/recipes-bsp/imx-vpu-hantro-vc/imx-vpu-hantro-vc_1.11.0.bb
@@ -1,6 +1,9 @@
 # Copyright 2019-2022 NXP
 
-DESCRIPTION = "i.MX VC8000E Encoder library"
+SUMMARY = "i.MX VC8000E encoder library"
+DESCRIPTION = "Hantro VC8000E video encoder library for i.MX SoCs."
+HOMEPAGE = "https://www.nxp.com/"
+SECTION = "multimedia"
 LICENSE = "Proprietary"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bc649096ad3928ec06a8713b8d787eac"
 
@@ -29,8 +32,8 @@ do_install () {
     rm ${D}${D_SUBDIR}/${SCR}
 }
 
-FILES:${PN} = "/"
-
 PACKAGE_ARCH = "${MACHINE_SOCARCH}"
+
+FILES:${PN} = "/"
 
 COMPATIBLE_MACHINE = "(mx8mp-nxp-bsp)"

--- a/recipes-bsp/imx-vpu-hantro/imx-vpu-hantro-daemon_1.9.0.bb
+++ b/recipes-bsp/imx-vpu-hantro/imx-vpu-hantro-daemon_1.9.0.bb
@@ -1,5 +1,8 @@
 # Copyright 2021 NXP
-DESCRIPTION = "i.MX Hantro V4L2 Daemon"
+SUMMARY = "i.MX Hantro V4L2 daemon"
+DESCRIPTION = "V4L2 userspace daemon for the Hantro VPU on i.MX SoCs."
+HOMEPAGE = "https://www.nxp.com/"
+SECTION = "multimedia"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=cd8bc2a79509c22fc9c1782a151210b1"
 

--- a/recipes-bsp/imx-vpu-hantro/imx-vpu-hantro_1.40.0.bb
+++ b/recipes-bsp/imx-vpu-hantro/imx-vpu-hantro_1.40.0.bb
@@ -1,6 +1,9 @@
 # Copyright (C) 2017-2020,2026 NXP
 
-DESCRIPTION = "i.MX Hantro VPU library"
+SUMMARY = "i.MX Hantro VPU library"
+DESCRIPTION = "Hantro video processing unit (VPU) codec library for i.MX SoCs."
+HOMEPAGE = "https://www.nxp.com/"
+SECTION = "multimedia"
 LICENSE = "Proprietary"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bc649096ad3928ec06a8713b8d787eac"
 
@@ -39,7 +42,8 @@ do_install () {
     oe_runmake install DEST_DIR="${D}"
 }
 
+PACKAGE_ARCH = "${MACHINE_SOCARCH}"
+
 FILES:${PN} += "/unit_tests"
 
-PACKAGE_ARCH = "${MACHINE_SOCARCH}"
 COMPATIBLE_MACHINE = "(mx8mq-nxp-bsp|mx8mm-nxp-bsp|mx8mp-nxp-bsp)"

--- a/recipes-bsp/imx-vpu/imx-vpu_5.4.39.3.bb
+++ b/recipes-bsp/imx-vpu/imx-vpu_5.4.39.3.bb
@@ -2,7 +2,10 @@
 # Copyright (C) 2013-2016 Freescale Semiconductor
 # Copyright (C) 2017-2020 NXP
 
+SUMMARY = "i.MX VPU library for Chips&Media VPU"
 DESCRIPTION = "Freescale VPU library for Chips&Media VPU"
+HOMEPAGE = "https://www.nxp.com/"
+SECTION = "multimedia"
 LICENSE = "Proprietary"
 LIC_FILES_CHKSUM = "file://COPYING;md5=228c72f2a91452b8a03c4cab30f30ef9"
 

--- a/recipes-bsp/isp-imx/basler-camera_4.2.2.26.1.bb
+++ b/recipes-bsp/isp-imx/basler-camera_4.2.2.26.1.bb
@@ -1,6 +1,9 @@
 # Copyright 2020-2024 NXP
 
-DESCRIPTION = "Basler camera binary drivers"
+SUMMARY = "Basler camera binary drivers"
+DESCRIPTION = "Basler camera binary drivers for the i.MX ISP."
+HOMEPAGE = "https://www.nxp.com/"
+SECTION = "multimedia"
 LICENSE = "Proprietary"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bc649096ad3928ec06a8713b8d787eac"
 

--- a/recipes-bsp/isp-imx/isp-imx_4.2.2.26.1.bb
+++ b/recipes-bsp/isp-imx/isp-imx_4.2.2.26.1.bb
@@ -1,6 +1,9 @@
 # Copyright 2020-2025 NXP
 
-DESCRIPTION = "i.MX Verisilicon Software ISP"
+SUMMARY = "i.MX VeriSilicon software ISP"
+DESCRIPTION = "VeriSilicon image signal processing (ISP) software stack for i.MX SoCs."
+HOMEPAGE = "https://www.nxp.com/"
+SECTION = "multimedia"
 LICENSE = "Proprietary"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bc649096ad3928ec06a8713b8d787eac"
 

--- a/recipes-core/udev/udev-rules-imx.bb
+++ b/recipes-core/udev/udev-rules-imx.bb
@@ -1,5 +1,7 @@
+SUMMARY = "udev rules for i.MX SoCs"
 DESCRIPTION = "udev rules for Freescale i.MX SOCs"
 HOMEPAGE = "https://github.com/Freescale/meta-freescale/"
+SECTION = "base"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 

--- a/recipes-core/udev/udev-rules-qoriq.bb
+++ b/recipes-core/udev/udev-rules-qoriq.bb
@@ -1,4 +1,7 @@
+SUMMARY = "udev rules for QorIQ SoCs"
 DESCRIPTION = "udev rules for Freescale QorIQ SOCs"
+HOMEPAGE = "https://github.com/Freescale/meta-freescale/"
+SECTION = "base"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 

--- a/recipes-extended/merge-files/merge-files_1.0.bb
+++ b/recipes-extended/merge-files/merge-files_1.0.bb
@@ -1,4 +1,7 @@
+SUMMARY = "Merge extra files into the rootfs"
 DESCRIPTION = "Merge prebuilt/extra files into rootfs"
+HOMEPAGE = "https://github.com/Freescale/meta-freescale/"
+SECTION = "base"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
 

--- a/recipes-fsl/fsl-rc-local/fsl-rc-local.bb
+++ b/recipes-fsl/fsl-rc-local/fsl-rc-local.bb
@@ -1,6 +1,9 @@
 # Copyright (C) 2012 O.S. Systems Software LTDA.
 
-DESCRIPTION = "Extra files for fsl-gui-image"
+SUMMARY = "Extra rc.local files for i.MX images"
+DESCRIPTION = "rc.local init snippets and helper files for Freescale/NXP images."
+HOMEPAGE = "https://github.com/Freescale/meta-freescale/"
+SECTION = "base"
 LICENSE = "LGPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=39ec502560ab2755c4555ee8416dfe42"
 

--- a/recipes-fsl/mcore-demos/imx-mcore-demos.inc
+++ b/recipes-fsl/mcore-demos/imx-mcore-demos.inc
@@ -2,6 +2,8 @@
 # Released under the MIT license (see COPYING.MIT for the terms)
 
 SUMMARY = "i.MX M4/M7/M33 core Demo images"
+DESCRIPTION = "Prebuilt demo firmware images for the Cortex-M auxiliary cores (M4/M7/M33) found on i.MX application processors."
+HOMEPAGE = "https://www.nxp.com/"
 SECTION = "app"
 LICENSE = "Proprietary"
 

--- a/recipes-graphics/imx-g2d/imx-dpu-g2d_2.5.0.2.bb
+++ b/recipes-graphics/imx-g2d/imx-dpu-g2d_2.5.0.2.bb
@@ -2,7 +2,10 @@
 # Copyright 2017-2025 NXP
 # Released under the MIT license (see COPYING.MIT for the terms)
 
+SUMMARY = "i.MX DPU G2D library"
 DESCRIPTION = "G2D library using i.MX DPU"
+HOMEPAGE = "https://www.nxp.com/"
+SECTION = "graphics"
 LICENSE = "Proprietary"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bc649096ad3928ec06a8713b8d787eac"
 
@@ -33,6 +36,8 @@ do_install () {
     cp -Pr ${S}/g2d/usr/include/* ${D}${includedir}
 }
 
+PACKAGE_ARCH = "${MACHINE_SOCARCH}"
+
 INSANE_SKIP:append:libc-musl = " file-rdeps"
 RDEPENDS:${PN}:append:libc-musl = " gcompat"
 
@@ -42,5 +47,4 @@ INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
 INHIBIT_PACKAGE_STRIP = "1"
 INHIBIT_SYSROOT_STRIP = "1"
 
-PACKAGE_ARCH = "${MACHINE_SOCARCH}"
 COMPATIBLE_MACHINE = "(imxdpu)"

--- a/recipes-graphics/imx-g2d/imx-g2d-samples_git.bb
+++ b/recipes-graphics/imx-g2d/imx-g2d-samples_git.bb
@@ -1,6 +1,7 @@
 SUMMARY = "i.MX G2D Samples"
 DESCRIPTION = "Set of sample applications for i.MX G2D"
 HOMEPAGE = "https://github.com/nxp-imx/g2d-samples"
+SECTION = "graphics"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=0858ec9c7a80c4a2cf16e4f825a2cc91"
 
@@ -69,8 +70,8 @@ do_install() {
     oe_runmake install DESTDIR=${D}
 }
 
-FILES:${PN} += "/opt"
-
 PACKAGE_ARCH = "${MACHINE_SOCARCH}"
+
+FILES:${PN} += "/opt"
 
 COMPATIBLE_MACHINE = "(imxgpu2d|mx93-nxp-bsp|mx943-nxp-bsp|mx95-nxp-bsp)"

--- a/recipes-graphics/imx-g2d/imx-gpu-g2d_6.4.11.p4.4.bb
+++ b/recipes-graphics/imx-g2d/imx-gpu-g2d_6.4.11.p4.4.bb
@@ -3,7 +3,10 @@
 # Copyright 2018 (C) O.S. Systems Software LTDA.
 # Released under the MIT license (see COPYING.MIT for the terms)
 
+SUMMARY = "i.MX GPU G2D library"
 DESCRIPTION = "G2D library using i.MX GPU"
+HOMEPAGE = "https://www.nxp.com/"
+SECTION = "graphics"
 LICENSE = "Proprietary"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bc649096ad3928ec06a8713b8d787eac"
 DEPENDS = "libgal-imx"

--- a/recipes-graphics/imx-g2d/imx-pxp-g2d_git.bb
+++ b/recipes-graphics/imx-g2d/imx-pxp-g2d_git.bb
@@ -2,8 +2,10 @@
 # Copyright 2017-2026 NXP
 # Released under the MIT license (see COPYING.MIT for the terms)
 
+SUMMARY = "i.MX PXP G2D library"
 DESCRIPTION = "G2D library using i.MX PXP"
 HOMEPAGE = "https://github.com/nxp-imx/imx-g2d-pxp"
+SECTION = "graphics"
 LICENSE = "Proprietary"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=a93b654673e1bc8398ed1f30e0813359"
 

--- a/recipes-multimedia/imx-codec/imx-codec_4.10.0.bb
+++ b/recipes-multimedia/imx-codec/imx-codec_4.10.0.bb
@@ -3,9 +3,11 @@
 # Copyright 2018 (C) O.S. Systems Software LTDA.
 # Released under the MIT license (see COPYING.MIT for the terms)
 
+SUMMARY = "i.MX multimedia codec libraries"
 DESCRIPTION = "Freescale Multimedia codec libs"
-LICENSE = "Proprietary"
+HOMEPAGE = "https://www.nxp.com/"
 SECTION = "multimedia"
+LICENSE = "Proprietary"
 LIC_FILES_CHKSUM = "file://COPYING;md5=a93b654673e1bc8398ed1f30e0813359"
 
 # Backward compatibility

--- a/recipes-multimedia/imx-dsp/imx-dsp-codec-ext_2.1.8.bb
+++ b/recipes-multimedia/imx-dsp/imx-dsp-codec-ext_2.1.8.bb
@@ -1,6 +1,9 @@
 # Copyright 2018-2023 NXP
 
+SUMMARY = "i.MX DSP codec wrapper and library extension"
 DESCRIPTION = "i.MX DSP Codec Wrapper and Lib owned by NXP"
+HOMEPAGE = "https://www.nxp.com/"
+SECTION = "multimedia"
 LICENSE = "Proprietary"
 LIC_FILES_CHKSUM = "file://COPYING;md5=10c0fda810c63b052409b15a5445671a"
 

--- a/recipes-multimedia/imx-dsp/imx-dsp_2.1.10.bb
+++ b/recipes-multimedia/imx-dsp/imx-dsp_2.1.10.bb
@@ -1,6 +1,9 @@
 # Copyright 2017-2022,2024 NXP
 
+SUMMARY = "i.MX DSP wrapper, firmware and codec libraries"
 DESCRIPTION = "i.MX DSP Wrapper, Firmware Binary, Codec Libraries"
+HOMEPAGE = "https://www.nxp.com/"
+SECTION = "multimedia"
 LICENSE = "Proprietary"
 LIC_FILES_CHKSUM = "file://COPYING;md5=c0fb372b5d7f12181de23ef480f225f3"
 

--- a/recipes-multimedia/imx-dspc-asrc/imx-dspc-asrc_1.0.2.bb
+++ b/recipes-multimedia/imx-dspc-asrc/imx-dspc-asrc_1.0.2.bb
@@ -1,7 +1,9 @@
 # Copyright 2019, 2025 NXP
+SUMMARY = "i.MX asynchronous sample rate converter"
 DESCRIPTION = "NXP Asynchronous Sample Rate Converter"
-LICENSE = "Proprietary"
+HOMEPAGE = "https://www.nxp.com/"
 SECTION = "multimedia"
+LICENSE = "Proprietary"
 LIC_FILES_CHKSUM = "file://COPYING;md5=a93b654673e1bc8398ed1f30e0813359"
 
 SRC_URI = "${FSL_MIRROR}/${BPN}-${PV}-${IMX_SRCREV_ABBREV}.bin;fsl-eula=true"

--- a/recipes-multimedia/imx-opencl-converter/imx-opencl-converter_0.11.0.bb
+++ b/recipes-multimedia/imx-opencl-converter/imx-opencl-converter_0.11.0.bb
@@ -1,7 +1,9 @@
 # Copyright 2023-2025 NXP
+SUMMARY = "i.MX multimedia OpenCL converter library"
 DESCRIPTION = "NXP Multimedia opencl converter lib"
-LICENSE = "Proprietary"
+HOMEPAGE = "https://www.nxp.com/"
 SECTION = "multimedia"
+LICENSE = "Proprietary"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bc649096ad3928ec06a8713b8d787eac"
 DEPENDS = "virtual/libopencl1"
 

--- a/recipes-multimedia/imx-parser/imx-parser_4.10.3.bb
+++ b/recipes-multimedia/imx-parser/imx-parser_4.10.3.bb
@@ -2,22 +2,24 @@
 # Copyright (C) 2012-2016 Freescale Semiconductor
 # Copyright (C) 2017-2023 NXP
 # Released under the MIT license (see COPYING.MIT for the terms)
+SUMMARY = "i.MX multimedia parser libraries"
 DESCRIPTION = "Freescale Multimedia parser libs"
-LICENSE = "Proprietary"
+HOMEPAGE = "https://www.nxp.com/"
 SECTION = "multimedia"
+LICENSE = "Proprietary"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bc649096ad3928ec06a8713b8d787eac"
-
-# For backwards compatibility
-PROVIDES += "libfslparser"
-RREPLACES:${PN} = "libfslparser"
-RPROVIDES:${PN} = "libfslparser"
-RCONFLICTS:${PN} = "libfslparser"
 
 SRC_URI = "${FSL_MIRROR}/${BP}-${IMX_SRCREV_ABBREV}.bin;fsl-eula=true"
 IMX_SRCREV_ABBREV = "65603f3"
 S = "${UNPACKDIR}/${BP}-${IMX_SRCREV_ABBREV}"
 
 SRC_URI[sha256sum] = "03079bb0fa989dc50fadb66a0fcc7cf65423833c3def04085603d4b66e8f8c70"
+
+# For backwards compatibility
+PROVIDES += "libfslparser"
+RREPLACES:${PN} = "libfslparser"
+RPROVIDES:${PN} = "libfslparser"
+RCONFLICTS:${PN} = "libfslparser"
 
 inherit fsl-eula-unpack autotools pkgconfig
 

--- a/recipes-multimedia/imx-sw-pdm/imx-sw-pdm_1.0.3.bb
+++ b/recipes-multimedia/imx-sw-pdm/imx-sw-pdm_1.0.3.bb
@@ -1,8 +1,10 @@
 # Copyright 2020,2023 NXP
 
+SUMMARY = "i.MX PDM-to-PCM software decimation library"
 DESCRIPTION = "NXP PDM to PCM Software Decimation SIMD Library"
-LICENSE = "Proprietary"
+HOMEPAGE = "https://www.nxp.com/"
 SECTION = "multimedia"
+LICENSE = "Proprietary"
 LIC_FILES_CHKSUM = "file://COPYING;md5=63a38e9f392d8813d6f1f4d0d6fbe657"
 
 SRC_URI = "${FSL_MIRROR}/${BP}.bin;fsl-eula=true"

--- a/recipes-multimedia/imx-vpuwrap/imx-vpuwrap_git.bb
+++ b/recipes-multimedia/imx-vpuwrap/imx-vpuwrap_git.bb
@@ -2,10 +2,11 @@
 # Copyright (C) 2017-2023,2025 NXP
 # Released under the MIT license (see COPYING.MIT for the terms)
 
+SUMMARY = "i.MX VPU wrapper library"
 DESCRIPTION = "Freescale Multimedia VPU wrapper"
 HOMEPAGE = "https://github.com/NXP/imx-vpuwrap"
-LICENSE = "Proprietary"
 SECTION = "multimedia"
+LICENSE = "Proprietary"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bc649096ad3928ec06a8713b8d787eac"
 
 DEPENDS = "virtual/imxvpu"

--- a/recipes-multimedia/libimxvpuapi/libimxvpuapi2_2.3.1.bb
+++ b/recipes-multimedia/libimxvpuapi/libimxvpuapi2_2.3.1.bb
@@ -1,8 +1,9 @@
+SUMMARY = "i.MX VPU API library (v2)"
 DESCRIPTION = "frontend for the i.MX6 / i.MX8 VPU hardware video engines"
 HOMEPAGE = "https://github.com/Freescale/libimxvpuapi"
+SECTION = "multimedia"
 LICENSE = "LGPL-2.1-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=38fa42a5a6425b26d2919b17b1527324"
-SECTION = "multimedia"
 DEPENDS = "libimxdmabuffer virtual/imxvpu"
 # Add imx-vpu-hantro-vc as dependency for being
 # able to encode video using the VC8000E encoder
@@ -11,8 +12,8 @@ DEPENDS:append:mx8mp-nxp-bsp = " imx-vpu-hantro-vc"
 PV .= "+git${SRCPV}"
 
 SRCBRANCH ?= "master"
-SRCREV = "37095a854aa176bb763a25ce98ceb6a787501271"
 SRC_URI = "git://github.com/Freescale/libimxvpuapi.git;branch=${SRCBRANCH};protocol=https"
+SRCREV = "37095a854aa176bb763a25ce98ceb6a787501271"
 
 inherit waf pkgconfig use-imx-headers python3native
 

--- a/recipes-multimedia/libimxvpuapi/libimxvpuapi_git.bb
+++ b/recipes-multimedia/libimxvpuapi/libimxvpuapi_git.bb
@@ -1,16 +1,17 @@
 # Copyright 2018 (C) O.S. Systems Software LTDA.
+SUMMARY = "i.MX VPU API library (v1)"
 DESCRIPTION = "frontend for the i.MX6 VPU hardware video engine"
 HOMEPAGE = "https://github.com/Freescale/libimxvpuapi"
+SECTION = "multimedia"
 LICENSE = "LGPL-2.1-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=38fa42a5a6425b26d2919b17b1527324"
-SECTION = "multimedia"
 DEPENDS = "imx-vpu"
 
 PV = "0.10.3+${SRCPV}"
 
 SRCBRANCH ?= "v1"
-SRCREV = "3a1ee3a54fe93813868d38c3d32ea065b59e227e"
 SRC_URI = "git://github.com/Freescale/libimxvpuapi.git;branch=${SRCBRANCH};protocol=https"
+SRCREV = "3a1ee3a54fe93813868d38c3d32ea065b59e227e"
 
 inherit waf pkgconfig python3native
 

--- a/recipes-multimedia/nxp-afe/nxp-afe-voiceseeker_git.bb
+++ b/recipes-multimedia/nxp-afe/nxp-afe-voiceseeker_git.bb
@@ -1,6 +1,7 @@
 # Copyright 2025 NXP
 
-DESCRIPTION = "NXP RetuneDSP Voice Seeker Libraries"
+SUMMARY = "NXP RetuneDSP Voice Seeker libraries"
+DESCRIPTION = "NXP RetuneDSP Voice Seeker far-field voice pickup libraries."
 HOMEPAGE = "https://github.com/nxp-imx/imx-voiceui"
 SECTION = "multimedia"
 LICENSE = "Proprietary"

--- a/recipes-multimedia/nxp-afe/nxp-afe_git.bb
+++ b/recipes-multimedia/nxp-afe/nxp-afe_git.bb
@@ -1,7 +1,9 @@
 # Copyright 2025 NXP
 
+SUMMARY = "NXP Audio Front End (AFE)"
 DESCRIPTION = "NXP Audio Front End (AFE) for incorporating Voice Assistants"
 HOMEPAGE = "https://github.com/nxp-imx/nxp-afe"
+SECTION = "multimedia"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=7bdef19938f3503cfc4c586461f99012"
 
@@ -9,11 +11,11 @@ PV = "1.0+git"
 
 SRCBRANCH = "MM_04.10.03_2512_L6.18.2"
 NXPAFE_SRC ?= "git://github.com/nxp-imx/nxp-afe.git;protocol=https"
+DEPENDS += "alsa-lib"
+
 SRC_URI = "${NXPAFE_SRC};branch=${SRCBRANCH}"
 
 SRCREV = "7d518eb0b18f7c7faadeb3c3397f8b73f0012f3e"
-
-DEPENDS += "alsa-lib"
 
 TARGET_CC_ARCH += "${LDFLAGS}"
 


### PR DESCRIPTION
Part **5 of 5** (top) of the stacked oelint-adv remediation series.
Based on #2554 (PR 4).

## What

Per-recipe metadata, one commit per PN, filling oelint's mandatory/suggested
variables and fixing the coupled variable ordering:

- Add mandatory SUMMARY / DESCRIPTION / HOMEPAGE where missing
- Set SECTION
- Coupled reorders: SECTION before LICENSE/LIC_FILES_CHKSUM, SRC_URI before
  SRCREV, PACKAGE_ARCH before FILES/RDEPENDS
- Shared metadata placed in include files where a family shares one upstream
  (imx-mcore-demos, qoriq-atf)

HOMEPAGE convention for NXP proprietary firmware/libs: `https://www.nxp.com/`.

Recipes covered include the imx multimedia libs (imx-dsp, imx-codec,
imx-parser, …), the VPU/g2d families, BSP firmware (dp-firmware-cadence,
imx-sc-firmware, firmware-*), ATF, imx-mkimage/imx-boot, isp-imx, libimxvpuapi,
udev rules, and more.

## Why

Semantic, judgement-based edits (short human-readable summaries/descriptions),
so grouped separately from the mechanical PRs and handled one recipe at a time.

## Notes / not included here

Opinionated or intentional findings are deliberately left as documented
residuals rather than churned: `filesoverride`, `noncoreoverride` (mostly
bbappend false positives), `insaneskip` (intentional in binary/firmware
recipes), `task.docstrings`, `var.override` (inc+bb double-sets), `task.nocopy`.
A few chained/conditional var-order warnings are also deferred. This PR is the
current tip; more per-recipe metadata can follow.

## Testing

Parse-level; metadata-only edits.

## Stack

1. #2551 — treewide: Normalize whitespace and add .editorconfig
2. #2552 — treewide: Set HOMEPAGE and lowercase SECTION
3. #2553 — treewide: Sort DEPENDS/RDEPENDS and drop double blank lines
4. #2554 — oelint: Suppress layer-inapplicable rules
5. **treewide: Set mandatory SUMMARY/DESCRIPTION/HOMEPAGE and SECTION** ← this PR