### PR TITLE
gstreamer1.0-plugins-bad: enable v4l2codecs on mainline BSPs

### DIFF
--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.28.%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.28.%.bbappend
@@ -1,0 +1,1 @@
+PACKAGECONFIG:append:use-mainline-bsp = " v4l2codecs"


### PR DESCRIPTION
The NXP BSP uses the vendor Hantro stack for hardware video decoding, which isn't available with `use-mainline-bsp`.

Enable `v4l2codecs` on mainline BSPs to provide hardware decoding through the kernel V4L2 stateless codec API.

This change should be backported to Wrynose.