### PR TITLE
oelint: Recipe metadata fixes (SUMMARY/DESCRIPTION/SECTION, variable order, dedup)

### DIFF
--- a/recipes-bsp/boot-format/boot-format_git.bb
+++ b/recipes-bsp/boot-format/boot-format_git.bb
@@ -1,5 +1,7 @@
-DESCRIPTION = "Boot format utility for booting from eSDHC/eSPI"
+SUMMARY = "Boot format utility for eSDHC/eSPI"
+DESCRIPTION = "Utility to format the boot partition for booting NXP QorIQ boards from eSDHC or eSPI."
 HOMEPAGE = "https://github.com/nxp-qoriq-yocto-sdk/boot-format"
+SECTION = "bootloaders"
 LICENSE = "GPL-2.0-only"
 PR = "r6"
 LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"

--- a/recipes-bsp/u-boot/u-boot-fslc-mxsboot_2025.01.bb
+++ b/recipes-bsp/u-boot/u-boot-fslc-mxsboot_2025.01.bb
@@ -6,7 +6,6 @@ SECTION = "bootloader"
 inherit python3native
 
 DEPENDS += "\
-    bison-native \
     dtc \
     gnutls \
     openssl \

--- a/recipes-devtools/uuu/uuu-bin_1.5.233.bb
+++ b/recipes-devtools/uuu/uuu-bin_1.5.233.bb
@@ -2,7 +2,7 @@
 # Released under the MIT License (see COPYING.MIT for the terms)
 
 SUMMARY = "Universal Update Utility - Binaries"
-DESCRIPTION = "Image deploy tool for i.MX chips"
+DESCRIPTION = "Prebuilt Universal Update Utility (uuu) binaries used to download and deploy bootloader and OS images to NXP i.MX chips over USB."
 HOMEPAGE = "https://github.com/nxp-imx/mfgtools"
 
 LICENSE = "BSD-3-Clause AND LGPL-2.1-or-later"

--- a/recipes-extended/ofp/ofp_git.bb
+++ b/recipes-extended/ofp/ofp_git.bb
@@ -6,15 +6,13 @@ SECTION = "console/network"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=fbe4957c430eed6cc20521d4eb429fae"
 
+DEPENDS = "odp"
+
 SRC_URI = "git://github.com/nxp-qoriq/ofp;protocol=https;nobranch=1"
 
 SRCREV = "fe66f4659f7d356f7aa73a8fb32fcf67c6cf1108"
 
 inherit autotools-brokensep pkgconfig
