### PR TITLE
fixup! iproute2: Fix hardcoded include path and do_install copies per…

### DIFF
--- a/recipes-connectivity/iproute2/iproute2_%.bbappend
+++ b/recipes-connectivity/iproute2/iproute2_%.bbappend
@@ -1,11 +1,11 @@
 do_install:append:imx-generic-bsp () {
     install -d ${D}${includedir}/tc
-    cp -R ${B}/include ${D}${includedir}
+    cp -R ${B}/include/* ${D}${includedir}
     install -m 0644 ${B}/tc/*.h ${D}${includedir}/tc
 }
 
 do_install:append:qoriq-generic-bsp () {
     install -d ${D}${includedir}/tc
-    cp -R ${B}/include ${D}${includedir}
+    cp -R ${B}/include/* ${D}${includedir}
     install -m 0644 ${B}/tc/*.h ${D}${includedir}/tc
 }


### PR DESCRIPTION
… oelint

The recent commit accidentally moved header files from /usr/include to /usr/include/include.