### PR TITLE
oelint: Clear oelint.vars.multilineident on weston and gstreamer1.0

### DIFF
--- a/recipes-graphics/wayland/weston_10.0.5.imx.bb
+++ b/recipes-graphics/wayland/weston_10.0.5.imx.bb
@@ -43,16 +43,17 @@ WESTON_MAJOR_VERSION = "${@'.'.join(d.getVar('PV').split('.')[0:1])}"
 
 EXTRA_OEMESON += "-Dpipewire=false"
 
-PACKAGECONFIG ??= "${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'kms wayland egl clients', '', d)} \
-                   ${@bb.utils.contains('DISTRO_FEATURES', 'x11 wayland', 'xwayland', '', d)} \
-                   ${@bb.utils.filter('DISTRO_FEATURES', 'systemd x11', d)} \
-                   ${@bb.utils.contains_any('DISTRO_FEATURES', 'wayland x11', '', 'headless', d)} \
-                   ${@oe.utils.conditional('VIRTUAL-RUNTIME_init_manager', 'sysvinit', 'launcher-libseat', '', d)} \
-                   image-jpeg \
-                   screenshare \
-                   shell-desktop \
-                   shell-fullscreen \
-                   shell-ivi"
+PACKAGECONFIG ??= "\
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'kms wayland egl clients', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'x11 wayland', 'xwayland', '', d)} \
+    ${@bb.utils.filter('DISTRO_FEATURES', 'systemd x11', d)} \
+    ${@bb.utils.contains_any('DISTRO_FEATURES', 'wayland x11', '', 'headless', d)} \
+    ${@oe.utils.conditional('VIRTUAL-RUNTIME_init_manager', 'sysvinit', 'launcher-libseat', '', d)} \
+    image-jpeg \
+    screenshare \
+    shell-desktop \
+    shell-fullscreen \
+    shell-ivi"
 
 # Can be 'damage', 'im', 'egl', 'shm', 'touch', 'dmabuf-feedback', 'dmabuf-v4l', 'dmabuf-egl' or 'all'
 SIMPLECLIENTS ?= "all"

--- a/recipes-graphics/wayland/weston_14.0.2.imx.bb
+++ b/recipes-graphics/wayland/weston_14.0.2.imx.bb
@@ -44,17 +44,18 @@ WESTON_MAJOR_VERSION = "${@'.'.join(d.getVar('PV').split('.')[0:1])}"
 
 EXTRA_OEMESON += "-Dpipewire=false -Dtests=false"
 
-PACKAGECONFIG ??= "${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'kms wayland egl clients', '', d)} \
-                   ${@bb.utils.contains('DISTRO_FEATURES', 'x11 wayland', 'xwayland', '', d)} \
-                   ${@bb.utils.filter('DISTRO_FEATURES', 'systemd x11', d)} \
-                   ${@bb.utils.contains_any('DISTRO_FEATURES', 'wayland x11', '', 'headless', d)} \
-                   image-jpeg \
-                   screenshare \
-                   shell-desktop \
-                   shell-fullscreen \
-                   shell-ivi \
-                   shell-kiosk \
-                   "
+PACKAGECONFIG ??= "\
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'kms wayland egl clients', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'x11 wayland', 'xwayland', '', d)} \
+    ${@bb.utils.filter('DISTRO_FEATURES', 'systemd x11', d)} \
+    ${@bb.utils.contains_any('DISTRO_FEATURES', 'wayland x11', '', 'headless', d)} \
+    image-jpeg \
+    screenshare \
+    shell-desktop \
+    shell-fullscreen \
+    shell-ivi \
+    shell-kiosk \
+    "
 
 # Can be 'damage', 'im', 'egl', 'shm', 'touch', 'dmabuf-feedback', 'dmabuf-v4l', 'dmabuf-egl' or 'all'
 SIMPLECLIENTS ?= "all"

--- a/recipes-multimedia/gstreamer/gstreamer1.0_1.28.1.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0_1.28.1.imx.bb
@@ -31,10 +31,11 @@ SRC_URI = "https://gstreamer.freedesktop.org/src/gstreamer/gstreamer-${PV}.tar.x
            "
 SRC_URI[sha256sum] = "4408d7930f381809e85917acc19712f173261ba85bdf20c5567b2a21b1193b61"
 
-PACKAGECONFIG ??= "${@bb.utils.contains('PTEST_ENABLED', '1', 'tests', '', d)} \
-                   check \
-                   debug \
-                   tools"
+PACKAGECONFIG ??= "\
+    ${@bb.utils.contains('PTEST_ENABLED', '1', 'tests', '', d)} \
+    check \
+    debug \
+    tools"
 
 PACKAGECONFIG[debug] = "-Dgst_debug=true,-Dgst_debug=false"
 PACKAGECONFIG[tracer-hooks] = "-Dtracer_hooks=true,-Dtracer_hooks=false"


### PR DESCRIPTION
Clears the remaining `oelint.vars.multilineident` findings in the layer,
which reappeared on the weston and gstreamer1.0 recipes after PR #2642.

## Problem

The rule is **non-convergent** on these recipes' `PACKAGECONFIG ??=`
assignments, where the first value is an inline-python
`${@bb.utils.contains(...)}` starting on the operator line. At indent 19
the rule reports "19 set, 4 desirable"; re-indenting the continuations to
4 makes it report "4 set, 19 desirable" on its other analysis branch, so
no indentation clears it.

## Fix

Rewrite each assignment to the value-on-next-line form: the opening quote
is followed by a line continuation, and every value sits on its own line
indented by four spaces. This makes the rule compute a stable desirable
indent of 4, which the reformat matches, clearing the finding. It also
removes the redundant leading space that `oelint.vars.notneededspace`
flagged (3 findings).

Both recipes are verbatim i.MX forks of the OE-core recipes, whose
`PACKAGECONFIG` blocks use the same same-line form (and would trip the
same rule). This reformat therefore diverges the copied blocks from
upstream OE-core on purpose, to satisfy lint; each commit body records
this so a future OE-core re-sync re-applies it.

## Commits

- `weston: Reformat PACKAGECONFIG to satisfy multilineident` (10.0.5 + 14.0.2)
- `gstreamer1.0: Reformat PACKAGECONFIG to satisfy multilineident`

## Validation

Whitespace only — the effective `PACKAGECONFIG` value (a space-separated
token list) is unchanged. Verified inert by building weston (14.0.2) and
gstreamer1.0 with the original and reformatted recipes (DISTRO
`fslc-wayland`, MACHINE `imx8mm-lpddr4-evk`) and comparing buildhistory:
the package set, `CONFIG`, dependencies, file lists and sizes are
byte-identical across the change.

Layer-wide oelint survey: `oelint.vars.multilineident` 16 → 0 and
`oelint.vars.notneededspace` reduced by 3; error and warning counts
unchanged (no findings introduced).