### PR TITLE
Quote variable values on the assignment line (oelint.vars.valuequoted)

### DIFF
--- a/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
+++ b/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
@@ -62,10 +62,9 @@ IMX_BOOT_SOC_TARGET ?= "INVALID"
 DEPLOY_OPTEE = "${@bb.utils.contains('MACHINE_FEATURES', 'optee', 'true', 'false', d)}"
 DEPLOY_OPTEE_STMM = "${@bb.utils.contains('MACHINE_FEATURES', 'optee stmm', 'true', 'false', d)}"
 
-IMXBOOT_TARGETS ?= \
-    "${@bb.utils.contains('UBOOT_CONFIG', 'fspi', 'flash_flexspi', \
-        bb.utils.contains('UBOOT_CONFIG', 'nand', 'flash_nand', \
-                                                  'flash_multi_cores flash_dcd', d), d)}"
+IMXBOOT_TARGETS ?= "${@bb.utils.contains('UBOOT_CONFIG', 'fspi', 'flash_flexspi', \
+                       bb.utils.contains('UBOOT_CONFIG', 'nand', 'flash_nand', \
+                                         'flash_multi_cores flash_dcd', d), d)}"
 
 BOOT_STAGING = "${S}/${IMX_BOOT_SOC_TARGET}"
 BOOT_STAGING:mx8m-generic-bsp = "${S}/iMX8M"

--- a/recipes-graphics/imx-gpu-sdk/imx-gpu-sdk_6.1.1.bb
+++ b/recipes-graphics/imx-gpu-sdk/imx-gpu-sdk_6.1.1.bb
@@ -5,10 +5,8 @@ SECTION = "graphics"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://License.md;md5=9d58a2573275ce8c35d79576835dbeb8"
 
-DEPENDS_BACKEND = \
-    "${@bb.utils.contains('DISTRO_FEATURES', 'wayland', ' libxdg-shell wayland', \
-        bb.utils.contains('DISTRO_FEATURES',     'x11',               ' xrandr', \
-                                                                             '', d), d)}"
+DEPENDS_BACKEND = "${@bb.utils.contains('DISTRO_FEATURES', 'wayland', ' libxdg-shell wayland', \
+                      bb.utils.contains('DISTRO_FEATURES', 'x11', ' xrandr', '', d), d)}"
 DEPENDS_MX8 = ""
 DEPENDS_MX8:mx8-nxp-bsp = "\
     glslang-native \
@@ -46,10 +44,8 @@ DEPENDS:append:imxgpu3d = " virtual/libgles2"
 
 require imx-gpu-sdk-src.inc
 
-WINDOW_SYSTEM = \
-    "${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'Wayland_XDG', \
-        bb.utils.contains('DISTRO_FEATURES',     'x11',         'X11', \
-                                                                 'FB', d), d)}"
+WINDOW_SYSTEM = "${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'Wayland_XDG', \
+                    bb.utils.contains('DISTRO_FEATURES', 'x11', 'X11', 'FB', d), d)}"
 
 # FEATURES is a comma-separated list passed to FslBuild.py as
 # --UseFeatures [${FEATURES}], so each appended token starts with a comma

--- a/recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc
+++ b/recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc
@@ -103,9 +103,8 @@ PACKAGES_OPENCL = "libclc-imx libopencl-imx libopencl-imx-dev"
 PACKAGES_OPENCL:mx7-nxp-bsp = ""
 PACKAGES_OPENCL:mx8mm-nxp-bsp = ""
 
-PACKAGES_OPENVX = \
-    "${@bb.utils.contains("PROVIDES_OPENVX", "virtual/libopenvx", \
-        "libopenvx-imx libopenvx-imx-dev", "", d)}"
+PACKAGES_OPENVX = "${@bb.utils.contains("PROVIDES_OPENVX", "virtual/libopenvx", \
+                      "libopenvx-imx libopenvx-imx-dev", "", d)}"
 
 PACKAGES_VULKAN = ""
 PACKAGES_VULKAN:imxvulkan = "libvulkan-imx libvulkan-imx-dev"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.28.1.imx.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.28.1.imx.bbappend
@@ -1,9 +1,6 @@
-PACKAGECONFIG_GL:imxgpu2d = \
-    "${@bb.utils.contains('DISTRO_FEATURES', 'opengl x11', 'opengl', '', d)}"
-PACKAGECONFIG_GL:imxgpu3d = \
-    "${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'gles2 egl', '', d)}"
-PACKAGECONFIG_GL:use-mainline-bsp = \
-    "${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'gles2 egl gbm', '', d)}"
+PACKAGECONFIG_GL:imxgpu2d = "${@bb.utils.contains('DISTRO_FEATURES', 'opengl x11', 'opengl', '', d)}"
+PACKAGECONFIG_GL:imxgpu3d = "${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'gles2 egl', '', d)}"
+PACKAGECONFIG_GL:use-mainline-bsp = "${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'gles2 egl gbm', '', d)}"
 
 # The i.MX8 uses KMS instead of the Vivante specific framebuffer API.
 # The i.MX7 does not have a GPU, except for ULP.


### PR DESCRIPTION
Clears `oelint.vars.valuequoted` across meta-freescale: 7 findings in 4
recipes, now 0.

Each of these four assignments put a line continuation before the opening
quote:

    PACKAGES_OPENVX = \
        "${@bb.utils.contains(...)}"

That form hides the value from every reader and tool that looks at the
assignment line, and a stray space after the backslash breaks the parse
silently with no error. This series moves the value onto the assignment
line and aligns the continuation under the expression it continues.

Only the Python source inside `${@...}` is reflowed. The reflowed spaces
sit between arguments, outside every string literal, so no expanded value
changes.

## Commits

| Commit | Recipe | Variable |
| --- | --- | --- |
| `35598eef7` | gstreamer1.0-plugins-base | `PACKAGECONFIG_GL` |
| `9d95af68d` | imx-gpu-viv | `PACKAGES_OPENVX` |
| `18a3d6a07` | imx-boot | `IMXBOOT_TARGETS` |
| `c4e5b04a4` | imx-gpu-sdk | `DEPENDS_BACKEND`, `WINDOW_SYSTEM` |

## Validation

Every commit is a metadata change, so each one was built and compared, not
just parsed. In each case the buildhistory delta is nothing.

| Recipe | MACHINE / DISTRO | Forced task | Buildhistory |
| --- | --- | --- | --- |
| gstreamer1.0-plugins-base | imx6qdlsabresd / fslc-wayland | `-c package -f` | byte-identical |
| imx-gpu-viv | imx8mp-lpddr4-evk | `-C unpack -c package` | byte-identical |
| imx-boot | imx8mp-lpddr4-evk | `-c deploy -f` | deployed images byte-identical |
| imx-gpu-sdk | imx8mm-lpddr4-evk / fslc-wayland | `-C configure` | byte-identical |

For `imx-gpu-sdk`, the full `bitbake -e` dump was compared between the two
sides as well. `DEPENDS_BACKEND`, `WINDOW_SYSTEM` and `DEPENDS` are
byte-identical; the only variables that differ are per-run log paths, PIDs,
timestamps, and `COMBINED_FEATURES`, whose token set is the same but whose
order BitBake does not fix.

No suppression was added. The layer total falls from 117 to 115 findings,
and the full scan confirms no finding was introduced elsewhere.
