### PR TITLE
oelint: Recipe metadata and variable-order cleanups

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-devtools/uuu/uuu_git.bb
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/uuu/uuu_git.bb
@@ -1,16 +1,16 @@
 SUMMARY = "Universal Update Utility"
 DESCRIPTION = "Image deploy tool for i.MX chips"
 HOMEPAGE = "https://github.com/nxp-imx/mfgtools"
+SECTION = "devel"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=38ec0c18112e9a92cffc4951661e85a5"
+DEPENDS = "bzip2 libtinyxml2 libusb openssl zlib zstd"
+
+PV = "1.5.233"
 
 SRC_URI = "git://github.com/nxp-imx/mfgtools.git;protocol=https;branch=master"
 SRCREV = "79ce7d2b2e7459e7b7c94f902d172c30b08884ab"
-PV = "1.5.233"
-
-LICENSE = "BSD-3-Clause"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=38ec0c18112e9a92cffc4951661e85a5"
 
 inherit cmake pkgconfig
-
-DEPENDS = "bzip2 libtinyxml2 libusb openssl zlib zstd"
 
 BBCLASSEXTEND = "native nativesdk"

--- a/recipes-bsp/imx-secure-enclave/imx-secure-enclave.inc
+++ b/recipes-bsp/imx-secure-enclave/imx-secure-enclave.inc
@@ -1,12 +1,17 @@
 # Copyright 2021-2025 NXP
 
 SUMMARY = "NXP i.MX SECURE ENCLAVE library"
-DESCRIPTION = "NXP IMX SECURE ENCLAVE library"
+DESCRIPTION = "Library providing access to the NXP i.MX Secure Enclave \
+               (EdgeLock Enclave) on-chip security subsystem, exposing its \
+               cryptographic and key-management services to userspace."
 HOMEPAGE = "https://github.com/NXP/imx-secure-enclave"
 SECTION = "base"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=8636bd68fc00cc6a3809b7b58b45f982"
 
+# Canonical DEPENDS for the library; this .inc is the base definition, so the
+# plain assignment is intentional (the require sits at the top of the .bb).
+# nooelint: oelint.vars.dependsappend
 DEPENDS = "mbedtls openssl"
 
 SRC_URI = "${SECURE_ENCLAVE_LIB_SRC};branch=${SRCBRANCH}"

--- a/recipes-bsp/imx-secure-enclave/imx-secure-enclave_git.bb
+++ b/recipes-bsp/imx-secure-enclave/imx-secure-enclave_git.bb
@@ -9,10 +9,10 @@ PLAT = "ele"
 
 PACKAGES =+ "${PN}-crrm"
 
-RDEPENDS:${PN} = "${@bb.utils.contains('UBOOT_CONFIG', 'crrm', '${PN}-crrm', '', d)}"
-
-FILES:${PN}-crrm = "\
+FILES:${PN}-crrm += "\
     ${bindir}/ele_crrm_test \
     ${libdir}/lib*crrm${SOLIBS}"
+
+RDEPENDS:${PN} = "${@bb.utils.contains('UBOOT_CONFIG', 'crrm', '${PN}-crrm', '', d)}"
 
 COMPATIBLE_MACHINE = "(mx8ulp-nxp-bsp|mx9-nxp-bsp)"

--- a/recipes-bsp/imx-test/imx-test_00.00.00.bb
+++ b/recipes-bsp/imx-test/imx-test_00.00.00.bb
@@ -1,9 +1,17 @@
 SUMMARY = "Dummy package for SoCs lacking imx-test package"
-DESCRIPTION = "Dummy package for SoCs lacking imx-test package"
+DESCRIPTION = "Empty placeholder package that provides imx-test on SoCs where \
+               the real test suite is unavailable, so images can depend on it \
+               unconditionally."
 HOMEPAGE = "https://github.com/nxp-imx/imx-test"
 SECTION = "base"
 LICENSE = "MIT"
+# The license text is not shipped in the source tree, so reference the
+# common-licenses copy; this is intentionally a local (non-remote) file.
+# nooelint: oelint.var.licenseremotefile
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+# Empty placeholder (ALLOW_EMPTY) with no upstream sources.
+SRC_URI = ""
 
 ALLOW_EMPTY:${PN} = "1"
 

--- a/recipes-bsp/imx-test/imx-test_git.bb
+++ b/recipes-bsp/imx-test/imx-test_git.bb
@@ -7,6 +7,9 @@ DESCRIPTION = "Unit tests for the i.MX BSP"
 HOMEPAGE = "https://github.com/nxp-imx/imx-test"
 SECTION = "base"
 LICENSE = "GPL-2.0-or-later"
