### PR TITLE
oelint: Document accepted INSANE_SKIP QA exceptions (oelint.vars.insaneskip)

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-support/opencv/opencv_4.13.0.imx.bb
+++ b/dynamic-layers/openembedded-layer/recipes-support/opencv/opencv_4.13.0.imx.bb
@@ -210,7 +210,13 @@ FILES:${PN}-java = "${datadir}/OpenCV/java"
 # nooelint: oelint.var.filesoverride
 FILES:${PN}-samples = "${datadir}/opencv4/samples/"
 
+# Kept byte-identical to meta-openembedded meta-oe/recipes-support/opencv/
+# opencv_*.bb (the verbatim copy section above). Diverging from the upstream
+# recipe to satisfy this check would create fork drift on every re-sync.
+# UPSTREAM-PARITY.
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:${PN}-java = "libdir"
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:${PN}-dbg = "libdir"
 
 ALLOW_EMPTY:${PN} = "1"

--- a/dynamic-layers/qt5-layer/recipes-qt/qt5/qtmultimedia_%.bbappend
+++ b/dynamic-layers/qt5-layer/recipes-qt/qt5/qtmultimedia_%.bbappend
@@ -6,4 +6,7 @@ do_install:append:imxgpu() {
     ln -sf ../video/videonode/libimx6vivantevideonode.so ${D}${libdir}/plugins/videoimx6vivantevideonode/libimx6vivantevideonode.so
 }
 
+# The compatibility symlinks installed above ship an unversioned .so in the
+# runtime -plugins package, so the dev-so QA check does not apply.
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:${PN}-plugins:imxgpu = "dev-so"

--- a/recipes-bsp/isp-imx/basler-camera_4.2.2.26.1.bb
+++ b/recipes-bsp/isp-imx/basler-camera_4.2.2.26.1.bb
@@ -27,6 +27,9 @@ SYSTEMD_AUTO_ENABLE = "enable"
 # The Basler camera stack installs into ${libdir} and /opt and is packed explicitly.
 # nooelint: oelint.var.filesoverride
 FILES:${PN} = "${libdir} /opt"
+# The Basler camera stack ships prebuilt binaries that are already stripped, so
+# the already-stripped QA check does not apply.
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:${PN} = "already-stripped"
 RDEPENDS:${PN} += "isp-imx"
 

--- a/recipes-bsp/isp-imx/isp-imx_4.2.2.26.1.bb
+++ b/recipes-bsp/isp-imx/isp-imx_4.2.2.26.1.bb
@@ -93,6 +93,9 @@ FILES_SOLIBS_VERSIONED = "\
     ${libdir}/libos08a20.so \
 "
 
+# The prebuilt ISP and sensor driver libraries are shipped already stripped, so
+# the already-stripped QA check does not apply.
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:${PN} = "already-stripped"
 
 RDEPENDS:${PN} = "libdrm"

--- a/recipes-devtools/qemu/qemu-qoriq.inc
+++ b/recipes-devtools/qemu/qemu-qoriq.inc
@@ -158,6 +158,9 @@ PACKAGECONFIG[vhost] = "--enable-vhost-net,--disable-vhost-net,,"
 PACKAGECONFIG[ust] = "--enable-trace-backend=ust,--enable-trace-backend=nop,lttng-ust,"
 PACKAGECONFIG[pie] = "--enable-pie,--disable-pie,,"
 
+# QEMU ships firmware and BIOS blobs built for guest architectures other than
+# the build target, so the arch QA check flags them by design.
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:${PN} = "arch"
 
 FILES:${PN} += "${datadir}/icons"

--- a/recipes-devtools/uuu/uuu-bin_1.5.233.bb
+++ b/recipes-devtools/uuu/uuu-bin_1.5.233.bb
@@ -31,7 +31,10 @@ do_install() {
     install -D -m 0644 ${UNPACKDIR}/uuu-${PV}.exe       ${D}${libdir}/uuu/uuu.exe
 }
 
-# HACK! We are not aiming to run those binaries during the build but copy then for MFGTOOL bundle.
+# These prebuilt binaries are bundled for the MFGTOOL package, not run on target,
+# so their foreign arch and unresolved file-rdeps are expected and the arch and
+# file-rdeps QA checks do not apply.
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:${PN} += "arch file-rdeps"
 # Prebuilt uuu host binaries are staged under ${libdir}/uuu for the MFGTOOL
 # bundle only; the main package holds exactly that directory.

