### PR TITLE
Recipe cleanup: enforce oelint variable ordering (oelint.var.order)

### DIFF
--- a/dynamic-layers/virtualization-layer/recipes-extended/libvirt/libvirt_%.bbappend
+++ b/dynamic-layers/virtualization-layer/recipes-extended/libvirt/libvirt_%.bbappend
@@ -1,12 +1,11 @@
-PACKAGECONFIG:qoriq-ppc = "qemu yajl lxc test remote macvtap libvirtd netcf udev python"
-
 # Standard bbappend idiom: cannot carry an override, and FILESEXTRAPATHS is
 # in BB_BASEHASH_IGNORE_VARS, so it cannot reach a task signature.
 # nooelint: oelint.vars.noncoreoverride
 FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
 SRC_URI:append:qoriq-ppc = " file://qemu.conf"
 
+PACKAGECONFIG:qoriq-ppc = "qemu yajl lxc test remote macvtap libvirtd netcf udev python"
+
 do_install:append:qoriq-ppc() {
     install -m 0644 ${UNPACKDIR}/qemu.conf ${D}${sysconfdir}/libvirt/qemu.conf
 }
-

--- a/recipes-downgrade/vulkan/vulkan-tools_1.3.275.0.imx.bb
+++ b/recipes-downgrade/vulkan/vulkan-tools_1.3.275.0.imx.bb
@@ -6,14 +6,13 @@ SECTION = "libs"
 
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
+DEPENDS += "vulkan-headers vulkan-loader vulkan-volk"
 SRC_URI = "git://github.com/KhronosGroup/Vulkan-Tools.git;branch=main;protocol=https"
 SRCREV = "c86d42cf9eb620eeac377e3bff46ae342c5cd664"
 
 inherit cmake features_check pkgconfig
 ANY_OF_DISTRO_FEATURES = "x11 wayland"
 REQUIRED_DISTRO_FEATURES = "vulkan"
-
-DEPENDS += "vulkan-headers vulkan-loader vulkan-volk"
 
 EXTRA_OECMAKE = "\
     -DBUILD_TESTS=OFF \

--- a/recipes-downgrade/vulkan/vulkan-utility-libraries_1.3.275.0.imx.bb
+++ b/recipes-downgrade/vulkan/vulkan-utility-libraries_1.3.275.0.imx.bb
@@ -8,13 +8,12 @@ SECTION = "libs"
 
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE.md;md5=4ca2d6799091aaa98a8520f1b793939b"
+DEPENDS = "vulkan-headers"
 
 SRC_URI = "git://github.com/KhronosGroup/Vulkan-Utility-Libraries.git;branch=main;protocol=https"
 SRCREV = "4cfc176e3242b4dbdfd3f6c5680c5d8f2cb7db45"
 
 REQUIRED_DISTRO_FEATURES = "vulkan"
-
-DEPENDS = "vulkan-headers"
 
 EXTRA_OECMAKE = "\
     -DBUILD_TESTS=OFF \

--- a/recipes-downgrade/vulkan/vulkan-validation-layers_1.3.275.0.imx.bb
+++ b/recipes-downgrade/vulkan/vulkan-validation-layers_1.3.275.0.imx.bb
@@ -7,13 +7,12 @@ SECTION = "libs"
 
 LICENSE = "Apache-2.0 AND MIT"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=cd3c0bc366cd9b6a906e22f0bcb5910f"
+DEPENDS = "glslang spirv-headers spirv-tools vulkan-headers vulkan-loader vulkan-utility-libraries"
 
 SRC_URI = "git://github.com/KhronosGroup/Vulkan-ValidationLayers.git;branch=vulkan-sdk-1.3.275;protocol=https"
 SRCREV = "780c65337e111c7385109c7b720d757a778e4fe2"
 
 REQUIRED_DISTRO_FEATURES = "vulkan"
-
-DEPENDS = "glslang spirv-headers spirv-tools vulkan-headers vulkan-loader vulkan-utility-libraries"
 
 # BUILD_TESTS            - Not required for OE builds
 # USE_ROBIN_HOOD_HASHING - Provides substantial performance improvements on all platforms.