+# The license text is not shipped in the source tree, so reference the
+# common-licenses copy; this is intentionally a local (non-remote) file.
+# nooelint: oelint.var.licenseremotefile
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-2.0-or-later;md5=fed54355545ffd980b814dab4a3b312c"
 
 DEPENDS = "alsa-lib freetype libdrm"
@@ -85,6 +88,6 @@ do_install() {
 }
 
 FILES:${PN} += "/unit_tests ${ROOT_HOME}/.profile"
-RDEPENDS:${PN} = "bash"
-
 FILES:${PN}-dbg += "/unit_tests/.debug"
+
+RDEPENDS:${PN} = "bash"

--- a/recipes-bsp/libimxdmabuffer/libimxdmabuffer_1.2.0.bb
+++ b/recipes-bsp/libimxdmabuffer/libimxdmabuffer_1.2.0.bb
@@ -1,26 +1,20 @@
+SUMMARY = "Contiguous DMA memory allocation library for i.MX"
 DESCRIPTION = 'Library for allocating and managing physically contiguous memory \
               ("DMA memory" or "DMA buffers") on i.MX devices.'
 HOMEPAGE = "https://github.com/Freescale/libimxdmabuffer"
+SECTION = "base"
 LICENSE = "LGPL-2.1-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=38fa42a5a6425b26d2919b17b1527324"
-SECTION = "base"
 
 PV .= "+git${SRCPV}"
 
 SRCBRANCH ?= "master"
-SRCREV = "d44deb80af881b82f394d44696433e6695022c8c"
 SRC_URI = "git://github.com/Freescale/libimxdmabuffer.git;branch=${SRCBRANCH};protocol=https \
            file://run-ptest \
            "
+SRCREV = "d44deb80af881b82f394d44696433e6695022c8c"
 
 inherit pkgconfig waf use-imx-headers ptest
-
-EXTRA_OECONF = "--imx-linux-headers-path=${STAGING_INCDIR_IMX} \
-                --libdir=${libdir} \
-                ${@bb.utils.contains_any('PACKAGECONFIG', \
-                   [ 'dma-heap-cached', 'dma-heap-uncached' ], \
-                   '', '--with-dma-heap-allocator=no',d)} \
-                ${PACKAGECONFIG_CONFARGS}"
 
 # If imxdpu is in use, the DPU is also used for implementing
 # libg2d. However, that implementation's g2d_alloc() function
@@ -77,6 +71,13 @@ PACKAGECONFIG[dma-heap-cached] = "--with-dma-heap-allocator=yes ${CACHED_DMA_HEA
                                     ,,,,dma-heap-uncached"
 PACKAGECONFIG[dma-heap-uncached] = "--with-dma-heap-allocator=yes ${UNCACHED_DMA_HEAP_CONF}, \
                                     ,,,,dma-heap-cached"
+
+EXTRA_OECONF = "--imx-linux-headers-path=${STAGING_INCDIR_IMX} \
+                --libdir=${libdir} \
+                ${@bb.utils.contains_any('PACKAGECONFIG', \
+                   [ 'dma-heap-cached', 'dma-heap-uncached' ], \
+                   '', '--with-dma-heap-allocator=no',d)} \
+                ${PACKAGECONFIG_CONFARGS}"
 
 # Using do_install_ptest_base instead of do_install_ptest, since
 # the default do_install_ptest_base is hardcoded to expect Makefiles.

--- a/recipes-downgrade/glslang/glslang/0001-generate-glslang-pkg-config.patch
+++ b/recipes-downgrade/glslang/glslang/0001-generate-glslang-pkg-config.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] generate glslang pkg-config
 
 Based on https://src.fedoraproject.org/rpms/glslang/blob/main/f/0001-pkg-config-compatibility.patch
 
