### PR TITLE
oelint: Set the mandatory SUMMARY and DESCRIPTION variables

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-support/opencv/opencv_4.13.0.imx.bb
+++ b/dynamic-layers/openembedded-layer/recipes-support/opencv/opencv_4.13.0.imx.bb
@@ -7,6 +7,7 @@
 # Upstream hash: 9b77eae6988e98adbec5323d2491afc6b327c91a
 
 SUMMARY = "Opencv : The Open Computer Vision Library"
+DESCRIPTION = "A computer vision and machine learning library that gives applications a common infrastructure for image processing, video analysis, camera calibration, object detection and machine learning."
 HOMEPAGE = "http://opencv.org/"
 SECTION = "libs"
 

--- a/recipes-bsp/u-boot/u-boot-fslc-mxsboot_2025.01.bb
+++ b/recipes-bsp/u-boot/u-boot-fslc-mxsboot_2025.01.bb
@@ -1,6 +1,7 @@
 require u-boot-fslc-common_${PV}.inc
 
-DESCRIPTION = "U-boot bootloader mxsboot tool"
+SUMMARY = "mxsboot boot-stream tool from the FSL Community BSP U-Boot"
+DESCRIPTION = "The mxsboot tool from the FSL Community BSP U-Boot. It converts a U-Boot binary into the boot stream format that the i.MX23 and i.MX28 boot ROM reads from SD or NAND."
 SECTION = "bootloader"
 
 inherit python3native

--- a/recipes-bsp/u-boot/u-boot-fslc_2025.01.bb
+++ b/recipes-bsp/u-boot/u-boot-fslc_2025.01.bb
@@ -1,6 +1,7 @@
 require recipes-bsp/u-boot/u-boot.inc
 require u-boot-fslc-common_${PV}.inc
 
+SUMMARY = "Mainline U-Boot bootloader for the FSL Community BSP"
 DESCRIPTION = "U-Boot based on mainline U-Boot used by FSL Community BSP in \
                order to provide support for some backported features and fixes, or because it \
                was submitted for revision and it takes some time to become part of a stable \

--- a/recipes-bsp/u-boot/u-boot-imx-common_2025.04.inc
+++ b/recipes-bsp/u-boot/u-boot-imx-common_2025.04.inc
@@ -1,4 +1,4 @@
-DESCRIPTION = "i.MX U-Boot suppporting i.MX reference boards."
+DESCRIPTION = "The U-Boot bootloader that NXP maintains for the i.MX reference boards. It carries the SoC and board support that the mainline U-Boot tree does not yet provide."
 
 LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://Licenses/gpl-2.0.txt;md5=b234ee4d69f5fce4486a80fdaf4a4263"

--- a/recipes-bsp/u-boot/u-boot-imx_2025.04.bb
+++ b/recipes-bsp/u-boot/u-boot-imx_2025.04.bb
@@ -4,6 +4,7 @@
 
 require recipes-bsp/u-boot/u-boot.inc
 require u-boot-imx-common_${PV}.inc
+SUMMARY = "U-Boot bootloader for the NXP i.MX reference boards"
 HOMEPAGE = "https://github.com/nxp-imx/uboot-imx"
 SECTION = "bootloaders"
 

--- a/recipes-bsp/u-boot/u-boot-qoriq_2025.04.bb
+++ b/recipes-bsp/u-boot/u-boot-qoriq_2025.04.bb
@@ -1,5 +1,6 @@
 require recipes-bsp/u-boot/u-boot.inc
 
+SUMMARY = "U-Boot bootloader for NXP QorIQ boards"
 DESCRIPTION = "U-Boot provided by Freescale with focus on QorIQ boards"
 HOMEPAGE = "https://github.com/nxp-qoriq/u-boot"
 SECTION = "bootloaders"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.28.1.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.28.1.imx.bb
@@ -9,6 +9,7 @@ require recipes-multimedia/gstreamer/gstreamer1.0-plugins-common.inc
 require recipes-multimedia/gstreamer/gstreamer1.0-plugins-license.inc
 
 SUMMARY = "'Bad' GStreamer plugins and helper libraries "
+DESCRIPTION = "GStreamer plugins that do not yet meet the standard of the other plugin sets, because each one still lacks a code review, documentation, tests, an active maintainer or wide use."
 HOMEPAGE = "https://gstreamer.freedesktop.org/"
 BUGTRACKER = "https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad/-/issues"
 CVE_PRODUCT = "gst-plugins-bad"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.28.1.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.28.1.imx.bb
@@ -8,6 +8,7 @@
 require recipes-multimedia/gstreamer/gstreamer1.0-plugins-common.inc
 
 SUMMARY = "'Base' GStreamer plugins and helper libraries"
+DESCRIPTION = "A well-maintained collection of GStreamer plugins and helper libraries that covers the element types an application needs, such as decoders, converters, sources and sinks."
 HOMEPAGE = "https://gstreamer.freedesktop.org/"
 BUGTRACKER = "https://gitlab.freedesktop.org/gstreamer/gst-plugins-base/-/issues"
 LICENSE = "LGPL-2.1-or-later"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.28.1.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.28.1.imx.bb
@@ -8,6 +8,7 @@
 require recipes-multimedia/gstreamer/gstreamer1.0-plugins-common.inc
 
 SUMMARY = "'Good' GStreamer plugins"