--- a/recipes-kernel/linux/linux-qoriq.inc
+++ b/recipes-kernel/linux/linux-qoriq.inc
@@ -11,6 +11,8 @@ DEPENDS:append = " libgcc coreutils-native"
 # Set the PV to the correct kernel version to satisfy the kernel version sanity check
 PV = "${LINUX_VERSION}+git${SRCPV}"
 
+FILES:${KERNEL_PACKAGE_NAME}-image += "/boot/zImage*"
+
 # not put Images into /boot of rootfs, install kernel-image if needed
 RDEPENDS:${KERNEL_PACKAGE_NAME}-base = ""
 
@@ -49,6 +51,5 @@ do_configure() {
     cp .config ${UNPACKDIR}/defconfig
 }
 
-FILES:${KERNEL_PACKAGE_NAME}-image += "/boot/zImage*"
 INSANE_SKIP:${PN}-src += "buildpaths"
 COMPATIBLE_MACHINE = "(qoriq)"

--- a/recipes-multimedia/gstreamer/gst-devtools_1.28.1.bb
+++ b/recipes-multimedia/gstreamer/gst-devtools_1.28.1.bb
@@ -6,6 +6,8 @@ SECTION = "multimedia"
 LICENSE = "LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://validate/COPYING;md5=a6f89e2100d9b6cdffcea4f398e37343"
 
+DEPENDS = "glib-2.0 glib-2.0-native gstreamer1.0 gstreamer1.0-plugins-base json-glib"
+
 #S = "${WORKDIR}/gst-devtools-${PV}"
 
 SRC_URI = "https://gstreamer.freedesktop.org/src/gst-devtools/gst-devtools-${PV}.tar.xz \
@@ -14,10 +16,8 @@ SRC_URI = "https://gstreamer.freedesktop.org/src/gst-devtools/gst-devtools-${PV}
 
 SRC_URI[sha256sum] = "a4e49cd082972a132ca5f54be52a3c386db37c4cb0e487e017ba00d83a5f985d"
 
-DEPENDS = "glib-2.0 glib-2.0-native gstreamer1.0 gstreamer1.0-plugins-base json-glib"
-RRECOMMENDS:${PN} = "git"
-
 FILES:${PN} += "${datadir}/gstreamer-1.0/* ${libdir}/gst-validate-launcher/* ${libdir}/gstreamer-1.0/*"
+RRECOMMENDS:${PN} = "git"
 
 inherit meson pkgconfig gettext upstream-version-is-even gobject-introspection
 

--- a/recipes-multimedia/gstreamer/gstreamer1.0-libav_1.28.1.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-libav_1.28.1.bb
@@ -11,12 +11,12 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=69333daa044cb77e486cc36129f7a770 \
                     file://ext/libav/gstav.h;beginline=1;endline=18;md5=a752c35267d8276fd9ca3db6994fca9c \
                     "
 
+DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base ffmpeg"
+
 SRC_URI = "https://gstreamer.freedesktop.org/src/gst-libav/gst-libav-${PV}.tar.xz"
 SRC_URI[sha256sum] = "bfa91aaca38d0fd8addcdd559e35b7541e3f32a5f410194ec4ba18040defee9b"
 
 S = "${UNPACKDIR}/gst-libav-${PV}"
-
-DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base ffmpeg"
 
 inherit meson pkgconfig upstream-version-is-even
 

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.28.1.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.28.1.imx.bb
@@ -13,17 +13,17 @@ HOMEPAGE = "https://gstreamer.freedesktop.org/"
 BUGTRACKER = "https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad/-/issues"
 CVE_PRODUCT = "gst-plugins-bad"
 
