### PR TITLE
iproute2: Fix v6.19.0 install issue

### DIFF
--- a/recipes-connectivity/iproute2/iproute2_%.bbappend
+++ b/recipes-connectivity/iproute2/iproute2_%.bbappend
@@ -1,11 +1,21 @@
 do_install:append:imx-generic-bsp () {
+    cp -Rf --no-preserve=ownership ${B}/include/* ${D}${includedir}
     install -d ${D}${includedir}/tc
     cp -R ${B}/include/* ${D}${includedir}
     install -m 0644 ${B}/tc/*.h ${D}${includedir}/tc
+    # Remove files that conflict with glibc
+    rm -f ${D}${includedir}/dlfcn.h
+    rm -f ${D}${includedir}/netinet/tcp.h
+    rm -f ${D}${includedir}/xtables.h
 }
 
 do_install:append:qoriq-generic-bsp () {
+    cp -Rf --no-preserve=ownership ${B}/include/* ${D}${includedir}
     install -d ${D}${includedir}/tc
     cp -R ${B}/include/* ${D}${includedir}
     install -m 0644 ${B}/tc/*.h ${D}${includedir}/tc
+    # Remove files that conflict with glibc
+    rm -f ${D}${includedir}/dlfcn.h
+    rm -f ${D}${includedir}/netinet/tcp.h
+    rm -f ${D}${includedir}/xtables.h
 }


### PR DESCRIPTION
1,Operation not permitted after adjustments to the install path Errors were encountered while processing:
 ```
/tmp/apt-dpkg-install-swecwu/293-iproute2-dev_6.19.0-r0_arm64.deb
W: chown to _apt:root of directory /.../yocto/build/tmp/work/imx8mqevk-poky-linux/test-internal-qt6/1.0/recipe-sysroot-native/var/cache/apt/archives/partial failed - SetupAPTPartialDirectory (1: Operation not permitted) W: chown to _apt:root of directory /.../yocto/build/tmp/work/imx8mqevk-poky-linux/test-internal-qt6/1.0/apt/lists/auxfiles failed - SetupAPTPartialDirectory (1: Operation not permitted) W: chown to root:adm of file /.../yocto/build/tmp/work/imx8mqevk-poky-linux/test-internal-qt6/1.0/recipe-sysroot-native/var/log/apt/term.log failed - OpenLog (1: Operation not permitted) E: Sub-process dpkg returned an error code (1)
```

2,Remove conflict files with glibc
```
do_prepare_recipe_sysroot: The file /usr/include/dlfcn.h is installed by both glibc and iproute2, aborting
```