### PR TITLE
treewide: Set mandatory SUMMARY/DESCRIPTION/HOMEPAGE and SECTION (part 2)

### DIFF
--- a/recipes-dpaa/eth-config/eth-config_git.bb
+++ b/recipes-dpaa/eth-config/eth-config_git.bb
@@ -1,3 +1,4 @@
+SUMMARY = "Ethernet config files"
 DESCRIPTION = "Ethernet Configuration Files"
 HOMEPAGE = "https://github.com/nxp-qoriq/eth-config"
 SECTION = "eth-config"

--- a/recipes-dpaa/flib/flib_git.bb
+++ b/recipes-dpaa/flib/flib_git.bb
@@ -1,4 +1,5 @@
-DESCRIPTION = "Foundation Library"
+SUMMARY = "SEC descriptor foundation library"
+DESCRIPTION = "Foundation library of frame descriptors for the QorIQ SEC (crypto) block."
 HOMEPAGE = "https://github.com/nxp-qoriq/flib"
 SECTION = "flib"
 LICENSE = "BSD-3-Clause & GPL-2.0-only"

--- a/recipes-dpaa/fm-ucode/fm-ucode_git.bb
+++ b/recipes-dpaa/fm-ucode/fm-ucode_git.bb
@@ -1,3 +1,4 @@
+SUMMARY = "Fman microcode"
 DESCRIPTION = "Fman microcode binary"
 HOMEPAGE = "https://github.com/NXP/qoriq-fm-ucode"
 SECTION = "fm-ucode"

--- a/recipes-dpaa/fmlib/fmlib_git.bb
+++ b/recipes-dpaa/fmlib/fmlib_git.bb
@@ -1,4 +1,5 @@
-DESCRIPTION = "Frame Manager User Space Library"
+SUMMARY = "Frame Manager userspace library"
+DESCRIPTION = "Userspace library to configure the QorIQ DPAA Frame Manager (FMan)."
 HOMEPAGE = "https://github.com/nxp-qoriq/fmlib"
 SECTION = "fman"
 LICENSE = "BSD-3-Clause & GPL-2.0-only"

--- a/recipes-dpaa2/aiopsl/aiopsl_git.bb
+++ b/recipes-dpaa2/aiopsl/aiopsl_git.bb
@@ -1,3 +1,4 @@
+SUMMARY = "DPAA2 AIOP service layer"
 DESCRIPTION = "DPAA2 Accelerated I/O Processing service layer"
 HOMEPAGE = "https://github.com/nxp-qoriq/aiopsl"
 SECTION = "dpaa2"

--- a/recipes-dpaa2/dce/dce_git.bb
+++ b/recipes-dpaa2/dce/dce_git.bb
@@ -1,3 +1,4 @@
+SUMMARY = "DPAA2 DCE userspace utilities"
 DESCRIPTION = "Decompression Compression Engine Userspace Utils"
 HOMEPAGE = "https://github.com/nxp-qoriq/dce"
 SECTION = "dpaa2"

--- a/recipes-dpaa2/gpp-aioptool/gpp-aioptool_git.bb
+++ b/recipes-dpaa2/gpp-aioptool/gpp-aioptool_git.bb
@@ -1,3 +1,4 @@
+SUMMARY = "AIOP Tool userspace application"
 DESCRIPTION = "AIOP Tool is a userspace application for performing operations \
                on an AIOP Tile using MC interfaces. This application enables the user to \
                fetch status of tile, load a valid ELF file and run it on a tile and get and set \

--- a/recipes-dpaa2/management-complex/management-complex_10.39.0.bb
+++ b/recipes-dpaa2/management-complex/management-complex_10.39.0.bb
@@ -1,5 +1,7 @@
 SUMMARY = "DPAA2 Management Complex Firmware"
+DESCRIPTION = "DPAA2 Management Complex (MC) firmware for NXP QorIQ Layerscape SoCs."
 HOMEPAGE = "https://github.com/nxp/qoriq-mc-binary"
+SECTION = "bsp"
 LICENSE = "NXP-Binary-EULA"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=0701845051a61f6012009d7d6d11b32b"
 

--- a/recipes-dpaa2/restool/restool_git.bb
+++ b/recipes-dpaa2/restool/restool_git.bb
@@ -1,5 +1,7 @@
 SUMMARY = "DPAA2 Resource Manager Tool"
