### PR TITLE
weston: Fix PACKAGES order so xwayland.so stays in weston-xwayland

### DIFF
--- a/recipes-graphics/wayland/weston_10.0.5.imx.bb
+++ b/recipes-graphics/wayland/weston_10.0.5.imx.bb
@@ -132,8 +132,8 @@ do_install:append() {
     fi
 }
 
-PACKAGES += "libweston-${WESTON_MAJOR_VERSION} ${PN}-examples"
 PACKAGES += "${@bb.utils.contains('PACKAGECONFIG', 'xwayland', '${PN}-xwayland', '', d)}"
+PACKAGES += "libweston-${WESTON_MAJOR_VERSION} ${PN}-examples"
 
 FILES:${PN}-dev += "${libdir}/${BPN}/libexec_weston.so"
 # Main package is curated to weston's own binaries, config and plugins; the

--- a/recipes-graphics/wayland/weston_14.0.2.imx.bb
+++ b/recipes-graphics/wayland/weston_14.0.2.imx.bb
@@ -132,8 +132,8 @@ do_install:append() {
     fi
 }
 
-PACKAGES += "libweston-${WESTON_MAJOR_VERSION} ${PN}-examples"
 PACKAGES += "${@bb.utils.contains('PACKAGECONFIG', 'xwayland', '${PN}-xwayland', '', d)}"
+PACKAGES += "libweston-${WESTON_MAJOR_VERSION} ${PN}-examples"
 
 FILES:${PN}-dev += "${libdir}/${BPN}/libexec_weston.so"
 # Main package is curated to weston's own binaries, config and plugins; the


### PR DESCRIPTION
### Problem

Commit 74ee90ad ("weston: Split PACKAGES += to fix inconspaces leading space") split the single `PACKAGES +=` line into two and changed the order of the runtime packages: `libweston-${WESTON_MAJOR_VERSION}` now comes before `${PN}-xwayland`.

Package order is significant. `FILES:libweston-${WESTON_MAJOR_VERSION}` includes the glob `${libdir}/libweston-${WESTON_MAJOR_VERSION}/*.so`, which also matches `xwayland.so`. bitbake assigns each file to the first package in `PACKAGES` whose `FILES` matches, so with `libweston` listed first it captures `xwayland.so` and the `weston-xwayland` package becomes empty.

This breaks images that install the `weston-xwayland` runtime package, e.g. `recipes-fsl/images/fsl-image-machine-test.bb` and `recipes-fsl/images/fsl-image-multimedia.bb`.

### Fix

Keep the two-line split (it satisfies `oelint.vars.inconspaces`), but list the conditional `${PN}-xwayland` package first, matching the original single line. Applied identically to `weston_10.0.5.imx.bb` and `weston_14.0.2.imx.bb`.

### Verification

Effective `PACKAGES` on `weston_14.0.2.imx` (imx8mn-ddr4-evk, NXP BSP):

    broken:  ... weston libweston-14 weston-examples weston-xwayland
    fixed:   ... weston weston-xwayland libweston-14 weston-examples

With the fix, `xwayland.so` is assigned to `weston-xwayland` again.