--- a/recipes-dpaa2/aiopsl/aiopsl_git.bb
+++ b/recipes-dpaa2/aiopsl/aiopsl_git.bb
@@ -25,6 +25,9 @@ do_install () {
 }
 
 FILES:${PN} += "/usr/aiop/*"
+# The package ships AIOP accelerator-core firmware, whose ELF machine type is not
+# the host BSP arch, so the arch QA check flags it by design.
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:${PN} += "arch"
 INHIBIT_PACKAGE_STRIP = "1"
 INHIBIT_PACKAGE_DEBUG_SPLIT = "1"

--- a/recipes-dpaa2/dce/dce_git.bb
+++ b/recipes-dpaa2/dce/dce_git.bb
@@ -20,5 +20,8 @@ do_install () {
     oe_runmake install DESTDIR=${D}
 }
 
+# The upstream Makefile controls linking through its own CC/CROSS_COMPILE and does
+# not consume the OE LDFLAGS, so the ldflags QA check cannot pass here.
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:${PN} = "ldflags"
 COMPATIBLE_MACHINE = "(qoriq-arm64)"

--- a/recipes-extended/jailhouse/jailhouse-imx_git.bb
+++ b/recipes-extended/jailhouse/jailhouse-imx_git.bb
@@ -109,12 +109,18 @@ RDEPENDS:pyjailhouse = "\
 
 RPROVIDES:${PN} += "jailhouse"
 
+# The hypervisor firmware and inmate binaries are linked bare-metal (the recipe
+# passes LDFLAGS="") and the vendor Makefile bakes build paths into them, so the
+# ldflags and buildpaths QA checks cannot pass for these packages.
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:${PN} = "ldflags buildpaths"
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:${PN}-dbg = "buildpaths"
 
 # The QA error in package kernel-module-${KERNEL_VERSION} cannot be skipped with
 # INSANE_SKIP, so adjust at the ERROR_QA level
 ERROR_QA:remove = "buildpaths"
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:kernel-module-${KERNEL_VERSION} = "buildpaths"
 
 COMPATIBLE_MACHINE = "(mx8m-nxp-bsp|mx8ulp-nxp-bsp|mx9-nxp-bsp)"

--- a/recipes-fsl/mcore-demos/imx-mcore-demos.inc
+++ b/recipes-fsl/mcore-demos/imx-mcore-demos.inc
@@ -71,4 +71,7 @@ PACKAGE_ARCH = "${MACHINE_SOCARCH}"
 # nooelint: oelint.var.filesoverride
 FILES:${PN} = "${nonarch_base_libdir}/firmware"
 
+# The package ships Cortex-M firmware, whose ELF machine type differs from the
+# Cortex-A BSP target, so the arch QA check flags it by design.
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:${PN} = "arch"

