### PR TITLE
gst: fix build errors introduced by update to gstreamer 1.28.1

### DIFF
--- a/recipes-multimedia/gstreamer/gst-examples/0001-Make-player-examples-installable.patch
+++ b/recipes-multimedia/gstreamer/gst-examples/0001-Make-player-examples-installable.patch
@@ -17,7 +17,7 @@ Index: gst-examples/playback/player/gst-play/meson.build
 ===================================================================
 --- gst-examples.orig/playback/player/gst-play/meson.build
 +++ gst-examples/playback/player/gst-play/meson.build
-@@ -2,5 +2,6 @@ executable('gst-play',
+@@ -2,5 +2,6 @@
      ['gst-play.c',
       'gst-play-kb.c',
       'gst-play-kb.h'],
@@ -28,10 +28,10 @@ Index: gst-examples/playback/player/gtk/meson.build
 ===================================================================
 --- gst-examples.orig/playback/player/gtk/meson.build
 +++ gst-examples/playback/player/gtk/meson.build
-@@ -20,5 +20,6 @@ if gtk_dep.found()
+@@ -21,5 +21,6 @@
         'gtk-video-renderer.h',
         'gtk-video-renderer.c'],
        c_args :  extra_c_args,
 +      install: true,
-       dependencies : [gst_dep, gsttag_dep, gstplay_dep, gtk_dep, x11_dep])
+       dependencies : [gst_dep, gsttag_dep, gstplay_dep, gtk_dep, x11_dep, gmodule_dep])
  endif

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.28.1.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.28.1.imx.bb
@@ -204,14 +204,13 @@ PACKAGECONFIG_REMOVE ?= "\
 PACKAGECONFIG:remove = "${PACKAGECONFIG_REMOVE}"
 PACKAGECONFIG:remove:mx93-nxp-bsp = "gl"
 PACKAGECONFIG:remove:mx943-nxp-bsp = "gl"
-PACKAGECONFIG:append:mx8-nxp-bsp = " kms tinycompress"
+PACKAGECONFIG:append:mx8-nxp-bsp = " kms"
 
 PACKAGECONFIG:append = " ${PACKAGECONFIG_G2D}"
 PACKAGECONFIG_G2D ??= ""
 PACKAGECONFIG_G2D:imxgpu2d ??= "g2d"
 
 PACKAGECONFIG[g2d] = ",,virtual/libg2d"
-PACKAGECONFIG[tinycompress] = "-Dtinycompress=enabled,-Dtinycompress=disabled,tinycompress"
 
 EXTRA_OEMESON += "\
     -Dc_args="${CFLAGS} -I${STAGING_INCDIR_IMX}" \


### PR DESCRIPTION
Two simple commits fixing two regressions.

tinycompresssink is no longer available in gstreamer1.0-plugins-bad, which was previously used by imx8 devices. Not sure if some people will be impacted by it, but the config option simply doesn't exist in this new version.

These fixes are probably required in wrynose as well.