### PR TITLE
weston: Relax the upper bound for libdisplay-info check

### DIFF
--- a/recipes-graphics/wayland/weston/0001-libweston-backend-drm-meson.build-allow-libdisplay-i.patch
+++ b/recipes-graphics/wayland/weston/0001-libweston-backend-drm-meson.build-allow-libdisplay-i.patch
@@ -13,8 +13,6 @@ Signed-off-by: Alexander Kanavin <alex@linutronix.de>
  libweston/backend-drm/meson.build | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/libweston/backend-drm/meson.build b/libweston/backend-drm/meson.build
-index 002669e..a8f2ea5 100644
 --- a/libweston/backend-drm/meson.build
 +++ b/libweston/backend-drm/meson.build
 @@ -4,7 +4,7 @@ endif
@@ -22,7 +20,7 @@ index 002669e..a8f2ea5 100644
  dep_libdisplay_info = dependency(
  	'libdisplay-info',
 -	version: ['>= 0.1.1', '< 0.3.0'],
-+	version: ['>= 0.1.1', '< 0.4.0'],
++	version: ['>= 0.1.1', '< 0.6.0'],
  	fallback: ['display-info', 'di_dep'],
  	default_options: [
  		'werror=false',


### PR DESCRIPTION
OE-Core upgraded libdisplay-info to 0.5 recently, see https://git.openembedded.org/openembedded-core/commit/?id=b709f948ebdf8e8e27331ba17df9f2e9972ab7f8