### PR TITLE
[Backport wrynose] oelint: Recipe metadata, do_install and split-package FILES cleanups 

### DIFF
--- a/recipes-bsp/firmware-imx/firmware-ele-imx_2.0.5.bb
+++ b/recipes-bsp/firmware-imx/firmware-ele-imx_2.0.5.bb
@@ -29,6 +29,8 @@ do_deploy () {
 }
 addtask deploy after do_install before do_build
 
+# Package the deployed ELE firmware blob explicitly (filesoverride).
+# nooelint: oelint.var.filesoverride
 FILES:${PN} = "${nonarch_base_libdir}/firmware"
 
 RREPLACES:${PN} = "firmware-sentinel"

--- a/recipes-bsp/firmware-imx/firmware-imx_8.31.bb
+++ b/recipes-bsp/firmware-imx/firmware-imx_8.31.bb
@@ -163,15 +163,15 @@ PACKAGES_DYNAMIC = "${PN}-vpu-* ${PN}-sdma-* ${PN}-easrc-* ${PN}-xcvr-* ${PN}-xu
 # files it makes no sense.
 PACKAGES = "${PN} ${PN}-epdc ${PN}-hdmi ${PN}-vpu-amphion ${PN}-vpu-coda980 ${PN}-vpu-wave511 ${PN}-vpu-wave"
 
-FILES:${PN}-epdc = "${nonarch_base_libdir}/firmware/imx/epdc/"
-FILES:${PN}-hdmi = "\
+FILES:${PN}-epdc += "${nonarch_base_libdir}/firmware/imx/epdc/"
+FILES:${PN}-hdmi += "\
     ${nonarch_base_libdir}/firmware/hdmitxfw.bin \
     ${nonarch_base_libdir}/firmware/hdmirxfw.bin \
     ${nonarch_base_libdir}/firmware/dpfw.bin \
 "
-FILES:${PN}-vpu-amphion = "${nonarch_base_libdir}/firmware/amphion/vpu/*"
-FILES:${PN}-vpu-coda980 = "${nonarch_base_libdir}/firmware/cnm/coda980_enc_fw.bin"
-FILES:${PN}-vpu-wave511 = "${nonarch_base_libdir}/firmware/cnm/wave511_dec_fw.bin"
-FILES:${PN}-vpu-wave = "${nonarch_base_libdir}/firmware/wave633c_codec_fw.bin"
+FILES:${PN}-vpu-amphion += "${nonarch_base_libdir}/firmware/amphion/vpu/*"
+FILES:${PN}-vpu-coda980 += "${nonarch_base_libdir}/firmware/cnm/coda980_enc_fw.bin"
+FILES:${PN}-vpu-wave511 += "${nonarch_base_libdir}/firmware/cnm/wave511_dec_fw.bin"
+FILES:${PN}-vpu-wave += "${nonarch_base_libdir}/firmware/wave633c_codec_fw.bin"
 
 COMPATIBLE_MACHINE = "(imx-generic-bsp)"

--- a/recipes-bsp/firmware-imx/firmware-nxp-wifi_1.1.bb
+++ b/recipes-bsp/firmware-imx/firmware-nxp-wifi_1.1.bb
@@ -74,12 +74,15 @@ RDEPENDS:${PN}-all-usb = "\
     ${PN}-nxpiw610-usb \
 "
 
-FILES:${PN}-nxp-common = "\
+# The firmware is split into per-chip sub-packages; each block keeps its FILES
+# beside the matching R* vars for readability.
+# nooelint: oelint.var.order.FILES
+FILES:${PN}-nxp-common += "\
     ${nonarch_base_libdir}/firmware/nxp/wifi_mod_para.conf \
     ${nonarch_base_libdir}/firmware/nxp/helper_uart_3000000.bin \
 "
 