-
-PACKAGE_ARCH = "${MACHINE_ARCH}"
-
-DEPENDS = "odp"
 
 EXTRA_OECONF = "\
     --prefix=/usr \
@@ -22,6 +20,8 @@ EXTRA_OECONF = "\
     --host=${SIMPLE_TARGET_SYS} \
     --with-odp=${STAGING_DIR_TARGET} \
 "
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 do_configure () {
     export SIMPLE_TARGET_SYS="$(echo ${TARGET_SYS} | sed s:${TARGET_VENDOR}::g)"

--- a/recipes-fsl/mcore-demos/imx-m7-demos_26.06.00.bb
+++ b/recipes-fsl/mcore-demos/imx-m7-demos_26.06.00.bb
@@ -3,7 +3,7 @@
 
 require imx-mcore-demos.inc
 
-LIC_FILES_CHKSUM = "file://COPYING;md5=bc649096ad3928ec06a8713b8d787eac" 
+LIC_FILES_CHKSUM = "file://COPYING;md5=bc649096ad3928ec06a8713b8d787eac"
 
 SRC_URI[imx8mn.sha256sum] = "fd4350c9ceceda29d6f7483f83a946b1876b364a4d9c8d9a9e6b618415d27b8e"
 SRC_URI[imx8mnddr3l.sha256sum] = "cdaad7f840eec638568bde934408044a386e56b85d22a20c1de7faf77b0674c7"

--- a/recipes-graphics/mesa/mesa-etnaviv-env_0.1.bb
+++ b/recipes-graphics/mesa/mesa-etnaviv-env_0.1.bb
@@ -10,9 +10,9 @@ SRC_URI = "\
     file://mesa-etnaviv.sh \
 "
 
-PACKAGE_ARCH = "${MACHINE_ARCH}"
-
 S = "${UNPACKDIR}"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 do_configure[noexec] = "1"
 do_compile[noexec] = "1"

--- a/recipes-kernel/linux/linux-qoriq.inc
+++ b/recipes-kernel/linux/linux-qoriq.inc
@@ -2,6 +2,7 @@ inherit kernel qoriq_build_64bit_kernel siteinfo
 inherit fsl-kernel-localversion kernel-yocto
 
 SUMMARY = "Linux Kernel for NXP QorIQ platforms"
+DESCRIPTION = "Linux kernel for NXP QorIQ and Layerscape processors, based on the NXP lf (Layerscape factory) kernel tree."
 SECTION = "kernel"
 LICENSE = "GPL-2.0-only"
 

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-imx_2.2.0.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-imx_2.2.0.bb
@@ -1,5 +1,6 @@
 # Copyright (C) 2018 O.S. Systems Software LTDA.
-DESCRIPTION = "GStreamer 1.0 plugins for i.MX platforms"
+SUMMARY = "GStreamer 1.0 plugins for i.MX platforms"
+DESCRIPTION = "GStreamer 1.0 plugins providing hardware-accelerated video and audio elements (VPU decoders/encoders, G2D/IPU-based blitters and uniaudio) for NXP i.MX platforms."
 HOMEPAGE = "https://github.com/Freescale/gstreamer-imx"
 LICENSE = "LGPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=55ca817ccb7d5b5b66355690e9abc605"

--- a/recipes-security/smw/itest_git.bb
+++ b/recipes-security/smw/itest_git.bb
@@ -1,6 +1,6 @@
 # Copyright 2026 NXP
 SUMMARY = "NXP i.MX Itest"
-DESCRIPTION = "NXP i.MX Itest"
+DESCRIPTION = "NXP i.MX Itest, an integration test suite exercising the i.MX secure enclave (EdgeLock Enclave and SECO) interfaces."
 HOMEPAGE = "https://github.com/nxp-imx/itest"
 SECTION = "base"
 LICENSE = "BSD-3-Clause"

--- a/recipes-security/smw/keyctl-caam_git.bb
+++ b/recipes-security/smw/keyctl-caam_git.bb
@@ -7,12 +7,12 @@ SECTION = "base"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=8636bd68fc00cc6a3809b7b58b45f982"
 
+DEPENDS = "openssl"
+
 SRCBRANCH = "lf-6.18.2_1.0.0"
 SRC_URI = "git://github.com/nxp-imx/keyctl_caam.git;protocol=https;branch=${SRCBRANCH}"
 
 SRCREV = "71cb18f17d766145217a5517748e37e250b055bf"
-
-DEPENDS = "openssl"
 
 TARGET_CC_ARCH += "${LDFLAGS}"
 

--- a/recipes-security/smw/smw_5.3.bb
+++ b/recipes-security/smw/smw_5.3.bb
@@ -2,8 +2,8 @@
 require recipes-security/optee-imx/optee-fslc.inc
 
 SUMMARY = "NXP i.MX Security Middleware Library"
+DESCRIPTION = "NXP i.MX Security Middleware (SMW) library providing a unified API to the i.MX platform hardware security subsystems (e.g. EdgeLock Enclave and SECO) for key management and cryptographic operations."
 HOMEPAGE = "https://github.com/nxp-imx/imx-smw"
-DESCRIPTION = "NXP i.MX Security Middleware Library"
 SECTION = "base"
 LICENSE = "BSD-3-Clause"
 LICENSE = "Apache-2.0 AND BSD-3-Clause AND Zlib"


### PR DESCRIPTION
## Summary

  Conservative oelint-adv cleanup of genuine metadata defects in meta-freescale's
  own recipes. Each finding was classified to root cause before any change; only
  real defects are fixed, with the smallest upstream-quality diff. Findings that
  are linter false positives, fork-mirror-of-upstream, or intentional layer idioms
  were deliberately left visible rather than suppressed.

  ## Changes

  ### Missing / weak descriptive metadata
  - **boot-format** — add `SUMMARY` + `SECTION = "bootloaders"`, expand `DESCRIPTION`
    (was tripping `mandatoryvar.SUMMARY` / `suggestedvar.SECTION`)
  - **gstreamer1.0-plugins-imx** — add `SUMMARY`, expand `DESCRIPTION`
  - **linux-qoriq** — add `DESCRIPTION` to the shared include (`SUMMARY` was set,
    `DESCRIPTION` was not)
  - **smw**, **itest** — give `DESCRIPTION` a distinct value (was identical to
    `SUMMARY` → `descriptionsame`)
  - **uuu-bin** — expand the too-brief `DESCRIPTION` (`descriptiontoobrief`)

  ### Variable ordering (canonical order per the Recipe Style Guide)
  - **ofp** — `DEPENDS` before `SRC_URI`, `EXTRA_OECONF` before `PACKAGE_ARCH`
  - **keyctl-caam** — `DEPENDS` before the `SRC_URI`/`SRCREV` block
  - **mesa-etnaviv-env** — `S` before `PACKAGE_ARCH`
  - **smw** — move `DESCRIPTION` into canonical order (`order.DESCRIPTION`)

 ### Redundancy / whitespace
  - **u-boot-fslc-mxsboot** — drop redundant `bison-native` from `DEPENDS`
    (already added by the required `u-boot-fslc-common` include)
  - **imx-m7-demos** — strip trailing whitespace on `LIC_FILES_CHKSUM`

  ## Validation

  - oelint-adv scoped re-scan of each touched recipe: targeted findings resolved,
    no new order/format regressions introduced.
  - Changes are string-only recipe metadata (no task/build semantics altered).

  ## Deliberately not changed

  The remaining oelint findings in these areas were audited and left visible as
  false positives / intentional exceptions (e.g. `mandatoryvar` on recipes whose
  metadata comes from a cross-layer `require` into oe-core; DESCRIPTION on i.MX
  forks that mirror oe-core recipes which also omit it; `:append` "missing space"
  on values where a space would corrupt them; hardcoded paths that are literal
  relocation sources or host/native paths). No suppressions were added for these —
  they stay as understood, documented findings.
