### PR TITLE
oelint.vars.dependsordered: Order DEPENDS/RDEPENDS across the layer

### DIFF
--- a/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
+++ b/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
@@ -9,14 +9,14 @@ SECTION = "bsp"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6"
 
-DEPENDS += "xxd-native"
+DEPENDS:append = " xxd-native"
 DEPENDS:append:mx8m-generic-bsp = " u-boot-mkimage-native dtc-native u-boot-mkeficapsule-native"
 DEPENDS:append:mx93-generic-bsp = " u-boot-mkimage-native dtc-native u-boot-mkeficapsule-native"
 DEPENDS:append:mx95-generic-bsp = " u-boot-mkeficapsule-native"
 
 # This package aggregates output deployed by other packages,
 # so set the appropriate dependencies
-DEPENDS += "\
+DEPENDS:append = " \
     virtual/bootloader \
     ${IMX_EXTRA_FIRMWARE} \
     imx-atf \

--- a/recipes-bsp/u-boot/u-boot-fslc-mxsboot_2025.01.bb
+++ b/recipes-bsp/u-boot/u-boot-fslc-mxsboot_2025.01.bb
@@ -5,7 +5,7 @@ SECTION = "bootloader"
 
 inherit python3native
 
-DEPENDS += "\
+DEPENDS:append = " \
     dtc \
     gnutls \
     openssl \

--- a/recipes-bsp/u-boot/u-boot-fslc_2025.01.bb
+++ b/recipes-bsp/u-boot/u-boot-fslc_2025.01.bb
@@ -7,7 +7,7 @@ DESCRIPTION = "U-Boot based on mainline U-Boot used by FSL Community BSP in \
                version, or because it is not applicable for upstreaming."
 SECTION = "bootloaders"
 
-DEPENDS += "bc-native dtc-native python3-setuptools-native gnutls-native"
+DEPENDS:append = " bc-native dtc-native gnutls-native python3-setuptools-native"
 
 PROVIDES += "u-boot u-boot-mfgtool"
 

--- a/recipes-graphics/imx-gpu-sdk/imx-gpu-sdk_6.1.1.bb
+++ b/recipes-graphics/imx-gpu-sdk/imx-gpu-sdk_6.1.1.bb
@@ -23,6 +23,8 @@ DEPENDS_MX8:mx8mm-nxp-bsp = "\
     opencv \
 "
 DEPENDS = "\
+    ${DEPENDS_BACKEND} \
+    ${DEPENDS_MX8} \
     assimp \
     cmake-native \
     devil \
@@ -38,8 +40,6 @@ DEPENDS = "\
     rapidjson \
     stb \
     zlib \
-    ${DEPENDS_BACKEND} \
-    ${DEPENDS_MX8} \
 "
 DEPENDS:append:imxgpu2d = " virtual/libg2d virtual/libopenvg"
 DEPENDS:append:imxgpu3d = " virtual/libgles2"
@@ -144,8 +144,8 @@ RDEPENDS_VULKAN_LOADER = ""
 RDEPENDS_VULKAN_LOADER:mx8-nxp-bsp = "vulkan-loader vulkan-validation-layers"
 RDEPENDS_VULKAN_LOADER:mx8mm-nxp-bsp = ""
 RDEPENDS:${PN} += "\
-    ${RDEPENDS_EMPTY_MAIN_PACKAGE} \
     ${RDEPENDS_EMPTY_MAIN_PACKAGE_MX8} \
+    ${RDEPENDS_EMPTY_MAIN_PACKAGE} \
     ${RDEPENDS_VULKAN_LOADER} \
 "
 

--- a/recipes-multimedia/gstreamer/gstreamer1.0-libav_1.28.1.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-libav_1.28.1.bb
@@ -11,7 +11,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=69333daa044cb77e486cc36129f7a770 \
                     file://ext/libav/gstav.h;beginline=1;endline=18;md5=a752c35267d8276fd9ca3db6994fca9c \
                     "
 
-DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base ffmpeg"
+DEPENDS = "ffmpeg gstreamer1.0 gstreamer1.0-plugins-base"
 
 SRC_URI = "https://gstreamer.freedesktop.org/src/gst-libav/gst-libav-${PV}.tar.xz"
 SRC_URI[sha256sum] = "bfa91aaca38d0fd8addcdd559e35b7541e3f32a5f410194ec4ba18040defee9b"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.28.1.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.28.1.imx.bb
@@ -107,7 +107,7 @@ LIC_FILES_CHKSUM = "\
 PACKAGECONFIG:append = " pulseaudio"
 
 # fb implementation of v4l2 uses libdrm
-DEPENDS += "${@bb.utils.contains('PACKAGECONFIG', 'v4l2', '${DEPENDS_V4L2}', '', d)}"
+DEPENDS:append = " ${@bb.utils.contains('PACKAGECONFIG', 'v4l2', '${DEPENDS_V4L2}', '', d)}"
 DEPENDS_V4L2 = "${@bb.utils.contains_any('DISTRO_FEATURES', 'wayland x11', '', 'libdrm', d)}"
 
 # FIXME: imx93/943 DISTRO_FEATURES contains x11 but v4l2 implement by libdrm ?

--- a/recipes-multimedia/libcamera/libcamera_0.7.1.imx.bb
+++ b/recipes-multimedia/libcamera/libcamera_0.7.1.imx.bb
@@ -27,8 +27,8 @@ SRCREV = "e2e7c015cee997b9f992376fd2c29fa2d8813e1b"
 
 PE = "1"
 
