### PR TITLE
opencv: fix 4.13.0.imx build regressions

### DIFF
--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -618,8 +618,8 @@ PREFERRED_VERSION_optee-test:imx-nxp-bsp   ??= "4.8.0.imx"
 PREFERRED_VERSION_optee-os-tadevkit:imx-nxp-bsp   ??= "4.8.0.imx"
 
 # Use i.MX opencv Version
-PREFERRED_VERSION_opencv:mx8-nxp-bsp ??= "4.6.0.imx"
-PREFERRED_VERSION_opencv:mx9-nxp-bsp ??= "4.6.0.imx"
+PREFERRED_VERSION_opencv:mx8-nxp-bsp ??= "4.13.0.imx"
+PREFERRED_VERSION_opencv:mx9-nxp-bsp ??= "4.13.0.imx"
 
 # Handle default kernel
 IMX_DEFAULT_KERNEL:imx-mainline-bsp ??= "linux-fslc"

--- a/dynamic-layers/openembedded-layer/recipes-support/opencv/opencv_4.13.0.imx.bb
+++ b/dynamic-layers/openembedded-layer/recipes-support/opencv/opencv_4.13.0.imx.bb
@@ -84,18 +84,16 @@ EXTRA_OECMAKE = "-DOPENCV_EXTRA_MODULES_PATH=${S}/contrib/modules \
                  -DOPENCV_GENERATE_PKGCONFIG=ON \
                  -DOPENCV_DOWNLOAD_PATH=${OPENCV_DLDIR} \
                  -DOPENCV_ALLOW_DOWNLOADS=OFF \
-    ${@bb.utils.contains("TARGET_CC_ARCH", "-msse3", "-DENABLE_SSE=1 -DENABLE_SSE2=1 -DENABLE_SSE3=1 -DENABLE_SSSE3=1", "", d)} \
-    ${@bb.utils.contains("TARGET_CC_ARCH", "-msse4.1", "-DENABLE_SSE=1 -DENABLE_SSE2=1 -DENABLE_SSE3=1 -DENABLE_SSSE3=1 -DENABLE_SSE41=1", "", d)} \
-    ${@bb.utils.contains("TARGET_CC_ARCH", "-msse4.2", "-DENABLE_SSE=1 -DENABLE_SSE2=1 -DENABLE_SSE3=1 -DENABLE_SSSE3=1 -DENABLE_SSE41=1 -DENABLE_SSE42=1", "", d)} \
+    ${@bb.utils.contains("TARGET_CC_ARCH", "-msse3", "-DCPU_DISPATCH=SSE,SSE2,SSE3,SSSE3", "", d)} \
+    ${@bb.utils.contains("TARGET_CC_ARCH", "-msse4.1", "-DCPU_DISPATCH=SSE,SSE2,SSE3,SSSE3,SSE41", "", d)} \
+    ${@bb.utils.contains("TARGET_CC_ARCH", "-msse4.2", "-DCPU_DISPATCH=SSE,SSE2,SSE3,SSSE3,SSE41,SSE42", "", d)} \
 "
 
 LDFLAGS:append:mips = " -Wl,--no-as-needed -latomic -Wl,--as-needed"
 LDFLAGS:append:riscv32 = " -Wl,--no-as-needed -latomic -Wl,--as-needed"
 
 EXTRA_OECMAKE:append:x86 = " -DX86=ON"
-# disable sse4.1 and sse4.2 to fix 32bit build failure
-# https://github.com/opencv/opencv/issues/21597
-EXTRA_OECMAKE:remove:x86 = "-DENABLE_SSE41=1 -DENABLE_SSE42=1"
+EXTRA_OECMAKE:append:aarch64 = " -DKLEIDICV_SOURCE_PATH=${S}/3rdparty/kleidicv"
 
 PACKAGECONFIG ??= "python3 eigen jpeg png tiff v4l libv4l samples tbb \
     ${@bb.utils.contains_any('DISTRO_FEATURES', '${GTK3DISTROFEATURES}', 'gtk', '', d)}"


### PR DESCRIPTION
## Summary

  Fix the OpenCV 4.13.0.imx build for i.MX targets by:

  - Pointing CMake to the Kleidicv source already fetched by the recipe on
    AArch64.
  - Guarding the optional `/usr/bin/cpp` rename during `do_install`.
  - Selecting OpenCV 4.13.0.imx for the mx8 and mx9 NXP BSP overrides.

  ## Problem

  On AArch64, CMake attempted to download Kleidicv during `do_configure`
  despite the source already being fetched by the recipe. Since network
  downloads are disabled during configuration, this caused the task to fail.

  After correcting that, `do_install` failed because it unconditionally tried
  to rename `${D}${bindir}/cpp`, which is not produced by OpenCV 4.13.0 in
  the reported configuration.

  The mx8 and mx9 preferred-version overrides also continued to request
  OpenCV 4.6.0.imx, producing version-selection warnings.

  ## Solution

  Pass `KLEIDICV_SOURCE_PATH` to CMake for AArch64 builds so it uses the
  pre-fetched source tree. Only rename the `cpp` path when it exists, and
  update the BSP preferences to 4.13.0.imx.
