### PR TITLE
image_populate_mfgtool: use oe.utils.base_set_filespath

### DIFF
--- a/classes/image_populate_mfgtool.bbclass
+++ b/classes/image_populate_mfgtool.bbclass
@@ -42,7 +42,7 @@
 # SPDX-License-Identifier: MIT
 
 MFGTOOL_FILESPATH ??= "\
-    ${@base_set_filespath(["%s/mfgtool"% p for p in "${BBPATH}".split(":")] \
+    ${@oe.utils.base_set_filespath(["%s/mfgtool"% p for p in "${BBPATH}".split(":")] \
                              + ["${FILE_DIRNAME}/${BP}/mfgtool", \
                                 "${FILE_DIRNAME}/${BPN}/mfgtool", \
                                 "${FILE_DIRNAME}/files/mfgtool"] \


### PR DESCRIPTION
Commit `4e04ca516c6b` ("utils: Move functions from utils.bbclass to utils.py") from openembedded-core moved `base_set_filespath` into oe.utils.

This change is not part of wrynose yet. No backport is needed for now.