### PR TITLE
oelint: Recipe metadata and variable-order cleanups

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-devtools/utp-com/utp-com_git.bb
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/utp-com/utp-com_git.bb
@@ -1,16 +1,17 @@
+SUMMARY = "NXP UTP protocol command-line tool"
 DESCRIPTION = "Tool used to send commands to hardware via NXP's UTP protocol"
 HOMEPAGE = "https://github.com/Freescale/utp_com"
+SECTION = "devel"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=8264535c0c4e9c6c335635c4026a8022"
 
 DEPENDS = "sg3-utils"
 
-SRCREV = "dee512ced1e9367d223d22f10797fbf9aeacfab6"
+PV = "1.0+git${SRCPV}"
 SRC_URI = "\
     git://github.com/Freescale/utp_com;protocol=https;branch=master \
 "
-
-PV = "1.0+git${SRCPV}"
+SRCREV = "dee512ced1e9367d223d22f10797fbf9aeacfab6"
 
 do_configure[noexec] = "1"
 

--- a/recipes-bsp/ddr-phy/ddr-phy_git.bb
+++ b/recipes-bsp/ddr-phy/ddr-phy_git.bb
@@ -1,16 +1,18 @@
 SUMMARY = "DDR firmware repository"
+DESCRIPTION = "DDR PHY training firmware binaries for NXP LX2160A/LX2162A SoCs"
 HOMEPAGE = "https://github.com/nxp/ddr-phy-binary"
+SECTION = "firmware"
 LICENSE = "NXP-Binary-EULA"
 LIC_FILES_CHKSUM = "file://NXP-Binary-EULA.txt;md5=89cc852481956e861228286ac7430d74"
 
 inherit deploy
 
+DEPENDS += "qoriq-atf-tools-native"
+
 SRC_URI = "git://github.com/nxp/ddr-phy-binary.git;nobranch=1;protocol=https"
 SRCREV = "fbc036b88acb6c06ffed02c898cbae9856ec75ba"
 
 REGLEX = "lx2160a"
