### PR TITLE
oelint.task.nocopy: drop ownership inheritance from do_install copies

### DIFF
--- a/recipes-devtools/qemu/qemu-qoriq.inc
+++ b/recipes-devtools/qemu/qemu-qoriq.inc
@@ -34,7 +34,7 @@ do_compile_ptest() {
 }
 
 do_install_ptest() {
-    cp -rL ${B}/tests ${D}${PTEST_PATH}
+    cp --no-preserve=ownership -rL ${B}/tests ${D}${PTEST_PATH}
     find ${D}${PTEST_PATH}/tests -type f -name "*.[Sshcod]" | xargs -i rm -rf {}
 
     install -m 0644 ${S}/tests/Makefile.include ${D}${PTEST_PATH}/tests

--- a/recipes-devtools/qemu/qemu-qoriq_4.2.bb
+++ b/recipes-devtools/qemu/qemu-qoriq_4.2.bb
@@ -30,7 +30,7 @@ EXTRA_OECONF:append:class-target = " --target-list=${@get_qemu_target_list(d)}"
 EXTRA_OECONF:append:class-target:mipsarcho32 = " ${@bb.utils.contains('BBEXTENDCURR', 'multilib', '--disable-capstone', '', d)}"
 
 do_install_ptest() {
-        cp -rL ${B}/tests ${D}${PTEST_PATH}
+        cp --no-preserve=ownership -rL ${B}/tests ${D}${PTEST_PATH}
         find ${D}${PTEST_PATH}/tests -type f -name "*.[Sshcod]" | xargs -i rm -rf {}
 
         install -m 0644 ${S}/tests/Makefile.include ${D}${PTEST_PATH}/tests

--- a/recipes-dpaa2/aiopsl/aiopsl_git.bb
+++ b/recipes-dpaa2/aiopsl/aiopsl_git.bb
@@ -19,9 +19,9 @@ DEMOS_PATH:ls1088a = "LS1088A"
 do_install () {
     install -d ${D}/usr/aiop/bin
     install -d ${D}/usr/aiop/
-    cp -rf ${S}/demos/images/*  ${D}/usr/aiop/bin
-    cp -rf ${S}/misc/setup/scripts ${D}/usr/aiop/
-    cp -rf ${S}/misc/setup/traffic_files/ ${D}/usr/aiop/
+    cp --no-preserve=ownership -rf ${S}/demos/images/*  ${D}/usr/aiop/bin
+    cp --no-preserve=ownership -rf ${S}/misc/setup/scripts ${D}/usr/aiop/
+    cp --no-preserve=ownership -rf ${S}/misc/setup/traffic_files/ ${D}/usr/aiop/
 }
 
 FILES:${PN} += "/usr/aiop/*"

--- a/recipes-extended/dpdk/dpdk_22.11.bb
+++ b/recipes-extended/dpdk/dpdk_22.11.bb
@@ -40,7 +40,7 @@ EXTRA_OEMESON = "\
 
 do_install:append(){
     install -d ${D}/${sysconfdir}/dpdk
-    cp -rf ${S}/nxp/* ${D}/${sysconfdir}/dpdk
+    cp --no-preserve=ownership -rf ${S}/nxp/* ${D}/${sysconfdir}/dpdk
 }
 
 # DPDK ships versioned and unversioned .so in the main runtime package.

--- a/recipes-extended/odp/odp_git.bb
+++ b/recipes-extended/odp/odp_git.bb
@@ -50,10 +50,10 @@ do_install:append () {
     install -d ${D}${includedir}/odp/flib/mc
     install -d ${D}${includedir}/odp/flib/qbman/include/drivers
 
-    cp -rf ${S}/platform/linux-dpaa2/include/* ${D}${includedir}/odp/
-    cp -rf ${S}/platform/linux-dpaa2/kni/*.h ${D}${includedir}/odp/kni/
-    cp -rf ${S}/kern/*.h ${D}${includedir}/odp/kern/
-    cp -rf ${S}/platform/linux-dpaa2/flib/mc/*.h ${D}${includedir}/odp/flib/mc/
+    cp --no-preserve=ownership -rf ${S}/platform/linux-dpaa2/include/* ${D}${includedir}/odp/
+    cp --no-preserve=ownership -rf ${S}/platform/linux-dpaa2/kni/*.h ${D}${includedir}/odp/kni/
+    cp --no-preserve=ownership -rf ${S}/kern/*.h ${D}${includedir}/odp/kern/
+    cp --no-preserve=ownership -rf ${S}/platform/linux-dpaa2/flib/mc/*.h ${D}${includedir}/odp/flib/mc/
 
     sed -i -e 's#platform/linux-dpaa2/##g' ${D}${includedir}/odp/kern/*.h
 }

--- a/recipes-graphics/imx-g2d/imx-gpu-g2d_6.4.11.p4.4.bb
+++ b/recipes-graphics/imx-g2d/imx-gpu-g2d_6.4.11.p4.4.bb
@@ -28,11 +28,11 @@ SOC_INSTALL_DIR:mx8mm-nxp-bsp = "mx8mm"
 do_install () {
     install -d ${D}${libdir}
     install -d ${D}${includedir}
-    cp -d ${S}/g2d/usr/lib/*.so* ${D}${libdir}
+    cp --no-preserve=ownership -d ${S}/g2d/usr/lib/*.so* ${D}${libdir}
     if [ -d ${S}/g2d/usr/lib/${SOC_INSTALL_DIR} ]; then
-        cp -d ${S}/g2d/usr/lib/${SOC_INSTALL_DIR}/*.so* ${D}${libdir}
+        cp --no-preserve=ownership -d ${S}/g2d/usr/lib/${SOC_INSTALL_DIR}/*.so* ${D}${libdir}
     fi
-    cp -Pr ${S}/g2d/usr/include/* ${D}${includedir}
+    cp --no-preserve=ownership -Pr ${S}/g2d/usr/include/* ${D}${includedir}
 }
 
 # The packaged binaries have been stripped of debug info, so disable

--- a/recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc
+++ b/recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc
@@ -184,17 +184,17 @@ do_install () {
     install -d ${D}${includedir}
     install -d ${D}${bindir}
 
-    cp -P ${S}/gpu-core/usr/lib/*.so* ${D}${libdir}
-    cp -r ${S}/gpu-core/usr/include/* ${D}${includedir}
-    cp -r ${S}/gpu-demos/opt ${D}
-    cp -r ${S}/gpu-tools/gmem-info/usr/bin/* ${D}${bindir}
+    cp --no-preserve=ownership -P ${S}/gpu-core/usr/lib/*.so* ${D}${libdir}
+    cp --no-preserve=ownership -r ${S}/gpu-core/usr/include/* ${D}${includedir}
+    cp --no-preserve=ownership -r ${S}/gpu-demos/opt ${D}
+    cp --no-preserve=ownership -r ${S}/gpu-tools/gmem-info/usr/bin/* ${D}${bindir}
 
     # Use vulkan header from vulkan-headers recipe to support vkmark
     rm -rf ${D}${includedir}/vulkan/
 
     # Install SOC-specific drivers
     if [ -d ${S}/gpu-core/usr/lib/${IMX_SOC} ]; then
-        cp -r ${S}/gpu-core/usr/lib/${IMX_SOC}/* ${D}${libdir}
+        cp --no-preserve=ownership -r ${S}/gpu-core/usr/lib/${IMX_SOC}/* ${D}${libdir}
     fi
 
     install -d ${D}${libdir}/pkgconfig
@@ -213,15 +213,15 @@ do_install () {
             install -m 0644 ${S}/gpu-core/usr/lib/pkgconfig/gl.pc ${D}${libdir}/pkgconfig/gl.pc
         fi
         install -m 0644 ${S}/gpu-core/usr/lib/pkgconfig/egl_wayland.pc ${D}${libdir}/pkgconfig/egl.pc
-        cp -r ${S}/gpu-core/usr/lib/wayland/* ${D}${libdir}
+        cp --no-preserve=ownership -r ${S}/gpu-core/usr/lib/wayland/* ${D}${libdir}
     elif [ "${IS_MX8}" != "1" ]; then
         # Framebuffer backend for i.MX 6 and 7
         install -m 0644 ${S}/gpu-core/usr/lib/pkgconfig/egl_linuxfb.pc ${D}${libdir}/pkgconfig/egl.pc
-        cp -r ${S}/gpu-core/usr/lib/fb/* ${D}${libdir}
+        cp --no-preserve=ownership -r ${S}/gpu-core/usr/lib/fb/* ${D}${libdir}
     else
         # Framebuffer backend for i.MX 8 and beyond
         install -m 0644 ${S}/gpu-core/usr/lib/pkgconfig/egl.pc         ${D}${libdir}/pkgconfig/egl.pc
-        cp -r ${S}/gpu-core/usr/lib/wayland/* ${D}${libdir}
+        cp --no-preserve=ownership -r ${S}/gpu-core/usr/lib/wayland/* ${D}${libdir}
         set -f
         for f in ${FILES:libvdk-imx} ${FILES:libvdk-imx-dev}; do
             set +f

--- a/recipes-security/optee-imx/optee-os-tadevkit-fslc-imx.inc
+++ b/recipes-security/optee-imx/optee-os-tadevkit-fslc-imx.inc
@@ -13,7 +13,7 @@ do_install() {
     #install TA devkit
     install -d ${D}${includedir}/optee/export-user_ta/
     for f in ${B}/export-ta_${OPTEE_ARCH}/* ; do
-        cp -aR $f ${D}${includedir}/optee/export-user_ta/
+        cp -aR --no-preserve=ownership $f ${D}${includedir}/optee/export-user_ta/
     done
 }
 

--- a/recipes-security/optee-qoriq/optee-os-qoriq-tadevkit_4.8.0.bb
+++ b/recipes-security/optee-qoriq/optee-os-qoriq-tadevkit_4.8.0.bb
@@ -13,7 +13,7 @@ do_install() {
     #install TA devkit
     install -d ${D}${includedir}/optee/export-user_ta/
     for f in ${B}/export-ta_${OPTEE_ARCH}/* ; do
-        cp -aR $f ${D}${includedir}/optee/export-user_ta/
+        cp -aR --no-preserve=ownership $f ${D}${includedir}/optee/export-user_ta/
     done
 }
 


### PR DESCRIPTION
## oelint.task.nocopy: drop ownership inheritance from do_install copies

### What

Fixes every `oelint.task.nocopy` finding in meta-freescale (16 findings across 9 recipes). Each flagged `cp` in a `do_install`/`do_install_ptest` gains `--no-preserve=ownership`, so installed files no longer inherit the build user's uid/gid — which is exactly what the rule guards against.

### Why not `install`

The rule text suggests `install`, but `install` cannot replace any of these copies. Every flagged `cp` is one of:

- a **recursive** directory/glob copy (`cp -r` / `cp -rf` / `cp -rL` / `cp -aR`) — `install` has no recursive mode; and/or
- a **symlink-preserving** copy (`cp -d` / `cp -P` / `cp -L` / `cp -a`) — `install` dereferences symlinks, which would turn a `.so` version symlink into a second full copy of the library and break the runtime linker.

`--no-preserve=ownership` is the alternative the rule's own documentation lists. It drops only the ownership metadata the rule cares about while keeping the recursive/symlink behaviour the recipes require.

### Recipes

| Recipe | Copy kind |
|---|---|
| odp | recursive header trees (`-rf`) |
| aiopsl | recursive firmware/script dirs (`-rf`) |
| imx-gpu-g2d | `.so` symlink + header copies (`-d` / `-Pr`) |
| imx-gpu-viv | `.so` symlinks + driver/demo trees (`-P` / `-r`, all 8 copies) |
| optee-os-tadevkit / optee-os-qoriq-tadevkit | TA devkit export tree (`-aR`) |
| dpdk | NXP config tree into `/etc/dpdk` (`-rf`) |
| qemu-qoriq (.inc and _4.2.bb) | ptest `tests` tree (`-rL`) |

### Forks

`qemu-qoriq.inc`, `qemu-qoriq_4.2.bb` (forks of oe-core `qemu.inc`) and `optee-os-tadevkit-fslc-imx.inc` (fork of meta-imx) are verbatim forks. They are fixed structurally like everything else; each commit body records that the line now diverges from its upstream source on purpose, so a future re-sync carries the flag forward instead of dropping it.

### Validation

Every change was validated with a before/after **buildhistory** comparison (compatible MACHINE per recipe: ls1046ardb / ls2088ardb / imx8mp-lpddr4-evk). All packages come out **byte-identical** — file lists, sizes, dependencies and `.so` symlinks unchanged — because packaging runs under pseudo and records files as root-owned regardless. Expected delta was nothing; measured delta was nothing. A green build alone was not treated as proof.
