### PR TITLE
Set FILESEXTRAPATHS only where it is needed

### DIFF
--- a/recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc
+++ b/recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc
@@ -66,7 +66,6 @@ PE = "1"
 
 inherit fsl-eula-unpack
 
-FILESEXTRAPATHS:append := "${THISDIR}/imx-gpu-viv:"
 SRC_URI = "${FSL_MIRROR}/${BPN}-${PV}-${IMX_SRCREV_ABBREV}.bin;fsl-eula=true"
 
 S = "${UNPACKDIR}/${BPN}-${PV}-${IMX_SRCREV_ABBREV}"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-rtsp-server_1.28.1.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-rtsp-server_1.28.1.bb
@@ -8,8 +8,6 @@ DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base"
 
 PNREAL = "gst-rtsp-server"
 
-FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
-
 SRC_URI = "https://gstreamer.freedesktop.org/src/${PNREAL}/${PNREAL}-${PV}.tar.xz \
            file://0001-YOCIMX-9113-rtsp-examples-install-test-launch-and-te.patch \
            "

--- a/recipes-security/optee-imx/optee-client-fslc-imx.inc
+++ b/recipes-security/optee-imx/optee-client-fslc-imx.inc
@@ -5,7 +5,6 @@ require optee-client-fslc.inc
 
 DEPENDS += "util-linux-libuuid"
 
-FILESEXTRAPATHS:prepend := "${THISDIR}/optee-client:"
 SRC_URI:remove = "git://github.com/OP-TEE/optee_client.git;branch=master;protocol=https"
 SRC_URI:prepend = "${OPTEE_CLIENT_SRC};branch=${SRCBRANCH} "
 OPTEE_CLIENT_SRC ?= "git://github.com/nxp-imx/imx-optee-client.git;protocol=https"

--- a/recipes-security/optee-imx/optee-os-common-fslc-imx.inc
+++ b/recipes-security/optee-imx/optee-os-common-fslc-imx.inc
@@ -4,8 +4,6 @@ require optee-os-fslc.inc
 
 DEPENDS:append:arm = " u-boot-mkimage-native"
 
-FILESEXTRAPATHS:prepend := "${THISDIR}/optee-os:"
-
 SRC_URI:remove = "git://github.com/OP-TEE/optee_os.git;branch=master;protocol=https"
 SRC_URI:prepend = "${OPTEE_OS_SRC};branch=${SRCBRANCH} "
 SRC_URI:remove = "file://0001-allow-setting-sysroot-for-libgcc-lookup.patch \

--- a/recipes-security/optee-imx/optee-test-fslc-imx.inc
+++ b/recipes-security/optee-imx/optee-test-fslc-imx.inc
@@ -6,8 +6,6 @@ inherit features_check
 
 REQUIRED_MACHINE_FEATURES = "optee"
 
-FILESEXTRAPATHS:prepend := "${THISDIR}/optee-test:"
-
 SRC_URI:remove = "git://github.com/OP-TEE/optee_test.git;branch=master;protocol=https"
 SRC_URI:prepend = "${OPTEE_TEST_SRC};branch=${SRCBRANCH} "
 

--- a/recipes-security/optee-qoriq/optee-client.nxp.inc
+++ b/recipes-security/optee-qoriq/optee-client.nxp.inc
@@ -4,6 +4,12 @@ require recipes-security/optee-imx/optee-client-fslc.inc
 
 # The patch same as imx-optee, so point FILESEXTRAPATHS to optee-imx/optee-client,
 # avoid duplicate copy files to optee-qoriq
+# The entry cannot be dropped: this recipe's BPN is optee-client-qoriq, so the
+# default FILESPATH only searches directories named after it, and the shared
+# i.MX directory that holds tee-supplicant.sh is unreachable without this line.
+# The entry also keeps the files this include adds to SRC_URI reachable when a
+# recipe in another layer requires the include.
+# nooelint: oelint.vars.outofcontext
 FILESEXTRAPATHS:prepend := "${THISDIR}/../optee-imx/optee-client:"
 
 DEPENDS = "util-linux-libuuid"

--- a/recipes-security/optee-qoriq/optee-os.nxp.inc
+++ b/recipes-security/optee-qoriq/optee-os.nxp.inc
@@ -3,10 +3,6 @@ require recipes-security/optee-imx/optee-os-fslc.inc
 
 DEPENDS:append = " dtc-native"
 