+DESCRIPTION = "GStreamer plugins with good quality code and correct functionality that carry the preferred licence: LGPL for the plugin code and an LGPL-compatible licence for the supporting libraries."
 HOMEPAGE = "https://gstreamer.freedesktop.org/"
 BUGTRACKER = "https://gitlab.freedesktop.org/gstreamer/gst-plugins-good/-/issues"
 

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly_1.28.1.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly_1.28.1.bb
@@ -2,6 +2,7 @@ require recipes-multimedia/gstreamer/gstreamer1.0-plugins-common.inc
 require recipes-multimedia/gstreamer/gstreamer1.0-plugins-license.inc
 
 SUMMARY = "'Ugly GStreamer plugins"
+DESCRIPTION = "GStreamer plugins with good quality code and correct functionality that can still be a problem to distribute, because the licence of the plugin or of a library it needs is a concern."
 HOMEPAGE = "https://gstreamer.freedesktop.org/"
 BUGTRACKER = "https://gitlab.freedesktop.org/gstreamer/gst-plugins-ugly/-/issues"
 

--- a/recipes-multimedia/gstreamer/gstreamer1.0-rtsp-server_1.28.1.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-rtsp-server_1.28.1.bb
@@ -1,4 +1,5 @@
 SUMMARY = "A library on top of GStreamer for building an RTSP server"
+DESCRIPTION = "A GStreamer library that supplies the objects an application needs to build an RTSP server, such as media factories, session pools and stream transports."
 HOMEPAGE = "http://cgit.freedesktop.org/gstreamer/gst-rtsp-server/"
 SECTION = "multimedia"
 LICENSE = "LGPL-2.1-or-later"

--- a/recipes-multimedia/libcamera/libcamera_0.7.1.imx.bb
+++ b/recipes-multimedia/libcamera/libcamera_0.7.1.imx.bb
@@ -6,6 +6,7 @@
 # Upstream hash: f4b9dfa0c903bc94c344c657917a3fbb229c322f
 
 SUMMARY = "Linux libcamera framework"
+DESCRIPTION = "A camera stack for Linux that hides the complexity of modern camera hardware, and gives applications one interface for capture, 3A control and pipeline handling."
 HOMEPAGE = "https://github.com/nxp-imx/libcamera"
 SECTION = "libs"
 


### PR DESCRIPTION
## What this does

This series clears the `oelint.var.mandatoryvar.SUMMARY` and
`oelint.var.mandatoryvar.DESCRIPTION` findings in the layer. It adds a
recipe-specific `SUMMARY` to four recipes and a `DESCRIPTION` to seven
recipes. It also extends two descriptions that were too short. It
changes metadata only. No recipe changes its build, its
packages or its files.

## Why

Three defects made the packages hard to tell apart in a feed:

1. The three bootloader recipes inherited the same `SUMMARY` from
   OE-core's `u-boot.inc`: "Universal Boot Loader for embedded devices".
   The three packages were therefore indistinguishable.
2. `u-boot-fslc-mxsboot` set no `SUMMARY` at all, so `bitbake.conf`
   applied the fallback `SUMMARY ?= "${PN} version ${PV}-${PR}"` and the
   package shipped a placeholder.
3. The seven recipes without a `DESCRIPTION` got
   `DESCRIPTION ?= "${SUMMARY}."`, so each one shipped its one-line
   summary as its full description.

The Yocto recipe style guide lists both variables among the ones a
recipe must set.

## The commits

| Recipe | Change |
|---|---|
| `gstreamer1.0-plugins-bad` | Add a DESCRIPTION |
| `gstreamer1.0-plugins-base` | Add a DESCRIPTION |
| `gstreamer1.0-plugins-good` | Add a DESCRIPTION |
| `gstreamer1.0-plugins-ugly` | Add a DESCRIPTION |
| `gstreamer1.0-rtsp-server` | Add a DESCRIPTION |
| `libcamera` | Add a DESCRIPTION |
| `opencv` | Add a DESCRIPTION |
| `u-boot-qoriq` | Add a recipe-specific SUMMARY |
| `u-boot-fslc` | Add a recipe-specific SUMMARY |
| `u-boot-fslc-mxsboot` | Add a SUMMARY and extend the DESCRIPTION |
| `u-boot-imx` | Add a SUMMARY and extend the DESCRIPTION |

Two recipes needed more than a new line. For `u-boot-fslc-mxsboot` and
`u-boot-imx`, the new `SUMMARY` left `DESCRIPTION` shorter than
`SUMMARY`. The terse original hid this defect: "U-boot bootloader
mxsboot tool" does not say what the tool does, and the `u-boot-imx`
line said little and misspelled "supporting". Both descriptions are
now extended.

## Validation

I forced `do_package` for each recipe and compared buildhistory before
and after the change. Buildhistory is unchanged apart from
`metadata-revs`.

| Machine | Recipes |
|---|---|
| `imx8mp-lpddr4-evk` | the five gstreamer recipes, `opencv` |
| `imx8mm-lpddr4-evk` | `libcamera`, `u-boot-fslc` |
| `imx6qdlsabresd` | `u-boot-imx` |
| `imx28evk` | `u-boot-fslc-mxsboot` |
| `ls1046ardb` | `u-boot-qoriq` |

`libcamera` was built on `imx8mm-lpddr4-evk` because
`COMPATIBLE_MACHINE` allows that machine. `u-boot-imx` was built on
`imx6qdlsabresd` because the i.MX8 defconfigs enable
`CONFIG_EFI_CAPSULE_AUTHENTICATE`, which needs `cert-to-efi-sig-list`
from `efitools`. No layer here provides that tool, so `u-boot-imx` does
not build for those machines today.
