### PR TITLE
Clear all oelint.vars.inconspaces findings

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-support/opencv/opencv_4.13.0.imx.bb
+++ b/dynamic-layers/openembedded-layer/recipes-support/opencv/opencv_4.13.0.imx.bb
@@ -148,7 +148,7 @@ export ANT_DIR = "${STAGING_DIR_NATIVE}/usr/share/ant/"
 
 TARGET_CC_ARCH += "-I${S}/include "
 
-PACKAGES += " \
+PACKAGES += "\
     ${@bb.utils.contains('PACKAGECONFIG', 'samples', '${PN}-samples', '', d)} \
     ${@bb.utils.contains('PACKAGECONFIG', 'oracle-java', '${PN}-java', '', d)} \
     ${@bb.utils.contains('PACKAGECONFIG', 'java', '${PN}-java', '', d)} \
@@ -305,6 +305,9 @@ SRC_URI += "\
     git://github.com/opencv/opencv_extra.git;destsuffix=extra;name=extra;branch=4.x;protocol=https \
     file://0001-Add-smaller-version-of-download_models.py.patch;patchdir=${UNPACKDIR}/extra \
 "
+# SRCREV_FORMAT is an underscore-joined list of SRC_URI names; the appended
+# component must attach directly with no leading space.
+# nooelint: oelint.vars.inconspaces
 SRCREV_FORMAT:append = "_extra"
 SRCREV_extra = "b6db059e9b80072d80d009d2ab344f8606a8e964"
 

--- a/recipes-bsp/atf/qoriq-atf-tools_2.12.bb
+++ b/recipes-bsp/atf/qoriq-atf-tools_2.12.bb
@@ -2,6 +2,9 @@ require qoriq-atf-${PV}.inc
 
 DEPENDS += "openssl"
 
+# PV is a version string; the appended part concatenates with a leading '+'
+# and must not contain a space.
+# nooelint: oelint.vars.inconspaces
 PV:append = "+${SRCPV}"
 
 EXTRA_OEMAKE = "fiptool V=1 PLAT=lx2162aqds HOSTCC='${CC} ${CPPFLAGS} ${CFLAGS} ${LDFLAGS}'"

--- a/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
+++ b/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
@@ -45,7 +45,12 @@ SC_FIRMWARE_NAME ?= "scfw_tcm.bin"
 OEI_NAME ?= "oei-${OEI_CORE}-*.bin"
 
 ATF_MACHINE_NAME ?= "bl31-${ATF_PLATFORM}.bin"
+# ATF_MACHINE_NAME is a filename used as ${DEPLOY_DIR_IMAGE}/${ATF_MACHINE_NAME}.
+# The appended tokens are hyphen-joined name suffixes and must not start with a
+# space, or the resulting path would contain a space and the copy would fail.
+# nooelint: oelint.vars.inconspaces
 ATF_MACHINE_NAME:append = "${@bb.utils.contains('UBOOT_CONFIG', 'crrm', '-crrm', '', d)}"
+# nooelint: oelint.vars.inconspaces
 ATF_MACHINE_NAME:append = "${@bb.utils.contains('MACHINE_FEATURES', 'optee', '-optee', '', d)}"
 
 BOOT_VARIANT ?= ""

--- a/recipes-bsp/isp-imx/isp-imx_4.2.2.26.1.bb
+++ b/recipes-bsp/isp-imx/isp-imx_4.2.2.26.1.bb
@@ -33,7 +33,7 @@ OECMAKE_SOURCEPATH = "${S}/appshell"
 OECMAKE_GENERATOR = "Unix Makefiles"
 
 # Workaround for linking issues seen with gold linker
-LDFLAGS:append = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-gold', ' -fuse-ld=bfd ', '', d)}"
+LDFLAGS:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-gold', '-fuse-ld=bfd', '', d)}"
 
 SYSTEMD_SERVICE:${PN} = "imx8-isp.service"
 

--- a/recipes-bsp/u-boot/u-boot-qoriq_2025.04.bb
+++ b/recipes-bsp/u-boot/u-boot-qoriq_2025.04.bb
@@ -21,7 +21,11 @@ DEPENDS:append:qoriq-ppc = " boot-format-native"
 
 PROVIDES += "u-boot"
 
+# PV is a version string; the appended parts concatenate with a leading '+'
+# and must not contain a space.
+# nooelint: oelint.vars.inconspaces
 PV:append = "+${SRCPV}"
+# nooelint: oelint.vars.inconspaces
 PV:append = "+fslgit"
 
 UBOOT_BRANCH ?= "lf_v2025.04"

