### PR TITLE
[Backport wrynose] oelint: Resolve oelint.var.licenseremotefile findings (10 -> 0)

### DIFF
--- a/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
+++ b/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
@@ -7,7 +7,7 @@ DESCRIPTION = "Generate Boot Loader for i.MX 8 device"
 HOMEPAGE = "https://github.com/nxp-imx/imx-mkimage"
 SECTION = "bsp"
 LICENSE = "GPL-2.0-only"
-LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=59530bdf33659b29e73d4adb9f9f6552"
 
 DEPENDS:append = " xxd-native"
 DEPENDS:append:mx8m-generic-bsp = " u-boot-mkimage-native dtc-native u-boot-mkeficapsule-native"

--- a/recipes-bsp/imx-mkimage/imx-mkimage_git.bb
+++ b/recipes-bsp/imx-mkimage/imx-mkimage_git.bb
@@ -11,9 +11,7 @@ DESCRIPTION = "Tooling to assemble i.MX boot images (mkimage_imx8 and related)."
 HOMEPAGE = "https://github.com/nxp-imx/imx-mkimage"
 SECTION = "bsp"
 LICENSE = "GPL-2.0-only"
-# Source ships no standalone license file; reference the common GPL-2.0-only text.
-# nooelint: oelint.var.licenseremotefile
-LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=59530bdf33659b29e73d4adb9f9f6552"
 
 inherit deploy native
 

--- a/recipes-core/udev/udev-rules-imx/10-imx.rules
+++ b/recipes-core/udev/udev-rules-imx/10-imx.rules
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 # Create symlinks for i.mx keypads and touchscreens
 #SUBSYSTEM=="input" KERNEL=="event*" ATTRS{name}=="mxckpd",     SYMLINK+="input/keyboard0"
 #SUBSYSTEM=="input" KERNEL=="event*" ATTRS{name}=="mxc_ts",     SYMLINK+="input/ts0"

--- a/recipes-core/udev/udev-rules-imx_1.0.bb
+++ b/recipes-core/udev/udev-rules-imx_1.0.bb
@@ -3,7 +3,7 @@ DESCRIPTION = "udev rules for Freescale i.MX SOCs"
 HOMEPAGE = "https://github.com/Freescale/meta-freescale/"
 SECTION = "base"
 LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+LIC_FILES_CHKSUM = "file://10-imx.rules;beginline=1;endline=1;md5=b2dccaa94b3629a08bfb4f983cad6f89"
 
 SRC_URI = "file://10-imx.rules"
 

--- a/recipes-core/udev/udev-rules-qoriq/71-fsl-dpaa-persistent-networking.rules
+++ b/recipes-core/udev/udev-rules-qoriq/71-fsl-dpaa-persistent-networking.rules
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 # Rules for handling naming the DPAA FMan ethernet ports in a consistent way
 SUBSYSTEM=="net", DRIVERS=="fsl_dpa*", ATTR{device_addr}=="ffe4e0000", NAME="fm1-gb0"
 SUBSYSTEM=="net", DRIVERS=="fsl_dpa*", ATTR{device_addr}=="ffe4e2000", NAME="fm1-gb1"

--- a/recipes-core/udev/udev-rules-qoriq/72-fsl-dpaa-persistent-networking.rules
+++ b/recipes-core/udev/udev-rules-qoriq/72-fsl-dpaa-persistent-networking.rules
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 # Rules for handling naming the DPAA FMan ethernet ports in a consistent way
 SUBSYSTEM=="net", DRIVERS=="fsl_dpa*", ATTR{device_addr}=="ffe4e0000", NAME="fm1-mac1"
 SUBSYSTEM=="net", DRIVERS=="fsl_dpa*", ATTR{device_addr}=="ffe4e2000", NAME="fm1-mac2"

--- a/recipes-core/udev/udev-rules-qoriq/73-fsl-dpaa-persistent-networking.rules
+++ b/recipes-core/udev/udev-rules-qoriq/73-fsl-dpaa-persistent-networking.rules
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 # Rules for handling naming the DPAA FMan ethernet ports in a consistent way
 SUBSYSTEM=="net", DRIVERS=="fsl_dpa*", ATTR{device_addr}=="1ae0000", NAME="fm1-mac1"
 SUBSYSTEM=="net", DRIVERS=="fsl_dpa*", ATTR{device_addr}=="1ae2000", NAME="fm1-mac2"

--- a/recipes-core/udev/udev-rules-qoriq/73-fsl-enetc-networking.rules
+++ b/recipes-core/udev/udev-rules-qoriq/73-fsl-enetc-networking.rules
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 # ENETC rules
 ACTION=="add", SUBSYSTEM=="net", KERNELS=="0000:00:00.0", DRIVERS=="fsl_enetc", NAME:="eno0"
 ACTION=="add", SUBSYSTEM=="net", KERNELS=="0000:00:00.1", DRIVERS=="fsl_enetc", NAME:="eno1"