+DESCRIPTION = "Userspace resource manager tool for DPAA2 objects on NXP QorIQ SoCs."
 HOMEPAGE = "https://github.com/nxp-qoriq/restool"
+SECTION = "base"
 LICENSE = "BSD-3-Clause | GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=83af78c71766dd5fb1c1c3dd64a75ee7"
 

--- a/recipes-dpaa2/spc/spc_git.bb
+++ b/recipes-dpaa2/spc/spc_git.bb
@@ -1,5 +1,7 @@
 SUMMARY = "Soft Parser Configuration tool"
+DESCRIPTION = "Soft Parser Configuration tool for the DPAA Frame Manager."
 HOMEPAGE = "https://github.com/nxp-qoriq/spc"
+SECTION = "base"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=163b09a1c249a6ff2b28da1ceca2e0a8"
 

--- a/recipes-extended/crconf/crconf_git.bb
+++ b/recipes-extended/crconf/crconf_git.bb
@@ -1,4 +1,5 @@
 SUMMARY = "crconf -Linux crypto layer configuraton tool"
+DESCRIPTION = "Command-line tool to configure the Linux kernel crypto layer (crconf)."
 HOMEPAGE = "https://sourceforge.net/projects/crconf/"
 SECTION = "base"
 LICENSE = "GPL-2.0-only"

--- a/recipes-extended/skmm-ep/skmm-ep_git.bb
+++ b/recipes-extended/skmm-ep/skmm-ep_git.bb
@@ -1,3 +1,4 @@
+SUMMARY = "SKMM PCIe endpoint application"
 DESCRIPTION = "SKMM application for PCIe endpoint"
 HOMEPAGE = "https://github.com/nxp-qoriq-yocto-sdk/skmm-ep"
 SECTION = "skmm-ep"

--- a/recipes-extended/testfloat/testfloat_2a.bb
+++ b/recipes-extended/testfloat/testfloat_2a.bb
@@ -1,5 +1,7 @@
+SUMMARY = "Floating-point implementation test suite"
 DESCRIPTION = "A program for testing floating-point implementation"
 HOMEPAGE = "http://www.jhauser.us/arithmetic/TestFloat.html"
+SECTION = "devel"
 LICENSE = "TestFloat"
 
 LIC_FILES_CHKSUM = "file://testfloat/testfloat.txt;beginline=87;endline=95;md5=bdb2e8111838a48015c29bd97f5b6145"

--- a/recipes-graphics/devil/devil_1.8.0.bb
+++ b/recipes-graphics/devil/devil_1.8.0.bb
@@ -1,6 +1,7 @@
+SUMMARY = "Cross-platform image library"
 DESCRIPTION = "A full featured cross-platform image library"
-SECTION = "libs"
 HOMEPAGE = "https://openil.sourceforge.net/"
+SECTION = "libs"
 LICENSE = "LGPL-2.1-only"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/LGPL-2.1-only;md5=1a6d268fd218675ffea8be556788b780"
 PR = "r0"

--- a/recipes-graphics/imx-gpu-apitrace/imx-gpu-apitrace_10.0.0.bb
+++ b/recipes-graphics/imx-gpu-apitrace/imx-gpu-apitrace_10.0.0.bb
@@ -1,6 +1,8 @@
 # Copyright 2018 (C) O.S. Systems Software LTDA.
 SUMMARY = "Samples for OpenGL ES"
+DESCRIPTION = "OpenGL ES / EGL API tracing, replay and inspection tools for i.MX GPUs."
 HOMEPAGE = "https://github.com/nxp-imx/apitrace-imx"
+SECTION = "graphics"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=aeb969185a143c3c25130bc2c3ef9a50"
 DEPENDS = "libpng procps zlib"
@@ -32,6 +34,8 @@ PACKAGECONFIG[waffle] = "-DENABLE_WAFFLE=ON,-DENABLE_WAFFLE=OFF,waffle"
 PACKAGECONFIG[x11] = "-DENABLE_X11=ON,-DENABLE_X11=OFF"
 PACKAGECONFIG[vivante] = "-DENABLE_VIVANTE=ON,-DENABLE_VIVANTE=OFF,virtual/libg2d"
 