--- a/recipes-connectivity/mbedtls/mbedtls_3.6.5.bb
+++ b/recipes-connectivity/mbedtls/mbedtls_3.6.5.bb
@@ -43,7 +43,7 @@ PACKAGECONFIG[psa] = ""
 PACKAGECONFIG[tests] = "-DENABLE_TESTING=ON,-DENABLE_TESTING=OFF"
 
 # For now the only way to enable PSA is to explicitly pass a -D via CFLAGS
-CFLAGS:append = "${@bb.utils.contains('PACKAGECONFIG', 'psa', ' -DMBEDTLS_USE_PSA_CRYPTO', '', d)}"
+CFLAGS:append = " ${@bb.utils.contains('PACKAGECONFIG', 'psa', '-DMBEDTLS_USE_PSA_CRYPTO', '', d)}"
 
 PACKAGES =+ "${PN}-programs"
 FILES:${PN}-programs += "${bindir}/"

--- a/recipes-devtools/qemu/qemu-qoriq_4.2.bb
+++ b/recipes-devtools/qemu/qemu-qoriq_4.2.bb
@@ -27,7 +27,7 @@ python() {
 RDEPENDS:${PN}:class-target += "bash"
 
 EXTRA_OECONF:append:class-target = " --target-list=${@get_qemu_target_list(d)}"
-EXTRA_OECONF:append:class-target:mipsarcho32 = "${@bb.utils.contains('BBEXTENDCURR', 'multilib', ' --disable-capstone', '', d)}"
+EXTRA_OECONF:append:class-target:mipsarcho32 = " ${@bb.utils.contains('BBEXTENDCURR', 'multilib', '--disable-capstone', '', d)}"
 
 do_install_ptest() {
         cp -rL ${B}/tests ${D}${PTEST_PATH}

--- a/recipes-graphics/imx-gpu-sdk/imx-gpu-sdk_6.1.1.bb
+++ b/recipes-graphics/imx-gpu-sdk/imx-gpu-sdk_6.1.1.bb
@@ -51,10 +51,18 @@ WINDOW_SYSTEM = \
         bb.utils.contains('DISTRO_FEATURES',     'x11',         'X11', \
                                                                  'FB', d), d)}"
 
+# FEATURES is a comma-separated list passed to FslBuild.py as
+# --UseFeatures [${FEATURES}], so each appended token starts with a comma
+# and must NOT start with a space. A leading space would inject an invalid
+# feature name into the build.
 FEATURES = "ConsoleHost,EarlyAccess,EGL,GoogleUnitTest,Lib_NlohmannJson,OpenVG,Test_RequireUserInputToExit,WindowHost"
+# nooelint: oelint.vars.inconspaces
 FEATURES:append:imxgpu = ",HW_GPU_VIVANTE"
+# nooelint: oelint.vars.inconspaces
 FEATURES:append:imxgpu2d = ",G2D"
+# nooelint: oelint.vars.inconspaces
 FEATURES:append:imxgpu3d = ",OpenGLES2"
+# nooelint: oelint.vars.inconspaces
 FEATURES:append = "${FEATURES_SOC}"
 
 FEATURES_SOC = ""

--- a/recipes-graphics/wayland/weston_10.0.5.imx.bb
+++ b/recipes-graphics/wayland/weston_10.0.5.imx.bb
@@ -131,8 +131,8 @@ do_install:append() {
     fi
 }
 
-PACKAGES += "${@bb.utils.contains('PACKAGECONFIG', 'xwayland', '${PN}-xwayland', '', d)} \
-             libweston-${WESTON_MAJOR_VERSION} ${PN}-examples"
+PACKAGES += "libweston-${WESTON_MAJOR_VERSION} ${PN}-examples"
+PACKAGES += "${@bb.utils.contains('PACKAGECONFIG', 'xwayland', '${PN}-xwayland', '', d)}"
 
 FILES:${PN}-dev += "${libdir}/${BPN}/libexec_weston.so"
 # Main package is curated to weston's own binaries, config and plugins; the

--- a/recipes-graphics/wayland/weston_14.0.2.imx.bb
+++ b/recipes-graphics/wayland/weston_14.0.2.imx.bb
@@ -131,8 +131,8 @@ do_install:append() {
     fi
 }
 
-PACKAGES += "${@bb.utils.contains('PACKAGECONFIG', 'xwayland', '${PN}-xwayland', '', d)} \
-             libweston-${WESTON_MAJOR_VERSION} ${PN}-examples"
+PACKAGES += "libweston-${WESTON_MAJOR_VERSION} ${PN}-examples"
+PACKAGES += "${@bb.utils.contains('PACKAGECONFIG', 'xwayland', '${PN}-xwayland', '', d)}"
 
 FILES:${PN}-dev += "${libdir}/${BPN}/libexec_weston.so"
 # Main package is curated to weston's own binaries, config and plugins; the