--- a/recipes-graphics/imx-gpu-sdk/imx-gpu-sdk_6.1.1.bb
+++ b/recipes-graphics/imx-gpu-sdk/imx-gpu-sdk_6.1.1.bb
@@ -105,6 +105,9 @@ do_install () {
 
 FILES:${PN} += "/opt/${PN}"
 FILES:${PN}-dbg += "/opt/${PN}/*/*/.debug /usr/src/debug"
+# The SDK demo binaries under /opt are shipped already stripped and carry vendor
+# rpaths, so the already-stripped and rpaths QA checks do not apply.
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:${PN} += "already-stripped rpaths"
 
 # Unfortunately recipes with an empty main package, like header-only libraries,

--- a/recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc
+++ b/recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc
@@ -323,12 +323,16 @@ FILES:libclc-imx += "${libdir}/libCLC${SOLIBS}"
 FILES:libegl-imx += "${libdir}/libEGL${REALSOLIBS} ${libdir}/libEGL${SOLIBS} "
 FILES:libegl-imx-dev += "${includedir}/EGL ${includedir}/KHR ${libdir}/pkgconfig/egl.pc"
 # libEGL.so is used by some demo apps from Freescale
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:libegl-imx += "dev-so"
 
 FILES:libgal-imx += "${libdir}/libGAL${SOLIBS} ${libdir}/libGAL_egl${SOLIBS}"
 RDEPENDS:libgal-imx += "${@bb.utils.contains('PACKAGECONFIG', 'valgrind', 'valgrind', '', d)}"
 RPROVIDES:libgal-imx += "libgal-imx"
 RRECOMMENDS:libgal-imx += "kernel-module-imx-gpu-viv"
+# Prebuilt Vivante blob: its build-time dependencies are not expressed as recipe
+# DEPENDS, so the build-deps QA check cannot be satisfied here.
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:libgal-imx += "build-deps"
 
 FILES:libvsc-imx += "${libdir}/libVSC${SOLIBS}"
@@ -336,6 +340,8 @@ FILES:libvsc-imx += "${libdir}/libVSC${SOLIBS}"
 FILES:libgbm-imx += "${libdir}/libgbm*${REALSOLIBS} ${libdir}/libgbm${SOLIBS} ${libdir}/libgbm_viv${SOLIBS}"
 FILES:libgbm-imx-dev += "${libdir}/pkgconfig/gbm.pc ${includedir}/gbm.h"
 RDEPENDS:libgbm-imx:append = " libdrm"
+# libgbm ships its unversioned .so in the runtime package for dlopen consumers.
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:libgbm-imx += "dev-so"
 
 FILES:libvulkan-imx += "\
@@ -360,6 +366,9 @@ RDEPENDS:libopenvx-imx = "${OPENCL_VX_INTRINSIC_EXTENSION_PACKAGES}"
 OPENCL_VX_INTRINSIC_EXTENSION_PACKAGES = ""
 OPENCL_VX_INTRINSIC_EXTENSION_PACKAGES:mx8qm-nxp-bsp = "libclc-imx libopencl-imx-dev"
 OPENCL_VX_INTRINSIC_EXTENSION_PACKAGES:mx8mp-nxp-bsp = "libclc-imx libopencl-imx-dev"
+# The runtime package pulls -dev packages (OpenCL/VX intrinsic extensions) by
+# design; the dev-deps QA check does not fit this prebuilt driver layout.
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:libopenvx-imx += "dev-deps"
 
 FILES:libgles1-imx += "${libdir}/libGLESv1*${REALSOLIBS} ${libdir}/libGLESv1*${SOLIBS} ${libdir}/libGLES_*${REALSOLIBS} ${libdir}/libGLES_*${SOLIBS}"
@@ -367,12 +376,14 @@ FILES:libgles1-imx-dev += "${includedir}/GLES ${libdir}/pkgconfig/glesv1_cm.pc"
 RPROVIDES:libgles1-imx = "libgles-imx"
 RPROVIDES:libgles1-imx-dev = "libgles-imx-dev"
 # libEGL does dlopen of libGLESv1.so
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:libgles1-imx += "dev-so"
 
 FILES:libgles2-imx += "${libdir}/libGLESv2${REALSOLIBS} ${libdir}/libGLESv2${SOLIBS}"
 FILES:libgles2-imx-dev += "${includedir}/GLES2 ${libdir}/pkgconfig/glesv2.pc"
 RDEPENDS:libgles2-imx = "libglslc-imx"
 # libEGL does dlopen of libGLESv2.so
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:libgles2-imx += "dev-so"
 
 FILES:libgles3-imx-dev += "${includedir}/GLES3"
@@ -395,6 +406,7 @@ RPROVIDES:libopencl-imx:mx8mm-nxp-bsp = ""
 FILES:libopenvg-imx += "${libdir}/libOpenVG*${REALSOLIBS} ${libdir}/libOpenVG*${SOLIBS}"
 FILES:libopenvg-imx-dev += "${includedir}/VG ${libdir}/pkgconfig/vg.pc"
 # libEGL does dlopen of libOpenVG.so
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:libopenvg-imx += "dev-so"
 
 FILES:libvdk-imx += "${libdir}/libVDK*${REALSOLIBS}"
@@ -403,11 +415,15 @@ FILES:libvdk-imx-dev += "${includedir}/*vdk*.h ${libdir}/libVDK${SOLIBSDEV}"
 FILES:imx-gpu-viv-tools += "${bindir}/gmem_info"
 
 FILES:imx-gpu-viv-demos += "/opt"
+# Prebuilt demo binaries under /opt carry vendor rpaths and link the -dev
+# packages; the rpaths and dev-deps QA checks do not apply to them.
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:imx-gpu-viv-demos += "rpaths dev-deps"
 
 FILES:libnn-imx += "${libdir}/libNN*${SOLIBS}"
 
 # It will use gcompat at runtime therefore checking for these at compile time wont be useful as
 # they dont match musl/gcompat but it should run fine
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:append:libc-musl = " file-rdeps"
 

--- a/recipes-graphics/mali/mali-imx.inc
+++ b/recipes-graphics/mali/mali-imx.inc
@@ -34,6 +34,9 @@ FILES:${PN} += "\
     ${libdir}/libmali.so \
     ${nonarch_base_libdir}/firmware"
 FILES_SOLIBSDEV = ""
+# libmali.so is shipped in the main package for dlopen consumers (above), so the
+# dev-so QA check does not apply.
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:${PN} = "dev-so"
 FILES:${PN}-libegl += "\
     ${libdir}/libEGL${SOLIBS}"

--- a/recipes-kernel/kernel-modules/kernel-module-ar_git.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-ar_git.bb
@@ -28,6 +28,9 @@ do_install(){
 }
 
 FILES:${PN} += "${bindir}/"
+# The userspace tools are linked by the module Makefile via CROSS_COMPILE and do
+# not consume the OE LDFLAGS, so the ldflags QA check cannot pass here.
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:${PN} = "ldflags"
 COMPATIBLE_MACHINE = "(t1040|t1042)"
 

--- a/recipes-kernel/linux/linux-qoriq.inc
+++ b/recipes-kernel/linux/linux-qoriq.inc
@@ -51,5 +51,8 @@ do_configure() {
     cp .config ${UNPACKDIR}/defconfig
 }
 
+# The kernel -src package ships generated build files (Makefiles, configs) that
+# reference build paths, so the buildpaths QA check cannot pass for it.
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:${PN}-src += "buildpaths"
 COMPATIBLE_MACHINE = "(qoriq)"

--- a/recipes-multimedia/imx-dsp/imx-dsp-codec-ext_2.1.8.bb
+++ b/recipes-multimedia/imx-dsp/imx-dsp-codec-ext_2.1.8.bb
@@ -24,6 +24,9 @@ EXTRA_OECONF:append:mx8ulp-nxp-bsp = " --enable-imx8ulp"
 INHIBIT_PACKAGE_STRIP = "1"
 INHIBIT_SYSROOT_STRIP = "1"
 INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
+# Prebuilt NXP DSP codec blob (shipped as a .bin under EULA, not built from
+# source), so the arch, dev-so and ldflags QA checks cannot apply to it.
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:${PN} = "arch dev-so ldflags"
 
 FILES:${PN} += "${libdir}/imx-mm/audio-codec/dsp ${datadir}/imx-mm"

--- a/recipes-multimedia/imx-sw-pdm/imx-sw-pdm_git.bb
+++ b/recipes-multimedia/imx-sw-pdm/imx-sw-pdm_git.bb
@@ -34,6 +34,9 @@ do_install() {
     install -m 0644 ${S}/include/imx-swpdm.h ${D}${includedir}/imx-mm/audio-codec/swpdm
 }
 
+# The library ships prebuilt objects that are already stripped, so the
+# already-stripped QA check does not apply.
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:${PN} = "already-stripped"
 
 FILES:${PN} += "${datadir}/imx-mm ${libdir}/*"

--- a/recipes-multimedia/libcamera/neo-ipa-uguzzi_0.2.7.bb
+++ b/recipes-multimedia/libcamera/neo-ipa-uguzzi_0.2.7.bb
@@ -31,7 +31,9 @@ FILES:${PN} += "${libdir}/libcamera ${datadir}/libcamera"
 SOLIBS = ".so"
 FILES_SOLIBSDEV = ""
 
-# Pre-built binaries are already stripped, so skip the QA test
+# Pre-built binaries are already stripped, so the already-stripped QA check
+# does not apply.
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:${PN} = "already-stripped"
 
 COMPATIBLE_MACHINE = "(mx95-generic-bsp)"

--- a/recipes-security/optee-imx/optee-os-fslc.inc
+++ b/recipes-security/optee-imx/optee-os-fslc.inc
@@ -83,7 +83,11 @@ PACKAGES += "${PN}-ta"
 FILES:${PN} = "${nonarch_base_libdir}/firmware/"
 FILES:${PN}-ta += "${nonarch_base_libdir}/optee_armtz/*"
 
-# note: "textrel" is not triggered on all archs
+# The OP-TEE OS image contains text relocations by design (not triggered on all
+# archs) and the -dev package ships the TA devkit static libraries, so the textrel
+# and staticdev QA checks do not apply.
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:${PN} = "textrel"
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:${PN}-dev = "staticdev"
 INHIBIT_PACKAGE_STRIP = "1"

--- a/recipes-security/optee-imx/optee-os-tadevkit-fslc-imx.inc
+++ b/recipes-security/optee-imx/optee-os-tadevkit-fslc-imx.inc
@@ -30,5 +30,7 @@ do_deploy() {
 # nooelint: oelint.var.filesoverride oelint.var.override
 FILES:${PN} = "${includedir}/optee/"
 
-# Build paths are currently embedded
+# The TA devkit -dev package embeds build paths in its generated files, so the
+# buildpaths QA check cannot pass for it.
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:${PN}-dev += "buildpaths"

--- a/recipes-security/smw/smw_5.3.bb
+++ b/recipes-security/smw/smw_5.3.bb
@@ -83,10 +83,14 @@ PACKAGES =+ "${PN}-tests"
 
 FILES:${PN} += "${nonarch_base_libdir}/optee_armtz/*"
 
+# The debug package and the test binaries embed build paths that the upstream
+# build does not sanitize, so the buildpaths QA check cannot pass for them.
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:${PN}-dbg = "buildpaths"
 
 FILES:${PN}-tests += "${bindir}/* ${datadir}/${BPN}/*"
 RDEPENDS:${PN}-tests = "cmake"
+# nooelint: oelint.vars.insaneskip
 INSANE_SKIP:${PN}-tests = "buildpaths"
 
 COMPATIBLE_MACHINE = "(imx-nxp-bsp)"


### PR DESCRIPTION
## Summary

  Clears the `oelint.vars.insaneskip` rule across meta-freescale: **34 findings → 0**,
  in 21 commits (one per recipe/include).

  `oelint.vars.insaneskip` flags every use of `INSANE_SKIP` regardless of value, on the
  principle that it disables core QA checks. In a vendor BSP each use is a genuine QA
  exception on a prebuilt binary, firmware blob, or bare-metal artifact — removing it
  would break the build's QA gate, not improve it. The rule's own documented resolution
  for a necessary skip is an inline justification, so each finding is resolved by adding a
  `# nooelint: oelint.vars.insaneskip` directive with the domain reason it applies.

  ## What changed

  Comment-only additions above each `INSANE_SKIP` — the effective BitBake metadata is
  unchanged (86 insertions, all comments; no assignment touched). Each comment explains
  *why the QA exception is correct*, e.g.:

  - **jailhouse-imx** — hypervisor/inmate binaries linked bare-metal (`LDFLAGS=""`) with
    vendor-baked build paths → `ldflags`/`buildpaths` cannot pass.
  - **uuu-bin** — prebuilt MFGTOOL host binaries, not run on target → `arch`/`file-rdeps`
    expected.
  - **imx-gpu-viv, mali-imx** — NXP prebuilt GPU libraries → `dev-so`/`build-deps`.
  - **isp-imx, basler-camera, imx-sw-pdm, imx-dsp-codec-ext, neo-ipa-uguzzi** — prebuilt
    blobs already stripped → `already-stripped`.
  - **opencv** — kept byte-identical to meta-openembedded `opencv_*.bb`; suppressed as
    **UPSTREAM-PARITY** to avoid fork drift on every re-sync.

  Outcome split: **20 justified suppressions, 1 upstream-parity (opencv), 0 structural,
  0 needs-investigation.**

  ## Validation

  - `oelint-adv --rule oelint.vars.insaneskip`: **34 → 0** on this branch.
  - Every commit is suppression-only (comments only), so no package output can change —
    build/buildhistory gates do not apply.
  - Full-layer survey: **no findings introduced.** The 5 `inlinesuppress_na` findings are
    all pre-existing (2 `dependsordered`, 3 `oelint.var.override` in `optee-os-fslc.inc`);
    none is for `insaneskip` and none is on a line this PR adds.

  ## Files (21)

  recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc · recipes-extended/jailhouse/jailhouse-imx_git.bb ·
  recipes-security/optee-imx/{optee-os-fslc.inc,optee-os-tadevkit-fslc-imx.inc} ·
  opencv_4.13.0.imx.bb · recipes-security/smw/smw_5.3.bb · recipes-devtools/qemu/qemu-qoriq.inc ·
  recipes-fsl/mcore-demos/imx-mcore-demos.inc · recipes-graphics/mali/mali-imx.inc ·
  recipes-kernel/linux/linux-qoriq.inc · recipes-dpaa2/{aiopsl,dce}_git.bb ·
  recipes-bsp/isp-imx/{basler-camera,isp-imx}_*.bb · imx-dsp-codec-ext_2.1.8.bb ·
  imx-gpu-sdk_6.1.1.bb · imx-sw-pdm_git.bb · kernel-module-ar_git.bb ·
  neo-ipa-uguzzi_0.2.7.bb · qtmultimedia_%.bbappend · uuu-bin_1.5.233.bb

  ---