+PACKAGE_ARCH = "${MACHINE_SOCARCH}"
+
 SOLIBS = ".so"
 FILES_SOLIBSDEV = ""
 FILES:${PN} += "\
@@ -44,7 +48,6 @@ EXTRA_OECMAKE += "\
     -DENABLE_STATIC_LIBSTDCXX=OFF \
     -DPython3_ROOT_DIR=/usr/bin/python3-native \
 "
-PACKAGE_ARCH = "${MACHINE_SOCARCH}"
 COMPATIBLE_MACHINE = "(imxgpu)"
 SECURITY_CFLAGS:toolchain-clang = ""
 

--- a/recipes-graphics/imx-gpu-sdk/imx-gpu-sdk_6.1.1.bb
+++ b/recipes-graphics/imx-gpu-sdk/imx-gpu-sdk_6.1.1.bb
@@ -1,6 +1,7 @@
 SUMMARY = "i.MX GPU SDK Samples"
 DESCRIPTION = "Set of sample applications for i.MX GPU"
 HOMEPAGE = "https://github.com/nxp-imx/gtec-demo-framework"
+SECTION = "graphics"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://License.md;md5=9d58a2573275ce8c35d79576835dbeb8"
 

--- a/recipes-graphics/imx-gpu-sdk/libxdg-shell.bb
+++ b/recipes-graphics/imx-gpu-sdk/libxdg-shell.bb
@@ -1,4 +1,7 @@
 SUMMARY = "Provides XDG shell header and glue code library"
+DESCRIPTION = "XDG shell protocol header and glue-code library used by the i.MX GPU SDK samples."
+HOMEPAGE = "https://github.com/nxp-imx/gtec-demo-framework"
+SECTION = "graphics"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://${UNPACKDIR}/${BP}/License.md;md5=9d58a2573275ce8c35d79576835dbeb8"
 

--- a/recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc
+++ b/recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc
@@ -3,6 +3,7 @@
 # Copyright 2017-2024 NXP
 # Released under the MIT license (see COPYING.MIT for the terms)
 
+SUMMARY = "i.MX Vivante GPU driver"
 DESCRIPTION = "GPU driver and apps for i.MX"
 HOMEPAGE = "https://www.nxp.com/"
 SECTION = "libs"

--- a/recipes-graphics/mali/mali-imx.inc
+++ b/recipes-graphics/mali/mali-imx.inc
@@ -1,4 +1,6 @@
 SUMMARY = "Graphics libraries and driver for i.MX Mali GPU"
+DESCRIPTION = "Arm Mali GPU user-space graphics libraries and driver for i.MX SoCs."
+HOMEPAGE = "https://www.nxp.com/"
 SECTION = "libs"
 DEPENDS = "\
     libdrm \

--- a/recipes-graphics/mesa/mesa-etnaviv-env_0.1.bb
+++ b/recipes-graphics/mesa/mesa-etnaviv-env_0.1.bb
@@ -1,14 +1,16 @@
 SUMMARY = "Mesa environment variables for etnaviv on xserver"
+DESCRIPTION = "Environment variable configuration to enable the etnaviv Mesa driver on the X server."
 HOMEPAGE = "https://github.com/Freescale/meta-freescale/"
+SECTION = "graphics"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
-
-PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 SRC_URI = "\
     file://mesa-etnaviv.conf \
     file://mesa-etnaviv.sh \
 "
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 S = "${UNPACKDIR}"
 

--- a/recipes-graphics/rapidopencl/rapidopencl_1.1.0.1.bb
+++ b/recipes-graphics/rapidopencl/rapidopencl_1.1.0.1.bb
@@ -1,5 +1,7 @@
 SUMMARY = "Experimental low level header only C++11 RAII wrapper classes for the OpenCL API"
+DESCRIPTION = "Experimental header-only C++11 RAII wrapper classes that manage OpenCL API object lifetimes automatically."
 HOMEPAGE = "https://github.com/Unarmed1000/RapidOpenCL"
+SECTION = "graphics"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=b98f636daed34d12d11e25f3185c0204"
 

--- a/recipes-graphics/rapidopenvx/rapidopenvx_1.1.0.bb
+++ b/recipes-graphics/rapidopenvx/rapidopenvx_1.1.0.bb
@@ -1,5 +1,7 @@
 SUMMARY = "Low level header only C++11 RAII wrapper classes for the OpenVX API"
