### PR TITLE
oelint: Clear the remaining vars.pkgspecific findings on linux-qoriq

### DIFF
--- a/recipes-kernel/linux/linux-qoriq.inc
+++ b/recipes-kernel/linux/linux-qoriq.inc
@@ -11,8 +11,9 @@ DEPENDS:append = " libgcc coreutils-native"
 # Set the PV to the correct kernel version to satisfy the kernel version sanity check
 PV = "${LINUX_VERSION}+git${SRCPV}"
 
-# Package declared by kernel.bbclass PACKAGES, invisible to standalone lint.
-# nooelint: oelint.vars.specific
+# kernel-image is declared by kernel.bbclass PACKAGES; this include sets no
+# PACKAGES, so the name is invisible to standalone lint.
+# nooelint: oelint.vars.specific oelint.vars.pkgspecific
 FILES:${KERNEL_PACKAGE_NAME}-image += "/boot/zImage*"
 
 KERNEL_CC:append = " ${TOOLCHAIN_OPTIONS}"

--- a/recipes-kernel/linux/linux-qoriq.inc
+++ b/recipes-kernel/linux/linux-qoriq.inc
@@ -15,11 +15,6 @@ PV = "${LINUX_VERSION}+git${SRCPV}"
 # nooelint: oelint.vars.specific
 FILES:${KERNEL_PACKAGE_NAME}-image += "/boot/zImage*"
 
-# not put Images into /boot of rootfs, install kernel-image if needed
-# Package declared by kernel.bbclass PACKAGES, invisible to standalone lint.
-# nooelint: oelint.vars.specific
-RDEPENDS:${KERNEL_PACKAGE_NAME}-base = ""
-
 KERNEL_CC:append = " ${TOOLCHAIN_OPTIONS}"
 KERNEL_LD:append = " ${TOOLCHAIN_OPTIONS}"
 KERNEL_EXTRA_ARGS += "LOADADDR=${UBOOT_ENTRYPOINT}"


### PR DESCRIPTION
Clears the last two `oelint.vars.pkgspecific` findings in the layer, both in
`recipes-kernel/linux/linux-qoriq.inc`. PR #2650 (`vars.specific`) incidentally
cleared the other 29.

Rule count: **2 -> 0**. Full scan: 3 findings removed, **0 introduced**.

### Commits

1. **`linux-qoriq: Drop the dead RDEPENDS assignment for kernel-base`** — STRUCTURAL FIX.
   `kernel.bbclass` sets no `RDEPENDS` for `kernel-base`; it links base to image
   through `RRECOMMENDS` since oe-core `1c90b27d2c`. The line assigned empty to an
   already-empty variable. Commit `5171b4b5` fixed this once and the
   LF-6.12.20_2.0.0 resync reverted it.
2. **`linux-qoriq: Suppress vars.pkgspecific on the kernel-image override`** —
   JUSTIFIED SUPPRESSION. `kernel.bbclass` declares `kernel-image` in `PACKAGES`
   and sets its `FILES` to `""`, so this include is the only thing that adds
   `zImage`: the override is load-bearing. oelint-adv scans this layer alone and
   never parses that class. Hard-coding `kernel-image` would defeat
   `KERNEL_PACKAGE_NAME`.

### Validation

Commit 1 was built on `MACHINE=ls1046ardb`, `DISTRO=fslc-framebuffer` with
`do_package` forced. The buildhistory `packages/` tree is byte-identical.
Commit 2 changes comments only.

### Open question for a maintainer

If the BSP really wants `kernel-base` not to pull `kernel-image`, the correct
line is `RRECOMMENDS:${KERNEL_PACKAGE_NAME}-base = ""`. That is a behaviour
change and is deliberately **not** made here.
