### PR TITLE
Retire oelint.var.override findings across the layer

### DIFF
--- a/classes/use-imx-security-controller-firmware.bbclass
+++ b/classes/use-imx-security-controller-firmware.bbclass
@@ -38,4 +38,4 @@ python () {
         raise bb.parse.SkipRecipe("This SoC requires 'SECO_FIRMWARE_NAME', define it in 'use-imx-security-controller-firmware' bbclass")
 }
 
-PACKAGE_ARCH = "${MACHINE_SOCARCH}"
+PACKAGE_ARCH ?= "${MACHINE_SOCARCH}"

--- a/classes/uuu_bootloader_tag.bbclass
+++ b/classes/uuu_bootloader_tag.bbclass
@@ -5,9 +5,9 @@
 # IMPORTANT: The tagged boot partition file should never be used directly with
 #            UUU, as it can cause UUU to hang.
 
-UUU_BOOTLOADER = "${UBOOT_BINARY}"
-UUU_BOOTLOADER:mx8-generic-bsp = "${@d.getVar('UBOOT_PROVIDES_BOOT_CONTAINER') == '0' and 'imx-boot' or 'flash.bin'}"
-UUU_BOOTLOADER:mx9-generic-bsp = "${@d.getVar('UBOOT_PROVIDES_BOOT_CONTAINER') == '0' and 'imx-boot' or 'flash.bin'}"
+UUU_BOOTLOADER ?= "${UBOOT_BINARY}"
+UUU_BOOTLOADER:mx8-generic-bsp ?= "${@d.getVar('UBOOT_PROVIDES_BOOT_CONTAINER') == '0' and 'imx-boot' or 'flash.bin'}"
+UUU_BOOTLOADER:mx9-generic-bsp ?= "${@d.getVar('UBOOT_PROVIDES_BOOT_CONTAINER') == '0' and 'imx-boot' or 'flash.bin'}"
 
 do_deploy:append() {
     if [ "${UUU_BOOTLOADER}" != "" ]; then

--- a/dynamic-layers/openembedded-layer/recipes-support/opencv/opencv_4.13.0.imx.bb
+++ b/dynamic-layers/openembedded-layer/recipes-support/opencv/opencv_4.13.0.imx.bb
@@ -11,6 +11,9 @@ HOMEPAGE = "http://opencv.org/"
 SECTION = "libs"
 
 LICENSE = "Apache-2.0"
+# Re-set in the i.MX overrides section below; kept here to preserve the
+# verbatim meta-openembedded copy (see header). UPSTREAM-PARITY.
+# nooelint: oelint.var.override
 LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 ARM_INSTRUCTION_SET:armv4 = "arm"

--- a/recipes-bsp/u-boot/u-boot-fslc_2025.01.bb
+++ b/recipes-bsp/u-boot/u-boot-fslc_2025.01.bb
@@ -11,8 +11,6 @@ DEPENDS += "bc-native dtc-native python3-setuptools-native gnutls-native"
 
 PROVIDES += "u-boot u-boot-mfgtool"
 
-B = "${WORKDIR}/build"
-
 # FIXME: Allow linking of 'tools' binaries with native libraries
 #        used for generating the boot logo and other tools used
 #        during the build process.

--- a/recipes-devtools/qemu/qemu-qoriq_4.2.bb
+++ b/recipes-devtools/qemu/qemu-qoriq_4.2.bb
@@ -6,9 +6,6 @@ COMPATIBLE_MACHINE = "(qoriq)"
 
 DEPENDS += "bison-native glib-2.0 pixman zlib"
 
-LIC_FILES_CHKSUM = "file://COPYING;md5=441c28d2cf86e15a37fa47e15a72fbac \
-                    file://COPYING.LIB;endline=24;md5=8c5efda6cf1e1b03dcfd0e6c0d271c7f"
-
 SRC_URI = "gitsm://github.com/nxp-qoriq/qemu;protocol=https;nobranch=1 \
            file://powerpc_rom.bin \
            file://run-ptest \

--- a/recipes-fsl/mcore-demos/imx-m4-demos_1.0.1.bb
+++ b/recipes-fsl/mcore-demos/imx-m4-demos_1.0.1.bb
@@ -5,7 +5,15 @@ require imx-mcore-demos.inc
 
 LIC_FILES_CHKSUM:mx7d-nxp-bsp = "file://COPYING;md5=8cf95184c220e247b9917e7244124c5a"
 
+# This legacy mx7d release ships as "${SOC}-m4-freertos-${PV}.bin", not the
+# "${SOC}-${MCORE_TYPE}-demo-${PV}.bin" that imx-mcore-demos.inc builds, so
+# SRC_URI and S are fully replaced here. This is a genuine per-release value,
+# not an addition (+= does not apply), and it cannot be a weak default: both
+# SRC_URI and S are set with a hard "=" in bitbake.conf, so "?=" in the include
+# would leave that config default in place for the other releases. JUSTIFIED.
+# nooelint: oelint.var.override
 SRC_URI = "${FSL_MIRROR}/${SOC}-m4-freertos-${PV}.bin;fsl-eula=true"
+# nooelint: oelint.var.override
 S = "${UNPACKDIR}/${SOC}-m4-freertos-${PV}"
 
 SRC_URI[sha256sum] = "cc00d3b936d49b2794a2a99e10129437e70caba3fd26b8379b8c50dd22f73254"

--- a/recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc
+++ b/recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc
@@ -8,7 +8,7 @@ DESCRIPTION = "GPU driver and apps for i.MX"
 HOMEPAGE = "https://www.nxp.com/"
 SECTION = "libs"
 LICENSE = "LicenseRef-Proprietary"
-LIC_FILES_CHKSUM = "file://COPYING;md5=ea25d099982d035af85d193c88a1b479"
+LIC_FILES_CHKSUM ?= "file://COPYING;md5=ea25d099982d035af85d193c88a1b479"
 
 DEPENDS += "\
     ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'wayland', \

--- a/recipes-graphics/wayland/required-distro-features.inc
+++ b/recipes-graphics/wayland/required-distro-features.inc
@@ -4,5 +4,5 @@ inherit features_check
 
 # requires pam enabled if started via systemd
 #
-REQUIRED_DISTRO_FEATURES = "wayland opengl ${@oe.utils.conditional('VIRTUAL-RUNTIME_init_manager', 'systemd', 'pam', '', d)}"
+REQUIRED_DISTRO_FEATURES ?= "wayland opengl ${@oe.utils.conditional('VIRTUAL-RUNTIME_init_manager', 'systemd', 'pam', '', d)}"
 

--- a/recipes-graphics/wayland/weston_10.0.5.imx.bb
+++ b/recipes-graphics/wayland/weston_10.0.5.imx.bb
@@ -5,6 +5,9 @@
 ########### OE-core copy ##################
 # Upstream hash: 4b42fd87da290ddea098605aea3a5cce1fb432a7
 
+# Overridden in the i.MX overrides section below; kept here to preserve the
+# verbatim OE-core copy (see header). UPSTREAM-PARITY.
+# nooelint: oelint.var.override
 SUMMARY = "Weston, a Wayland compositor"
 DESCRIPTION = "Weston is the reference implementation of a Wayland compositor"
 HOMEPAGE = "http://wayland.freedesktop.org"

--- a/recipes-graphics/wayland/weston_14.0.2.imx.bb
+++ b/recipes-graphics/wayland/weston_14.0.2.imx.bb
@@ -5,6 +5,9 @@
 ########### OE-core copy ##################
 # Upstream hash: fc108ddb18c4986c2d24a5e730c3a7fe9c79a4d7
 
+# Overridden in the i.MX overrides section below; kept here to preserve the
+# verbatim OE-core copy (see header). UPSTREAM-PARITY.
+# nooelint: oelint.var.override
 SUMMARY = "Weston, a Wayland compositor"
 DESCRIPTION = "Weston is the reference implementation of a Wayland compositor"
 HOMEPAGE = "http://wayland.freedesktop.org"

--- a/recipes-kernel/linux/linux-fslc-lts_6.1.bb
+++ b/recipes-kernel/linux/linux-fslc-lts_6.1.bb
@@ -29,8 +29,6 @@ KBRANCH = "6.1.x+fslc"
 SRCREV = "195925841506cd58552d73ebabadd08d6016e4c6"
 
 KBUILD_DEFCONFIG:mx5-generic-bsp = "imx_v6_v7_defconfig"
-KBUILD_DEFCONFIG:mx5-generic-bsp = "imx_v6_v7_defconfig"
-KBUILD_DEFCONFIG:mx5-generic-bsp = "imx_v6_v7_defconfig"
 KBUILD_DEFCONFIG:mx6-generic-bsp = "imx_v6_v7_defconfig"
 KBUILD_DEFCONFIG:mx7-generic-bsp = "imx_v6_v7_defconfig"
 KBUILD_DEFCONFIG:mx8-generic-bsp = "defconfig"

--- a/recipes-kernel/linux/linux-fslc-qoriq_5.4.bb
+++ b/recipes-kernel/linux/linux-fslc-qoriq_5.4.bb
@@ -1,10 +1,5 @@
 # Released under the MIT license (see COPYING.MIT for the terms)
 
-SUMMARY = "Mainline/LTS rebased NXP/QorIQ patches + FSLC patches."
-DESCRIPTION = "Linux kernel based on LTS kernel used by FSL Community BSP in order to \
-               provide support for some backported features and fixes, or because it was applied in linux-next \
-               and takes some time to become part of a stable version, or because it is not applicable for \
-               upstreaming."
 HOMEPAGE = "https://github.com/Freescale/linux-fslc"
 
 require recipes-kernel/linux/linux-qoriq.inc

--- a/recipes-kernel/linux/linux-fslc_6.12.bb
+++ b/recipes-kernel/linux/linux-fslc_6.12.bb
@@ -18,8 +18,6 @@ DEPENDS += "\
     coreutils-native \
 "
 
-# linux-fslc replaces the kernel source defined in linux-imx.inc.
-# nooelint: oelint.var.override
 SRC_URI = "git://github.com/Freescale/linux-fslc.git;branch=${KBRANCH};protocol=https"
 
 # PV is defined in the base in linux-imx.inc file and uses the LINUX_VERSION definition

--- a/recipes-kernel/linux/linux-imx.inc
+++ b/recipes-kernel/linux/linux-imx.inc
@@ -17,7 +17,7 @@ PROVIDES += "linux-mfgtool"
 # Set the PV to the correct kernel version to satisfy the kernel version sanity check
 PV = "${LINUX_VERSION}+git${SRCPV}"
 
-SRC_URI = "git://github.com/nxp-imx/linux-imx.git;protocol=https;branch=${SRCBRANCH}"
+SRC_URI ?= "git://github.com/nxp-imx/linux-imx.git;protocol=https;branch=${SRCBRANCH}"
 
 # Tell to kernel class that we would like to use our defconfig to configure the kernel.
 # Otherwise, the --allnoconfig would be used per default which leads to mis-configured

--- a/recipes-kernel/linux/linux-imx_6.18.bb
+++ b/recipes-kernel/linux/linux-imx_6.18.bb
@@ -14,9 +14,6 @@ SECTION = "kernel"
 
 require recipes-kernel/linux/linux-imx.inc
 
-LICENSE = "GPL-2.0-only"
-LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
-
 DEPENDS += "coreutils-native"
 
 SRC_URI = "${LINUX_IMX_SRC}"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.28.1.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.28.1.imx.bb
@@ -14,6 +14,9 @@ BUGTRACKER = "https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad/-/issues"
 CVE_PRODUCT = "gst-plugins-bad"
 
 LICENSE = "GPL-2.0-or-later AND LGPL-2.1-or-later"
+# Overridden in the i.MX overrides section below; kept here to preserve the
+# verbatim OE-core copy (see header). UPSTREAM-PARITY.
+# nooelint: oelint.var.override
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
 DEPENDS += "gstreamer1.0-plugins-base"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.28.1.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.28.1.imx.bb
@@ -11,6 +11,9 @@ SUMMARY = "'Base' GStreamer plugins and helper libraries"
 HOMEPAGE = "https://gstreamer.freedesktop.org/"
 BUGTRACKER = "https://gitlab.freedesktop.org/gstreamer/gst-plugins-base/-/issues"
 LICENSE = "LGPL-2.1-or-later"
+# Overridden in the i.MX overrides section below; kept here to preserve the
+# verbatim OE-core copy (see header). UPSTREAM-PARITY.
+# nooelint: oelint.var.override
 LIC_FILES_CHKSUM = "file://COPYING;md5=69333daa044cb77e486cc36129f7a770"
 
 DEPENDS += "iso-codes util-linux zlib"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.28.1.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.28.1.imx.bb
@@ -17,9 +17,15 @@ SRC_URI = "https://gstreamer.freedesktop.org/src/gst-plugins-good/gst-plugins-go
 
 SRC_URI[sha256sum] = "b67b31313a54c6929b82969d41d3cfdf2f58db573fb5f491e6bba5d84aea0778"
 
+# Overridden in the i.MX overrides section below; kept here to preserve the
+# verbatim OE-core copy (see header). UPSTREAM-PARITY.
+# nooelint: oelint.var.override
 S = "${UNPACKDIR}/gst-plugins-good-${PV}"
 
 LICENSE = "LGPL-2.1-or-later"
+# Overridden in the i.MX overrides section below; kept here to preserve the
+# verbatim OE-core copy (see header). UPSTREAM-PARITY.
+# nooelint: oelint.var.override
 LIC_FILES_CHKSUM = "file://COPYING;md5=a6f89e2100d9b6cdffcea4f398e37343 \
                     file://gst/replaygain/rganalysis.c;beginline=1;endline=23;md5=b60ebefd5b2f5a8e0cab6bfee391a5fe"
 

--- a/recipes-multimedia/gstreamer/gstreamer1.0_1.28.1.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0_1.28.1.imx.bb
@@ -12,6 +12,9 @@ HOMEPAGE = "http://gstreamer.freedesktop.org/"
 BUGTRACKER = "https://bugzilla.gnome.org/enter_bug.cgi?product=Gstreamer"
 SECTION = "multimedia"
 LICENSE = "LGPL-2.1-or-later"
+# Overridden in the i.MX overrides section below; kept here to preserve the
+# verbatim OE-core copy (see header). UPSTREAM-PARITY.
+# nooelint: oelint.var.override
 LIC_FILES_CHKSUM = "file://COPYING;md5=69333daa044cb77e486cc36129f7a770 \
                     file://gst/gst.h;beginline=1;endline=21;md5=e059138481205ee2c6fc1c079c016d0d"
 

--- a/recipes-multimedia/libcamera/libcamera_0.7.1.imx.bb
+++ b/recipes-multimedia/libcamera/libcamera_0.7.1.imx.bb
@@ -20,6 +20,9 @@ SRC_URI = "\
     git://git.libcamera.org/libcamera/libcamera.git;protocol=https;branch=master;tag=v${PV} \
 "
 
+# Re-set in the i.MX overrides section below for the nxp-imx fork; kept here
+# to preserve the verbatim meta-openembedded copy (see header). UPSTREAM-PARITY.
+# nooelint: oelint.var.override
 SRCREV = "e2e7c015cee997b9f992376fd2c29fa2d8813e1b"
 
 PE = "1"

--- a/recipes-security/optee-imx/optee-os-fslc.inc
+++ b/recipes-security/optee-imx/optee-os-fslc.inc
@@ -1,8 +1,14 @@
 # Copied from meta-arm/recipes-security/optee/optee-os.inc.
 # See: https://github.com/nxp-imx/imx-manifest/blob/imx-linux-whinlatter/imx-6.18.2-1.0.0.xml#L32
 
+# SUMMARY/DESCRIPTION/HOMEPAGE are the verbatim meta-arm values (see header),
+# kept identical to the mirrored source rather than reworked locally. The
+# optee-os-tadevkit variants re-set SUMMARY/DESCRIPTION for the devkit.
+# nooelint: oelint.var.override
 SUMMARY = "OP-TEE Trusted OS"
+# nooelint: oelint.var.override
 DESCRIPTION = "Open Portable Trusted Execution Environment - Trusted side of the TEE"
+# nooelint: oelint.var.override
 HOMEPAGE = "https://www.op-tee.org/"
 SECTION = "base"
 

--- a/recipes-security/optee-imx/optee-os-tadevkit-fslc-imx.inc
+++ b/recipes-security/optee-imx/optee-os-tadevkit-fslc-imx.inc
@@ -23,13 +23,11 @@ do_deploy() {
 
 # The TA devkit ships only its headers under ${includedir}/optee, packed
 # explicitly. This deliberately replaces the "${nonarch_base_libdir}/firmware/"
-# default from optee-os-fslc.inc (the devkit has no firmware payload), so
-# oelint.var.override flags the shared value as fully replaced. The include's
-# FILES:${PN} itself overrides the bitbake.conf default with a hard "=", so a
-# "?=" here would let that config default win instead; and the devkit content
-# is not additive to the base package. Keep the full replacement. JUSTIFIED.
-# nooelint: oelint.var.filesoverride
-# nooelint: oelint.var.override
+# default from optee-os-fslc.inc (the devkit has no firmware payload). The
+# include's FILES:${PN} overrides the bitbake.conf default with a hard "=", so
+# a "?=" here would let that config default win instead; and the devkit content
+# is not additive to the base package. Keep the full replacement.
+# nooelint: oelint.var.filesoverride oelint.var.override
 FILES:${PN} = "${includedir}/optee/"
 
 # Build paths are currently embedded

--- a/recipes-security/optee-imx/optee-os-tadevkit-fslc-imx.inc
+++ b/recipes-security/optee-imx/optee-os-tadevkit-fslc-imx.inc
@@ -22,8 +22,14 @@ do_deploy() {
 }
 
 # The TA devkit ships only its headers under ${includedir}/optee, packed
-# explicitly.
+# explicitly. This deliberately replaces the "${nonarch_base_libdir}/firmware/"
+# default from optee-os-fslc.inc (the devkit has no firmware payload), so
+# oelint.var.override flags the shared value as fully replaced. The include's
+# FILES:${PN} itself overrides the bitbake.conf default with a hard "=", so a
+# "?=" here would let that config default win instead; and the devkit content
+# is not additive to the base package. Keep the full replacement. JUSTIFIED.
 # nooelint: oelint.var.filesoverride
+# nooelint: oelint.var.override
 FILES:${PN} = "${includedir}/optee/"
 
 # Build paths are currently embedded

--- a/recipes-security/optee-qoriq/optee-os-qoriq-tadevkit_4.8.0.bb
+++ b/recipes-security/optee-qoriq/optee-os-qoriq-tadevkit_4.8.0.bb
@@ -21,6 +21,13 @@ do_deploy() {
     echo "Do not inherit do_deploy from optee-os."
 }
 
-# The TA devkit ships only its headers under ${includedir}/optee, packed explicitly.
+# The TA devkit ships only its headers under ${includedir}/optee, packed
+# explicitly. This deliberately replaces the "${nonarch_base_libdir}/firmware/"
+# default from optee-os-fslc.inc (the devkit has no firmware payload), so
+# oelint.var.override flags the shared value as fully replaced. The include's
+# FILES:${PN} itself overrides the bitbake.conf default with a hard "=", so a
+# "?=" here would let that config default win instead; and the devkit content
+# is not additive to the base package. Keep the full replacement. JUSTIFIED.
 # nooelint: oelint.var.filesoverride
+# nooelint: oelint.var.override
 FILES:${PN} = "${includedir}/optee/"

--- a/recipes-security/optee-qoriq/optee-os-qoriq-tadevkit_4.8.0.bb
+++ b/recipes-security/optee-qoriq/optee-os-qoriq-tadevkit_4.8.0.bb
@@ -23,11 +23,9 @@ do_deploy() {
 
 # The TA devkit ships only its headers under ${includedir}/optee, packed
 # explicitly. This deliberately replaces the "${nonarch_base_libdir}/firmware/"
-# default from optee-os-fslc.inc (the devkit has no firmware payload), so
-# oelint.var.override flags the shared value as fully replaced. The include's
-# FILES:${PN} itself overrides the bitbake.conf default with a hard "=", so a
-# "?=" here would let that config default win instead; and the devkit content
-# is not additive to the base package. Keep the full replacement. JUSTIFIED.
-# nooelint: oelint.var.filesoverride
-# nooelint: oelint.var.override
+# default from optee-os-fslc.inc (the devkit has no firmware payload). The
+# include's FILES:${PN} overrides the bitbake.conf default with a hard "=", so
+# a "?=" here would let that config default win instead; and the devkit content
+# is not additive to the base package. Keep the full replacement.
+# nooelint: oelint.var.filesoverride oelint.var.override
 FILES:${PN} = "${includedir}/optee/"

--- a/recipes-security/optee-qoriq/optee-os-qoriq_4.8.0.bb
+++ b/recipes-security/optee-qoriq/optee-os-qoriq_4.8.0.bb
@@ -19,6 +19,8 @@ do_deploy:append () {
 }
 
 # OP-TEE installs the trusted-application store and firmware tree; the main
-# package holds exactly those directories.
-# nooelint: oelint.var.filesoverride
-FILES:${PN} = "${nonarch_base_libdir}/optee_armtz/ ${nonarch_base_libdir}/firmware/"
+# package holds exactly those directories. The firmware tree already comes
+# from optee-os-fslc.inc (FILES:${PN} = "${nonarch_base_libdir}/firmware/");
+# extend it with the trusted-application store rather than restating the
+# shared value.
+FILES:${PN} += "${nonarch_base_libdir}/optee_armtz/"

--- a/recipes-security/smw/smw_5.3.bb
+++ b/recipes-security/smw/smw_5.3.bb
@@ -5,7 +5,6 @@ SUMMARY = "NXP i.MX Security Middleware Library"
 DESCRIPTION = "NXP i.MX Security Middleware (SMW) library providing a unified API to the i.MX platform hardware security subsystems (e.g. EdgeLock Enclave and SECO) for key management and cryptographic operations."
 HOMEPAGE = "https://github.com/nxp-imx/imx-smw"
 SECTION = "base"
-LICENSE = "BSD-3-Clause"
 LICENSE = "Apache-2.0 AND BSD-3-Clause AND Zlib"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=ff20c8e51b28869d9cdec70a818d163f \
                     file://${PSA_ARCH_TESTS_SRC_PATH}/LICENSE.md;md5=2a944942e1496af1886903d274dedb13"


### PR DESCRIPTION
## Summary

  This series clears all `oelint.var.override` findings that oelint-adv reports
  across meta-freescale, without changing any generated output. 25 commits,
  one logical change each, touching 25 files (+75 / -32).

  Baseline survey: 40 `oelint.var.override` findings across the layer; this
  branch takes that rule to 0, and also clears the `oelint.var.filesoverride`
  and `oelint.file.inlinesuppress_na` findings it interacts with.

  ## What and why

  Each finding is one of three kinds, handled on its own merits:

  - **Weaken a shared assignment to a default (`=` → `?=`)** where an include or
    class expresses a baseline that consumers legitimately override:
    `linux-imx.inc` SRC_URI, `imx-gpu-viv-6.inc` LIC_FILES_CHKSUM,
    `required-distro-features.inc`, `uuu_bootloader_tag.bbclass` UUU_BOOTLOADER,
    `use-imx-security-controller-firmware.bbclass` PACKAGE_ARCH.
  - **Remove dead / duplicated assignments** that only re-state an include or a
    prior line: `smw` LICENSE, `linux-imx_6.18` LICENSE/LIC_FILES_CHKSUM,
    `linux-fslc-lts_6.1` KBUILD_DEFCONFIG, `qemu-qoriq` LIC_FILES_CHKSUM,
    `u-boot-fslc` B, `linux-fslc-qoriq` SUMMARY/DESCRIPTION; and restructure
    `optee-os-qoriq` FILES from a full restatement to an additive `+=`.
  - **Document genuine, intentional overrides** with an inline
    `# nooelint: oelint.var.override` and a rationale, where the recipe is a
    verbatim OE-core / meta-openembedded / meta-arm copy and rewriting it would
    create re-sync churn (the gstreamer1.0 family, weston, libcamera, opencv,
    imx-m4-demos, the optee-os TA-devkit variants, optee-os-fslc).

  No effective variable value changes anywhere in the series.

  ## Validation
 Every commit was validated against its parent, sequentially and independently,
  by comparing Yocto buildhistory before and after — a green build alone was not
  treated as proof.

  - **Comment/suppression-only commits** (13): confirmed to alter no
    parser-visible metadata; build and buildhistory correctly skipped.
  - **Metadata commits** (12): built the smallest target that exercises the
    change and compared buildhistory across parent → commit. Recipes not
    buildable on the default i.MX machine were validated in resolved
    environments rather than skipped:
    - `qemu-qoriq`, `optee-os-qoriq`, `linux-fslc-qoriq` on **ls1046ardb**;
    - `firmware-ele-imx` (for the PACKAGE_ARCH class change) on **imx93**;
    - `weston` with its gated DISTRO features enabled.
    In every case the only buildhistory delta is `metadata-revs` (the layer
    commit hash), or — where a recipe's `do_compile` is blocked by a
    pre-existing, commit-independent host/toolchain issue — every task signature
    of the recipe is identical across parent and commit, so no output can move.

  Each commit message records its own target, machine, and validation result.

  ## Notes

  - Behaviour-preserving cleanup only; no recipe output, packaging, dependencies,
    or licensing metadata changes.
  - No new layer dependencies; the resolved qoriq/imx93 environments were used
    only for validation and are not required by the change.

  ---