+DESCRIPTION = "Header-only C++11 RAII wrapper classes that manage OpenVX API object lifetimes automatically."
 HOMEPAGE = "https://github.com/Unarmed1000/RapidOpenVX"
+SECTION = "graphics"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=b98f636daed34d12d11e25f3185c0204"
 

--- a/recipes-graphics/rapidvulkan/rapidvulkan_1.2.162.0.bb
+++ b/recipes-graphics/rapidvulkan/rapidvulkan_1.2.162.0.bb
@@ -1,5 +1,7 @@
 SUMMARY = "Low level header only C++11 RAII wrapper classes for the Vulkan API"
+DESCRIPTION = "Header-only C++11 RAII wrapper classes that manage Vulkan API object lifetimes automatically."
 HOMEPAGE = "https://github.com/Unarmed1000/RapidVulkan"
+SECTION = "graphics"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=b98f636daed34d12d11e25f3185c0204"
 

--- a/recipes-graphics/vulkan/assimp_5.4.3.bb
+++ b/recipes-graphics/vulkan/assimp_5.4.3.bb
@@ -1,3 +1,4 @@
+SUMMARY = "Portable library to import 3D model formats"
 DESCRIPTION = "Open Asset Import Library is a portable Open Source library to import \
                various well-known 3D model formats in a uniform manner."
 HOMEPAGE = "http://www.assimp.org/"

--- a/recipes-graphics/vulkan/vulkan-wsi-layer_git.bb
+++ b/recipes-graphics/vulkan/vulkan-wsi-layer_git.bb
@@ -1,5 +1,7 @@
+SUMMARY = "Vulkan WSI layer"
 DESCRIPTION = "Vulkan Window System Integration Layer"
 HOMEPAGE = "https://gitlab.freedesktop.org/mesa/vulkan-wsi-layer"
+SECTION = "graphics"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=c2e771b72d60a13d2de384cb49055d00"
 DEPENDS = "libdrm vulkan-loader"

--- a/recipes-kernel/ceetm/ceetm_git.bb
+++ b/recipes-kernel/ceetm/ceetm_git.bb
@@ -1,5 +1,7 @@
-DESCRIPTION = "CEETM TC QDISC"
+SUMMARY = "CEETM traffic-control qdisc"
+DESCRIPTION = "Traffic-control qdisc for the QorIQ DPAA CEETM hardware scheduler."
 HOMEPAGE = "https://github.com/nxp-qoriq/ceetm"
+SECTION = "kernel"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 

--- a/recipes-kernel/kernel-modules/kernel-module-ar_git.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-ar_git.bb
@@ -1,5 +1,7 @@
 SUMMARY = "Auto Response Control Module"
+DESCRIPTION = "Kernel module providing QorIQ SEC auto-response control."
 HOMEPAGE = "https://github.com/nxp-qoriq-yocto-sdk/auto-resp"
+SECTION = "kernel"
 LICENSE = "GPL-2.0-only & BSD"
 LIC_FILES_CHKSUM = "file://COPYING;md5=b5881ecf398da8a03a3f4c501e29d287"
 

--- a/recipes-kernel/kernel-modules/kernel-module-imx-gpu-viv_6.4.11.p2.2+fslc.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-imx-gpu-viv_6.4.11.p2.2+fslc.bb
@@ -5,6 +5,7 @@ SUMMARY = "Kernel loadable module for Vivante GPU"
 DESCRIPTION = "This package uses an exact copy of the GPU kernel driver source code of \
                the same version as base and include fixes and improvements developed by FSL Community"
 HOMEPAGE = "https://github.com/Freescale/kernel-module-imx-gpu-viv"
+SECTION = "kernel"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e"
 

--- a/recipes-kernel/kernel-modules/kernel-module-imx-gpu-viv_6.4.11.p4.4.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-imx-gpu-viv_6.4.11.p4.4.bb
@@ -5,6 +5,7 @@ SUMMARY = "Kernel loadable module for Vivante GPU"
 DESCRIPTION = "Builds the Vivante GPU kernel driver as a loadable kernel module, \
                allowing flexibility to use a newer graphics release with an older kernel."
 HOMEPAGE = "https://github.com/nxp-imx/linux-imx"
+SECTION = "kernel"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6"
 

