### PR TITLE
oelint: Kernel, bootloader, OP-TEE and GStreamer metadata cleanups 

### DIFF
--- a/recipes-bsp/firmware-imx/imx-boot-firmware-files_8.31.bb
+++ b/recipes-bsp/firmware-imx/imx-boot-firmware-files_8.31.bb
@@ -19,6 +19,7 @@ deploy_for_mx8() {
     install -m 0644 ${S}/firmware/hdmi/cadence/hdmirxfw.bin ${DEPLOYDIR}
     install -m 0644 ${S}/firmware/hdmi/cadence/dpfw.bin ${DEPLOYDIR}
 }
+deploy_for_mx8[doc] = "Deploy the Cadence HDMI firmware blobs for i.MX8"
 
 deploy_for_mx8m() {
     # Synopsys DDR
@@ -30,6 +31,7 @@ deploy_for_mx8m() {
     install -m 0644 ${S}/firmware/hdmi/cadence/signed_dp_imx8m.bin ${DEPLOYDIR}
     install -m 0644 ${S}/firmware/hdmi/cadence/signed_hdmi_imx8m.bin ${DEPLOYDIR}
 }
+deploy_for_mx8m[doc] = "Deploy the Synopsys DDR and Cadence DP/HDMI firmware blobs for i.MX8M"
 
 deploy_for_mx9() {
     # Synopsys DDR
@@ -37,7 +39,10 @@ deploy_for_mx9() {
         install -m 0644 ${S}/firmware/ddr/synopsys/${ddr_firmware} ${DEPLOYDIR}
     done
 }
+deploy_for_mx9[doc] = "Deploy the Synopsys DDR firmware blobs for i.MX9"
 
+# injects the deploy_for_* helpers as do_deploy vardeps
+# nooelint: oelint.task.noanonpython
 python () {
     # Manually add the required functions as dependencies otherwise they won't be included in the
     # final run script.

--- a/recipes-bsp/u-boot/u-boot-fslc-common_2025.01.inc
+++ b/recipes-bsp/u-boot/u-boot-fslc-common_2025.01.inc
@@ -3,18 +3,16 @@
 
 inherit fsl-u-boot-localversion
 
-LICENSE = "GPL-2.0-or-later"
 HOMEPAGE = "https://github.com/Freescale/u-boot-fslc"
+LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://Licenses/README;md5=2ca5f2c35c8cc335f0a19756634782f1"
 
 DEPENDS += "flex-native bison-native"
 
+PV = "2025.01+fslc+git${SRCPV}"
 SRC_URI = "git://github.com/Freescale/u-boot-fslc.git;branch=${SRCBRANCH};protocol=https"
-
 SRCREV = "aa4bc52d08c342df83e3c576e2c108d7c8816e0e"
 SRCBRANCH = "2025.01+fslc"
-
-PV = "2025.01+fslc+git${SRCPV}"
 CVE_PRODUCT = "denx:u-boot"
 
 B = "${WORKDIR}/build"

--- a/recipes-bsp/u-boot/u-boot-fslc_2025.01.bb
+++ b/recipes-bsp/u-boot/u-boot-fslc_2025.01.bb
@@ -1,16 +1,16 @@
 require recipes-bsp/u-boot/u-boot.inc
 require u-boot-fslc-common_${PV}.inc
 
+SUMMARY = "U-Boot bootloader for the FSL Community BSP"
 DESCRIPTION = "U-Boot based on mainline U-Boot used by FSL Community BSP in \
                order to provide support for some backported features and fixes, or because it \
                was submitted for revision and it takes some time to become part of a stable \
                version, or because it is not applicable for upstreaming."
+SECTION = "bootloaders"
 
-DEPENDS += "bc-native dtc-native python3-setuptools-native gnutls-native"
+DEPENDS += "bc-native dtc-native gnutls-native python3-setuptools-native"
 
 PROVIDES += "u-boot u-boot-mfgtool"
-
-B = "${WORKDIR}/build"
 
 # FIXME: Allow linking of 'tools' binaries with native libraries
 #        used for generating the boot logo and other tools used
@@ -19,7 +19,7 @@ EXTRA_OEMAKE += 'HOSTCC="${BUILD_CC} ${BUILD_CPPFLAGS}" \
                 HOSTLDFLAGS="${BUILD_LDFLAGS}" \
                 HOSTSTRIP=true'
 
-inherit ${@oe.utils.ifelse(d.getVar('UBOOT_PROVIDES_BOOT_CONTAINER') == '1', 'imx-boot-container', '')}
+inherit_defer ${@oe.utils.ifelse(d.getVar('UBOOT_PROVIDES_BOOT_CONTAINER') == '1', 'imx-boot-container', '')}
 inherit uuu_bootloader_tag
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"

--- a/recipes-bsp/u-boot/u-boot-qoriq_2025.04.bb
+++ b/recipes-bsp/u-boot/u-boot-qoriq_2025.04.bb
@@ -1,11 +1,9 @@
 require recipes-bsp/u-boot/u-boot.inc
 
+SUMMARY = "Universal Boot Loader for QorIQ based boards"
 DESCRIPTION = "U-Boot provided by Freescale with focus on QorIQ boards"
 HOMEPAGE = "https://github.com/nxp-qoriq/u-boot"
-PROVIDES += "u-boot"
-
-inherit fsl-u-boot-localversion
-
+SECTION = "bootloaders"
 LICENSE = "BSD-2-Clause AND BSD-3-Clause AND GPL-2.0-only AND LGPL-2.0-only AND LGPL-2.1-only"
 LIC_FILES_CHKSUM = "\
     file://Licenses/gpl-2.0.txt;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
@@ -15,7 +13,24 @@ LIC_FILES_CHKSUM = "\
     file://Licenses/lgpl-2.1.txt;md5=4fbd65380cdd255951079008b364516c \
 "
 
+INHIBIT_DEFAULT_DEPS = "1"
+# full explicit set under INHIBIT_DEFAULT_DEPS
+# nooelint: oelint.vars.dependsappend
+DEPENDS = "bc-native bison-native gnutls-native libgcc python3-native swig-native virtual/cross-cc"
+DEPENDS:append:qoriq-arm64 = " dtc-native"
+DEPENDS:append:qoriq-arm = " dtc-native"
+DEPENDS:append:qoriq-ppc = " boot-format-native"
+
+PROVIDES += "u-boot"
+
+inherit fsl-u-boot-localversion
+
+# no space: version-string concatenation
+# nooelint: oelint.vars.inconspaces
 PV:append = "+${SRCPV}"
+# no space: version-string concatenation
+# nooelint: oelint.vars.inconspaces
+PV:append = "+fslgit"
 
 UBOOT_BRANCH ?= "lf_v2025.04"
 UBOOT_SRC ?= "git://github.com/nxp-qoriq/u-boot.git;protocol=https"
@@ -23,15 +38,10 @@ SRC_URI = "${UBOOT_SRC};branch=${UBOOT_BRANCH}"
 SRCREV = "4ddbad60eff308a5b356fb9ab8734ac382ddd692"
 
 B = "${UNPACKDIR}/build"
-PV:append = "+fslgit"
 LOCALVERSION = "+fsl"
 
-INHIBIT_DEFAULT_DEPS = "1"
-DEPENDS = "bc-native bison-native gnutls-native libgcc python3-native swig-native virtual/cross-cc"
-DEPENDS:append:qoriq-arm64 = " dtc-native"
-DEPENDS:append:qoriq-arm = " dtc-native"
-DEPENDS:append:qoriq-ppc = " boot-format-native"
-
+# multilib toolchain setup + SkipRecipe guard
+# nooelint: oelint.task.noanonpython
 python () {
     if d.getVar("TCMODE") == "external-fsl":
         return

--- a/recipes-devtools/uuu/uuu-bin_1.5.233.bb
+++ b/recipes-devtools/uuu/uuu-bin_1.5.233.bb
@@ -2,10 +2,13 @@
 # Released under the MIT License (see COPYING.MIT for the terms)
 
 SUMMARY = "Universal Update Utility - Binaries"
-DESCRIPTION = "Image deploy tool for i.MX chips"
+DESCRIPTION = "Prebuilt Universal Update Utility (uuu) binaries for Linux, macOS and Windows, used to deploy images to i.MX chips as part of the manufacturing-tool bundle."
 HOMEPAGE = "https://github.com/nxp-imx/mfgtools"
+SECTION = "console/utils"
 
 LICENSE = "BSD-3-Clause AND LGPL-2.1-or-later"
+# prebuilt binaries ship no source tree; use common-licenses
+# nooelint: oelint.var.licenseremotefile
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/BSD-3-Clause;md5=550794465ba0ec5312d6919e203a55f9 \
                     file://${COMMON_LICENSE_DIR}/LGPL-2.1-or-later;md5=2a4f4fd2128ea2f65047ee63fbca9f68"
 
@@ -31,6 +34,10 @@ do_install() {
 }
 
 # HACK! We are not aiming to run those binaries during the build but copy then for MFGTOOL bundle.
+# prebuilt cross-platform binaries are only bundled, never run on target
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:${PN} += "arch file-rdeps"
+# package ships only the prebuilt uuu binaries under ${libdir}/uuu
+# nooelint: oelint.var.filesoverride
 FILES:${PN} = "${libdir}/uuu"
 SYSROOT_DIRS = "${libdir}/uuu"

--- a/recipes-graphics/imx-gpu-sdk/imx-gpu-sdk_6.1.1.bb
+++ b/recipes-graphics/imx-gpu-sdk/imx-gpu-sdk_6.1.1.bb
@@ -5,10 +5,9 @@ SECTION = "graphics"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://License.md;md5=9d58a2573275ce8c35d79576835dbeb8"
 
-DEPENDS_BACKEND = \
-    "${@bb.utils.contains('DISTRO_FEATURES', 'wayland', ' libxdg-shell wayland', \
-        bb.utils.contains('DISTRO_FEATURES',     'x11',               ' xrandr', \
-                                                                             '', d), d)}"
+DEPENDS_BACKEND = "${@bb.utils.contains('DISTRO_FEATURES', 'wayland', ' libxdg-shell wayland', \
+                      bb.utils.contains('DISTRO_FEATURES', 'x11', ' xrandr', \
+                                        '', d), d)}"
 DEPENDS_MX8 = ""
 DEPENDS_MX8:mx8-nxp-bsp = "\
     glslang-native \
@@ -22,6 +21,8 @@ DEPENDS_MX8:mx8-nxp-bsp = "\
 DEPENDS_MX8:mx8mm-nxp-bsp = "\
     opencv \
 "
+# trailing ${DEPENDS_BACKEND}/${DEPENDS_MX8} expansions are unsortable
+# nooelint: oelint.vars.dependsordered
 DEPENDS = "\
     assimp \
     cmake-native \
@@ -46,15 +47,22 @@ DEPENDS:append:imxgpu3d = " virtual/libgles2"
 
 require imx-gpu-sdk-src.inc
 
-WINDOW_SYSTEM = \
-    "${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'Wayland_XDG', \
-        bb.utils.contains('DISTRO_FEATURES',     'x11',         'X11', \
-                                                                 'FB', d), d)}"
+WINDOW_SYSTEM = "${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'Wayland_XDG', \
+                    bb.utils.contains('DISTRO_FEATURES', 'x11', 'X11', \
+                                      'FB', d), d)}"
 
 FEATURES = "ConsoleHost,EarlyAccess,EGL,GoogleUnitTest,Lib_NlohmannJson,OpenVG,Test_RequireUserInputToExit,WindowHost"
+# FEATURES is a comma-separated list; the leading comma is the separator, no space
+# nooelint: oelint.vars.inconspaces
 FEATURES:append:imxgpu = ",HW_GPU_VIVANTE"
+# FEATURES is a comma-separated list; the leading comma is the separator, no space
+# nooelint: oelint.vars.inconspaces
 FEATURES:append:imxgpu2d = ",G2D"
+# FEATURES is a comma-separated list; the leading comma is the separator, no space
+# nooelint: oelint.vars.inconspaces
 FEATURES:append:imxgpu3d = ",OpenGLES2"
+# FEATURES_SOC expands to a leading-comma token; no space
+# nooelint: oelint.vars.inconspaces
 FEATURES:append = "${FEATURES_SOC}"
 
 FEATURES_SOC = ""
@@ -104,7 +112,9 @@ do_install () {
 }
 
 FILES:${PN} += "/opt/${PN}"
-FILES:${PN}-dbg += "/opt/${PN}/*/*/.debug /usr/src/debug"
+FILES:${PN}-dbg += "/opt/${PN}/*/*/.debug"
+# prebuilt/relocated SDK sample binaries under /opt are already stripped and carry rpaths
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:${PN} += "already-stripped rpaths"
 
 # Unfortunately recipes with an empty main package, like header-only libraries,
@@ -132,6 +142,8 @@ RDEPENDS_EMPTY_MAIN_PACKAGE_MX8:mx8mm-nxp-bsp = ""
 RDEPENDS_VULKAN_LOADER = ""
 RDEPENDS_VULKAN_LOADER:mx8-nxp-bsp = "vulkan-loader vulkan-validation-layers"
 RDEPENDS_VULKAN_LOADER:mx8mm-nxp-bsp = ""
+# entries are ${...} expansions, unsortable
+# nooelint: oelint.vars.dependsordered
 RDEPENDS:${PN} += "\
     ${RDEPENDS_EMPTY_MAIN_PACKAGE} \
     ${RDEPENDS_EMPTY_MAIN_PACKAGE_MX8} \

--- a/recipes-kernel/linux/linux-fslc-lts_6.1.bb
+++ b/recipes-kernel/linux/linux-fslc-lts_6.1.bb
@@ -10,11 +10,14 @@ DESCRIPTION = "Linux kernel based on LTS kernel used by FSL Community BSP in ord
                and will not become part of a LTS version, or because it is not applicable for \
                upstreaming in any form."
 HOMEPAGE = "https://github.com/Freescale/linux-fslc"
+SECTION = "kernel"
 
 require linux-imx.inc
 
 KERNEL_DEVICETREE_32BIT_COMPATIBILITY_UPDATE = "1"
 
+# deliberately points at the linux-fslc fork instead of the linux-imx.inc nxp-imx base
+# nooelint: oelint.var.override
 SRC_URI = "git://github.com/Freescale/linux-fslc.git;branch=${KBRANCH};protocol=https"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition
@@ -27,8 +30,6 @@ LINUX_VERSION = "6.1.111"
 KBRANCH = "6.1.x+fslc"
 SRCREV = "195925841506cd58552d73ebabadd08d6016e4c6"
 
-KBUILD_DEFCONFIG:mx5-generic-bsp = "imx_v6_v7_defconfig"
-KBUILD_DEFCONFIG:mx5-generic-bsp = "imx_v6_v7_defconfig"
 KBUILD_DEFCONFIG:mx5-generic-bsp = "imx_v6_v7_defconfig"
 KBUILD_DEFCONFIG:mx6-generic-bsp = "imx_v6_v7_defconfig"
 KBUILD_DEFCONFIG:mx7-generic-bsp = "imx_v6_v7_defconfig"

--- a/recipes-kernel/linux/linux-fslc-lts_6.6.bb
+++ b/recipes-kernel/linux/linux-fslc-lts_6.6.bb
@@ -10,9 +10,12 @@ DESCRIPTION = "Linux kernel based on LTS kernel used by FSL Community BSP in ord
                and will not become part of a LTS version, or because it is not applicable for \
                upstreaming in any form."
 HOMEPAGE = "https://github.com/Freescale/linux-fslc"
+SECTION = "kernel"
 
 require linux-imx.inc
 
+# deliberately points at the linux-fslc fork instead of the linux-imx.inc nxp-imx base
+# nooelint: oelint.var.override
 SRC_URI = "git://github.com/Freescale/linux-fslc.git;branch=${KBRANCH};protocol=https"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition

--- a/recipes-kernel/linux/linux-imx.inc
+++ b/recipes-kernel/linux/linux-imx.inc
@@ -62,3 +62,4 @@ python kernel_devicetree_32bit_compatibility_update() {
 }
 addhandler kernel_devicetree_32bit_compatibility_update
 kernel_devicetree_32bit_compatibility_update[eventmask] = "bb.event.RecipeParsed"
+kernel_devicetree_32bit_compatibility_update[doc] = "Strip 32-bit dtb sub-folders from KERNEL_DEVICETREE for older kernel builds"

--- a/recipes-kernel/linux/linux-imx_6.18.bb
+++ b/recipes-kernel/linux/linux-imx_6.18.bb
@@ -10,14 +10,14 @@ SUMMARY = "Linux Kernel provided and supported by NXP"
 DESCRIPTION = "Linux Kernel provided and supported by NXP with focus on \
                i.MX Family Reference Boards. It includes support for many IPs such as GPU, VPU and IPU."
 HOMEPAGE = "https://github.com/nxp-imx/linux-imx"
+SECTION = "kernel"
 
 require recipes-kernel/linux/linux-imx.inc
 
-LICENSE = "GPL-2.0-only"
-LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
-
 DEPENDS += "coreutils-native"
 
+# adds the LINUX_IMX_SRC override hook over the linux-imx.inc default
+# nooelint: oelint.var.override
 SRC_URI = "${LINUX_IMX_SRC}"
 LINUX_IMX_SRC ?= "git://github.com/nxp-imx/linux-imx.git;protocol=https;branch=${SRCBRANCH}"
 SRCBRANCH = "lf-6.18.y"
@@ -39,6 +39,8 @@ KBUILD_DEFCONFIG:mx9-generic-bsp = "imx_v8_defconfig"
 
 DEFAULT_PREFERENCE = "1"
 
+# fail-fast guard rejecting the deprecated DELTA_KERNEL_DEFCONFIG
+# nooelint: oelint.task.noanonpython
 python __anonymous () {
     import bb
     # Fail fast if DELTA_KERNEL_DEFCONFIG is present in the datastore (even if empty)

--- a/recipes-kernel/linux/linux-qoriq.inc
+++ b/recipes-kernel/linux/linux-qoriq.inc
@@ -2,11 +2,21 @@ inherit kernel qoriq_build_64bit_kernel siteinfo
 inherit fsl-kernel-localversion kernel-yocto
 
 SUMMARY = "Linux Kernel for NXP QorIQ platforms"
+DESCRIPTION = "Linux kernel for NXP QorIQ / Layerscape platforms, tracking the NXP LSDK kernel tree."
 SECTION = "kernel"
 LICENSE = "GPL-2.0-only"
 
 DEPENDS:append = " libgcc coreutils-native"
+
+# Set the PV to the correct kernel version to satisfy the kernel version sanity check
+PV = "${LINUX_VERSION}+git${SRCPV}"
+
 # not put Images into /boot of rootfs, install kernel-image if needed
+# ${KERNEL_PACKAGE_NAME}-image kernel sub-package
+# nooelint: oelint.vars.pkgspecific.FILES oelint.vars.specific
+FILES:${KERNEL_PACKAGE_NAME}-image += "/boot/zImage*"
+# ${KERNEL_PACKAGE_NAME}-base kernel sub-package
+# nooelint: oelint.vars.pkgspecific.RDEPENDS oelint.vars.specific
 RDEPENDS:${KERNEL_PACKAGE_NAME}-base = ""
 
 KERNEL_CC:append = " ${TOOLCHAIN_OPTIONS}"
@@ -15,9 +25,6 @@ KERNEL_EXTRA_ARGS += "LOADADDR=${UBOOT_ENTRYPOINT}"
 
 ZIMAGE_BASE_NAME = "zImage-${PKGE}-${PKGV}-${PKGR}-${MACHINE}-${DATETIME}"
 ZIMAGE_BASE_NAME[vardepsexclude] = "DATETIME"
-
-# Set the PV to the correct kernel version to satisfy the kernel version sanity check
-PV = "${LINUX_VERSION}+git${SRCPV}"
 
 SCMVERSION ?= "y"
 LOCALVERSION = ""
@@ -47,6 +54,7 @@ do_configure() {
     cp .config ${UNPACKDIR}/defconfig
 }
 
-FILES:${KERNEL_PACKAGE_NAME}-image += "/boot/zImage*"
+# cross-build leaves buildpaths in the -src package
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:${PN}-src += "buildpaths"
 COMPATIBLE_MACHINE = "(qoriq)"

--- a/recipes-kernel/linux/linux-qoriq_6.12.bb
+++ b/recipes-kernel/linux/linux-qoriq_6.12.bb
@@ -1,3 +1,4 @@
+HOMEPAGE = "https://github.com/nxp-qoriq/linux"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 LINUX_VERSION = "6.12.49"
 
@@ -7,4 +8,3 @@ SRC_URI = "${LINUX_QORIQ_SRC};branch=${LINUX_QORIQ_BRANCH}"
 SRCREV = "df24f9428e38740256a410b983003a478e72a7c0"
 
 require linux-qoriq.inc
-HOMEPAGE = "https://github.com/nxp-qoriq/linux"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-imx_2.2.0.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-imx_2.2.0.bb
@@ -1,23 +1,17 @@
 # Copyright (C) 2018 O.S. Systems Software LTDA.
-DESCRIPTION = "GStreamer 1.0 plugins for i.MX platforms"
+SUMMARY = "GStreamer 1.0 plugins for i.MX hardware acceleration"
+DESCRIPTION = "GStreamer 1.0 plugins exposing the i.MX hardware video, audio and 2D blitter acceleration blocks (VPU, IPU, PxP, G2D and the uniaudio codecs) as GStreamer elements."
 HOMEPAGE = "https://github.com/Freescale/gstreamer-imx"
+SECTION = "multimedia"
 LICENSE = "LGPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=55ca817ccb7d5b5b66355690e9abc605"
-SECTION = "multimedia"
 DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base libimxdmabuffer"
-# add the audioparsers and the videoparsersbad plugins as RDEPENDS ; audioparsers
-# for the uniaudio decoder, videoparsersbad for the VPU video decoder
-# the gstreamer1.0-plugins-imx RDEPENDS is necessary to ensure the -good recipe is
-# built (it is not a compile-time dependency however, hence RDEPENDS and not DEPENDS)
-RDEPENDS:gstreamer1.0-plugins-imx = "gstreamer1.0-plugins-bad gstreamer1.0-plugins-good"
-RDEPENDS:gstreamer1.0-plugins-imx-imxaudio = "gstreamer1.0-plugins-good-audioparsers"
-RDEPENDS:gstreamer1.0-plugins-imx-imxvpu = "gstreamer1.0-plugins-bad-videoparsersbad"
 
 PV .= "+git${SRCPV}"
 
 SRCBRANCH ?= "master"
-SRCREV = "ce4f86e60f12c56574f727f3317fa8aa30a11387"
 SRC_URI = "git://github.com/Freescale/gstreamer-imx.git;branch=${SRCBRANCH};protocol=https"
+SRCREV = "ce4f86e60f12c56574f727f3317fa8aa30a11387"
 
 inherit pkgconfig meson use-imx-headers
 
@@ -63,5 +57,13 @@ require recipes-multimedia/gstreamer/gstreamer1.0-plugins-packaging.inc
 
 # the following line is required to produce one package for each plugin
 PACKAGES_DYNAMIC = "^${PN}-.*"
+
+# add the audioparsers and the videoparsersbad plugins as RDEPENDS ; audioparsers
+# for the uniaudio decoder, videoparsersbad for the VPU video decoder
+# the gstreamer1.0-plugins-imx RDEPENDS is necessary to ensure the -good recipe is
+# built (it is not a compile-time dependency however, hence RDEPENDS and not DEPENDS)
+RDEPENDS:gstreamer1.0-plugins-imx = "gstreamer1.0-plugins-bad gstreamer1.0-plugins-good"
+RDEPENDS:gstreamer1.0-plugins-imx-imxaudio = "gstreamer1.0-plugins-good-audioparsers"
+RDEPENDS:gstreamer1.0-plugins-imx-imxvpu = "gstreamer1.0-plugins-bad-videoparsersbad"
 
 COMPATIBLE_MACHINE = "(mx6dl-nxp-bsp|mx6q-nxp-bsp|mx6sl-nxp-bsp|mx6sx-nxp-bsp|mx6ul-nxp-bsp|mx6ull-nxp-bsp|mx7d-nxp-bsp|mx8-nxp-bsp)"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly_1.26.6.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly_1.26.6.bb
@@ -1,15 +1,18 @@
 require recipes-multimedia/gstreamer/gstreamer1.0-plugins-common.inc
 require recipes-multimedia/gstreamer/gstreamer1.0-plugins-license.inc
 
-SUMMARY = "'Ugly GStreamer plugins"
+SUMMARY = "'Ugly' GStreamer plugins"
+DESCRIPTION = "A set of good-quality GStreamer 1.0 plugins that might pose distribution problems, covering codecs and elements such as A52, CDIO, DVD read, MPEG-2 and x264."
 HOMEPAGE = "https://gstreamer.freedesktop.org/"
 BUGTRACKER = "https://gitlab.freedesktop.org/gstreamer/gst-plugins-ugly/-/issues"
-
-LIC_FILES_CHKSUM = "file://COPYING;md5=a6f89e2100d9b6cdffcea4f398e37343 \
-                    "
+SECTION = "multimedia"
 
 LICENSE = "GPL-2.0-or-later AND LGPL-2.1-or-later"
 LICENSE_FLAGS = "commercial"
+LIC_FILES_CHKSUM = "file://COPYING;md5=a6f89e2100d9b6cdffcea4f398e37343 \
+                    "
+
+DEPENDS += "gstreamer1.0-plugins-base"
 
 SRC_URI = "\
     https://gstreamer.freedesktop.org/src/gst-plugins-ugly/gst-plugins-ugly-${PV}.tar.xz \
@@ -18,8 +21,6 @@ SRC_URI = "\
 SRC_URI[sha256sum] = "95032eee4580bb9826c008cbce5a2c3a78b980abb270c96a19b645f77255c491"
 
 S = "${UNPACKDIR}/gst-plugins-ugly-${PV}"
-
-DEPENDS += "gstreamer1.0-plugins-base"
 
 GST_PLUGIN_SET_HAS_EXAMPLES = "0"
 
@@ -40,5 +41,9 @@ EXTRA_OEMESON += "\
     -Dsidplay=disabled \
 "
 
+# ${PN}-amrnb per-plugin sub-package
+# nooelint: oelint.vars.pkgspecific.FILES oelint.vars.specific
 FILES:${PN}-amrnb += "${datadir}/gstreamer-1.0/presets/GstAmrnbEnc.prs"
+# ${PN}-x264 per-plugin sub-package
+# nooelint: oelint.vars.pkgspecific.FILES oelint.vars.specific
 FILES:${PN}-x264 += "${datadir}/gstreamer-1.0/presets/GstX264Enc.prs"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-rtsp-server/0001-YOCIMX-9113-rtsp-examples-install-test-launch-and-te.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-rtsp-server/0001-YOCIMX-9113-rtsp-examples-install-test-launch-and-te.patch
@@ -7,7 +7,7 @@ Subject: [PATCH] YOCIMX-9113 rtsp examples: install test-launch and test-uri
 gstreamer community has no plan to install these binary as test tool
 https://discourse.gstreamer.org/t/gst-rtsp-server-examples-are-not-installed-by-default/4806
 
-Upstream-Status: Inappropriate [i.MX specific]
+Upstream-Status: Inappropriate [embedded specific]
 
 Signed-off-by: Haihua Hu <jared.hu@nxp.com>
 ---

--- a/recipes-multimedia/gstreamer/gstreamer1.0-rtsp-server_1.26.6.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-rtsp-server_1.26.6.bb
@@ -1,4 +1,5 @@
 SUMMARY = "A library on top of GStreamer for building an RTSP server"
+DESCRIPTION = "gst-rtsp-server is a library on top of GStreamer for building an RTSP server that streams media to RTSP clients, handling session management, transport negotiation and the RTP/RTCP data flow."
 HOMEPAGE = "http://cgit.freedesktop.org/gstreamer/gst-rtsp-server/"
 SECTION = "multimedia"
 LICENSE = "LGPL-2.1-or-later"
@@ -7,8 +8,6 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=69333daa044cb77e486cc36129f7a770"
 DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base"
 
 PNREAL = "gst-rtsp-server"
-
-FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 SRC_URI = "https://gstreamer.freedesktop.org/src/${PNREAL}/${PNREAL}-${PV}.tar.xz \
            file://0001-YOCIMX-9113-rtsp-examples-install-test-launch-and-te.patch \

--- a/recipes-security/optee-imx/optee-os-fslc.inc
+++ b/recipes-security/optee-imx/optee-os-fslc.inc
@@ -13,6 +13,8 @@ require optee-fslc.inc
 
 CVE_PRODUCT = "linaro:op-tee op-tee:op-tee_os"
 
+# full dependency set; the .inc chain defines none
+# nooelint: oelint.vars.dependsappend
 DEPENDS = "python3-cryptography-native python3-pyelftools-native"
 
 DEPENDS:append:toolchain-clang = " lld-native compiler-rt"
@@ -34,6 +36,8 @@ EXTRA_OEMAKE += "HOST_PREFIX=${HOST_PREFIX}"
 EXTRA_OEMAKE += "CROSS_COMPILE64=${HOST_PREFIX}"
 
 # Enable BTI in optee
+# leading space is inside the conditional ${@...} and separates the appended make flags
+# nooelint: oelint.vars.inconspaces oelint.vars.notneededspace
 EXTRA_OEMAKE += "${@bb.utils.contains('MACHINE_FEATURES', 'arm-branch-protection', ' CFG_TA_BTI=1 CFG_CORE_PAUTH=y CFG_TA_PAUTH=y', '', d)}"
 
 LDFLAGS[unexport] = "1"
@@ -71,10 +75,17 @@ addtask deploy before do_build after do_install
 SYSROOT_DIRS += "${nonarch_base_libdir}/firmware"
 
 PACKAGES += "${PN}-ta"
+# main package ships only the OP-TEE core firmware
+# nooelint: oelint.var.filesoverride
 FILES:${PN} = "${nonarch_base_libdir}/firmware/"
-FILES:${PN}-ta = "${nonarch_base_libdir}/optee_armtz/*"
+# dedicated -ta package ships the trusted applications
+FILES:${PN}-ta += "${nonarch_base_libdir}/optee_armtz/*"
 
 # note: "textrel" is not triggered on all archs
+# OP-TEE core firmware legitimately contains text relocations
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:${PN} = "textrel"
+# devkit static libs are intentional in the -dev package
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:${PN}-dev = "staticdev"
 INHIBIT_PACKAGE_STRIP = "1"

--- a/recipes-security/optee-imx/optee-os-tadevkit-fslc-imx.inc
+++ b/recipes-security/optee-imx/optee-os-tadevkit-fslc-imx.inc
@@ -4,16 +4,17 @@
 require optee-os-common-fslc-imx.inc
 
 SUMMARY = "OP-TEE Trusted OS TA devkit"
-DESCRIPTION = "OP-TEE TA devkit for build TAs"
-HOMEPAGE = "https://www.op-tee.org/"
+DESCRIPTION = "OP-TEE TA development kit (headers, linker script and helper makefiles) used to build Trusted Applications."
 
+# single entry
+# nooelint: oelint.vars.dependsordered
 DEPENDS += "python3-pycryptodome-native"
 
 do_install() {
     #install TA devkit
     install -d ${D}${includedir}/optee/export-user_ta/
     for f in ${B}/export-ta_${OPTEE_ARCH}/* ; do
-        cp -aR $f ${D}${includedir}/optee/export-user_ta/
+        cp -R $f ${D}${includedir}/optee/export-user_ta/
     done
 }
 
@@ -21,7 +22,11 @@ do_deploy() {
     echo "Do not inherit do_deploy from optee-os."
 }
 
+# devkit ships only the export include tree
+# nooelint: oelint.var.override oelint.var.filesoverride
 FILES:${PN} = "${includedir}/optee/"
 
 # Build paths are currently embedded
+# devkit headers embed cross-build paths
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:${PN}-dev += "buildpaths"

--- a/recipes-security/smw/files/0001-Fixed-discarded-qualifiers-error.patch
+++ b/recipes-security/smw/files/0001-Fixed-discarded-qualifiers-error.patch
@@ -1,5 +1,12 @@
-Upstream-Status: Pending
+From: Zelan Zou <zelan.zou@nxp.com>
+Subject: [PATCH] Fix discarded const qualifier errors
 
+Add the missing const qualifier and cast so the build does not fail with
+-Werror=discarded-qualifiers.
+
+Upstream-Status: Pending
+Signed-off-by: Zelan Zou <zelan.zou@nxp.com>
+---
 diff --git a/osal/linux/obj_db.c b/osal/linux/obj_db.c
 index 446a08b1..18e4931b 100644
 --- a/osal/linux/obj_db.c

--- a/recipes-security/smw/smw_5.3.bb
+++ b/recipes-security/smw/smw_5.3.bb
@@ -2,14 +2,15 @@
 require recipes-security/optee-imx/optee-fslc.inc
 
 SUMMARY = "NXP i.MX Security Middleware Library"
+DESCRIPTION = "NXP i.MX Security Middleware (SMW) provides a generic API abstracting the cryptographic and secure key management operations of the i.MX secure subsystems."
 HOMEPAGE = "https://github.com/nxp-imx/imx-smw"
-DESCRIPTION = "NXP i.MX Security Middleware Library"
 SECTION = "base"
-LICENSE = "BSD-3-Clause"
 LICENSE = "Apache-2.0 AND BSD-3-Clause AND Zlib"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=ff20c8e51b28869d9cdec70a818d163f \
                     file://${PSA_ARCH_TESTS_SRC_PATH}/LICENSE.md;md5=2a944942e1496af1886903d274dedb13"
 
+# full dependency set defined by this recipe
+# nooelint: oelint.vars.dependsappend
 DEPENDS = "\
     json-c \
     optee-client \
@@ -74,16 +75,21 @@ EXTRA_OECMAKE = "\
 OECMAKE_TARGET_COMPILE += "build_tests"
 OECMAKE_TARGET_INSTALL += "install_tests"
 
+PACKAGE_ARCH = "${MACHINE_SOCARCH}"
+
 PACKAGES =+ "${PN}-tests"
 
 FILES:${PN} += "${nonarch_base_libdir}/optee_armtz/*"
 
+# cross-build leaves buildpaths in -dbg
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:${PN}-dbg = "buildpaths"
 
-FILES:${PN}-tests = "${bindir}/* ${datadir}/${BPN}/*"
+# dedicated -tests sub-package payload
+FILES:${PN}-tests += "${bindir}/* ${datadir}/${BPN}/*"
 RDEPENDS:${PN}-tests = "cmake"
+# cross-build leaves buildpaths in -tests
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:${PN}-tests = "buildpaths"
-
-PACKAGE_ARCH = "${MACHINE_SOCARCH}"
 
 COMPATIBLE_MACHINE = "(imx-nxp-bsp)"


### PR DESCRIPTION
## Summary
 Continues the oelint-adv cleanup series. Per-recipe metadata, ordering
and packaging fixes across kernels, bootloaders, OP-TEE and GStreamer,
one commit per recipe, each re-scanned clean.
- **linux-imx, linux-fslc-lts, linux-qoriq, u-boot-fslc, u-boot-qoriq** —
add/expand metadata, drop duplicate assignments and fix variable
ordering; linux-imx also adds a task docstring.
- **gstreamer1.0-plugins-ugly, gstreamer1.0-rtsp-server,
gstreamer1.0-plugins-imx** — add SUMMARY/DESCRIPTION and fix metadata
ordering.
- **optee-os-fslc** — accept the split packaging and dependency findings
(documented inline); **optee-os-tadevkit-fslc-imx** — tidy `do_install`
and metadata.
- **imx-gpu-sdk** — quote values and tidy packaging.
- **imx-boot-firmware-files** — add task docstrings.
- **uuu-bin** — add SECTION and expand DESCRIPTION.
- **smw** — expand metadata and fix ordering.
 ## Impact
 Metadata, ordering and packaging documentation only, plus OP-TEE
`do_install` tidy-ups that install the same files. No functional change
to any package.
 ## Test
 `oelint-adv` reports no baseline findings for each touched recipe.