-Upstream-Status: Inappropriate [independently developed patch submitted at https://github.com/KhronosGroup/glslang/pull/3371]
+Upstream-Status: Submitted [https://github.com/KhronosGroup/glslang/pull/3371]
 
 Signed-off-by: Jose Quaresma <quaresma.jose@gmail.com>
 ---

--- a/recipes-downgrade/glslang/glslang_1.3.275.0.imx.bb
+++ b/recipes-downgrade/glslang/glslang_1.3.275.0.imx.bb
@@ -3,15 +3,16 @@ DESCRIPTION = "Glslang is the official reference compiler front end for the \
                OpenGL ES and OpenGL shading languages. It implements a strict interpretation \
                of the specifications for these languages. It is open and free for anyone to use, \
                either from a command line or programmatically."
-SECTION = "graphics"
 HOMEPAGE = "https://www.khronos.org/opengles/sdk/tools/Reference-Compiler"
+SECTION = "graphics"
 LICENSE = "BSD-3-Clause & BSD-2-Clause & MIT & Apache-2.0 & GPL-3-with-bison-exception"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=2a2b5acd7bc4844964cfda45fe807dc3"
+DEPENDS = "spirv-tools"
 
-SRCREV = "a91631b260cba3f22858d6c6827511e636c2458a"
 SRC_URI = "git://github.com/KhronosGroup/glslang.git;protocol=https;branch=main \
            file://0001-generate-glslang-pkg-config.patch \
            file://0002-SPIRV-SpvBuilder.h-add-missing-cstdint-include.patch"
+SRCREV = "a91631b260cba3f22858d6c6827511e636c2458a"
 PE = "1"
 # These recipes need to be updated in lockstep with each other:
 # glslang, vulkan-headers, vulkan-loader, vulkan-tools, spirv-headers, spirv-tools
@@ -21,8 +22,6 @@ PE = "1"
 UPSTREAM_CHECK_GITTAGREGEX = "sdk-(?P<pver>\d+(\.\d+)+)"
 
 inherit cmake python3native
-
-DEPENDS = "spirv-tools"
 
 EXTRA_OECMAKE = "\
     -DCMAKE_BUILD_TYPE=Release \

--- a/recipes-downgrade/spir/spirv-tools_1.3.275.0.imx.bb
+++ b/recipes-downgrade/spir/spirv-tools_1.3.275.0.imx.bb
@@ -1,14 +1,14 @@
-SUMMARY = "The SPIR-V Tools project provides an API and commands for \
-            processing SPIR-V modules"
+SUMMARY = "API and command-line tools for processing SPIR-V modules"
 DESCRIPTION = "The project includes an assembler, binary module parser, \
                disassembler, validator, and optimizer for SPIR-V."
 HOMEPAGE = "https://github.com/KhronosGroup/SPIRV-Tools"
 SECTION = "graphics"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
+DEPENDS = "spirv-headers"
 
-SRCREV = "f0cc85efdbbe3a46eae90e0f915dc1509836d0fc"
 SRC_URI = "git://github.com/KhronosGroup/SPIRV-Tools.git;branch=main;protocol=https"
+SRCREV = "f0cc85efdbbe3a46eae90e0f915dc1509836d0fc"
 PE = "1"
 # These recipes need to be updated in lockstep with each other:
 # glslang, vulkan-headers, vulkan-loader, vulkan-tools, spirv-headers, spirv-tools
@@ -18,8 +18,6 @@ PE = "1"
 UPSTREAM_CHECK_GITTAGREGEX = "sdk-(?P<pver>\d+(\.\d+)+)"
 
 inherit cmake
-
-DEPENDS = "spirv-headers"
 
 EXTRA_OECMAKE += "\
     -DSPIRV-Headers_SOURCE_DIR=${STAGING_EXECPREFIXDIR} \
@@ -40,7 +38,7 @@ SOLIBS = ".so"
 FILES_SOLIBSDEV = ""
 
 PACKAGES =+ "${PN}-lesspipe"
-FILES:${PN}-lesspipe = "${base_bindir}/spirv-lesspipe.sh"
+FILES:${PN}-lesspipe += "${base_bindir}/spirv-lesspipe.sh"
 RDEPENDS:${PN}-lesspipe += "${PN} bash"
 
 BBCLASSEXTEND = "native nativesdk"

--- a/recipes-extended/libpkcs11/libpkcs11_git.bb
+++ b/recipes-extended/libpkcs11/libpkcs11_git.bb
@@ -1,14 +1,16 @@
-DESCRIPTION = "PKCS library"
+SUMMARY = "PKCS#11 cryptographic token library"
+DESCRIPTION = "PKCS#11 library implementing cryptographic token operations \
+               backed by the NXP QorIQ secure object (secure-obj) subsystem."
 HOMEPAGE = "https://github.com/nxp-qoriq/libpkcs11"
+SECTION = "libs"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=803852533e29eb1d6d5e55ad3078b625"
+DEPENDS = "openssl secure-obj"
 
 SRC_URI = "git://github.com/nxp-qoriq/libpkcs11;protocol=https;nobranch=1 \
            file://0001-fix-multiple-definition-error.patch \
 "
 SRCREV = "8d85182b7a7cd393ab6dd72930f8d1b69468f741"
-
-DEPENDS = "openssl secure-obj"
 
 WRAP_TARGET_PREFIX ?= "${TARGET_PREFIX}"
 export CROSS_COMPILE_HOST = "${CROSS_COMPILE}"
@@ -25,15 +27,21 @@ do_compile() {
 }
 
 do_install(){
-    mkdir -p ${D}/${libdir}
-    mkdir -p ${D}/${includedir} ${D}/${bindir}
-    cp ${S}/out/export/lib/libpkcs11.so  ${D}/${libdir}
-    cp ${S}/out/export/include/*.h  ${D}/${includedir}
+    install -d ${D}${libdir}
+    install -d ${D}${includedir}
+    install -d ${D}${bindir}
+    install -m 0755 ${S}/out/export/lib/libpkcs11.so ${D}${libdir}
+    install -m 0644 ${S}/out/export/include/*.h ${D}${includedir}
     rm -f ${D}${includedir}/pkcs11.h
-    cp ${S}/out/export/app/*  ${D}/${bindir}
+    install -m 0755 ${S}/out/export/app/* ${D}${bindir}
 }
 
 PARALLEL_MAKE = ""
+
+# The library links against sysroot libraries and ships its .so in the main
+# package, so the ldflags/dev-deps/dev-elf QA checks do not apply cleanly here.
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:${PN} = "ldflags dev-deps"
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:${PN}-dev = "ldflags dev-elf"
 COMPATIBLE_MACHINE = "(qoriq-arm64)"

--- a/recipes-extended/odp/odp.inc
+++ b/recipes-extended/odp/odp.inc
@@ -6,8 +6,6 @@ SECTION = "console/network"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=ca6103dc75397fb6bec596187d6b7829"
 
-FILESEXTRAPATHS:prepend := "${THISDIR}/odp:"
-
 SRC_URI = "\
     git://github.com/nxp-qoriq/odp;protocol=https;nobranch=1 \
     git://github.com/nxp-qoriq/qbman_userspace;protocol=https;nobranch=1;name=qbman;destsuffix=${S}/platform/linux-dpaa2/flib/qbman \

--- a/recipes-extended/odp/odp_git.bb
+++ b/recipes-extended/odp/odp_git.bb
@@ -2,11 +2,10 @@ require odp.inc
 
 inherit autotools-brokensep
 
-PACKAGE_ARCH = "${MACHINE_ARCH}"
-
+# odp.inc does not set DEPENDS, so this is the canonical definition rather than
+# an override after the require.
+# nooelint: oelint.vars.dependsappend
 DEPENDS = "cunit libxml2 openssl"
-
-RDEPENDS:${PN} = "bash libcrypto libssl odp-counters odp-module"
 
 ODP_SOC ?= ""
 ODP_SOC:ls1043ardb = "LS1043"
@@ -16,6 +15,8 @@ ODP_BUILD_TYPE ?= "ls2088"
 ODP_BUILD_TYPE:ls1043ardb = "ls1043"
 ODP_BUILD_TYPE:ls1046ardb = "ls1046"
 ODP_BUILD_TYPE:ls1088ardb = "ls1088"
+
+PACKAGECONFIG[perf] = "--enable-test-perf,,,"
 
 EXTRA_OECONF = "--with-platform=${ODP_PLATFORM} \
                 --enable-test-vald \
@@ -31,7 +32,7 @@ CFLAGS += "-Wno-format-truncation -Wno-maybe-uninitialized -Wno-implicit-fallthr
            -Wno-stringop-truncation \
 "
 
-PACKAGECONFIG[perf] = "--enable-test-perf,,,"
+PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 do_configure:prepend () {
     export SOC=${ODP_SOC}
@@ -60,3 +61,5 @@ do_install:append () {
 FILES:${PN}-staticdev += "${datadir}/opendataplane/*.la"
 FILES:${PN} += "/usr/odp/bin /usr/odp/scripts /usr/odp/debug /usr/odp/test/validation /usr/odp/test/performance /usr/odp/test/miscellaneous /usr/odp/test/api_test"
 FILES:${PN}-dbg += "/usr/odp/bin/.debug /usr/odp/debug/.debug /usr/odp/test/validation/.debug /usr/odp/test/performance/.debug /usr/odp/test/miscellaneous/.debug /usr/odp/test/api_test/.debug"
+
+RDEPENDS:${PN} = "bash libcrypto libssl odp-counters odp-module"

--- a/recipes-extended/ovs-dpdk/ovs-dpdk_3.1.bb
+++ b/recipes-extended/ovs-dpdk/ovs-dpdk_3.1.bb
@@ -1,15 +1,17 @@
-DESCRIPTION = "Open Virtual switch based on DPDK"
+SUMMARY = "Open vSwitch accelerated with DPDK"
+DESCRIPTION = "Open vSwitch (multilayer virtual switch) built on top of DPDK for \
+               fast userspace packet forwarding on NXP QorIQ platforms."
 HOMEPAGE = "https://github.com/nxp-qoriq/ovs-dpdk"
+SECTION = "networking"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=1ce5d23a6429dff345518758f13aaeab"
 
 DEPENDS = "autoconf-native automake-native coreutils-native dpdk python3-six-native"
-RDEPENDS:${PN} = "bash libcrypto libssl python3"
-
-inherit python3native pkgconfig
 
 SRC_URI = "git://github.com/nxp-qoriq/ovs-dpdk;protocol=https;nobranch=1"
 SRCREV = "7b4861e1f77bbea5ff9952717b66362fdecbca4d"
+
+inherit python3native pkgconfig
 
 do_configure() {
     export SYSROOT_DPDK=${PKG_CONFIG_SYSROOT_DIR}
@@ -28,10 +30,18 @@ do_install:append() {
     install -m 0755 ${S}/utilities/ovs-ofctl ${D}${bindir}/ovs-dpdk
 }
 
+# The upstream build hardcodes cross host/CFLAGS paths, so the produced
+# binaries embed build paths that cannot be scrubbed; skip the buildpaths QA
+# check rather than fail packaging.
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:${PN}-dbg += "buildpaths"
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:${PN} += "buildpaths"
 
 ALLOW_EMPTY:${PN} = "1"
 INHIBIT_PACKAGE_STRIP = "1"
 PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+RDEPENDS:${PN} = "bash libcrypto libssl python3"
+
 COMPATIBLE_MACHINE = "(qoriq-arm64)"

--- a/recipes-multimedia/alsa/imx-alsa-plugins_git.bb
+++ b/recipes-multimedia/alsa/imx-alsa-plugins_git.bb
@@ -2,21 +2,17 @@
 # Copyright 2017-2026 NXP
 # Released under the MIT license (see COPYING.MIT for the terms)
 
-DESCRIPTION = "Freescale alsa-lib plugins"
+SUMMARY = "ALSA-lib plugins for i.MX SoCs"
+DESCRIPTION = "Freescale/NXP ALSA-lib plugins for i.MX SoCs, including the \
+               software PDM (pulse-density modulation) capture plugin."
 HOMEPAGE = "https://github.com/nxp-imx/imx-alsa-plugins"
-LICENSE = "GPL-2.0-only"
 SECTION = "multimedia"
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=94d55d512a9ba36caa9b7df079bae19f"
 DEPENDS = "alsa-lib"
 
-# For backwards compatibility
+# Provide the old fsl-alsa-plugins name for backwards compatibility
 PROVIDES += "fsl-alsa-plugins"
-RREPLACES:${PN} = "fsl-alsa-plugins"
-RPROVIDES:${PN} = "fsl-alsa-plugins"
-RCONFLICTS:${PN} = "fsl-alsa-plugins"
-
-LIC_FILES_CHKSUM = "file://LICENSE;md5=94d55d512a9ba36caa9b7df079bae19f"
-
-inherit autotools pkgconfig use-imx-headers
 
 PV = "1.0.26+${SRCPV}"
 
@@ -24,6 +20,8 @@ SRC_URI = "${IMXALSA_SRC};branch=${SRCBRANCH}"
 IMXALSA_SRC ?= "git://github.com/nxp-imx/imx-alsa-plugins.git;protocol=https"
 SRCBRANCH = "MM_04.10.03_2512_L6.18.2"
 SRCREV = "18eb79b6cf13fb988de7d4eef5b22eb60f8e2533"
+
+inherit autotools pkgconfig use-imx-headers
 
 CFLAGS:append = " -I${STAGING_INCDIR_IMX}"
 
@@ -33,10 +31,18 @@ PACKAGECONFIG_SWPDM:mx8-nxp-bsp = "swpdm"
 
 PACKAGECONFIG[swpdm] = "--enable-swpdm,--disable-swpdm,imx-sw-pdm"
 
+# ALSA plugins install versioned-looking .so modules into ${libdir}/alsa-lib;
+# these are runtime plugin objects (not dev symlinks), so dev-so must be skipped.
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:${PN} = "dev-so"
 
 FILES:${PN} += "${libdir}/alsa-lib/libasound_*.so"
 FILES:${PN}-dbg += "${libdir}/alsa-lib/.debug"
 FILES:${PN}-dev += "${libdir}/alsa-lib/*.la"
+
+# Runtime backwards compatibility with the old fsl-alsa-plugins name
+RREPLACES:${PN} = "fsl-alsa-plugins"
+RPROVIDES:${PN} = "fsl-alsa-plugins"
+RCONFLICTS:${PN} = "fsl-alsa-plugins"
 
 COMPATIBLE_MACHINE = "(imx-nxp-bsp)"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-vaapi_1.26.6.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-vaapi_1.26.6.bb
@@ -1,20 +1,21 @@
 SUMMARY = "VA-API support to GStreamer"
-HOMEPAGE = "https://gstreamer.freedesktop.org/"
 DESCRIPTION = "gstreamer-vaapi consists of a collection of VA-API \
                based plugins for GStreamer and helper libraries: `vaapidecode', \
                `vaapiconvert', and `vaapisink'."
+HOMEPAGE = "https://gstreamer.freedesktop.org/"
+SECTION = "multimedia"
 
 REALPN = "gstreamer-vaapi"
 
 LICENSE = "LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://COPYING.LIB;md5=4fbd65380cdd255951079008b364516c"
+DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-bad gstreamer1.0-plugins-base libva"
 
 SRC_URI = "https://gstreamer.freedesktop.org/src/${REALPN}/${REALPN}-${PV}.tar.xz"
 
 SRC_URI[sha256sum] = "d87c57244cecbd17bb030b698dcb67a66225de639f7c5b837391c4a8e5477667"
 
 S = "${UNPACKDIR}/${REALPN}-${PV}"
-DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-bad gstreamer1.0-plugins-base libva"
 
 inherit meson pkgconfig features_check upstream-version-is-even
 
@@ -25,8 +26,6 @@ EXTRA_OEMESON += "\
     -Dexamples=disabled \
     -Dtests=enabled \
 "
-
-PACKAGES =+ "${PN}-tests"
 
 # OpenGL packageconfig factored out to make it easy for distros
 # and BSP layers to pick either glx, egl, or no GL. By default,
@@ -47,7 +46,9 @@ PACKAGECONFIG[glx] = "-Dglx=enabled,-Dglx=disabled,virtual/libgl"
 PACKAGECONFIG[wayland] = "-Dwayland=enabled,-Dwayland=disabled,wayland-native wayland wayland-protocols"
 PACKAGECONFIG[x11] = "-Dx11=enabled,-Dx11=disabled,virtual/libx11 libxrandr libxrender"
 
+PACKAGES =+ "${PN}-tests"
+
 FILES:${PN} += "${libdir}/gstreamer-*/*.so"
 FILES:${PN}-dbg += "${libdir}/gstreamer-*/.debug"
 FILES:${PN}-dev += "${libdir}/gstreamer-*/*.a"
-FILES:${PN}-tests = "${bindir}/*"
+FILES:${PN}-tests += "${bindir}/*"

--- a/recipes-multimedia/gstreamer/imx-gst1.0-plugin_git.bb
+++ b/recipes-multimedia/gstreamer/imx-gst1.0-plugin_git.bb
@@ -2,19 +2,22 @@
 # Copyright 2017-2025 NXP
 # Copyright (C) 2012-2015 O.S. Systems Software LTDA.
 # Released under the MIT license (see COPYING.MIT for the terms)
-DESCRIPTION = "Gstreamer freescale plugins"
+SUMMARY = "GStreamer 1.0 plugins for i.MX"
+DESCRIPTION = "Freescale/NXP GStreamer 1.0 plugins providing hardware-accelerated \
+               multimedia (audio/video codec, capture and sink) elements for \
+               i.MX SoCs."
 HOMEPAGE = "https://github.com/nxp-imx/imx-gst1.0-plugin"
 SECTION = "multimedia"
 LICENSE = "GPL-2.0-only & LGPL-2.0-only & LGPL-2.1-only"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=fbc093901857fcd118f065f900982c24"
 
 DEPENDS = "\
+    ${DEPENDS_IMXGPU} \
     gstreamer1.0 \
-    gstreamer1.0-plugins-base \
     gstreamer1.0-plugins-bad \
+    gstreamer1.0-plugins-base \
     imx-codec \
     imx-parser \
-    ${DEPENDS_IMXGPU} \
     libinput \
 "
 DEPENDS:append:mx6-nxp-bsp = " imx-lib"
@@ -30,11 +33,6 @@ DEPENDS_IMX_OPENCL_CONVERTER = "imx-opencl-converter"
 DEPENDS_IMX_OPENCL_CONVERTER:mx6-nxp-bsp = ""
 DEPENDS_IMX_OPENCL_CONVERTER:mx7-nxp-bsp = ""
 DEPENDS_IMX_OPENCL_CONVERTER:mx8mm-nxp-bsp = ""
-
-# For backwards compatibility
-RREPLACES:${PN} = "gst1.0-fsl-plugin"
-RPROVIDES:${PN} = "gst1.0-fsl-plugin"
-RCONFLICTS:${PN} = "gst1.0-fsl-plugin"
 
 PV = "4.10.3+git${SRCPV}"
 
@@ -60,17 +58,6 @@ EXTRA_OEMESON = "-Dplatform=${PLATFORM} \
                  -Dc_args="${CFLAGS} -I${STAGING_INCDIR_IMX}" \
 "
 
-PACKAGES =+ "${PN}-tools ${PN}-libgstfsl"
-
-# Add codec list that the beep plugin run-time depended
-BEEP_RDEPENDS = "imx-codec-aac imx-codec-mp3 imx-codec-oggvorbis"
-RDEPENDS:${PN} += "imx-parser ${BEEP_RDEPENDS} gstreamer1.0-plugins-good-id3demux "
-RDEPENDS:${PN}:append:mx8qm-nxp-bsp = " imx-dsp"
-RDEPENDS:${PN}:append:mx8qxp-nxp-bsp = " imx-dsp"
-RDEPENDS:${PN}:append:mx8dx-nxp-bsp = " imx-dsp"
-RDEPENDS:${PN}:append:mx8mp-nxp-bsp = " imx-dsp"
-RDEPENDS:${PN}:append:mx8ulp-nxp-bsp = " imx-dsp"
-
 PACKAGECONFIG ?= ""
 
 # FIXME: Add all features
@@ -82,13 +69,34 @@ MSDEPENDS = "imx-msparser imx-mscodec"
 PACKAGECONFIG[wma10dec] = ",,${MSDEPENDS},${MSDEPENDS}"
 PACKAGECONFIG[wma8enc] = ",,${MSDEPENDS},${MSDEPENDS}"
 
-FILES:${PN} = "${libdir}/gstreamer-1.0/*.so ${datadir}"
+PACKAGES =+ "${PN}-tools ${PN}-libgstfsl"
 
+# Deliberately replace the default main-package file list so the (unversioned)
+# GStreamer plugin .so files land in ${PN} instead of ${PN}-dev.
+# nooelint: oelint.var.filesoverride
+FILES:${PN} = "${libdir}/gstreamer-1.0/*.so ${datadir}"
 FILES:${PN}-dbg += "${libdir}/gstreamer-1.0/.debug"
 FILES:${PN}-dev += "${libdir}/gstreamer-1.0/*.la ${libdir}/pkgconfig/*.pc"
 FILES:${PN}-tools += "${bindir}/* ${libdir}/librecorder_engine-1.0${SOLIBS}"
-FILES:${PN}-libgstfsl = "${libdir}/libgstfsl-1.0${SOLIBS}"
+FILES:${PN}-libgstfsl += "${libdir}/libgstfsl-1.0${SOLIBS}"
 
+# Add codec list that the beep plugin run-time depended
+BEEP_RDEPENDS = "imx-codec-aac imx-codec-mp3 imx-codec-oggvorbis"
+RDEPENDS:${PN} += "${BEEP_RDEPENDS} gstreamer1.0-plugins-good-id3demux imx-parser"
+RDEPENDS:${PN}:append:mx8qm-nxp-bsp = " imx-dsp"
+RDEPENDS:${PN}:append:mx8qxp-nxp-bsp = " imx-dsp"
+RDEPENDS:${PN}:append:mx8dx-nxp-bsp = " imx-dsp"
+RDEPENDS:${PN}:append:mx8mp-nxp-bsp = " imx-dsp"
+RDEPENDS:${PN}:append:mx8ulp-nxp-bsp = " imx-dsp"
+
+# The plugins pull in codec/parser build dependencies conditionally through
+# PACKAGECONFIG, so the static build-deps QA check cannot see them all.
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:${PN} = "build-deps"
+
+# Runtime backwards compatibility with the old gst1.0-fsl-plugin name
+RREPLACES:${PN} = "gst1.0-fsl-plugin"
+RPROVIDES:${PN} = "gst1.0-fsl-plugin"
+RCONFLICTS:${PN} = "gst1.0-fsl-plugin"
 
 COMPATIBLE_MACHINE = "(imx-nxp-bsp)"

--- a/recipes-multimedia/imx-codec/imx-codec_4.10.0.bb
+++ b/recipes-multimedia/imx-codec/imx-codec_4.10.0.bb
@@ -60,6 +60,7 @@ python __set_insane_skip() {
         else:
             d.setVar("INSANE_SKIP:%s" % p, "ldflags textrel")
 }
+__set_insane_skip[doc] = "Set DEBIAN_NOAUTONAME and INSANE_SKIP for the prebuilt codec plugin packages."
 
 do_package_qa[prefuncs] += "__set_insane_skip"
 
@@ -82,6 +83,7 @@ python __split_libfslcodec_plugins() {
             d.setVar('RPROVIDES:%s' % pkg, ' libfslcodec')
             d.setVar('RCONFLICTS:%s' % pkg, ' libfslcodec')
 }
+__split_libfslcodec_plugins[doc] = "Split the codec plugin .so files into per-codec packages."
 
 python __set_metapkg_rdepends() {
     # Allow addition of all codecs in a image; useful specially for
@@ -91,8 +93,11 @@ python __set_metapkg_rdepends() {
                         codec_pkgs)
     d.appendVar('RDEPENDS:imx-codec-meta', ' ' + ' '.join(codec_pkgs))
 }
+__set_metapkg_rdepends[doc] = "Make the -meta package RDEPEND on all split codec packages."
 
 PACKAGESPLITFUNCS =+ "__split_libfslcodec_plugins __set_metapkg_rdepends"
+
+PACKAGE_ARCH = "${MACHINE_SOCARCH}"
 
 # We need to ensure we don't have '-src' package overrided
 PACKAGE_DEBUG_SPLIT_STYLE = 'debug-without-src'
@@ -106,7 +111,9 @@ PACKAGES += "${PN}-meta ${PN}-test-bin ${PN}-test-source"
 ALLOW_EMPTY:${PN} = "1"
 ALLOW_EMPTY:${PN}-meta = "1"
 
-# Ensure we get warnings if we miss something
+# Reset PN's default FILES to empty so any unpackaged file is flagged as a
+# warning instead of silently landing in the main package.
+# nooelint: oelint.var.filesoverride
 FILES:${PN} = ""
 
 FILES:${PN}-dev += "${libdir}/imx-mm/*/*${SOLIBSDEV} \
@@ -122,5 +129,4 @@ FILES:${PN}-oggvorbis += "${libdir}/imx-mm/audio-codec/wrap/lib_vorbisd_wrap_arm
 FILES:${PN}-nb += "${libdir}/imx-mm/audio-codec/wrap/lib_nbamrd_wrap_arm*_elinux.so.*"
 FILES:${PN}-wb += "${libdir}/imx-mm/audio-codec/wrap/lib_wbamrd_wrap_arm*_elinux.so.*"
 
-PACKAGE_ARCH = "${MACHINE_SOCARCH}"
 COMPATIBLE_MACHINE = "(imx-nxp-bsp)"

--- a/recipes-multimedia/tinycompress/tinycompress_1.2.5.bb
+++ b/recipes-multimedia/tinycompress/tinycompress_1.2.5.bb
@@ -1,5 +1,9 @@
-DESCRIPTION = "A library to handle compressed formats like MP3 etc."
+SUMMARY = "ALSA compress-offload API library"
+DESCRIPTION = "A userspace library implementing the ALSA compress-offload API, \
+               used to stream hardware-compressed audio formats such as MP3 to \
+               the DSP without decoding them on the CPU."
 HOMEPAGE = "https://github.com/alsa-project/tinycompress"
+SECTION = "multimedia"
 LICENSE = "LGPL-2.1-only | BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://COPYING;md5=cf9105c1a2d4405cbe04bbe3367373a0"
 DEPENDS = "alsa-lib"
@@ -13,5 +17,3 @@ SRC_URI = "git://github.com/alsa-project/tinycompress.git;protocol=https;branch=
 SRCREV = "f3ba6e5c2126f2fb07e3d890f990d50c3e204e67"
 
 EXTRA_OECONF:append = " --enable-pcm"
-
-inherit autotools pkgconfig


### PR DESCRIPTION
## Summary

  Continues the oelint-adv cleanup series. Per-recipe metadata and
  variable-ordering fixes, one commit per recipe, each re-scanned clean.

  - **imx-alsa-plugins, libimxdmabuffer, tinycompress, uuu, ovs-dpdk,
    libpkcs11, imx-gst1.0-plugin** — add SUMMARY/SECTION, apply the
    canonical variable order (LICENSE/DEPENDS/SRC_URI/SRCREV, PV before the
    runtime vars), and expand DESCRIPTION where it was missing or too brief.
  - **imx-secure-enclave, gstreamer1.0-vaapi, imx-test, glslang,
    spirv-tools** — reorder metadata/package variables and switch
    fresh-subpackage `FILES` assignments to appends.
  - **imx-gst1.0-plugin, libpkcs11, ovs-dpdk, uuu, odp** — sort
    DEPENDS/RDEPENDS alphabetically and move DEPENDS ahead of the
    inherit/require where flagged.
  - **imx-codec** — add `task[doc]` docstrings to the custom package-split
    python functions and order PACKAGE_ARCH.
  - **glslang** — correct the pkg-config patch Upstream-Status from
    free-form `Inappropriate [...]` to `Submitted [PR 3371]`.
  - **odp** — drop a redundant FILESEXTRAPATHS (the dir is already the
    default `${FILE_DIRNAME}/${BPN}`); the patch is still found.
  - **libpkcs11** — replace `mkdir`/`cp` in do_install with `install`
    (same paths, files and modes).

  Deliberate cases keep an inline `# nooelint:` with rationale:
  prebuilt-firmware / hardcoded-path INSANE_SKIP (imx-alsa-plugins,
  ovs-dpdk, imx-gst1.0-plugin), base `DEPENDS =` in an .inc that is the
  canonical definition (imx-secure-enclave, odp), common-licenses
  LIC_FILES_CHKSUM on packages that ship no license text (imx-test), and
  the main `FILES:${PN} =` in imx-gst1.0-plugin (it deliberately replaces
  the default so the unversioned plugin .so land in `${PN}`, not
  `${PN}-dev`).
## Impact

  Metadata/ordering only, except libpkcs11's do_install, which installs
  the same files by a lint-approved method. No functional change to any
  package.

  ## Test

  `oelint-adv` reports no baseline findings for each touched recipe.