### PR TITLE
fixup! iproute2: Fix v6.19.0 install issue

### DIFF
--- a/recipes-connectivity/iproute2/iproute2_%.bbappend
+++ b/recipes-connectivity/iproute2/iproute2_%.bbappend
@@ -1,8 +1,11 @@
 do_install:append:imx-generic-bsp () {
-    cp -Rf --no-preserve=ownership ${B}/include/* ${D}${includedir}
+
+    # Add tc folder headers
     install -d ${D}${includedir}/tc
-    cp -R ${B}/include/* ${D}${includedir}
     install -m 0644 ${B}/tc/*.h ${D}${includedir}/tc
+
+    # Add include folder headers
+    cp -R --no-preserve=ownership ${B}/include/* ${D}${includedir}
     # Remove files that conflict with glibc
     rm -f ${D}${includedir}/dlfcn.h
     rm -f ${D}${includedir}/netinet/tcp.h
@@ -10,10 +13,13 @@ do_install:append:imx-generic-bsp () {
 }
 
 do_install:append:qoriq-generic-bsp () {
-    cp -Rf --no-preserve=ownership ${B}/include/* ${D}${includedir}
+
+    # Add tc folder headers
     install -d ${D}${includedir}/tc
-    cp -R ${B}/include/* ${D}${includedir}
     install -m 0644 ${B}/tc/*.h ${D}${includedir}/tc
+
+    # Add include folder headers
+    cp -R --no-preserve=ownership ${B}/include/* ${D}${includedir}
     # Remove files that conflict with glibc
     rm -f ${D}${includedir}/dlfcn.h
     rm -f ${D}${includedir}/netinet/tcp.h


### PR DESCRIPTION
Cleanup:
- Remove the redundant include folder copy
- Group the tc folder commands and the include folder commands