-DEPENDS = "python3-pyyaml-native python3-jinja2-native python3-ply-native python3-jinja2-native udev gnutls chrpath-native libevent libyaml"
-DEPENDS += "${@bb.utils.contains('DISTRO_FEATURES', 'qt', 'qtbase qtbase-native', '', d)}"
+DEPENDS = "chrpath-native gnutls libevent libyaml python3-jinja2-native python3-ply-native python3-pyyaml-native udev"
+DEPENDS:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'qt', 'qtbase qtbase-native', '', d)}"
 
 PACKAGES =+ "${PN}-gst ${PN}-pycamera"
 

--- a/recipes-security/optee-imx/optee-os-fslc.inc
+++ b/recipes-security/optee-imx/optee-os-fslc.inc
@@ -20,9 +20,9 @@ require optee-fslc.inc
 
 CVE_PRODUCT = "linaro:op-tee op-tee:op-tee_os"
 
-DEPENDS = "python3-cryptography-native python3-pyelftools-native"
+DEPENDS:append = " python3-cryptography-native python3-pyelftools-native"
 
-DEPENDS:append:toolchain-clang = " lld-native compiler-rt"
+DEPENDS:append:toolchain-clang = " compiler-rt lld-native"
 
 SRC_URI = "git://github.com/OP-TEE/optee_os.git;branch=master;protocol=https"
 

--- a/recipes-security/optee-imx/optee-test-fslc-imx.inc
+++ b/recipes-security/optee-imx/optee-test-fslc-imx.inc
@@ -2,8 +2,6 @@
 # See: https://github.com/nxp-imx/imx-manifest/blob/imx-linux-whinlatter/imx-6.18.2-1.0.0.xml#L39
 require optee-test-fslc.inc
 
-DEPENDS += "openssl"
-
 inherit features_check
 
 REQUIRED_MACHINE_FEATURES = "optee"


### PR DESCRIPTION
oelint.vars.dependsordered: Order DEPENDS/RDEPENDS across the layer

## Summary

This series clears every `oelint.vars.dependsordered` finding in
meta-freescale (11 → 0). The rule checks that each recipe's flattened
`DEPENDS`/`RDEPENDS` token list — accumulated across the recipe and the
`.inc` files it requires — is in case-insensitive alphabetical order,
per the Yocto Project Recipe Style Guide section 3.5.2 (DEPENDS/RDEPENDS
ordering).

All nine commits are structural fixes; there are no `# nooelint:`
suppressions. Each fix is one recipe, one commit, PN-prefixed.

## What changed, and why

Two distinct causes are behind the findings:

1. **A single list is simply out of order or has a duplicate.** Sort the
   entries; drop any duplicate (`DEPENDS` resolves as a set, so removing
   a redundant token is inert).
   - `imx-gpu-sdk` — order `DEPENDS` and `RDEPENDS`.
   - `gstreamer1.0-libav` — order `DEPENDS`.
   - `libcamera` — order and drop a duplicate `python3-jinja2-native`.

2. **A recipe's `+=` interleaves its tokens into a required include's
   list, breaking the accumulated order** even though each individual
   line is internally sorted. The fix isolates the recipe's tokens as a
   separate override group by changing the unconditional `DEPENDS +=` to
   `DEPENDS:append = " ..."`. `:append` with a leading space is an
   unconditional append, identical in effect to the previous `+=`; in
   each case the recipe has no later hard `DEPENDS` assignment and no
   bbappend touches `DEPENDS`, so the append timing does not matter.
   - `u-boot-fslc`, `u-boot-fslc-mxsboot` — both require
     `u-boot-fslc-common_${PV}.inc` (which adds `bison-native
     flex-native`); isolate each recipe's own list.
   - `imx-boot` — isolate both unconditional appends from
     `imx-mkimage_git.inc`'s `openssl-native zlib-native`.
   - `optee-os-fslc` — reorder the `toolchain-clang` append and separate
     the base list from consumer appends.
   - `optee-test-fslc` — drop a redundant `openssl` re-added by the i.MX
     override include.
   - `gstreamer1.0-plugins-good` — isolate the conditional v4l2
     `DEPENDS` (`libdrm`) so it no longer sorts after the base `zlib`.

## Validation

The reorder is behaviour-preserving by construction: `DEPENDS`/`RDEPENDS`
are whitespace-split sets, so reordering the tokens or dropping a
duplicate does not change the resolved dependency set. For the two units
touched most recently in this pass, that prediction was confirmed with a
buildhistory comparison:

- **imx-boot** — rebuilt from `cleansstate` before and after on
  imx8mm-lpddr4-evk (fslc-framebuffer), an `mx8m-generic-bsp` machine
  that activates the changed override. Effective `DEPENDS` token set is
  identical (13 tokens) and the buildhistory is byte-identical
  (`buildhistory-diff` reports no significant differences).
- **u-boot-fslc-mxsboot** — the target variant is
  `COMPATIBLE_MACHINE = "(mxs-generic-bsp)"` only, so validation used the
  `native` class extension (unrestricted), which exercises the same
  unconditional `DEPENDS` line. Rebuilt from `cleansstate` before and
  after; token set identical (9 tokens) and buildhistory byte-identical.

## Commits

- imx-gpu-sdk: Order DEPENDS and RDEPENDS entries alphabetically
- gstreamer1.0-libav: Order DEPENDS entries alphabetically
- libcamera: Order and de-duplicate DEPENDS entries
- u-boot-fslc: Order DEPENDS entries alphabetically
- optee-os-fslc: Order DEPENDS and isolate base from consumer appends
- optee-test-fslc: Drop redundant DEPENDS openssl duplicate
- gstreamer1.0-plugins-good: Isolate conditional v4l2 DEPENDS
- imx-boot: Order DEPENDS by isolating recipe appends from the include
- u-boot-fslc-mxsboot: Order DEPENDS by isolating the recipe append

9 files changed, 13 insertions(+), 15 deletions(-)
