### PR TITLE
oelint: Recipe SECTION/DEPENDS metadata and patch Upstream-Status cleanups

### DIFF
--- a/dynamic-layers/arm-toolchain/recipes-bsp/imx-system-manager/imx-system-manager_2026q1.bb
+++ b/dynamic-layers/arm-toolchain/recipes-bsp/imx-system-manager/imx-system-manager_2026q1.bb
@@ -9,6 +9,7 @@ DESCRIPTION = "\
     and pin control via a client RPC API based on ARM's System Control and \
     Management Interface (SCMI)."
 HOMEPAGE = "https://github.com/nxp-imx/imx-sm"
+SECTION = "firmware"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=f2a70813bc08547f509361c08b718861"
 

--- a/recipes-bsp/fsl-tlu/fsl-tlu_1.0.0.bb
+++ b/recipes-bsp/fsl-tlu/fsl-tlu_1.0.0.bb
@@ -2,6 +2,7 @@ SUMMARY = "Freescale TLU(Table Lookup Unit) test package"
 DESCRIPTION = "This package includes the TLU(Table Lookup Unit) test scripts \
                and configuration files."
 HOMEPAGE = "https://github.com/nxp-qoriq-yocto-sdk/fsl-tlu"
+SECTION = "console/utils"
 
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=8a71d0475d08eee76d8b6d0c6dbec543"

--- a/recipes-core/packagegroup/nativesdk-packagegroup-sdk-host.bbappend
+++ b/recipes-core/packagegroup/nativesdk-packagegroup-sdk-host.bbappend
@@ -1,6 +1,6 @@
 RDEPENDS:${PN} += "\
+    nativesdk-imx-usb-loader \
     nativesdk-mxsldr \
     nativesdk-u-boot-mkimage \
-    nativesdk-imx-usb-loader \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'nativesdk-wayland', '', d)} \
 "

--- a/recipes-devtools/half/half_2.1.0.bb
+++ b/recipes-devtools/half/half_2.1.0.bb
@@ -3,6 +3,7 @@ DESCRIPTION = "half is a C++ header-only library to provide an IEEE-754 conforma
                half-precision floating point type along with corresponding arithmetic operators, \
                type conversions and common mathematical functions."
 HOMEPAGE = "https://half.sourceforge.net/"
+SECTION = "libs"
 
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=813a6278831975d26c115ed6f9c21831"

--- a/recipes-devtools/qemu/qemu-qoriq.inc
+++ b/recipes-devtools/qemu/qemu-qoriq.inc
@@ -4,6 +4,7 @@ DESCRIPTION = "QEMU is a hosted virtual machine monitor: it emulates the \
                of different hardware and device models for the machine, enabling it to run \
                a variety of guest operating systems"
 HOMEPAGE = "http://qemu.org"
+SECTION = "devel"
 LICENSE = "GPL-2.0-only AND LGPL-2.1-only"
 
 RDEPENDS:${PN}-ptest = "bash make"

--- a/recipes-devtools/qemu/qemu-qoriq_4.2.bb
+++ b/recipes-devtools/qemu/qemu-qoriq_4.2.bb
@@ -4,7 +4,7 @@ require qemu-qoriq.inc
 
 COMPATIBLE_MACHINE = "(qoriq)"
 
-DEPENDS = "bison-native glib-2.0 pixman zlib"
+DEPENDS += "bison-native glib-2.0 pixman zlib"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=441c28d2cf86e15a37fa47e15a72fbac \
                     file://COPYING.LIB;endline=24;md5=8c5efda6cf1e1b03dcfd0e6c0d271c7f"

--- a/recipes-devtools/uuu/uuu-bin_1.5.233.bb
+++ b/recipes-devtools/uuu/uuu-bin_1.5.233.bb
@@ -4,6 +4,7 @@
 SUMMARY = "Universal Update Utility - Binaries"
 DESCRIPTION = "Prebuilt Universal Update Utility (uuu) binaries used to download and deploy bootloader and OS images to NXP i.MX chips over USB."
 HOMEPAGE = "https://github.com/nxp-imx/mfgtools"
+SECTION = "console/utils"
 
 LICENSE = "BSD-3-Clause AND LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/BSD-3-Clause;md5=550794465ba0ec5312d6919e203a55f9 \

--- a/recipes-dpaa2/dce/files/0001-support-user-merge.patch
+++ b/recipes-dpaa2/dce/files/0001-support-user-merge.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] support user merge
 
 Use Yocto base_sbindir to replace hardcode ./sbin
 
-Upstream-Status: Inappropriate [oe specific]
+Upstream-Status: Inappropriate [oe-specific]
 
 Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>
 ---

--- a/recipes-extended/jailhouse/files/arm-arm64-Makefile-Remove-march-option-from-Makefile.patch
+++ b/recipes-extended/jailhouse/files/arm-arm64-Makefile-Remove-march-option-from-Makefile.patch
@@ -9,7 +9,7 @@ It acomodates to [1].
 
 [1] https://git.yoctoproject.org/poky/commit/?id=04eac1f2b67eac5f892a9e0f8fcfe54849923af5
 
-Upstream-Status: Inappropriate [See above]
+Upstream-Status: Inappropriate [oe-specific]
 
 Signed-off-by: Daiane Angolini <daiane.angolini@foundries.io>
 ---

--- a/recipes-graphics/gli/gli_0.8.4.0.bb
+++ b/recipes-graphics/gli/gli_0.8.4.0.bb
@@ -1,6 +1,5 @@
 SUMMARY = "OpenGL Image Library"