--- a/recipes-core/udev/udev-rules-qoriq/74-ls1046a-xfi2-networking.rules
+++ b/recipes-core/udev/udev-rules-qoriq/74-ls1046a-xfi2-networking.rules
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 # Rules for handling the SDK DPAA ethernet ports
 SUBSYSTEM=="net", DRIVERS=="fsl_dpa*", ATTR{device_addr}=="1af2000", NAME="fm1-mac10"
 

--- a/recipes-core/udev/udev-rules-qoriq_1.0.bb
+++ b/recipes-core/udev/udev-rules-qoriq_1.0.bb
@@ -3,7 +3,7 @@ DESCRIPTION = "udev rules for Freescale QorIQ SOCs"
 HOMEPAGE = "https://github.com/Freescale/meta-freescale/"
 SECTION = "base"
 LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+LIC_FILES_CHKSUM = "file://71-fsl-dpaa-persistent-networking.rules;beginline=1;endline=1;md5=b2dccaa94b3629a08bfb4f983cad6f89"
 
 SRC_URI = "\
     file://71-fsl-dpaa-persistent-networking.rules \

--- a/recipes-devtools/uuu/uuu-bin_1.5.233.bb
+++ b/recipes-devtools/uuu/uuu-bin_1.5.233.bb
@@ -7,20 +7,29 @@ HOMEPAGE = "https://github.com/nxp-imx/mfgtools"
 SECTION = "console/utils"
 
 LICENSE = "BSD-3-Clause & LGPL-2.1-or-later"
-LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/BSD-3-Clause;md5=550794465ba0ec5312d6919e203a55f9 \
-                    file://${COMMON_LICENSE_DIR}/LGPL-2.1-or-later;md5=2a4f4fd2128ea2f65047ee63fbca9f68"
+LIC_FILES_CHKSUM = "file://mfgtools-${PV}-LICENSE;md5=38ec0c18112e9a92cffc4951661e85a5 \
+                    file://libusb-${PV}-COPYING;md5=fbc093901857fcd118f065f900982c24"
 
+# Prebuilt release binaries carry no license file; fetch it from source at the
+# matching release tag instead. The bundled libusb copy comes from the exact
+# submodule commit mfgtools pins for this release.
 SRC_URI = "\
     https://github.com/nxp-imx/mfgtools/releases/download/uuu_${PV}/uuu;downloadfilename=uuu-${PV};name=Linux \
     https://github.com/nxp-imx/mfgtools/releases/download/uuu_${PV}/uuu_mac_x86;downloadfilename=uuu-${PV}_mac_x86;name=Mac_x86 \
     https://github.com/nxp-imx/mfgtools/releases/download/uuu_${PV}/uuu_mac_arm;downloadfilename=uuu-${PV}_mac_arm;name=Mac_arm \
     https://github.com/nxp-imx/mfgtools/releases/download/uuu_${PV}/uuu.exe;downloadfilename=uuu-${PV}.exe;name=Windows \
+    https://raw.githubusercontent.com/nxp-imx/mfgtools/uuu_${PV}/LICENSE;downloadfilename=mfgtools-${PV}-LICENSE;name=License \
+    https://raw.githubusercontent.com/libusb/libusb/15a7ebb4d426c5ce196684347d2b7cafad862626/COPYING;downloadfilename=libusb-${PV}-COPYING;name=LibusbLicense \
 "
 
 SRC_URI[Linux.sha256sum] = "c609fe6c4d9656102f7e3139a70488ba3988c33332486c89e5fc6d85ccedd96a"
 SRC_URI[Mac_x86.sha256sum] = "cdbacab592661900d46e7f97f9c7dd8a720bf46b1c17f4dbb65adb372f5fc6cf"
 SRC_URI[Mac_arm.sha256sum] = "6f8854946dfbeeb36894baf0f5f555b918974d465f4b541457e65c926fdd6a6a"
 SRC_URI[Windows.sha256sum] = "a3c7241650c05dd6373a6aef086b34322c013103da729c1b446ec86694309939"
+SRC_URI[License.sha256sum] = "cc8d47f7b9260f6669ecd41c24554c552f17581d81ee8fc602c6d23edb8bf495"
+SRC_URI[LibusbLicense.sha256sum] = "5df07007198989c622f5d41de8d703e7bef3d0e79d62e24332ee739a452af62a"
+
+S = "${UNPACKDIR}"
 
 inherit allarch
 

--- a/recipes-dpaa2/gpp-aioptool/gpp-aioptool_git.bb
+++ b/recipes-dpaa2/gpp-aioptool/gpp-aioptool_git.bb
@@ -6,7 +6,7 @@ DESCRIPTION = "AIOP Tool is a userspace application for performing operations \
 HOMEPAGE = "https://github.com/nxp-qoriq/gpp-aioptool"
 SECTION = "dpaa2"
 LICENSE = "BSD-3-Clause"
-LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/BSD-3-Clause;md5=550794465ba0ec5312d6919e203a55f9"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=386a6287daa6504b7e7e5014ddfb3987"
 
 SRC_URI = "git://github.com/nxp-qoriq/gpp-aioptool;protocol=https;nobranch=1 \
            file://0001-remove-libio.h.patch \