-# The patch same as imx-optee, so point FILESEXTRAPATHS to optee-imx/optee-client,
-# avoid duplicate copy files to optee-qoriq
-FILESEXTRAPATHS:prepend := "${THISDIR}/../optee-imx/optee-os:"
-
 SRC_URI:remove = "git://github.com/OP-TEE/optee_os.git;branch=master;protocol=https"
 SRC_URI:prepend = "${OPTEE_OS_SRC};branch=${OPTEE_OS_BRANCH} "
 


### PR DESCRIPTION
oelint-adv reports 10 `oelint.vars.outofcontext` findings on this layer.
Every one is the same thing: `FILESEXTRAPATHS` set in a `.bb` or a `.inc`
instead of a `.bbappend`. This series takes them one at a time and brings
the rule to zero.

`FILESEXTRAPATHS` exists so a `.bbappend` can add its own files directory
to a recipe it does not own. Inside a recipe the default `FILESPATH`
normally already covers the recipe's own directory, so an entry there is
usually either a duplicate of what BitBake supplies or a leftover.

That is what six of the seven turned out to be. The method for each was
the same: run `bitbake -e` on both sides and compare the de-duplicated
`FILESPATH`. In every case the search reached **the same 60 unique
directories before and after** — the entry only added copies of paths the
default `${FILE_DIRNAME}/${BPN}` already supplies, so `FILESPATH` shrinks
from 84 entries to 63 while reaching exactly the same set.

Three entries were fully dead: the resolved `SRC_URI` of those recipes
carries no `file://` entry at all, so nothing was ever looked up through
the search path.

| Recipe / include | Why the entry could go |
| --- | --- |
| `imx-gpu-viv-6.inc` | Added in 2023 for `imx_icd.json`; commit 610fda22 deleted that file and its directory. No `file://` remains. |
| `optee-os-common-fslc-imx.inc` | `optee-os` and `optee-os-tadevkit` both resolve an empty set of `file://` entries. |
| `optee-os.nxp.inc` | Same, for `optee-os-qoriq` and `optee-os-qoriq-tadevkit`. |
| `optee-client-fslc-imx.inc` | Fetches `tee-supplicant.sh`, but `BPN` is `optee-client` in that same directory, so the default already reaches it. |
| `optee-test-fslc-imx.inc` | Fetches `run-ptest`; same reasoning. |
| `gstreamer1.0-rtsp-server_1.28.1.bb` | Fetches a patch; `PN` equals `BPN` here, so the entry duplicated the default. The default is also safer, since `PN` gains a `lib32-` prefix under multilib while `BPN` does not. |

The seventh is genuinely load-bearing and stays. `optee-client-qoriq`
shares `tee-supplicant.sh` with the i.MX client instead of carrying a
second copy, and its `BPN` is `optee-client-qoriq`, so the default
`FILESPATH` never reaches `recipes-security/optee-imx/optee-client`.
Removing the line makes BitBake halt while parsing:

    ERROR: optee-client-qoriq_4.8.0.bb: Unable to get checksum for
    optee-client-qoriq SRC_URI entry tee-supplicant.sh: file could not be found
    ERROR: Parsing halted due to errors

That commit adds the reason next to the line and a
`# nooelint: oelint.vars.outofcontext` directive, and changes nothing else.

Three of the touched files (`optee-*-fslc-imx.inc`) are verbatim copies
of meta-imx includes, as their headers record. Each commit body notes the
intentional divergence so a later re-sync knows the line is now local.

### Validation

Every commit that changes effective metadata was validated with
buildhistory: a baseline build and a candidate build with `do_unpack`
forced, on `imx8mp-lpddr4-evk` or `ls1046ardb` depending on the recipe.
Each recipe ran `do_unpack` through `do_package` on both sides, and every
buildhistory diff was empty apart from the `metadata-revs` "-- modified"
marker. The one comment-only commit needs no build.

The full survey goes from 251 findings to 234: 10 `outofcontext`, 6
`vars.fileextrapaths` cleared by the same edits, and 1 `vars.homepageping`
that is network noise on an untouched file. **Nothing was introduced.**
