### PR TITLE
oelint: Ignore known out-of-layer requires via oelint-require-file-ignore

### DIFF
--- a/oelint.constants.json
+++ b/oelint.constants.json
@@ -1,5 +1,12 @@
 {
     "comment": "Layer-specific oelint-adv constant DB. contrib/oelint/run-oelint.sh passes this file via --constantmods so standalone lint runs know about real variables/overrides that normally come from the full bitbake metadata context.",
+    "oelint-require-file-ignore": [
+        "recipes-bsp/u-boot/u-boot.inc",
+        "recipes-multimedia/gstreamer/gstreamer1.0-plugins-common.inc",
+        "recipes-multimedia/gstreamer/gstreamer1.0-plugins-license.inc",
+        "recipes-multimedia/gstreamer/gstreamer1.0-plugins-packaging.inc",
+        "u-boot-fslc-common_${PV}.inc"
+    ],
     "functions": {
         "known": [
             "do_image_uboot_mxsboot_nand",


### PR DESCRIPTION
## Summary

Clears the whole `oelint.file.requirenotfound` class (13 → 0) with a single change to the layer's constant DB, `oelint.constants.json`, and **no recipe changes and no `# nooelint` suppressions**. The lint driver `contrib/oelint/run-oelint.sh` is untouched.

The findings were never recipe defects. A layer is linted on its own but built with others: recipes here `require` a shared include another layer provides — `u-boot.inc` and the gstreamer `-common`/`-license`/`-packaging` includes live in OE-core — which bitbake resolves through `BBPATH` at build time. oelint-adv has no `BBPATH`; its resolver stops at the layer boundary by design, and upstream keeps it that way (priv-kweihmann/oelint-adv#376, #626). So it reported a file that is not missing.

## What changed

oelint-adv 9.11.1 adds a first-class exception list for exactly this case: the `oelint-require-file-ignore` constant (priv-kweihmann/oelint-adv@e767b12, PR #934). A `require` whose name or resolved path is in the list is not reported. This PR adds that list to `oelint.constants.json`:

- Four OE-core cross-layer includes, listed by the path each recipe writes (the rule matches the require string directly, so no expansion is needed):
  - `recipes-bsp/u-boot/u-boot.inc`
  - `recipes-multimedia/gstreamer/gstreamer1.0-plugins-common.inc`
  - `recipes-multimedia/gstreamer/gstreamer1.0-plugins-license.inc`
  - `recipes-multimedia/gstreamer/gstreamer1.0-plugins-packaging.inc`
- One in-layer include that oelint-adv cannot resolve because it does not expand `${PV}`: `u-boot-fslc-common_${PV}.inc`. The rule compares only the raw require string and its non-`${PV}` term expansion, so the exception must be the literal `${PV}` string — a version-resolved path would never match. This entry is version-agnostic and survives PV bumps, at the cost of not re-checking that the in-layer file still exists.

Every other `require` is still fully checked, so a real typo or a genuinely missing include elsewhere is never hidden, and no recipe carries a suppression for this.

This supersedes the earlier wrapper-side cross-layer resolver that this branch first proposed (never merged). The native constant needs no post-filter, no `${PV}`/`${PN}`/`${BPN}` re-implementation, and no `OELINT_LAYER_PATH` plumbing, so `contrib/oelint/run-oelint.sh` stays the plain `oelint-adv` invocation.

## Testing

Ran `contrib/oelint/run-oelint.sh` over the whole layer. The 13 `oelint.file.requirenotfound` findings are gone; no new finding appears and no `oelint.file.inlinesuppress_na` is raised.

**Requires oelint-adv >= 9.11.1.** Older versions do not know the constant and would report the 13 findings again.