--- a/recipes-graphics/devil/devil_1.8.0.bb
+++ b/recipes-graphics/devil/devil_1.8.0.bb
@@ -3,7 +3,7 @@ DESCRIPTION = "A full featured cross-platform image library"
 HOMEPAGE = "https://openil.sourceforge.net/"
 SECTION = "libs"
 LICENSE = "LGPL-2.1-only"
-LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/LGPL-2.1-only;md5=1a6d268fd218675ffea8be556788b780"
+LIC_FILES_CHKSUM = "file://../LICENSE;md5=fc178bcd425090939a8b634d1d6a9594"
 PR = "r0"
 
 DEPENDS = "jpeg libpng tiff xz"

--- a/recipes-graphics/imx-gpu-sdk/libxdg-shell_1.0.bb
+++ b/recipes-graphics/imx-gpu-sdk/libxdg-shell_1.0.bb
@@ -3,7 +3,7 @@ DESCRIPTION = "XDG shell protocol header and glue-code library used by the i.MX 
 HOMEPAGE = "https://github.com/nxp-imx/gtec-demo-framework"
 SECTION = "graphics"
 LICENSE = "BSD-3-Clause"
-LIC_FILES_CHKSUM = "file://${UNPACKDIR}/${BP}/License.md;md5=9d58a2573275ce8c35d79576835dbeb8"
+LIC_FILES_CHKSUM = "file://../../../License.md;md5=9d58a2573275ce8c35d79576835dbeb8"
 
 DEPENDS = "wayland wayland-native wayland-protocols"
 

--- a/recipes-graphics/mesa/mesa-etnaviv-env/mesa-etnaviv.conf
+++ b/recipes-graphics/mesa/mesa-etnaviv-env/mesa-etnaviv.conf
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 [Manager]
 DefaultEnvironment=MESA_GL_VERSION_OVERRIDE=2.1 ETNA_MESA_DEBUG=nir
 

--- a/recipes-graphics/mesa/mesa-etnaviv-env/mesa-etnaviv.sh
+++ b/recipes-graphics/mesa/mesa-etnaviv-env/mesa-etnaviv.sh
@@ -1,2 +1,3 @@
+# SPDX-License-Identifier: MIT
 export MESA_GL_VERSION_OVERRIDE=2.1
 export ETNA_MESA_DEBUG=nir

--- a/recipes-graphics/mesa/mesa-etnaviv-env_0.1.bb
+++ b/recipes-graphics/mesa/mesa-etnaviv-env_0.1.bb
@@ -3,7 +3,7 @@ DESCRIPTION = "Environment variable configuration to enable the etnaviv Mesa dri
 HOMEPAGE = "https://github.com/Freescale/meta-freescale/"
 SECTION = "graphics"
 LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+LIC_FILES_CHKSUM = "file://mesa-etnaviv.sh;beginline=1;endline=1;md5=b2dccaa94b3629a08bfb4f983cad6f89"
 
 SRC_URI = "\
     file://mesa-etnaviv.conf \

--- a/recipes-kernel/kernel-modules/kernel-module-imx-gpu-viv_6.4.11.p4.4.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-imx-gpu-viv_6.4.11.p4.4.bb
@@ -7,7 +7,7 @@ DESCRIPTION = "Builds the Vivante GPU kernel driver as a loadable kernel module,
 HOMEPAGE = "https://github.com/nxp-imx/linux-imx"
 SECTION = "kernel"
 LICENSE = "GPL-2.0-only"
-LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6"
+LIC_FILES_CHKSUM = "file://src/hal/kernel/gc_hal_kernel.h;beginline=1;endline=53;md5=3d2a1d218039b0a6f5b4b4c3a9f42931"
 
 SRC_URI = "${LINUX_IMX_SRC};subpath=drivers/mxc/gpu-viv;destsuffix=${BB_GIT_DEFAULT_DESTSUFFIX}/src \
            file://Add-makefile.patch"

--- a/recipes-kernel/kernel-modules/kernel-module-isp-vvcam_4.2.2.26.1.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-isp-vvcam_4.2.2.26.1.bb
@@ -5,7 +5,7 @@ DESCRIPTION = "Kernel loadable module for ISP"
 HOMEPAGE = "https://github.com/nxp-imx/isp-vvcam"
 SECTION = "kernel"
 LICENSE = "GPL-2.0-only"
-LIC_FILES_CHKSUM = "file://${S}/../LICENSE;md5=64381a6ea83b48c39fe524c85f65fb44"
+LIC_FILES_CHKSUM = "file://../LICENSE;md5=64381a6ea83b48c39fe524c85f65fb44"
 
 SRC_URI = "${ISP_KERNEL_SRC};branch=${SRCBRANCH} \
            file://0001-video-add-v4l2-fh-compat-for-pre-6.18-kernels.patch \


### PR DESCRIPTION
# Description
Backport of #2664 to `wrynose`.