-FILES:${PN}-nxp8987-sdio = "\
+FILES:${PN}-nxp8987-sdio += "\
     ${nonarch_base_libdir}/firmware/nxp/*8987* \
 "
 RDEPENDS:${PN}-nxp8987-sdio += "${PN}-nxp-common"
@@ -87,11 +90,12 @@ RPROVIDES:${PN}-nxp8987-sdio = "linux-firmware-nxp8987-sdio"
 RREPLACES:${PN}-nxp8987-sdio = "linux-firmware-nxp8987-sdio"
 RCONFLICTS:${PN}-nxp8987-sdio = "linux-firmware-nxp8987-sdio"
 
-FILES:${PN}-nxp8997-sdio = "\
+# nooelint: oelint.var.order.FILES
+FILES:${PN}-nxp8997-sdio += "\
     ${nonarch_base_libdir}/firmware/mrvl/sdiouart8997_combo_v4.bin \
 "
 
-FILES:${PN}-nxp9098-common = "\
+FILES:${PN}-nxp9098-common += "\
     ${nonarch_base_libdir}/firmware/nxp/ed_mac_ctrl_V3_909x.conf \
     ${nonarch_base_libdir}/firmware/nxp/txpwrlimit_cfg_9098.conf \
     ${nonarch_base_libdir}/firmware/nxp/uart9098_bt_v1.bin \
@@ -101,7 +105,8 @@ RPROVIDES:${PN}-nxp9098-common = "linux-firmware-nxp9098-common"
 RREPLACES:${PN}-nxp9098-common = "linux-firmware-nxp9098-common"
 RCONFLICTS:${PN}-nxp9098-common = "linux-firmware-nxp9098-common"
 
-FILES:${PN}-nxp9098-pcie = "\
+# nooelint: oelint.var.order.FILES
+FILES:${PN}-nxp9098-pcie += "\
     ${nonarch_base_libdir}/firmware/nxp/pcie*9098* \
 "
 RDEPENDS:${PN}-nxp9098-pcie += "${PN}-nxp9098-common"
@@ -109,7 +114,8 @@ RPROVIDES:${PN}-nxp9098-pcie = "linux-firmware-nxp9098-pcie"
 RREPLACES:${PN}-nxp9098-pcie = "linux-firmware-nxp9098-pcie"
 RCONFLICTS:${PN}-nxp9098-pcie = "linux-firmware-nxp9098-pcie"
 
-FILES:${PN}-nxp9098-sdio = "\
+# nooelint: oelint.var.order.FILES
+FILES:${PN}-nxp9098-sdio += "\
     ${nonarch_base_libdir}/firmware/nxp/sd*9098* \
 "
 RDEPENDS:${PN}-nxp9098-sdio += "${PN}-nxp9098-common"
@@ -117,13 +123,15 @@ RPROVIDES:${PN}-nxp9098-sdio = "linux-firmware-nxp9098-sdio"
 RREPLACES:${PN}-nxp9098-sdio = "linux-firmware-nxp9098-sdio"
 RCONFLICTS:${PN}-nxp9098-sdio = "linux-firmware-nxp9098-sdio"
 
+# nooelint: oelint.var.order.FILES
 FILES:${PN}-nxpaw693-pcie += "\
     ${nonarch_base_libdir}/firmware/nxp/pcie*aw693* \
     ${nonarch_base_libdir}/firmware/nxp/uart*aw693* \
 "
 RDEPENDS:${PN}-nxpaw693-pcie += "${PN}-nxp-common"
 
-FILES:${PN}-nxpiw416-sdio = "\
+# nooelint: oelint.var.order.FILES
+FILES:${PN}-nxpiw416-sdio += "\
     ${nonarch_base_libdir}/firmware/mrvl/sdiouartiw416_combo_v0.bin \
     ${nonarch_base_libdir}/firmware/nxp/*iw416* \
 "
@@ -132,6 +140,7 @@ RPROVIDES:${PN}-nxpiw416-sdio = "linux-firmware-nxpiw416-sdio"
 RREPLACES:${PN}-nxpiw416-sdio = "linux-firmware-nxpiw416-sdio"
 RCONFLICTS:${PN}-nxpiw416-sdio = "linux-firmware-nxpiw416-sdio"
 
+# nooelint: oelint.var.order.FILES
 FILES:${PN}-nxpiw610-sdio += "\
     ${nonarch_base_libdir}/firmware/nxp/sd_iw610.bin.se \
     ${nonarch_base_libdir}/firmware/nxp/sduart_iw610.bin.se \
@@ -144,12 +153,14 @@ RPROVIDES:${PN}-nxpiw610-sdio = "linux-firmware-nxpiw610-sdio"
 RREPLACES:${PN}-nxpiw610-sdio = "linux-firmware-nxpiw610-sdio"
 RCONFLICTS:${PN}-nxpiw610-sdio = "linux-firmware-nxpiw610-sdio"
 
+# nooelint: oelint.var.order.FILES
 FILES:${PN}-nxpiw610-usb += "\
     ${nonarch_base_libdir}/firmware/nxp/usb*_iw610.bin.se \
 "
 RDEPENDS:${PN}-nxpiw610-usb += "${PN}-nxp-common"
 
-FILES:${PN}-nxpiw612-sdio = "\
+# nooelint: oelint.var.order.FILES
+FILES:${PN}-nxpiw612-sdio += "\
     ${nonarch_base_libdir}/firmware/nxp/sd_w61x_v1.bin.se \
     ${nonarch_base_libdir}/firmware/nxp/sduart_nw61x_*.bin.se \
     ${nonarch_base_libdir}/firmware/nxp/uartspi_n61x_*.bin.se \

--- a/recipes-bsp/firmware-imx/firmware-sof-imx_2.3.0.bb
+++ b/recipes-bsp/firmware-imx/firmware-sof-imx_2.3.0.bb
@@ -21,4 +21,6 @@ do_install() {
     cp -r sof* ${D}${nonarch_base_libdir}/firmware/imx/
 }
 
+# Package the installed SOF firmware/topology tree explicitly (filesoverride).
+# nooelint: oelint.var.filesoverride
 FILES:${PN} = "${nonarch_base_libdir}/firmware/imx"

--- a/recipes-bsp/imx-lib/imx-lib_git.bb
+++ b/recipes-bsp/imx-lib/imx-lib_git.bb
@@ -2,10 +2,11 @@
 # Copyright (C) 2012-2018 O.S. Systems Software LTDA.
 # Copyright 2017 NXP
 
+SUMMARY = "i.MX platform-specific libraries"
 DESCRIPTION = "Platform specific libraries for imx platform"
 HOMEPAGE = "https://github.com/nxp-imx/imx-lib"
-LICENSE = "LGPL-2.1-only"
 SECTION = "multimedia"
+LICENSE = "LGPL-2.1-only"
 
 LIC_FILES_CHKSUM = "file://LICENSE;md5=fbc093901857fcd118f065f900982c24"
 

--- a/recipes-bsp/imx-seco/imx-seco_5.9.4.1.bb
+++ b/recipes-bsp/imx-seco/imx-seco_5.9.4.1.bb
@@ -2,6 +2,7 @@
 
 SUMMARY = "NXP i.MX SECO firmware"
 DESCRIPTION = "Firmware for i.MX Security Controller Subsystem"
+HOMEPAGE = "https://www.nxp.com/"
 SECTION = "base"
 LICENSE = "Proprietary"
 LIC_FILES_CHKSUM = "file://COPYING;md5=ca53281cc0caa7e320d4945a896fb837"
@@ -28,5 +29,8 @@ do_deploy () {
     install -m 0644 ${S}/firmware/seco/${SECO_FIRMWARE_NAME} ${DEPLOYDIR}
 }
 
+# The prebuilt SECO firmware is deployed under /lib/firmware, so the main
+# package claims the root path explicitly (filesoverride).
+# nooelint: oelint.var.filesoverride
 FILES:${PN} = "/"
 COMPATIBLE_MACHINE = "(mx8qm-generic-bsp|mx8qxp-generic-bsp|mx8dxl-generic-bsp|mx8dx-generic-bsp)"

--- a/recipes-bsp/imx-uuc/imx-uuc_git.bb
+++ b/recipes-bsp/imx-uuc/imx-uuc_git.bb
@@ -1,11 +1,12 @@
 # Copyright (C) 2016 Freescale Semiconductor
 # Copyright (C) 2017-2019,2024-2025 NXP
 SUMMARY = "A Daemon wait for NXP mfgtools host's command"
+DESCRIPTION = "Update Utility Client daemon that waits for commands from the NXP mfgtools host during manufacturing programming."
 HOMEPAGE = "https://github.com/nxp-imx/imx-uuc"
 SECTION = "base"
-DEPENDS = "dosfstools-native virtual/kernel"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b234ee4d69f5fce4486a80fdaf4a4263"
+DEPENDS = "dosfstools-native virtual/kernel"
 
 PR = "r1"
 PV = "0.5.1+git${SRCPV}"

--- a/recipes-bsp/mc-utils/mc-utils_git.bb
+++ b/recipes-bsp/mc-utils/mc-utils_git.bb
@@ -1,3 +1,4 @@
+SUMMARY = "QorIQ DPAA Management Complex config utilities"
 DESCRIPTION = "The Management Complex (MC) is a key component of DPAA"
 HOMEPAGE = "https://github.com/nxp-qoriq/mc-utils"
 SECTION = "mc-utils"
@@ -38,7 +39,7 @@ do_deploy () {
 }
 addtask deploy after do_install
 
+PACKAGE_ARCH = "${MACHINE_ARCH}"
 PACKAGES += "${PN}-image"
 FILES:${PN}-image += "/boot"
-PACKAGE_ARCH = "${MACHINE_ARCH}"
 COMPATIBLE_MACHINE = "(qoriq-arm64)"

--- a/recipes-bsp/qe-ucode/qe-ucode_git.bb
+++ b/recipes-bsp/qe-ucode/qe-ucode_git.bb
@@ -1,4 +1,5 @@
-DESCRIPTION = "qe microcode binary"
+SUMMARY = "QorIQ QE microcode"
+DESCRIPTION = "QUICC Engine (QE) microcode binary for NXP QorIQ SoCs"
 HOMEPAGE = "https://github.com/NXP/qoriq-qe-ucode"
 SECTION = "qe-ucode"
 LICENSE = "NXP-Binary-EULA"
@@ -20,9 +21,10 @@ do_deploy () {
 }
 addtask deploy before do_build after do_install
 
+PACKAGE_ARCH = "${MACHINE_SOCARCH}"
+
 PACKAGES += "${PN}-image"
 FILES:${PN}-image += "/boot/*"
 
 COMPATIBLE_MACHINE = "(qoriq)"
-PACKAGE_ARCH = "${MACHINE_SOCARCH}"
 

--- a/recipes-bsp/rcw/rcw_git.bb
+++ b/recipes-bsp/rcw/rcw_git.bb
@@ -1,6 +1,7 @@
 SUMMARY = "Reset Configuration Word"
 DESCRIPTION = "Reset Configuration Word - hardware boot-time parameters for the QorIQ targets"
 HOMEPAGE = "https://github.com/nxp-qoriq/rcw"
+SECTION = "bsp"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=44a0d0fad189770cc022af4ac6262cbe"
 
@@ -35,8 +36,9 @@ do_deploy () {
 }
 addtask deploy after do_install
 
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
 PACKAGES += "${PN}-image"
 FILES:${PN}-image += "/boot"
 
 COMPATIBLE_MACHINE = "(qoriq)"
-PACKAGE_ARCH = "${MACHINE_ARCH}"

--- a/recipes-bsp/uefi/uefi_git.bb
+++ b/recipes-bsp/uefi/uefi_git.bb
@@ -1,4 +1,5 @@
-DESCRIPTION = "Unified Extensible Firmware Interface"
+SUMMARY = "UEFI firmware for QorIQ platforms"
+DESCRIPTION = "Prebuilt UEFI (Unified Extensible Firmware Interface) firmware and GRUB binaries for NXP QorIQ platforms"
 HOMEPAGE = "https://github.com/NXP/qoriq-uefi-binary"
 SECTION = "bootloaders"
 LICENSE = "NXP-Binary-EULA"
@@ -26,9 +27,9 @@ do_deploy () {
 }
 addtask deploy before do_build after do_install
 
+PACKAGE_ARCH = "${MACHINE_SOCARCH}"
+
 PACKAGES += "${PN}-image"
 FILES:${PN}-image += "/uefi/*"
-
-PACKAGE_ARCH = "${MACHINE_SOCARCH}"
 
 COMPATIBLE_MACHINE = "(qoriq)"

--- a/recipes-connectivity/iproute2/iproute2_%.bbappend
+++ b/recipes-connectivity/iproute2/iproute2_%.bbappend
@@ -1,11 +1,11 @@
 do_install:append:imx-generic-bsp () {
-    install -d ${D}/usr/include/tc
-    cp -a ${B}/include  ${D}/usr/include
-    cp -a ${B}/tc/*.h    ${D}/usr/include/tc
+    install -d ${D}${includedir}/tc
+    cp -R ${B}/include ${D}${includedir}
+    install -m 0644 ${B}/tc/*.h ${D}${includedir}/tc
 }
 
 do_install:append:qoriq-generic-bsp () {
-    install -d ${D}/usr/include/tc
-    cp -a ${B}/include  ${D}/usr/include
-    cp -a ${B}/tc/*.h    ${D}/usr/include/tc
+    install -d ${D}${includedir}/tc
+    cp -R ${B}/include ${D}${includedir}
+    install -m 0644 ${B}/tc/*.h ${D}${includedir}/tc
 }

--- a/recipes-connectivity/mbedtls/mbedtls_3.6.5.bb
+++ b/recipes-connectivity/mbedtls/mbedtls_3.6.5.bb
@@ -16,11 +16,12 @@ DESCRIPTION = "mbedtls is a lean open source crypto library          \
 "
 
 HOMEPAGE = "https://tls.mbed.org/"
+SECTION = "libs"
 
 LICENSE = "Apache-2.0 | GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=379d5819937a6c2f1ef1630d341e026d"
 
-SECTION = "libs"
+PROVIDES += "polarssl"
 
 SRC_URI = "gitsm://github.com/Mbed-TLS/mbedtls.git;protocol=https;branch=mbedtls-3.6;tag=v${PV} \
            file://run-ptest \
@@ -44,11 +45,9 @@ PACKAGECONFIG[tests] = "-DENABLE_TESTING=ON,-DENABLE_TESTING=OFF"
 # For now the only way to enable PSA is to explicitly pass a -D via CFLAGS
 CFLAGS:append = "${@bb.utils.contains('PACKAGECONFIG', 'psa', ' -DMBEDTLS_USE_PSA_CRYPTO', '', d)}"
 
-PROVIDES += "polarssl"
-RPROVIDES:${PN} = "polarssl"
-
 PACKAGES =+ "${PN}-programs"
-FILES:${PN}-programs = "${bindir}/"
+FILES:${PN}-programs += "${bindir}/"
+RPROVIDES:${PN} = "polarssl"
 
 ALTERNATIVE:${PN}-programs = "${@bb.utils.contains('PACKAGECONFIG', 'programs', 'hello', '', d)}"
 ALTERNATIVE_LINK_NAME[hello] = "${bindir}/hello"
@@ -72,7 +71,7 @@ sysroot_stage_all:append() {
 do_install_ptest () {
     install -d ${D}${PTEST_PATH}/tests
     install -d ${D}${PTEST_PATH}/framework
-    cp -f ${B}/tests/test_suite_* ${D}${PTEST_PATH}/tests/
+    install -m 0755 ${B}/tests/test_suite_* ${D}${PTEST_PATH}/tests/
     find ${D}${PTEST_PATH}/tests/ -type f -name "*.c" -delete
-    cp -fR ${S}/framework/data_files ${D}${PTEST_PATH}/framework/
+    cp -R ${S}/framework/data_files ${D}${PTEST_PATH}/framework/
 }

--- a/recipes-devtools/qoriq-cst/qoriq-cst_git.bb
+++ b/recipes-devtools/qoriq-cst/qoriq-cst_git.bb
@@ -1,4 +1,5 @@
 SUMMARY = "utility for security boot"
+DESCRIPTION = "Code Signing Tool (CST) for QorIQ secure boot: generates keys, signs images and produces the CSF headers consumed by the SoC boot ROM"
 HOMEPAGE = "https://github.com/nxp-qoriq/cst"
 SECTION = "cst"
 LICENSE = "BSD-3-Clause"
@@ -6,7 +7,6 @@ LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=e959d5d617e33779d0e90ce1d9043eff"
 
 DEPENDS += "openssl qoriq-cst-native"
-RDEPENDS:${PN} = "bash"
 
 GENKEYS ?= "${STAGING_BINDIR_NATIVE}/cst/gen_keys"
 GENKEYS:class-native = "./gen_keys"
@@ -21,7 +21,7 @@ SRC_URI = "git://github.com/nxp-qoriq/cst;protocol=https;nobranch=1"
 SRCREV = "892d2ed3207d78a3cb5533eeb91bcc73967e3e36"
 
 EXTRA_OEMAKE = 'CC="${CC}" LD="${CC}"'
-CFLAGS:append = ' -Wno-deprecated-declarations'
+CFLAGS:append = " -Wno-deprecated-declarations"
 
 PARALLEL_MAKE = ""
 
@@ -29,14 +29,17 @@ do_install () {
     oe_runmake install DESTDIR=${D} BIN_DEST_DIR=${bindir}
 
     if [ -n "${SECURE_PRI_KEY}" ]; then
-       cp -f ${SECURE_PRI_KEY} ${D}/${bindir}/cst/srk.pri
-       cp -f ${SECURE_PUB_KEY} ${D}/${bindir}/cst/srk.pub
+       install -m 0600 ${SECURE_PRI_KEY} ${D}/${bindir}/cst/srk.pri
+       install -m 0644 ${SECURE_PUB_KEY} ${D}/${bindir}/cst/srk.pub
     elif [ ! -f ${D}/${bindir}/cst/srk.pri -o ! ${D}/${bindir}/cst/srk.pub ]; then
        cd ${D}/${bindir}/cst  && ${GENKEYS} 1024
     fi
 }
 
 FILES:${PN}-dbg += "${bindir}/cst/.debug"
+RDEPENDS:${PN} = "bash"
 BBCLASSEXTEND = "native nativesdk"
+# The cst tools live under ${bindir}/cst and retain build-host paths.
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:${PN}-dbg += "buildpaths"
 

--- a/recipes-extended/merge-files/merge-files_1.0.bb
+++ b/recipes-extended/merge-files/merge-files_1.0.bb
@@ -3,6 +3,9 @@ DESCRIPTION = "Merge prebuilt/extra files into rootfs"
 HOMEPAGE = "https://github.com/Freescale/meta-freescale/"
 SECTION = "base"
 LICENSE = "MIT"
+# The recipe ships no source tree of its own, so reference the shared
+# common-licenses MIT copy.
+# nooelint: oelint.var.licenseremotefile
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
 
 inherit allarch
@@ -13,12 +16,17 @@ MERGED_DST ?= "${ROOT_HOME}"
 do_install () {
     install -d ${D}/${MERGED_DST}
     find ${UNPACKDIR}/merge/ -maxdepth 1 -mindepth 1 -not -name README \
-    -exec cp -fr '{}' ${D}/${MERGED_DST}/ \;
+    -exec cp -r '{}' ${D}/${MERGED_DST}/ \;
     find ${UNPACKDIR}/merge/ -maxdepth 1 -mindepth 1 -exec rm -fr '{}' \;
 }
 do_configure[noexec] = "1"
 do_compile[noexec] = "1"
 
+# This package deliberately merges arbitrary prebuilt files anywhere under
+# the rootfs, so it claims everything (filesoverride) and skips the .so QA
+# for any shared objects that come along.
+# nooelint: oelint.var.filesoverride
 FILES:${PN} = "/*"
 ALLOW_EMPTY:${PN} = "1"
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:${PN} = "dev-so"

--- a/recipes-extended/secure-obj/secure-obj-module_git.bb
+++ b/recipes-extended/secure-obj/secure-obj-module_git.bb
@@ -1,5 +1,7 @@
 require secure-obj.inc
 
+SUMMARY = "Secure object securekeydev kernel module"
+SECTION = "kernel/modules"
 LIC_FILES_CHKSUM = "file://../LICENSE;md5=751419260aa954499f7abaabaa882bbe"
 
 DEPENDS += "virtual/kernel"

--- a/recipes-extended/secure-obj/secure-obj.inc
+++ b/recipes-extended/secure-obj/secure-obj.inc
@@ -1,10 +1,11 @@
-DESCRIPTION = "Secure Object"
+DESCRIPTION = "OP-TEE trusted application, key management library and OpenSSL engine for storing and using cryptographic keys inside the QorIQ ARM TrustZone secure world"
 HOMEPAGE = "https://github.com/nxp-qoriq/secure_obj"
 LICENSE = "BSD-3-Clause"
 
+# Canonical DEPENDS definition for the secure-obj recipes; oelint's
+# dependsappend rule wants only appends in an included file.
+# nooelint: oelint.vars.dependsappend
 DEPENDS = "openssl optee-client-qoriq optee-os-qoriq"
-RDEPENDS:${PN} = "bash libcrypto libssl"
-
 DEPENDS += "python3-pycryptodomex-native"
 
 inherit python3native
@@ -23,6 +24,10 @@ EXTRA_OEMAKE = 'CC="${CC}" LD="${CC}"'
 ALLOW_EMPTY:${PN} = "1"
 INHIBIT_PACKAGE_STRIP = "1"
 PARALLEL_MAKE = ""
+# Build links against toolchain libs without the distro LDFLAGS QA can track.
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:${PN} = "ldflags"
 COMPATIBLE_MACHINE = "(qoriq-arm64)"
 DEBUG_BUILD = "1"
+
+RDEPENDS:${PN} = "bash libcrypto libssl"

--- a/recipes-extended/secure-obj/secure-obj_git.bb
+++ b/recipes-extended/secure-obj/secure-obj_git.bb
@@ -1,9 +1,12 @@
 require secure-obj.inc
 
+SUMMARY = "OP-TEE-backed secure object library and OpenSSL engine"
+SECTION = "security"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=751419260aa954499f7abaabaa882bbe"
 
 DEPENDS:remove = "python3-pycryptodomex-native"
 DEPENDS:append = " python3-cryptography-native optee-os-qoriq-tadevkit"
+FILES:${PN} += "${base_libdir}/optee_armtz ${libdir}/${ARCH}-linux-gnu/openssl-1.0.0/engines"
 RDEPENDS:${PN} += "secure-obj-module"
 
 WRAP_TARGET_PREFIX ?= "${TARGET_PREFIX}"
@@ -33,16 +36,19 @@ do_install() {
     install -d ${D}${includedir}
     install -d ${D}${base_libdir}/optee_armtz
     install -d ${D}${libdir}/${ARCH}-linux-gnu/openssl-1.0.0/engines
-    cp ${S}/secure_storage_ta/ta/b05bcf48-9732-4efa-a9e0-141c7c888c34.ta ${D}${base_libdir}/optee_armtz
-    cp ${S}/securekey_lib/out/export/lib/libsecure_obj.so ${D}${libdir}
-    cp ${S}/secure_obj-openssl-engine/libeng_secure_obj.so ${D}${libdir}/${ARCH}-linux-gnu/openssl-1.0.0/engines
-    cp ${S}/securekey_lib/out/export/app/*_app ${D}${bindir}
-    cp ${S}/securekey_lib/out/export/app/mp_verify ${D}${bindir}
-    cp ${S}/secure_obj-openssl-engine/app/sobj_eng_app ${D}${bindir}
-    cp ${S}/securekey_lib/out/export/include/*  ${D}${includedir}
+    install -m 0644 ${S}/secure_storage_ta/ta/b05bcf48-9732-4efa-a9e0-141c7c888c34.ta ${D}${base_libdir}/optee_armtz
+    install -m 0755 ${S}/securekey_lib/out/export/lib/libsecure_obj.so ${D}${libdir}
+    install -m 0755 ${S}/secure_obj-openssl-engine/libeng_secure_obj.so ${D}${libdir}/${ARCH}-linux-gnu/openssl-1.0.0/engines
+    install -m 0755 ${S}/securekey_lib/out/export/app/*_app ${D}${bindir}
+    install -m 0755 ${S}/securekey_lib/out/export/app/mp_verify ${D}${bindir}
+    install -m 0755 ${S}/secure_obj-openssl-engine/app/sobj_eng_app ${D}${bindir}
+    install -m 0644 ${S}/securekey_lib/out/export/include/* ${D}${includedir}
     rm -rf ${D}${bindir}/test
 }
 
-FILES:${PN} += "${base_libdir}/optee_armtz ${libdir}/${ARCH}-linux-gnu/openssl-1.0.0/engines"
-INSANE_SKIP:${PN} = "dev-deps ldflags"
+# Prebuilt OP-TEE TA and OpenSSL engine link against toolchain libs and ship
+# dev files in the main package; INSANE_SKIP is unavoidable here.
+# nooelint: oelint.vars.insaneskip
+INSANE_SKIP:${PN} += "dev-deps"
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:${PN}-dev = "ldflags dev-elf"

--- a/recipes-extended/tsntool/tsntool_git.bb
+++ b/recipes-extended/tsntool/tsntool_git.bb
@@ -1,6 +1,7 @@
 SUMMARY = "Configure TSN funtionalitie"
 DESCRIPTION = "A tool to configure TSN funtionalities in user space"
 HOMEPAGE = "https://github.com/nxp-qoriq/tsntool"
+SECTION = "console/network"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=ef58f855337069acd375717db0dbbb6d"
 
@@ -8,14 +9,10 @@ DEPENDS = "cjson libnl readline"
 
 inherit pkgconfig
 
-FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
-
-SRC_URI = "git://github.com/nxp-qoriq/tsntool;protocol=https;nobranch=1"
-SRCREV = "a0769e23304957a22f0cbeee6d1f547b20c3c21e"
-
-SRC_URI:append = " \
-    file://0001-tsntool-remove-redundant-parameters-from-BIN_LDFLAGS.patch \
+SRC_URI = "git://github.com/nxp-qoriq/tsntool;protocol=https;nobranch=1 \
+           file://0001-tsntool-remove-redundant-parameters-from-BIN_LDFLAGS.patch \
 "
+SRCREV = "a0769e23304957a22f0cbeee6d1f547b20c3c21e"
 
 do_configure[depends] += "virtual/kernel:do_shared_workdir"
 
@@ -30,7 +27,12 @@ do_install() {
 }
 
 PACKAGES = "${PN}-dbg ${PN}"
+# libtsn.so is an unversioned runtime .so deliberately kept in the main
+# package (hence the dev-so skip), so FILES:${PN} is set explicitly.
+# nooelint: oelint.var.filesoverride
 FILES:${PN} = "${libdir}/libtsn.so ${bindir}/*"
+# Prebuilt-style .so with vendored rpaths and runtime deps QA can't map.
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:${PN} += "file-rdeps rpaths dev-so"
 COMPATIBLE_MACHINE = "(qoriq)"
 PARALLEL_MAKE = ""

--- a/recipes-graphics/drm/libdrm_2.4.127.imx.bb
+++ b/recipes-graphics/drm/libdrm_2.4.127.imx.bb
@@ -46,15 +46,15 @@ PACKAGES =+ "${PN}-tests ${PN}-drivers ${PN}-radeon ${PN}-nouveau ${PN}-omap \
              ${PN}-intel ${PN}-exynos ${PN}-freedreno ${PN}-amdgpu \
              ${PN}-etnaviv"
 
-FILES:${PN}-tests = "${bindir}/*"
-FILES:${PN}-radeon = "${libdir}/libdrm_radeon.so.*"
-FILES:${PN}-nouveau = "${libdir}/libdrm_nouveau.so.*"
-FILES:${PN}-omap = "${libdir}/libdrm_omap.so.*"
-FILES:${PN}-intel = "${libdir}/libdrm_intel.so.*"
-FILES:${PN}-exynos = "${libdir}/libdrm_exynos.so.*"
-FILES:${PN}-freedreno = "${libdir}/libdrm_freedreno.so.*"
-FILES:${PN}-amdgpu = "${libdir}/libdrm_amdgpu.so.* ${datadir}/${PN}/amdgpu.ids"
-FILES:${PN}-etnaviv = "${libdir}/libdrm_etnaviv.so.*"
+FILES:${PN}-tests += "${bindir}/*"
+FILES:${PN}-radeon += "${libdir}/libdrm_radeon.so.*"
+FILES:${PN}-nouveau += "${libdir}/libdrm_nouveau.so.*"
+FILES:${PN}-omap += "${libdir}/libdrm_omap.so.*"
+FILES:${PN}-intel += "${libdir}/libdrm_intel.so.*"
+FILES:${PN}-exynos += "${libdir}/libdrm_exynos.so.*"
+FILES:${PN}-freedreno += "${libdir}/libdrm_freedreno.so.*"
+FILES:${PN}-amdgpu += "${libdir}/libdrm_amdgpu.so.* ${datadir}/${PN}/amdgpu.ids"
+FILES:${PN}-etnaviv += "${libdir}/libdrm_etnaviv.so.*"
 
 RRECOMMENDS:${PN}-drivers = "${PN}-radeon ${PN}-nouveau ${PN}-omap ${PN}-intel \
                              ${PN}-exynos ${PN}-freedreno ${PN}-amdgpu \
@@ -62,9 +62,13 @@ RRECOMMENDS:${PN}-drivers = "${PN}-radeon ${PN}-nouveau ${PN}-omap ${PN}-intel \
 
 BBCLASSEXTEND = "native nativesdk"
 
+# The i.MX vivante driver additions are kept together as one block.
+# nooelint: oelint.var.order.PACKAGES
 PACKAGES:prepend:imxgpu = "${PN}-vivante "
 RRECOMMENDS:${PN}-drivers:append:imxgpu = " ${PN}-vivante"
-FILES:${PN}-vivante = "${libdir}/libdrm_vivante.so.*"
+# nooelint: oelint.var.order.FILES
+FILES:${PN}-vivante += "${libdir}/libdrm_vivante.so.*"
+# nooelint: oelint.var.order.PACKAGECONFIG
 PACKAGECONFIG:append:imxgpu = " vivante"
 PACKAGECONFIG[vivante] = "-Dvivante=true,-Dvivante=false"
 

--- a/recipes-graphics/imx-g2d/imx-dpu-g2d_2.5.0.2.bb
+++ b/recipes-graphics/imx-g2d/imx-dpu-g2d_2.5.0.2.bb
@@ -9,7 +9,7 @@ SECTION = "graphics"
 LICENSE = "Proprietary"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bc649096ad3928ec06a8713b8d787eac"
 
-DEPENDS = "libdrm ${LIBGAL_IMX}"
+DEPENDS = "${LIBGAL_IMX} libdrm"
 LIBGAL_IMX = ""
 LIBGAL_IMX:imxviv = "libgal-imx"
 
@@ -32,12 +32,15 @@ inherit fsl-eula-unpack
 do_install () {
     install -d ${D}${libdir}
     install -d ${D}${includedir}
-    cp -d ${S}/g2d/usr/lib/*.so* ${D}${libdir}
-    cp -Pr ${S}/g2d/usr/include/* ${D}${includedir}
+    cp -R ${S}/g2d/usr/lib/*.so* ${D}${libdir}
+    cp -R ${S}/g2d/usr/include/* ${D}${includedir}
 }
 
 PACKAGE_ARCH = "${MACHINE_SOCARCH}"
 
+# musl needs gcompat for these glibc-built prebuilt blobs; their runtime
+# deps can't be mapped by QA.
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:append:libc-musl = " file-rdeps"
 RDEPENDS:${PN}:append:libc-musl = " gcompat"
 

--- a/recipes-kernel/ceetm/ceetm_git.bb
+++ b/recipes-kernel/ceetm/ceetm_git.bb
@@ -5,12 +5,13 @@ SECTION = "kernel"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
-SRC_URI = "git://github.com/nxp-qoriq/ceetm;protocol=https;nobranch=1"
-SRCREV = "46b3565a48ca20f90ad601cef8250cdd35f18b22"
-SRC_URI:append = " file://0001-Makefile-update-CFLAGS.patch \
-                  file://0001-Makefile-Fix-build-error-with-gcc15-YOCIMX-8305.patch \
-"
 DEPENDS = "iproute2"
+
+SRC_URI = "git://github.com/nxp-qoriq/ceetm;protocol=https;nobranch=1 \
+           file://0001-Makefile-update-CFLAGS.patch \
+           file://0001-Makefile-Fix-build-error-with-gcc15-YOCIMX-8305.patch \
+"
+SRCREV = "46b3565a48ca20f90ad601cef8250cdd35f18b22"
 
 export IPROUTE2_DIR = "${STAGING_DIR_TARGET}"
 WRAP_TARGET_PREFIX ?= "${TARGET_PREFIX}"
@@ -19,12 +20,12 @@ export CROSS_COMPILE = "${WRAP_TARGET_PREFIX}"
 LDFLAGS += "${TOOLCHAIN_OPTIONS}"
 
 do_install(){
-    mkdir -p ${D}/${libdir}/tc
-    cp ${S}/q_ceetm.so ${D}/${libdir}/tc/
+    install -d ${D}${libdir}/tc
+    install -m 0755 ${S}/q_ceetm.so ${D}${libdir}/tc/
 }
 
+PACKAGE_ARCH = "${MACHINE_SOCARCH}"
 FILES:${PN} += "${libdir}/tc"
 INHIBIT_PACKAGE_STRIP = "1"
 
 COMPATIBLE_MACHINE = "(qoriq)"
-PACKAGE_ARCH = "${MACHINE_SOCARCH}"


### PR DESCRIPTION
## Summary
 Continues the oelint-adv cleanup series. Per-recipe metadata,
`do_install` and packaging fixes, one commit per recipe, each re-scanned
clean.
 - **qe-ucode, mc-utils, imx-uuc, imx-seco, imx-lib, rcw, uefi,
secure-obj-module, secure-obj, qoriq-cst** — add
SUMMARY/HOMEPAGE/DESCRIPTION/SECTION and apply the canonical order to
LICENSE/PACKAGE_ARCH and friends.
- **ceetm, iproute2, imx-dpu-g2d, merge-files, qoriq-cst, secure-obj,
mbedtls** — fix `do_install` (replace `mkdir`/`cp` with `install`,
remove hardcoded include paths, correct the ptest install).
- **imx-seco, firmware-sof-imx, firmware-ele-imx, firmware-imx, libdrm,
firmware-nxp-wifi** — document the split-package / main-package `FILES`
override findings (accepted via inline `# nooelint:` with rationale).
- **fsl-rc-local** — add the version to the recipe filename.
- **tsntool** — set SECTION, tidy SRC_URI and document findings.
 ## Impact
 Metadata and ordering, plus `do_install` changes that install the same
files by a lint-approved method. No functional change to any package.
 ## Test
 `oelint-adv` reports no baseline findings for each touched recipe.