+LICENSE = "GPL-2.0-or-later AND LGPL-2.1-or-later"
+LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
+
+DEPENDS += "gstreamer1.0-plugins-base"
+
 SRC_URI = "https://gstreamer.freedesktop.org/src/gst-plugins-bad/gst-plugins-bad-${PV}.tar.xz \
            file://0001-fix-maybe-uninitialized-warnings-when-compiling-with.patch \
            file://0002-avoid-including-sys-poll.h-directly.patch \
            file://0004-opencv-resolve-missing-opencv-data-dir-in-yocto-buil.patch \
            "
 SRC_URI[sha256sum] = "e64e75cdafd7ff2fc7fc34e855b06b1e3ed227cc06fa378d17bbcd76780c338c"
-
-LICENSE = "GPL-2.0-or-later AND LGPL-2.1-or-later"
-LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
-
-DEPENDS += "gstreamer1.0-plugins-base"
 
 inherit gobject-introspection
 

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.28.1.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.28.1.imx.bb
@@ -13,14 +13,14 @@ BUGTRACKER = "https://gitlab.freedesktop.org/gstreamer/gst-plugins-base/-/issues
 LICENSE = "LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=69333daa044cb77e486cc36129f7a770"
 
+DEPENDS += "iso-codes util-linux zlib"
+
 SRC_URI = "https://gstreamer.freedesktop.org/src/gst-plugins-base/gst-plugins-base-${PV}.tar.xz \
            file://0001-ENGR00312515-get-caps-from-src-pad-when-query-caps.patch \
            file://0003-viv-fb-Make-sure-config.h-is-included.patch \
            file://0002-ssaparse-enhance-SSA-text-lines-parsing.patch \
            "
 SRC_URI[sha256sum] = "edd4338b45c26a9af28c0d35aab964a024c3884ba6f520d8428df04212c8c93a"
-
-DEPENDS += "iso-codes util-linux zlib"
 
 inherit gobject-introspection
 

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly_1.28.1.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly_1.28.1.bb
@@ -5,11 +5,13 @@ SUMMARY = "'Ugly GStreamer plugins"
 HOMEPAGE = "https://gstreamer.freedesktop.org/"
 BUGTRACKER = "https://gitlab.freedesktop.org/gstreamer/gst-plugins-ugly/-/issues"
 
+LICENSE = "GPL-2.0-or-later AND LGPL-2.1-or-later"
+LICENSE_FLAGS = "commercial"
+
 LIC_FILES_CHKSUM = "file://COPYING;md5=a6f89e2100d9b6cdffcea4f398e37343 \
                     "
 
-LICENSE = "GPL-2.0-or-later AND LGPL-2.1-or-later"
-LICENSE_FLAGS = "commercial"
+DEPENDS += "gstreamer1.0-plugins-base"
 
 SRC_URI = "\
     https://gstreamer.freedesktop.org/src/gst-plugins-ugly/gst-plugins-ugly-${PV}.tar.xz \
@@ -18,8 +20,6 @@ SRC_URI = "\
 SRC_URI[sha256sum] = "4082f3cb063fccc3ffc04e5ab0854bafde82d1b373eb3c9eaa28115dd3f95a78"
 
 S = "${UNPACKDIR}/gst-plugins-ugly-${PV}"
-
-DEPENDS += "gstreamer1.0-plugins-base"
 
 GST_PLUGIN_SET_HAS_EXAMPLES = "0"
 

--- a/recipes-multimedia/gstreamer/gstreamer1.0-python_1.28.1.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-python_1.28.1.bb
@@ -7,13 +7,11 @@ SECTION = "multimedia"
 LICENSE = "LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=c34deae4e395ca07e725ab0076a5f740"
 
-SRC_URI = "https://gstreamer.freedesktop.org/src/${PNREAL}/${PNREAL}-${PV}.tar.xz"
-SRC_URI[sha256sum] = "d47cea95adb95ba10443ed7812c7c5fa0807aef43b98cd1c6d8fb9f9a86f7085"
-
 DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base python3-pygobject"
 DEPENDS:append = " gstreamer1.0-plugins-bad"
 
