### PR TITLE
master: add support for i.MX93 FRDM board

### DIFF
--- a/conf/machine/imx93-11x11-lpddr4x-frdm.conf
+++ b/conf/machine/imx93-11x11-lpddr4x-frdm.conf
@@ -1,0 +1,35 @@
+require conf/machine/include/imx93-evk.inc
+
+DDR_FIRMWARE_NAME = " \
+   lpddr4_dmem_1d_v202201.bin \
+   lpddr4_dmem_2d_v202201.bin \
+   lpddr4_imem_1d_v202201.bin \
+   lpddr4_imem_2d_v202201.bin \
+"
+
+# Bootloader
+PREFERRED_PROVIDER_virtual/bootloader ?= "u-boot-imx"
+UBOOT_CONFIG_BASENAME = "imx93_11x11_frdm"
+UBOOT_DTB_NAME = "imx93-11x11-frdm"
+
+# Kernel
+PREFERRED_PROVIDER_virtual/kernel ?= "linux-imx"
+
+KERNEL_DEVICETREE_BASENAME = "imx93-11x11-frdm"
+KERNEL_DEVICETREE = "freescale/${KERNEL_DEVICETREE_BASENAME}.dtb"
+
+# TODO: add the device trees below once linux-imx
+# is bumped to lf-6.18.20-2.0.0:
+# freescale/imx93-jailhouse-inmate.dtb
+# freescale/${KERNEL_DEVICETREE_BASENAME}-root.dtb
+
+KERNEL_DEVICETREE:append:use-nxp-bsp = " \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-8mic-reve.dtb \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-aud-hat.dtb \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-ld.dtb \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-lpuart.dtb \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-mt9m114.dtb \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-ov5640.dtb \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-tianma-wvga-panel.dtb \
+    freescale/${KERNEL_DEVICETREE_BASENAME}-waveshare-7inch-c-panel.dtb \
+ "

--- a/recipes-bsp/u-boot/u-boot-imx-common_2025.04.inc
+++ b/recipes-bsp/u-boot/u-boot-imx-common_2025.04.inc
@@ -16,7 +16,7 @@ SRC_URI = "${UBOOT_SRC};branch=${SRCBRANCH}"
 UBOOT_SRC ?= "git://github.com/nxp-imx/uboot-imx.git;protocol=https"
 SRCBRANCH = "lf_v2025.04"
 LOCALVERSION ?= "-${SRCBRANCH}"
-SRCREV = "4ddbad60eff308a5b356fb9ab8734ac382ddd692"
+SRCREV = "99518e6b6f20cb6a2bf19115e355db9f58100af8"
 
 B = "${WORKDIR}/build"
 


### PR DESCRIPTION
Hello,

This machine configuration is inspired on what is currently provided by meta-imx-frdm, and successfully works with the build configutarion below:

```
Build Configuration:
BB_VERSION           = "2.19.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "universal"
TARGET_SYS           = "aarch64-poky-linux"
MACHINE              = "imx93-11x11-lpddr4x-frdm"
SDKMACHINE           = "x86_64"
DISTRO               = "poky"
DISTRO_VERSION       = "6.0.99+snapshot-9949e7d68fd7be16d420492ff39655b684f75001"
TUNE_FEATURES        = "aarch64 crypto cortexa55"
meta                 = "master:9949e7d68fd7be16d420492ff39655b684f75001"
meta-poky            = "master:e4690557fb0fffcb5e9a86d1c1ebc550bb0da090"
meta-freescale       = "jmcosta/master:023fe009e505fe828c4cbd5bc0f0013da0ea8ecd"
meta-arm-toolchain
meta-arm             = "master:fd397fc751963d3585f52fa6f7048f30db258ffd"
```

Tested on both rev. B1 and B2 variants of the i.MX93 FRDM board.

This (temporarily) replaces #2617.

Best regards,