--- a/recipes-kernel/kernel-modules/kernel-module-isp-vvcam_4.2.2.26.1.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-isp-vvcam_4.2.2.26.1.bb
@@ -1,7 +1,9 @@
 # Copyright 2020-2026 NXP
 
+SUMMARY = "i.MX ISP kernel module"
 DESCRIPTION = "Kernel loadable module for ISP"
 HOMEPAGE = "https://github.com/nxp-imx/isp-vvcam"
+SECTION = "kernel"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://${S}/../LICENSE;md5=64381a6ea83b48c39fe524c85f65fb44"
 

--- a/recipes-kernel/kernel-modules/kernel-module-nxp-wlan_git.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-nxp-wlan_git.bb
@@ -1,5 +1,7 @@
 SUMMARY = "NXP Wi-Fi driver for module 88w8801/8987/8997/9098 IW416/610/612"
+DESCRIPTION = "Kernel driver for NXP 88W8801/8987/8997/9098 and IW416/610/612 Wi-Fi modules."
 HOMEPAGE = "https://github.com/nxp-imx/mwifiex"
+SECTION = "kernel"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=ab04ac0f249af12befccb94447c08b77"
 

--- a/recipes-kernel/kernel-modules/kernel-module-uio-seville_0.1.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-uio-seville_0.1.bb
@@ -1,5 +1,7 @@
+SUMMARY = "T1040 L2 switch UIO driver"
 DESCRIPTION = "UIO driver for T1040 L2 Switch"
 HOMEPAGE = "https://github.com/nxp-qoriq-yocto-sdk/l2switch-uio"
+SECTION = "kernel"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e"
 

--- a/recipes-kernel/skmm-host/skmm-host_git.bb
+++ b/recipes-kernel/skmm-host/skmm-host_git.bb
@@ -1,3 +1,4 @@
+SUMMARY = "SKMM host driver"
 DESCRIPTION = "skmm host driver offload data to PCIe EP and push the data en-decrypted back to application"
 HOMEPAGE = "https://github.com/nxp-qoriq-yocto-sdk/skmm-host"
 SECTION = "c293-skmm-host"


### PR DESCRIPTION
Part **6** of the stacked oelint-adv remediation series, continuing the
per-recipe metadata work from #2555. Based on #2555.

## What

More per-recipe metadata, one commit per PN, filling oelint's
mandatory/suggested variables (and, where already present, giving
DESCRIPTION distinct/expanded wording so it is not shorter than or equal
to SUMMARY):

- **graphics**: devil, imx-gpu-apitrace, imx-gpu-sdk, libxdg-shell,
  mesa-etnaviv-env, assimp, vulkan-wsi-layer, mali-imx (inc),
  imx-gpu-viv (inc), rapidopenvx, rapidopencl, rapidvulkan
- **dpaa / dpaa2**: aiopsl, dce, gpp-aioptool, management-complex,
  restool, spc, eth-config, flib, fmlib, fm-ucode
- **kernel**: ceetm, skmm-host, kernel-module-ar,
  kernel-module-isp-vvcam, kernel-module-nxp-wlan,
  kernel-module-uio-seville, kernel-module-imx-gpu-viv (x2)
- **extended**: crconf, testfloat, skmm-ep

Shared metadata is placed in the include where a family shares one
upstream (mali-imx.inc, imx-gpu-viv-6.inc). A few coupled variable
reorders (SECTION/HOMEPAGE/SRC_URI/PACKAGE_ARCH) are done where they sit
next to the metadata being edited.

## Not included

Consistent with #2555, opinionated/intentional findings (filesoverride,
insaneskip, noncoreoverride, task.docstrings, var.override, task.nocopy)
are left as documented residuals. Some standalone `var.order.*` warnings
(e.g. ceetm/nxp-wlan SRC_URI grouping, several PACKAGE_ARCH-before-FILES)
are deferred to a later ordering-focused pass rather than half-applied
here.

## Testing

Parse-level; metadata-only edits (plus small adjacent reorders).

## Stack

1. #2551 — Normalize whitespace + .editorconfig
2. #2552 — Set HOMEPAGE / lowercase SECTION
3. #2553 — Sort DEPENDS/RDEPENDS + drop blank lines
4. #2554 — Suppress layer-inapplicable rules
5. #2555 — Set mandatory metadata (part 1)
6. **Set mandatory metadata (part 2)** ← this PR