### PR TITLE
[Backport wrynose]  gstreamer1.0-plugins-bad: enable v4l2codecs on mainline BSPs

### DIFF
--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.28.%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.28.%.bbappend
@@ -1,0 +1,1 @@
+PACKAGECONFIG:append:use-mainline-bsp = " v4l2codecs"


### PR DESCRIPTION
Backport of https://github.com/Freescale/meta-freescale/pull/2639 to `wrynose`.