-RDEPENDS:${PN} += "gstreamer1.0 gstreamer1.0-plugins-base python3-pygobject"
+SRC_URI = "https://gstreamer.freedesktop.org/src/${PNREAL}/${PNREAL}-${PV}.tar.xz"
+SRC_URI[sha256sum] = "d47cea95adb95ba10443ed7812c7c5fa0807aef43b98cd1c6d8fb9f9a86f7085"
 
 PNREAL = "gst-python"
 
@@ -30,5 +28,7 @@ CFLAGS += "-Wno-error=implicit-function-declaration"
 inherit meson pkgconfig setuptools3-base upstream-version-is-even features_check
 
 FILES:${PN} += "${libdir}/gstreamer-1.0"
+
+RDEPENDS:${PN} += "gstreamer1.0 gstreamer1.0-plugins-base python3-pygobject"
 
 REQUIRED_DISTRO_FEATURES = "gobject-introspection-data"

--- a/recipes-multimedia/gstreamer/gstreamer1.0_1.28.1.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0_1.28.1.imx.bb
@@ -12,13 +12,12 @@ HOMEPAGE = "http://gstreamer.freedesktop.org/"
 BUGTRACKER = "https://bugzilla.gnome.org/enter_bug.cgi?product=Gstreamer"
 SECTION = "multimedia"
 LICENSE = "LGPL-2.1-or-later"
+LIC_FILES_CHKSUM = "file://COPYING;md5=69333daa044cb77e486cc36129f7a770 \
+                    file://gst/gst.h;beginline=1;endline=21;md5=e059138481205ee2c6fc1c079c016d0d"
 
 DEPENDS = "bison-native flex-native glib-2.0 glib-2.0-native libxml2"
 
 inherit meson pkgconfig gettext upstream-version-is-even gobject-introspection ptest-gnome
-
-LIC_FILES_CHKSUM = "file://COPYING;md5=69333daa044cb77e486cc36129f7a770 \
-                    file://gst/gst.h;beginline=1;endline=21;md5=e059138481205ee2c6fc1c079c016d0d"
 
 SRC_URI = "https://gstreamer.freedesktop.org/src/gstreamer/gstreamer-${PV}.tar.xz \
            file://run-ptest \

--- a/recipes-multimedia/imx-parser/imx-mp4-parser_git.bb
+++ b/recipes-multimedia/imx-parser/imx-mp4-parser_git.bb
@@ -6,11 +6,11 @@ SECTION = "multimedia"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=6f862c6751ebcaa393467694c7b0c69a"
 
+DEPENDS += "imx-parser"
+
 inherit pkgconfig meson
 
 PV = "4.11.0+git"
-
-DEPENDS += "imx-parser"
 
 SRCBRANCH = "MM_04.11.00_2605_L6.18.20"
 IMXMP4PARSER_SRC ?= "git://github.com/nxp-imx/imx-mp4-parser.git;protocol=https"


### PR DESCRIPTION
## Summary

  Applies the `oelint.var.order` rule across a set of recipes and bbappends,
  reordering variable assignments into oelint-adv's canonical order. These are
  non-functional metadata cleanups. No build output, task signatures, or
  package contents change.

  Part of an ongoing oelint remediation effort in meta-freescale.

  ## Changes

  Reordered variables (e.g. `LICENSE`/`LIC_FILES_CHKSUM`/`DEPENDS`/`SRC_URI`
  before dependent assignments) in:

  - **GStreamer stack:** gstreamer1.0, gstreamer1.0-plugins-base,
    gstreamer1.0-plugins-bad, gstreamer1.0-plugins-ugly, gstreamer1.0-libav,
    gstreamer1.0-python, gst-devtools
  - **Vulkan stack:** vulkan-tools, vulkan-utility-libraries,
    vulkan-validation-layers
  - **Others:** libvirt, linux-qoriq, imx-mp4-parser

  ## Notes

  - One commit per recipe, so any single change can be reverted independently.
  - `libvirt_%.bbappend` keeps the existing `nooelint: oelint.vars.noncoreoverride`
    suppression; only the assignment order changed.
