### PR TITLE
imx-imx-boot-bootpart.wks.in: Use variable to choose ptable type

### DIFF
--- a/conf/machine/include/imx-base.inc
+++ b/conf/machine/include/imx-base.inc
@@ -682,6 +682,8 @@ SOC_DEFAULT_WKS_FILE:mx8-generic-bsp ?= "imx-imx-boot-bootpart.wks.in"
 SOC_DEFAULT_WKS_FILE:mx9-generic-bsp ?= "imx-imx-boot-bootpart.wks.in"
 
 WKS_FILE ?= "${SOC_DEFAULT_WKS_FILE}"
+IMX_BOOTLOADER_PTABLE             ?= "msdos"
+IMX_BOOTLOADER_PTABLE:use-nxp-bsp ?= "gpt"
 
 SERIAL_CONSOLES = "115200;ttymxc0"
 SERIAL_CONSOLES:mxs-generic-bsp = "115200;ttyAMA0"

--- a/files/wic/imx-imx-boot-bootpart.wks.in
+++ b/files/wic/imx-imx-boot-bootpart.wks.in
@@ -17,4 +17,4 @@ part u-boot --source rawcopy --sourceparams="file=imx-boot.tagged" --ondisk mmcb
 part /boot --source bootimg-partition --ondisk mmcblk --fstype=vfat --label boot --active --align 8192 --fixed-size 256
 part / --source rootfs --ondisk mmcblk --fstype=ext4 --label root --align 8192
 
-bootloader --ptable msdos
+bootloader --ptable ${IMX_BOOTLOADER_PTABLE}


### PR DESCRIPTION
In NXP i.MX BSP, i.MX 8 & 9 is preferred to use gpt ptable:
- Boot ROM Compatibility: i.MX 8/9 Boot ROM can work with both MBR and GPT
- U-Boot Configuration: NXP U-Boot has configured to recognize GPT (CONFIG_EFI_PARTITION=y)
- Partition Alignment: GPT first usable LBA in GPT is in sector 34 (17KB), and i.MX 8&9 has IMX_BOOT_SEEK offset (32-33KB), so no conflict
- Advantages of GPT
    - Support for >2TB storage (not typically relevant for SD cards)
    - More robust with CRC32 checksums and backup partition table
    - Up to 128 partitions vs 4 primary partitions in MBR
    - Better partition naming and GUID identification