### PR TITLE
iproute2: Nest exported headers to fix glibc sysroot collision

### DIFF
--- a/recipes-connectivity/iproute2/iproute2_%.bbappend
+++ b/recipes-connectivity/iproute2/iproute2_%.bbappend
@@ -1,21 +1,11 @@
 do_install:append:imx-generic-bsp () {
-    cp -Rf --no-preserve=ownership ${B}/include/* ${D}${includedir}
     install -d ${D}${includedir}/tc
-    cp -R ${B}/include/* ${D}${includedir}
+    cp -R ${B}/include ${D}${includedir}
     install -m 0644 ${B}/tc/*.h ${D}${includedir}/tc
-    # Remove files that conflict with glibc
-    rm -f ${D}${includedir}/dlfcn.h
-    rm -f ${D}${includedir}/netinet/tcp.h
-    rm -f ${D}${includedir}/xtables.h
 }
 
 do_install:append:qoriq-generic-bsp () {
-    cp -Rf --no-preserve=ownership ${B}/include/* ${D}${includedir}
     install -d ${D}${includedir}/tc
-    cp -R ${B}/include/* ${D}${includedir}
+    cp -R ${B}/include ${D}${includedir}
     install -m 0644 ${B}/tc/*.h ${D}${includedir}/tc
-    # Remove files that conflict with glibc
-    rm -f ${D}${includedir}/dlfcn.h
-    rm -f ${D}${includedir}/netinet/tcp.h
-    rm -f ${D}${includedir}/xtables.h
 }


### PR DESCRIPTION
Commits d92fd4600 ("fixup! iproute2: Fix hardcoded include path and do_install copies per oelint") and 4bc71fe5a ("iproute2: Fix v6.19.0 install issue") changed the exported header copy from

    cp -R ${B}/include ${D}${includedir}

to a flattened

    cp -R ${B}/include/* ${D}${includedir}

which drops iproute2's build-tree include/ contents directly into ${includedir}. iproute2 vendors headers that shadow libc (dlfcn.h, netinet/tcp.h, xtables.h, ...), so iproute2-dev then co-owns those paths with glibc and do_prepare_recipe_sysroot aborts for any recipe that stages both:

    The file /usr/include/dlfcn.h is installed by both glibc and
    iproute2, aborting

The per-file "rm -f" workaround in 4bc71fe5a only removes the collisions found so far; the entire include/ tree is still dumped into ${includedir}, so the next shadowing header re-breaks the build.

Restore the nested layout the recipe used since it was added: the tree lands under ${includedir}/include/ and shares no path with glibc, so the collision cannot occur regardless of which headers iproute2 vendors. This reverts the copy changes from d92fd4600 and 4bc71fe5a and keeps the oelint cleanup from 6f839c2e8.

Consumers must reference these headers via ${includedir}/include. If a consumer instead requires them directly under ${includedir}, the correct fix is a dedicated ${includedir}/iproute2/ subdirectory rather than shadowing the global header namespace.