### PR TITLE
[Backport wrynose] oelint: Clear the remaining vars.pkgspecific findings on linux-qoriq

### DIFF
--- a/recipes-kernel/linux/linux-qoriq.inc
+++ b/recipes-kernel/linux/linux-qoriq.inc
@@ -11,6 +11,9 @@ DEPENDS:append = " libgcc coreutils-native"
 # Set the PV to the correct kernel version to satisfy the kernel version sanity check
 PV = "${LINUX_VERSION}+git${SRCPV}"
 
+# kernel-image is declared by kernel.bbclass PACKAGES; this include sets no
+# PACKAGES, so the name is invisible to standalone lint.
+# nooelint: oelint.vars.specific oelint.vars.pkgspecific
 FILES:${KERNEL_PACKAGE_NAME}-image += "/boot/zImage*"
 
 KERNEL_CC:append = " ${TOOLCHAIN_OPTIONS}"

--- a/recipes-kernel/linux/linux-qoriq.inc
+++ b/recipes-kernel/linux/linux-qoriq.inc
@@ -13,9 +13,6 @@ PV = "${LINUX_VERSION}+git${SRCPV}"
 
 FILES:${KERNEL_PACKAGE_NAME}-image += "/boot/zImage*"
 
-# not put Images into /boot of rootfs, install kernel-image if needed
-RDEPENDS:${KERNEL_PACKAGE_NAME}-base = ""
-
 KERNEL_CC:append = " ${TOOLCHAIN_OPTIONS}"
 KERNEL_LD:append = " ${TOOLCHAIN_OPTIONS}"
 KERNEL_EXTRA_ARGS += "LOADADDR=${UBOOT_ENTRYPOINT}"


### PR DESCRIPTION
# Description
Backport of #2666 to `wrynose`.