-DESCRIPTION = "OpenGL Image (GLI) is a header only C++ \
-image library for graphics software."
+DESCRIPTION = "OpenGL Image (GLI) is a header only C++ image library for graphics software."
 HOMEPAGE = "http://gli.g-truc.net"
 BUGTRACKER = "https://github.com/g-truc/gli/issues"
 

--- a/recipes-graphics/mali/mali-imx.inc
+++ b/recipes-graphics/mali/mali-imx.inc
@@ -2,7 +2,7 @@ SUMMARY = "Graphics libraries and driver for i.MX Mali GPU"
 DESCRIPTION = "Arm Mali GPU user-space graphics libraries and driver for i.MX SoCs."
 HOMEPAGE = "https://www.nxp.com/"
 SECTION = "libs"
-DEPENDS = "\
+DEPENDS += "\
     libdrm \
     vulkan-loader \
     wayland \

--- a/recipes-graphics/vulkan/vulkan-wsi-layer/0001-MGS-6801-ccc-vkmark-on-wayland.patch
+++ b/recipes-graphics/vulkan/vulkan-wsi-layer/0001-MGS-6801-ccc-vkmark-on-wayland.patch
@@ -5,7 +5,7 @@ Subject: [PATCH 1/2] MGS-6801 [#ccc] vkmark on wayland
 
 Extend the wayland surface properties with VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR
 
-Upstream-Status: Inappropriate [i.MX-specific]
+Upstream-Status: Inappropriate [embedded specific]
 Signed-off-by: Prabhu Sundararaj <prabhu.sundararaj@nxp.com>
 Signed-off-by: Jiyu Yang <jiyu.yang@nxp.com>
 ---

--- a/recipes-graphics/vulkan/vulkan-wsi-layer/0002-MGS-6823-nxp-Add-support-of-VK_COMPOSITE_ALPHA_OPAQU.patch
+++ b/recipes-graphics/vulkan/vulkan-wsi-layer/0002-MGS-6823-nxp-Add-support-of-VK_COMPOSITE_ALPHA_OPAQU.patch
@@ -7,7 +7,7 @@ Subject: [PATCH 2/2] MGS-6823 [#nxp] Add support of
 Mali vulkan driver doesn't support VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR. It caused unwanted blending effect in many vulkan cases.
 Add support of this feature to solve the problem.
 
-Upstream-Status: Inappropriate [i.MX-specific]
+Upstream-Status: Inappropriate [embedded specific]
 Signed-off-by: Yuan Tian <yuan.tian@nxp.com>
 Signed-off-by: Jiyu Yang <jiyu.yang@nxp.com>
 ---

--- a/recipes-kernel/kernel-modules/kernel-module-isp-vvcam/0001-video-add-v4l2-fh-compat-for-pre-6.18-kernels.patch
+++ b/recipes-kernel/kernel-modules/kernel-module-isp-vvcam/0001-video-add-v4l2-fh-compat-for-pre-6.18-kernels.patch
@@ -15,7 +15,7 @@ The relevant upstream commits are:
 Add a small compatibility layer for older kernels that keeps
 file->private_data management in this driver.
 
-Upstream-Status: Inappropriate
+Upstream-Status: Inappropriate [other]
 Signed-off-by: Ernest Van Hoecke <ernest.vanhoecke@toradex.com>
 ---
  video/video.c | 30 +++++++++++++++++++++++++++---

--- a/recipes-multimedia/imx-parser/imx-mp4-parser_git.bb
+++ b/recipes-multimedia/imx-parser/imx-mp4-parser_git.bb
@@ -1,5 +1,7 @@
 # Copyright 2026 NXP Semiconductors
-DESCRIPTION = "i.MX MP4 multimedia parser libraries"
+SUMMARY = "i.MX MP4 multimedia parser libraries"
+DESCRIPTION = "MP4 parser libraries for the i.MX multimedia framework."
+HOMEPAGE = "https://www.nxp.com/"
 SECTION = "multimedia"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=6f862c6751ebcaa393467694c7b0c69a"
@@ -8,7 +10,7 @@ inherit pkgconfig meson
 
 PV = "4.11.0+git"
 
-DEPENDS = "imx-parser"
+DEPENDS += "imx-parser"
 
 SRCBRANCH = "MM_04.11.00_2605_L6.18.20"
 IMXMP4PARSER_SRC ?= "git://github.com/nxp-imx/imx-mp4-parser.git;protocol=https"


### PR DESCRIPTION
# Description

  Recipe-quality cleanups from `oelint-adv`, one logical change per commit.
  No functional change intended — metadata, variable ordering, and patch-header
  annotations only.

  ### SECTION (suggestedvar.SECTION)
  Add a domain `SECTION` to recipes that lacked one:
  - `qemu-qoriq` → `devel`
  - `imx-system-manager` → `firmware`
  - `fsl-tlu`, `uuu-bin` → `console/utils`
  - `half` → `libs`

  ### DEPENDS (dependsappend)
  Append to `DEPENDS` instead of overwriting it, so contributions from included
  `.inc` files are preserved:
  - `qemu-qoriq`, `mali-imx`

  ### Recipe metadata
  - `imx-mp4-parser`: add `SUMMARY`, `HOMEPAGE`, and append `DEPENDS`
  - `gli`: put `DESCRIPTION` on a single line (multilineident)
  - `nativesdk-packagegroup-sdk-host`: order `RDEPENDS` alphabetically

  ### Patch Upstream-Status (patch.missing-reason / canonical reason)
  Add/normalise the oelint reason string in patch `Upstream-Status` headers:
  - `kernel-module-isp-vvcam`, `vulkan-wsi-layer`, `jailhouse-imx`, `dce`