--- a/recipes-security/optee-imx/optee-os-fslc.inc
+++ b/recipes-security/optee-imx/optee-os-fslc.inc
@@ -41,7 +41,7 @@ EXTRA_OEMAKE += "HOST_PREFIX=${HOST_PREFIX}"
 EXTRA_OEMAKE += "CROSS_COMPILE64=${HOST_PREFIX}"
 
 # Enable BTI in optee
-EXTRA_OEMAKE += "${@bb.utils.contains('MACHINE_FEATURES', 'arm-branch-protection', ' CFG_TA_BTI=1 CFG_CORE_PAUTH=y CFG_TA_PAUTH=y', '', d)}"
+EXTRA_OEMAKE += "${@bb.utils.contains('MACHINE_FEATURES', 'arm-branch-protection', 'CFG_TA_BTI=1 CFG_CORE_PAUTH=y CFG_TA_PAUTH=y', '', d)}"
 
 LDFLAGS[unexport] = "1"
 CPPFLAGS[unexport] = "1"


### PR DESCRIPTION
## Summary

This series removes every `oelint.vars.inconspaces` finding in the layer (17 → 0),
one recipe per commit. The rule reports a leading space in an `:append`/`+=`
value. Each finding is either a genuine formatting fix or a false positive on a
variable that is not a space-delimited list. No finding is silenced without a
reason.

Net layer findings drop 341 → 318. No new finding is introduced in any other rule.

## Two kinds of change

**Structural fixes (6 recipes)** — a genuine redundant or misplaced space:

- `opencv` — remove the redundant leading space in `PACKAGES += "\` (`+=` already
  inserts a separator).
- `weston` (10.0.5 + 14.0.2) — split one `PACKAGES +=` into two so the value no
  longer begins with a conditional-plus-space.
- `optee-os-fslc` — drop the leading space inside the BTI `EXTRA_OEMAKE +=`
  conditional (`+=` supplies the separator; matches the adjacent lines).
- `isp-imx`, `mbedtls`, `qemu-qoriq` — move the separator space out of the
  `${@bb.utils.contains(..., ' flag', '', d)}` value for `:append`, so the append
  begins with a literal space (matches OE idiom and the adjacent lines).

**Justified suppressions (5 recipes)** — the variable is not a space-delimited
list, so the space the linter wants would corrupt the value. Each carries an
inline `# nooelint: oelint.vars.inconspaces` and a semantic comment:

| Recipe | Variable | Delimiter |
| --- | --- | --- |
| `imx-gpu-sdk` | `FEATURES` | comma (passed to `FslBuild.py --UseFeatures`) |
| `imx-boot` | `ATF_MACHINE_NAME` | hyphen (a filename) |
| `opencv` | `SRCREV_FORMAT` | underscore (SRC_URI name list) |
| `u-boot-qoriq`, `qoriq-atf-tools` | `PV` | `+` (version string) |

## Verbatim forks

`weston` (copied from OE-core) and `optee-os-fslc` (mirrored from meta-arm) are
fixed structurally, not suppressed. The intentional divergence from the upstream
source is recorded in each commit body so a future re-sync knows the line is now
local.

## Validation

Every commit that changes effective BitBake metadata (the 6 structural fixes) was
validated with a before/after buildhistory diff, forcing `do_package`:

| Recipe | MACHINE / config |
| --- | --- |
| opencv | imx8mm-lpddr4-evk, fslc-framebuffer |
| weston 14.0.2.imx | imx8mm-lpddr4-evk, nxp BSP + wayland |
| optee-os | imx8mm-lpddr4-evk |
| isp-imx | imx8mp-lpddr4-evk, nxp BSP |
| mbedtls | imx8mm-lpddr4-evk |
| qemu-qoriq | ls1046ardb |

In every case the only buildhistory delta is `metadata-revs` (local-tree
bookkeeping); package versions, `FILELIST`, `PKGSIZE` and runtime dependencies are
byte-identical. The 5 suppression-only commits move no effective metadata, so the
build/buildhistory gates do not apply.

## Commits

Each commit is independently revertible and carries a DCO `Signed-off-by`:

```
imx-gpu-sdk: Suppress inconspaces on comma-joined FEATURES
imx-boot: Suppress inconspaces on hyphen-joined ATF_MACHINE_NAME
opencv: Fix PACKAGES spacing and suppress inconspaces on SRCREV_FORMAT
u-boot-qoriq: Suppress inconspaces on concatenated PV
weston: Split PACKAGES += to fix inconspaces leading space
optee-os-fslc: Drop redundant leading space in BTI EXTRA_OEMAKE
isp-imx: Move separator space out of conditional LDFLAGS append
mbedtls: Move separator space out of conditional CFLAGS append
qemu-qoriq: Move separator space out of conditional EXTRA_OECONF append
qoriq-atf-tools: Suppress inconspaces on concatenated PV
```
