### PR TITLE
wrynose: add support for i.MX93 FRDM board

### DIFF
--- a/conf/machine/imx93-frdm.conf
+++ b/conf/machine/imx93-frdm.conf
@@ -1,0 +1,15 @@
+require conf/machine/include/imx93-evk.inc
+
+DDR_FIRMWARE_NAME = " \
+   lpddr4_dmem_1d_v202201.bin \
+   lpddr4_dmem_2d_v202201.bin \
+   lpddr4_imem_1d_v202201.bin \
+   lpddr4_imem_2d_v202201.bin \
+"
+
+PREFERRED_PROVIDER_virtual/bootloader ?= "u-boot-imx"
+UBOOT_CONFIG_BASENAME = "imx93_11x11_frdm"
+UBOOT_DTB_NAME = "imx93-11x11-frdm"
+
+PREFERRED_PROVIDER_virtual/kernel ?= "linux-imx"
+KERNEL_DEVICETREE = "freescale/imx93-11x11-frdm.dtb"

--- a/recipes-bsp/u-boot/u-boot-imx-common_2025.04.inc
+++ b/recipes-bsp/u-boot/u-boot-imx-common_2025.04.inc
@@ -16,7 +16,7 @@ SRC_URI = "${UBOOT_SRC};branch=${SRCBRANCH}"
 UBOOT_SRC ?= "git://github.com/nxp-imx/uboot-imx.git;protocol=https"
 SRCBRANCH = "lf_v2025.04"
 LOCALVERSION ?= "-${SRCBRANCH}"
-SRCREV = "4ddbad60eff308a5b356fb9ab8734ac382ddd692"
+SRCREV = "99518e6b6f20cb6a2bf19115e355db9f58100af8"
 
 B = "${WORKDIR}/build"
 


### PR DESCRIPTION
Hello,

This machine configuration is inspired on what is currently provided by meta-imx-frdm, and successfully works with the build configutarion below:

```
Build Configuration:
BB_VERSION           = "2.18.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "universal"
TARGET_SYS           = "aarch64-poky-linux"
MACHINE              = "imx93-frdm"
SDKMACHINE           = "x86_64"
DISTRO               = "poky"
DISTRO_VERSION       = "6.0.2"
TUNE_FEATURES        = "aarch64 crypto cortexa55"
meta                 = "wrynose:f66b182e2ff431b624dfc3a506d25dc8f1fc6db2"
meta-poky            = "wrynose:824795b885b25e074a2880fbcd54e1a6c875d47d"
meta-freescale       = "jmcosta/wrynose:fe38e65a09ccddf921a2ece98ac7af7b12df5183"
meta-arm-toolchain
meta-arm             = "wrynose:0979b80429099f1a42dc0026c8c466cee780bc74"
```

Tested on both rev. B1 and B2 variants of the i.MX93 board.

Best regards,