-
-DEPENDS += "qoriq-atf-tools-native"
 
 do_compile() {
     cd ${S}/${REGLEX}
@@ -36,8 +38,9 @@ do_deploy () {
 }
 addtask deploy before do_populate_sysroot after do_install
 
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
 PACKAGES += "${PN}-image"
 FILES:${PN}-image += "/boot"
 
 COMPATIBLE_MACHINE = "(lx2160a|lx2162a)"
-PACKAGE_ARCH = "${MACHINE_ARCH}"

--- a/recipes-bsp/inphi/inphi_git.bb
+++ b/recipes-bsp/inphi/inphi_git.bb
@@ -1,5 +1,7 @@
 SUMMARY = "Firmwares and Standalone Applications"
+DESCRIPTION = "Inphi IN112525 PHY microcode firmware for NXP QorIQ platforms"
 HOMEPAGE = "https://github.com/nxp/qoriq-firmware-inphi"
+SECTION = "firmware"
 LICENSE = "NXP-Binary-EULA"
 LIC_FILES_CHKSUM = "file://EULA.txt;md5=86d76166990962fa552f840ff08e5798"
 
@@ -19,8 +21,9 @@ do_deploy () {
 }
 addtask deploy before do_build after do_install
 
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
 PACKAGES += "${PN}-image"
 FILES:${PN}-image += "/boot"
 
 COMPATIBLE_MACHINE = "(qoriq-arm64)"
-PACKAGE_ARCH = "${MACHINE_ARCH}"

--- a/recipes-bsp/ls2-phy/ls2-phy_git.bb
+++ b/recipes-bsp/ls2-phy/ls2-phy_git.bb
@@ -1,5 +1,7 @@
 SUMMARY = "Firmwares and Standalone Applications"
+DESCRIPTION = "Cortina PHY firmware and standalone applications for NXP QorIQ platforms"
 HOMEPAGE = "https://github.com/nxp/qoriq-firmware-cortina"
+SECTION = "firmware"
 LICENSE = "NXP-Binary-EULA"
 LIC_FILES_CHKSUM = "file://EULA.txt;md5=86d76166990962fa552f840ff08e5798"
 
@@ -10,7 +12,7 @@ SRCREV = "9143c2a3adede595966583c00ca4edc99ec698cf"
 
 do_install () {
     install -d ${D}/boot
-    cp -fr ${S}/* ${D}/boot
+    install -m 0644 ${S}/* ${D}/boot
 }
 
 do_deploy () {
@@ -19,9 +21,10 @@ do_deploy () {
 }
 addtask deploy before do_build after do_install
 
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
 PACKAGES += "${PN}-image"
 FILES:${PN}-image += "/boot"
 
 COMPATIBLE_MACHINE = "(qoriq)"
-PACKAGE_ARCH = "${MACHINE_ARCH}"
 

--- a/recipes-bsp/mxsldr/mxsldr_git.bb
+++ b/recipes-bsp/mxsldr/mxsldr_git.bb
@@ -1,18 +1,19 @@
 # Copyright (C) 2012 O.S. Systems Software LTDA.
 # Released under the MIT license (see COPYING.MIT for the terms)
 
+SUMMARY = "i.MX233/i.MX28 USB loader"
 DESCRIPTION = "Freescale i.MX233/i.MX28 USB loader"
 HOMEPAGE = "https://source.denx.de/denx/mxsldr"
-DEPENDS = "libusb1"
+SECTION = "devel"
 LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
+DEPENDS = "libusb1"
 
-SRCREV = "c40d80472525e1d57dae5317c028b745968c0399"
+PV = "0.0.0+git${SRCPV}"
 SRC_URI = "git://source.denx.de/denx/mxsldr.git;branch=master;protocol=https \
            file://0001-Do-not-ignore-OE-cflags-and-ldflags.patch \
            "
-
-PV = "0.0.0+git${SRCPV}"
+SRCREV = "c40d80472525e1d57dae5317c028b745968c0399"
 
 inherit pkgconfig
 

--- a/recipes-bsp/ppfe-firmware/ppfe-firmware_git.bb
+++ b/recipes-bsp/ppfe-firmware/ppfe-firmware_git.bb
@@ -1,5 +1,7 @@
 SUMMARY = "PPFE Linux firmware"
+DESCRIPTION = "Packet Forwarding Engine (PFE) firmware binaries for NXP LS1012A SoCs"
 HOMEPAGE = "https://github.com/NXP/qoriq-engine-pfe-bin"
+SECTION = "firmware"
 LICENSE = "NXP-Binary-EULA"
 LIC_FILES_CHKSUM = "file://NXP-Binary-EULA.txt;md5=92723670f432558b9e2494ed177d2a85"
 
@@ -26,6 +28,8 @@ do_deploy () {
 addtask deploy after do_install
 
 FILES:${PN} += "${nonarch_base_libdir}/firmware /boot/"
+# Prebuilt firmware blobs: foreign target arch, already stripped.
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:${PN} += "arch already-stripped"
 INHIBIT_PACKAGE_STRIP = "1"
 INHIBIT_SYSROOT_STRIP = "1"

--- a/recipes-devtools/devregs/devregs_git.bb
+++ b/recipes-devtools/devregs/devregs_git.bb
@@ -1,12 +1,12 @@
-DESCRIPTION = "i.MX Register tool"
+SUMMARY = "i.MX register access tool"
+DESCRIPTION = "Command-line tool to read and write i.MX SoC registers by name"
 HOMEPAGE = "https://github.com/boundarydevices/devregs"
 SECTION = "devel"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=5003fa041d799dd5dd5f646b74e36924"
 
-SRCREV = "dcc3e3f26d3d867d5297a104dc32bd99f5e6fa71"
-SRC_URI = "git://github.com/boundarydevices/devregs.git;protocol=https;branch=master"
-
 PV = "1.0+${SRCPV}"
+SRC_URI = "git://github.com/boundarydevices/devregs.git;protocol=https;branch=master"
+SRCREV = "dcc3e3f26d3d867d5297a104dc32bd99f5e6fa71"
 
 inherit autotools

--- a/recipes-devtools/imx-usb-loader/imx-usb-loader_git.bb
+++ b/recipes-devtools/imx-usb-loader/imx-usb-loader_git.bb
@@ -1,4 +1,5 @@
-DESCRIPTION = "i.MX/Vybrid recovery utility"
+SUMMARY = "i.MX/Vybrid USB recovery utility"
+DESCRIPTION = "Utility to load and run programs on i.MX/Vybrid SoCs over USB using the serial download protocol"
 HOMEPAGE = "https://github.com/boundarydevices/imx_usb_loader"
 SECTION = "devel"
 LICENSE = "LGPL-2.1-only"
@@ -6,10 +7,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
 DEPENDS = "libusb1"
 
-SRCREV = "f009770d841468204ab104bf7d3b0c5bc8425dbb"
-SRC_URI = "git://github.com/boundarydevices/imx_usb_loader.git;protocol=https;branch=master"
-
 PV = "1.0+${SRCPV}"
+SRC_URI = "git://github.com/boundarydevices/imx_usb_loader.git;protocol=https;branch=master"
+SRCREV = "f009770d841468204ab104bf7d3b0c5bc8425dbb"
 
 do_install () {
     oe_runmake DESTDIR=${D} install

--- a/recipes-devtools/stb/stb_git.bb
+++ b/recipes-devtools/stb/stb_git.bb
@@ -1,12 +1,14 @@
 SUMMARY = "single-file public domain (or MIT licensed) libraries for C/C++"
+DESCRIPTION = "Collection of single-file public domain (or MIT licensed) libraries for C/C++ covering image loading and writing, font rasterisation and more"
 HOMEPAGE = "https://github.com/nothings/stb"
+SECTION = "libs"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://stb.h;beginline=14418;endline=14433;md5=b10975d4c8155af1811ab611586f01d2"
 
 PV = "0.0+git${SRCPV}"
 
-SRCREV = "f67165c2bb2af3060ecae7d20d6f731173485ad0"
 SRC_URI = "git://github.com/nothings/stb.git;protocol=https;branch=master"
+SRCREV = "f67165c2bb2af3060ecae7d20d6f731173485ad0"
 
 do_install() {
     install -d ${D}${includedir}

--- a/recipes-extended/dpdk/dpdk_22.11.bb
+++ b/recipes-extended/dpdk/dpdk_22.11.bb
@@ -30,7 +30,7 @@ EXTRA_OEMESON = "\
     -Doptimization=3 \
     --cross-file ${S}/config/arm/arm64_poky_linux_gcc \
     -Denable_driver_sdk=true \
-        ${@bb.utils.contains('DISTRO_FEATURES', 'vpp', '-Dc_args="-Ofast -fPIC -ftls-model=local-dynamic"', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'vpp', '-Dc_args="-Ofast -fPIC -ftls-model=local-dynamic"', '', d)} \
     -Denable_examples_source_install=false \
     -Denable_apps=${DPDK_APPS} \
 "

--- a/recipes-multimedia/gstreamer/gst-examples_1.26.6.bb
+++ b/recipes-multimedia/gstreamer/gst-examples_1.26.6.bb
@@ -36,6 +36,6 @@ RDEPENDS:${PN} = "gstreamer1.0-plugins-base-playback"
 RRECOMMENDS:${PN} = "gstreamer1.0-plugins-base-meta \
                      gstreamer1.0-plugins-good-meta \
                      gstreamer1.0-plugins-bad-meta \
-                      ${@bb.utils.contains("LICENSE_FLAGS_ACCEPTED", "commercial", "gstreamer1.0-libav", "", d)} \
+                     ${@bb.utils.contains("LICENSE_FLAGS_ACCEPTED", "commercial", "gstreamer1.0-libav", "", d)} \
                      ${@bb.utils.contains("LICENSE_FLAGS_ACCEPTED", "commercial", "gstreamer1.0-plugins-ugly-meta", "", d)}"
 RPROVIDES:${PN} += "gst-player gst-player-bin"


### PR DESCRIPTION
## Summary

  Continues the oelint-adv cleanup series. Per-recipe metadata and
  variable-ordering fixes, one commit per recipe, each re-scanned clean.

  - **devregs, imx-usb-loader, utp-com, mxsldr** — add SUMMARY/SECTION,
    order PV/SRC_URI/SRCREV (and LICENSE) per oelint.
  - **inphi, stb, ddr-phy, ls2-phy, ppfe-firmware** — add
    DESCRIPTION/SECTION and fix variable ordering.
  - **ls2-phy** — replace recursive `cp` in do_install with `install`
    (upstream firmware tree is flat; functionally equivalent).
  - **ppfe-firmware** — accept the required prebuilt-firmware INSANE_SKIP
    with an inline `# nooelint:` and rationale.

  Also folds in two Phase A continuation-indent alignments (dpdk
  EXTRA_OEMESON, gst-examples RRECOMMENDS) — whitespace-only, value
  unchanged.

  ## Impact

  Metadata/whitespace only, except ls2-phy's do_install which installs the
  same files by a lint-approved method. No functional change to any package.

  ## Test

  `oelint-adv` reports no findings for each touched recipe.
