### PR TITLE
iproute2: Restore install behavior, limit override to QorIQ

### DIFF
--- a/recipes-connectivity/iproute2/iproute2_%.bbappend
+++ b/recipes-connectivity/iproute2/iproute2_%.bbappend
@@ -1,13 +1,3 @@
-do_install:append:imx-generic-bsp () {
-
-    # Add tc folder headers
-    install -d ${D}${includedir}/tc
-    install -m 0644 ${B}/tc/*.h ${D}${includedir}/tc
-
-    # Add include folder headers at /usr/include/include
-    cp -R --no-preserve=ownership ${B}/include ${D}${includedir}
-}
-
 do_install:append:qoriq-generic-bsp () {
 
     # Add tc folder headers

--- a/recipes-connectivity/iproute2/iproute2_%.bbappend
+++ b/recipes-connectivity/iproute2/iproute2_%.bbappend
@@ -4,12 +4,8 @@ do_install:append:imx-generic-bsp () {
     install -d ${D}${includedir}/tc
     install -m 0644 ${B}/tc/*.h ${D}${includedir}/tc
 
-    # Add include folder headers
-    cp -R --no-preserve=ownership ${B}/include/* ${D}${includedir}
-    # Remove files that conflict with glibc
-    rm -f ${D}${includedir}/dlfcn.h
-    rm -f ${D}${includedir}/netinet/tcp.h
-    rm -f ${D}${includedir}/xtables.h
+    # Add include folder headers at /usr/include/include
+    cp -R --no-preserve=ownership ${B}/include ${D}${includedir}
 }
 
 do_install:append:qoriq-generic-bsp () {
@@ -18,10 +14,6 @@ do_install:append:qoriq-generic-bsp () {
     install -d ${D}${includedir}/tc
     install -m 0644 ${B}/tc/*.h ${D}${includedir}/tc
 
-    # Add include folder headers
-    cp -R --no-preserve=ownership ${B}/include/* ${D}${includedir}
-    # Remove files that conflict with glibc
-    rm -f ${D}${includedir}/dlfcn.h
-    rm -f ${D}${includedir}/netinet/tcp.h
-    rm -f ${D}${includedir}/xtables.h
+    # Add include folder headers at /usr/include/include
+    cp -R --no-preserve=ownership ${B}/include ${D}${includedir}
 }


### PR DESCRIPTION
The overall effect of these commits is to restore the install behavior to
match the behavior before the oelint changes while also limiting the
install override to QorIQ platforms only.

I am concerned though that our QorIQ builds did fail with the original changes to begin with. As far as I know, the change now is equivalent, and yet my local build of ceetm is fine and does not show the error that precipitated the changes I'm reverting:

```
| In file included from dpaa1_ceetm.h:8,
|                  from dpaa1_ceetm.c:10:
| /.../tmp/work//git/recipe-sysroot/usr/include/tc/tc_util.h:15:10: fatal error: json_print.h: No such file or directory
|    15 | #include "json_print.h"
|       |          ^~~~~~~~~~~~~~
| compilation terminated.
```