### PR TITLE
oelint: Split the i.MX overrides into version-specific includes (var.order 43 -> 0)

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-support/opencv/opencv_4.13.0.imx.bb
+++ b/dynamic-layers/openembedded-layer/recipes-support/opencv/opencv_4.13.0.imx.bb
@@ -1,7 +1,7 @@
-# This recipe is modified for i.MX.
-# For ease of maintenance, the top section is a verbatim copy
-# of an OE-core recipe, and the second section customizes the
-# recipe for i.MX.
+# This recipe is modified for i.MX. For ease of maintenance the recipe itself
+# is a verbatim copy of a meta-openembedded recipe, so it can be diffed
+# against upstream directly; the i.MX customization lives in the required
+# opencv_4.13.0.imx.inc.
 
 ########## meta-openembedded copy ###########
 # Upstream hash: 9b77eae6988e98adbec5323d2491afc6b327c91a
@@ -12,7 +12,7 @@ HOMEPAGE = "http://opencv.org/"
 SECTION = "libs"
 
 LICENSE = "Apache-2.0"
-# Re-set in the i.MX overrides section below; kept here to preserve the
+# Re-set in the required opencv_4.13.0.imx.inc; kept here to preserve the
 # verbatim meta-openembedded copy (see header). UPSTREAM-PARITY.
 # nooelint: oelint.var.override
 LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
@@ -280,89 +280,4 @@ BBCLASSEXTEND = "native"
 
 ########## End of meta-openembedded copy ##########
 
-########## i.MX overrides ##########
-
-LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
-
-# Need to override opencv and contrib URL because they include PV
-IMX_BASE_VERSION = "${@'.'.join((d.getVar('PV') or '').split('.')[:3])}"
-SRC_URI:remove = "\
-    git://github.com/opencv/opencv.git;name=opencv;branch=4.x;protocol=https;tag=${PV} \
-    git://github.com/opencv/opencv_contrib.git;destsuffix=${BB_GIT_DEFAULT_DESTSUFFIX}/contrib;name=contrib;branch=4.x;protocol=https;tag=${PV}"
-SRC_URI:prepend = "\
-    git://github.com/opencv/opencv.git;name=opencv;branch=4.x;protocol=https;tag=${IMX_BASE_VERSION} \
-    git://github.com/opencv/opencv_contrib.git;destsuffix=${BB_GIT_DEFAULT_DESTSUFFIX}/contrib;name=contrib;branch=4.x;protocol=https;tag=${IMX_BASE_VERSION} "
-
-# i.MX patches
-#
-# 0107 and 0108 carry no Signed-off-by. They came in from upstream review
-# rather than from this layer, and a sign-off is a certification only their
-# author can make, so there is nothing here for us to correct. Note this
-# covers the whole block: a patch added below without a sign-off will not be
-# reported either.
-# nooelint: oelint.file.patchsignedoff
-SRC_URI += "\
-    file://0101-MGS-6470-ccc-Modify-host-ptr-alignment-size-in-UMAT.patch \
-    file://0102-MGS-6470-ccc-Add-configuration-parameter-to-force-en.patch \
-    file://0103-MGS-6470-ccc-Change-configuration-to-enable-hostptr-.patch \
-    file://0104-MGS-8011-ccc-Fix-the-problem-of-syntax-error-at-doub.patch \
-    file://0105-MGS-8318-ccc-Fix-error-implicit-declaration-of-funct.patch \
-    file://0106-core-opencl-fix-inplace-transpose-race-by-enforcing-.patch \
-    file://0107-imgproc-perf-HoughLines-Fix-test-tolerance-and-compa.patch \
-    file://0108-imgproc-perf-HoughLines-Fix-lower-bound-for-line-cou.patch \
-    file://0109-core-ocl-fix-incorrect-results-for-in-place-flip-on-.patch \
-"
-
-# Add opencv_extra
-SRC_URI += "\
-    git://github.com/opencv/opencv_extra.git;destsuffix=extra;name=extra;branch=4.x;protocol=https \
-    file://0001-Add-smaller-version-of-download_models.py.patch;patchdir=${UNPACKDIR}/extra \
-"
-# SRCREV_FORMAT is an underscore-joined list of SRC_URI names; the appended
-# component must attach directly with no leading space.
-# nooelint: oelint.vars.inconspaces
-SRCREV_FORMAT:append = "_extra"
-SRCREV_extra = "b6db059e9b80072d80d009d2ab344f8606a8e964"
-
-# Patch DNN example
-SRC_URI += "\
-    file://OpenCV_DNN_examples.patch \
-"
-
-PACKAGECONFIG:remove = "eigen"
-
-PACKAGECONFIG:append = " \
-    dnn \
-    text \
-    ${@bb.utils.contains('BBFILE_COLLECTIONS', 'qt6-layer', 'qt6', '', d)} \
-    ${PACKAGECONFIG_OPENCL} \
-"
-
-PACKAGECONFIG_OPENCL = ""
-PACKAGECONFIG_OPENCL:imxgpu = "opencl"
-PACKAGECONFIG_OPENCL:mx8mm-nxp-bsp = ""
-
-PACKAGECONFIG[openvx] = "-DWITH_OPENVX=ON -DOPENVX_ROOT=${STAGING_LIBDIR} -DOPENVX_LIB_CANDIDATES='OpenVX;OpenVXU',-DWITH_OPENVX=OFF,virtual/libopenvx,"
-PACKAGECONFIG[qt5] = "-DWITH_QT=ON -DOE_QMAKE_PATH_EXTERNAL_HOST_BINS=${STAGING_BINDIR_NATIVE} -DCMAKE_PREFIX_PATH=${STAGING_BINDIR_NATIVE}/cmake,-DWITH_QT=OFF,qtbase qtbase-native,"
-PACKAGECONFIG[qt6] = "-DWITH_QT=ON -DQT_HOST_PATH=${RECIPE_SYSROOT_NATIVE}${prefix_native},-DWITH_QT=OFF,qtbase qtbase-native qt5compat,"
-PACKAGECONFIG[tests-imx] = "-DINSTALL_TESTS=ON -DOPENCV_TEST_DATA_PATH=${UNPACKDIR}/extra/testdata, -DINSTALL_TESTS=OFF,"
-PACKAGECONFIG[tim-vx] = "-DWITH_TIMVX=ON -DTIMVX_INSTALL_DIR=${STAGING_DIR_HOST}${libdir},-DWITH_TIMVX=OFF,tim-vx"
-
-do_install:append() {
-    ln -sf opencv4/opencv2 ${D}${includedir}/opencv2
-    install -d ${D}${datadir}/opencv4/samples/data
-    cp -r ${S}/samples/data/* ${D}${datadir}/opencv4/samples/data
-    install -d ${D}${datadir}/opencv4/samples/bin/
-    install -m 0755 bin/example_* ${D}${datadir}/opencv4/samples/bin/
-    if ${@bb.utils.contains('PACKAGECONFIG', 'tests-imx', 'true', 'false', d)}; then
-        cp -r share/opencv4/testdata/cv/face/* ${D}${datadir}/opencv4/testdata/cv/face/
-    fi
-    # Rename cpp folder to avoid collision with GCC /usr/bin/cpp.
-    mv ${D}${bindir}/cpp ${D}${bindir}/opencv_cpp
-}
-
-PACKAGE_ARCH = "${MACHINE_SOCARCH}"
-
-COMPATIBLE_MACHINE = "(mx8-nxp-bsp|mx9-nxp-bsp)"
-
-########## End of i.MX overrides ##########
+require opencv_4.13.0.imx.inc

--- a/dynamic-layers/openembedded-layer/recipes-support/opencv/opencv_4.13.0.imx.bb
+++ b/dynamic-layers/openembedded-layer/recipes-support/opencv/opencv_4.13.0.imx.bb
@@ -228,6 +228,8 @@ INSANE_SKIP:${PN}-dbg = "libdir"
 
 ALLOW_EMPTY:${PN} = "1"
 
+# Ordering comes from the upstream recipe at the header's Upstream hash.
+# nooelint: oelint.var.order.SUMMARY
 SUMMARY:python3-opencv = "Python bindings to opencv"
 # Recipe-specific split package (no default FILES); '=' is a complete definition.
 # Kept byte-identical to meta-oe opencv_4.13.0.bb to avoid fork drift.

--- a/dynamic-layers/openembedded-layer/recipes-support/opencv/opencv_4.13.0.imx.inc
+++ b/dynamic-layers/openembedded-layer/recipes-support/opencv/opencv_4.13.0.imx.inc
@@ -1,0 +1,87 @@
+# i.MX customization for opencv_4.13.0.imx.bb.
+# Not a standalone recipe: required by that .bb, and must stay beside
+# it. Keeping it separate lets the .bb remain a verbatim copy of the
+# meta-openembedded original.
+
+LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
+
+# Need to override opencv and contrib URL because they include PV
+IMX_BASE_VERSION = "${@'.'.join((d.getVar('PV') or '').split('.')[:3])}"
+SRC_URI:remove = "\
+    git://github.com/opencv/opencv.git;name=opencv;branch=4.x;protocol=https;tag=${PV} \
+    git://github.com/opencv/opencv_contrib.git;destsuffix=${BB_GIT_DEFAULT_DESTSUFFIX}/contrib;name=contrib;branch=4.x;protocol=https;tag=${PV}"
+SRC_URI:prepend = "\
+    git://github.com/opencv/opencv.git;name=opencv;branch=4.x;protocol=https;tag=${IMX_BASE_VERSION} \
+    git://github.com/opencv/opencv_contrib.git;destsuffix=${BB_GIT_DEFAULT_DESTSUFFIX}/contrib;name=contrib;branch=4.x;protocol=https;tag=${IMX_BASE_VERSION} "
+
+# i.MX patches
+#
+# 0107 and 0108 carry no Signed-off-by. They came in from upstream review
+# rather than from this layer, and a sign-off is a certification only their
+# author can make, so there is nothing here for us to correct. Note this
+# covers the whole block: a patch added below without a sign-off will not be
+# reported either.
+# nooelint: oelint.file.patchsignedoff
+SRC_URI += "\
+    file://0101-MGS-6470-ccc-Modify-host-ptr-alignment-size-in-UMAT.patch \
+    file://0102-MGS-6470-ccc-Add-configuration-parameter-to-force-en.patch \
+    file://0103-MGS-6470-ccc-Change-configuration-to-enable-hostptr-.patch \
+    file://0104-MGS-8011-ccc-Fix-the-problem-of-syntax-error-at-doub.patch \
+    file://0105-MGS-8318-ccc-Fix-error-implicit-declaration-of-funct.patch \
+    file://0106-core-opencl-fix-inplace-transpose-race-by-enforcing-.patch \
+    file://0107-imgproc-perf-HoughLines-Fix-test-tolerance-and-compa.patch \
+    file://0108-imgproc-perf-HoughLines-Fix-lower-bound-for-line-cou.patch \
+    file://0109-core-ocl-fix-incorrect-results-for-in-place-flip-on-.patch \
+"
+
+# Add opencv_extra
+SRC_URI += "\
+    git://github.com/opencv/opencv_extra.git;destsuffix=extra;name=extra;branch=4.x;protocol=https \
+    file://0001-Add-smaller-version-of-download_models.py.patch;patchdir=${UNPACKDIR}/extra \
+"
+# SRCREV_FORMAT is an underscore-joined list of SRC_URI names; the appended
+# component must attach directly with no leading space.
+# nooelint: oelint.vars.inconspaces
+SRCREV_FORMAT:append = "_extra"
+SRCREV_extra = "b6db059e9b80072d80d009d2ab344f8606a8e964"
+
+# Patch DNN example
+SRC_URI += "\
+    file://OpenCV_DNN_examples.patch \
+"
+
+PACKAGECONFIG:remove = "eigen"
+
+PACKAGECONFIG:append = " \
+    dnn \
+    text \
+    ${@bb.utils.contains('BBFILE_COLLECTIONS', 'qt6-layer', 'qt6', '', d)} \
+    ${PACKAGECONFIG_OPENCL} \
+"
+
+PACKAGECONFIG_OPENCL = ""
+PACKAGECONFIG_OPENCL:imxgpu = "opencl"
+PACKAGECONFIG_OPENCL:mx8mm-nxp-bsp = ""
+
+PACKAGECONFIG[openvx] = "-DWITH_OPENVX=ON -DOPENVX_ROOT=${STAGING_LIBDIR} -DOPENVX_LIB_CANDIDATES='OpenVX;OpenVXU',-DWITH_OPENVX=OFF,virtual/libopenvx,"
+PACKAGECONFIG[qt5] = "-DWITH_QT=ON -DOE_QMAKE_PATH_EXTERNAL_HOST_BINS=${STAGING_BINDIR_NATIVE} -DCMAKE_PREFIX_PATH=${STAGING_BINDIR_NATIVE}/cmake,-DWITH_QT=OFF,qtbase qtbase-native,"
+PACKAGECONFIG[qt6] = "-DWITH_QT=ON -DQT_HOST_PATH=${RECIPE_SYSROOT_NATIVE}${prefix_native},-DWITH_QT=OFF,qtbase qtbase-native qt5compat,"
+PACKAGECONFIG[tests-imx] = "-DINSTALL_TESTS=ON -DOPENCV_TEST_DATA_PATH=${UNPACKDIR}/extra/testdata, -DINSTALL_TESTS=OFF,"
+PACKAGECONFIG[tim-vx] = "-DWITH_TIMVX=ON -DTIMVX_INSTALL_DIR=${STAGING_DIR_HOST}${libdir},-DWITH_TIMVX=OFF,tim-vx"
+
+do_install:append() {
+    ln -sf opencv4/opencv2 ${D}${includedir}/opencv2
+    install -d ${D}${datadir}/opencv4/samples/data
+    cp -r ${S}/samples/data/* ${D}${datadir}/opencv4/samples/data
+    install -d ${D}${datadir}/opencv4/samples/bin/
+    install -m 0755 bin/example_* ${D}${datadir}/opencv4/samples/bin/
+    if ${@bb.utils.contains('PACKAGECONFIG', 'tests-imx', 'true', 'false', d)}; then
+        cp -r share/opencv4/testdata/cv/face/* ${D}${datadir}/opencv4/testdata/cv/face/
+    fi
+    # Rename cpp folder to avoid collision with GCC /usr/bin/cpp.
+    mv ${D}${bindir}/cpp ${D}${bindir}/opencv_cpp
+}
+
+PACKAGE_ARCH = "${MACHINE_SOCARCH}"
+
+COMPATIBLE_MACHINE = "(mx8-nxp-bsp|mx9-nxp-bsp)"

--- a/recipes-devtools/qemu/qemu-qoriq.inc
+++ b/recipes-devtools/qemu/qemu-qoriq.inc
@@ -48,6 +48,53 @@ do_install_ptest() {
 # QEMU_TARGETS is overridable variable
 QEMU_TARGETS ?= "arm aarch64 i386 mips mipsel mips64 mips64el ppc ppc64 ppc64le riscv32 riscv64 sh4 x86_64"
 
+# Disable kvm/virgl/mesa on targets that do not support it
+PACKAGECONFIG:remove:darwin = "kvm virglrenderer glx gtk+"
+PACKAGECONFIG:remove:mingw32 = "kvm virglrenderer glx gtk+"
+
+PACKAGECONFIG[sdl] = "--enable-sdl,--disable-sdl,libsdl2"
+PACKAGECONFIG[virtfs] = "--enable-virtfs --enable-attr --enable-cap-ng,--disable-virtfs,libcap-ng attr,"
+PACKAGECONFIG[aio] = "--enable-linux-aio,--disable-linux-aio,libaio,"
+PACKAGECONFIG[xfs] = "--enable-xfsctl,--disable-xfsctl,xfsprogs,"
+PACKAGECONFIG[xen] = "--enable-xen,--disable-xen,xen-tools,xen-tools-libxenstore xen-tools-libxenctrl xen-tools-libxenguest"
+PACKAGECONFIG[vnc-sasl] = "--enable-vnc --enable-vnc-sasl,--disable-vnc-sasl,cyrus-sasl,"
+PACKAGECONFIG[vnc-jpeg] = "--enable-vnc --enable-vnc-jpeg,--disable-vnc-jpeg,jpeg,"
+PACKAGECONFIG[vnc-png] = "--enable-vnc --enable-vnc-png,--disable-vnc-png,libpng,"
+PACKAGECONFIG[libcurl] = "--enable-curl,--disable-curl,curl,"
+PACKAGECONFIG[nss] = "--enable-smartcard,--disable-smartcard,nss,"
+PACKAGECONFIG[curses] = "--enable-curses,--disable-curses,ncurses,"
+PACKAGECONFIG[gtk+] = "--enable-gtk,--disable-gtk,gtk+3 gettext-native"
+PACKAGECONFIG[vte] = "--enable-vte,--disable-vte,vte gettext-native"
+PACKAGECONFIG[libcap-ng] = "--enable-cap-ng,--disable-cap-ng,libcap-ng,"
+PACKAGECONFIG[ssh] = "--enable-libssh,--disable-libssh,libssh,"
+PACKAGECONFIG[gcrypt] = "--enable-gcrypt,--disable-gcrypt,libgcrypt,"
+PACKAGECONFIG[nettle] = "--enable-nettle,--disable-nettle,nettle"
+PACKAGECONFIG[libusb] = "--enable-libusb,--disable-libusb,libusb1"
+PACKAGECONFIG[fdt] = "--enable-fdt,--disable-fdt,dtc"
+PACKAGECONFIG[alsa] = "--audio-drv-list='oss alsa',,alsa-lib"
+PACKAGECONFIG[glx] = "--enable-opengl,--disable-opengl,virtual/libgl"
+PACKAGECONFIG[lzo] = "--enable-lzo,--disable-lzo,lzo"
+PACKAGECONFIG[numa] = "--enable-numa,--disable-numa,numactl"
+PACKAGECONFIG[gnutls] = "--enable-gnutls,--disable-gnutls,gnutls"
+PACKAGECONFIG[bzip2] = "--enable-bzip2,--disable-bzip2,bzip2"
+PACKAGECONFIG[libiscsi] = "--enable-libiscsi,--disable-libiscsi"
+PACKAGECONFIG[kvm] = "--enable-kvm,--disable-kvm"
+PACKAGECONFIG[virglrenderer] = "--enable-virglrenderer,--disable-virglrenderer,virglrenderer"
+# spice will be in meta-networking layer
+PACKAGECONFIG[spice] = "--enable-spice,--disable-spice,spice"
+# usbredir will be in meta-networking layer
+PACKAGECONFIG[usb-redir] = "--enable-usb-redir,--disable-usb-redir,usbredir"
+PACKAGECONFIG[snappy] = "--enable-snappy,--disable-snappy,snappy"
+PACKAGECONFIG[glusterfs] = "--enable-glusterfs,--disable-glusterfs,glusterfs"
+PACKAGECONFIG[xkbcommon] = "--enable-xkbcommon,--disable-xkbcommon,libxkbcommon"
+PACKAGECONFIG[libudev] = "--enable-libudev,--disable-libudev,eudev"
+PACKAGECONFIG[libxml2] = "--enable-libxml2,--disable-libxml2,libxml2"
+PACKAGECONFIG[attr] = "--enable-attr,--disable-attr,attr,"
+PACKAGECONFIG[rbd] = "--enable-rbd,--disable-rbd,ceph,ceph"
+PACKAGECONFIG[vhost] = "--enable-vhost-net,--disable-vhost-net,,"
+PACKAGECONFIG[ust] = "--enable-trace-backend=ust,--enable-trace-backend=nop,lttng-ust,"
+PACKAGECONFIG[pie] = "--enable-pie,--disable-pie,,"
+
 EXTRA_OECONF = "\
     --prefix=${prefix} \
     --bindir=${bindir} \
@@ -110,53 +157,6 @@ make_qemu_wrapper() {
         done
 }
 make_qemu_wrapper[doc] = "Wrap the installed qemu-system-* binaries so they find the gdk-pixbuf loaders, fontconfig and GTK theme at runtime"
-
-# Disable kvm/virgl/mesa on targets that do not support it
-PACKAGECONFIG:remove:darwin = "kvm virglrenderer glx gtk+"
-PACKAGECONFIG:remove:mingw32 = "kvm virglrenderer glx gtk+"
-
-PACKAGECONFIG[sdl] = "--enable-sdl,--disable-sdl,libsdl2"
-PACKAGECONFIG[virtfs] = "--enable-virtfs --enable-attr --enable-cap-ng,--disable-virtfs,libcap-ng attr,"
-PACKAGECONFIG[aio] = "--enable-linux-aio,--disable-linux-aio,libaio,"
-PACKAGECONFIG[xfs] = "--enable-xfsctl,--disable-xfsctl,xfsprogs,"
-PACKAGECONFIG[xen] = "--enable-xen,--disable-xen,xen-tools,xen-tools-libxenstore xen-tools-libxenctrl xen-tools-libxenguest"
-PACKAGECONFIG[vnc-sasl] = "--enable-vnc --enable-vnc-sasl,--disable-vnc-sasl,cyrus-sasl,"
-PACKAGECONFIG[vnc-jpeg] = "--enable-vnc --enable-vnc-jpeg,--disable-vnc-jpeg,jpeg,"
-PACKAGECONFIG[vnc-png] = "--enable-vnc --enable-vnc-png,--disable-vnc-png,libpng,"
-PACKAGECONFIG[libcurl] = "--enable-curl,--disable-curl,curl,"
-PACKAGECONFIG[nss] = "--enable-smartcard,--disable-smartcard,nss,"
-PACKAGECONFIG[curses] = "--enable-curses,--disable-curses,ncurses,"
-PACKAGECONFIG[gtk+] = "--enable-gtk,--disable-gtk,gtk+3 gettext-native"
-PACKAGECONFIG[vte] = "--enable-vte,--disable-vte,vte gettext-native"
-PACKAGECONFIG[libcap-ng] = "--enable-cap-ng,--disable-cap-ng,libcap-ng,"
-PACKAGECONFIG[ssh] = "--enable-libssh,--disable-libssh,libssh,"
-PACKAGECONFIG[gcrypt] = "--enable-gcrypt,--disable-gcrypt,libgcrypt,"
-PACKAGECONFIG[nettle] = "--enable-nettle,--disable-nettle,nettle"
-PACKAGECONFIG[libusb] = "--enable-libusb,--disable-libusb,libusb1"
-PACKAGECONFIG[fdt] = "--enable-fdt,--disable-fdt,dtc"
-PACKAGECONFIG[alsa] = "--audio-drv-list='oss alsa',,alsa-lib"
-PACKAGECONFIG[glx] = "--enable-opengl,--disable-opengl,virtual/libgl"
-PACKAGECONFIG[lzo] = "--enable-lzo,--disable-lzo,lzo"
-PACKAGECONFIG[numa] = "--enable-numa,--disable-numa,numactl"
-PACKAGECONFIG[gnutls] = "--enable-gnutls,--disable-gnutls,gnutls"
-PACKAGECONFIG[bzip2] = "--enable-bzip2,--disable-bzip2,bzip2"
-PACKAGECONFIG[libiscsi] = "--enable-libiscsi,--disable-libiscsi"
-PACKAGECONFIG[kvm] = "--enable-kvm,--disable-kvm"
-PACKAGECONFIG[virglrenderer] = "--enable-virglrenderer,--disable-virglrenderer,virglrenderer"
-# spice will be in meta-networking layer
-PACKAGECONFIG[spice] = "--enable-spice,--disable-spice,spice"
-# usbredir will be in meta-networking layer
-PACKAGECONFIG[usb-redir] = "--enable-usb-redir,--disable-usb-redir,usbredir"
-PACKAGECONFIG[snappy] = "--enable-snappy,--disable-snappy,snappy"
-PACKAGECONFIG[glusterfs] = "--enable-glusterfs,--disable-glusterfs,glusterfs"
-PACKAGECONFIG[xkbcommon] = "--enable-xkbcommon,--disable-xkbcommon,libxkbcommon"
-PACKAGECONFIG[libudev] = "--enable-libudev,--disable-libudev,eudev"
-PACKAGECONFIG[libxml2] = "--enable-libxml2,--disable-libxml2,libxml2"
-PACKAGECONFIG[attr] = "--enable-attr,--disable-attr,attr,"
-PACKAGECONFIG[rbd] = "--enable-rbd,--disable-rbd,ceph,ceph"
-PACKAGECONFIG[vhost] = "--enable-vhost-net,--disable-vhost-net,,"
-PACKAGECONFIG[ust] = "--enable-trace-backend=ust,--enable-trace-backend=nop,lttng-ust,"
-PACKAGECONFIG[pie] = "--enable-pie,--disable-pie,,"
 
 # QEMU ships firmware and BIOS blobs built for guest architectures other than
 # the build target, so the arch QA check flags them by design.

--- a/recipes-devtools/qemu/qemu-qoriq.inc
+++ b/recipes-devtools/qemu/qemu-qoriq.inc
@@ -7,8 +7,6 @@ HOMEPAGE = "http://qemu.org"
 SECTION = "devel"
 LICENSE = "GPL-2.0-only AND LGPL-2.1-only"
 
-RDEPENDS:${PN}-ptest = "bash make"
-
 require qemu-targets.inc
 inherit pkgconfig ptest
 
@@ -164,3 +162,5 @@ make_qemu_wrapper[doc] = "Wrap the installed qemu-system-* binaries so they find
 INSANE_SKIP:${PN} = "arch"
 
 FILES:${PN} += "${datadir}/icons"
+
+RDEPENDS:${PN}-ptest += "bash make"

--- a/recipes-devtools/qemu/qemu-qoriq_4.2.bb
+++ b/recipes-devtools/qemu/qemu-qoriq_4.2.bb
@@ -1,5 +1,3 @@
-BBCLASSEXTEND = ""
-
 require qemu-qoriq.inc
 
 COMPATIBLE_MACHINE = "(qoriq)"
@@ -24,7 +22,13 @@ python() {
             d.appendVar('RREPLACES:' + p, ' ' + p.replace('-qoriq', ''))
 }
 
-RDEPENDS:${PN}:class-target += "bash"
+PACKAGECONFIG ??= "\
+    fdt sdl kvm aio libusb vhost numa \
+    ${@bb.utils.filter('DISTRO_FEATURES', 'alsa xen', d)} \
+"
+
+PACKAGECONFIG[xkbcommon] = ",,"
+PACKAGECONFIG[libudev] = ",,"
 
 EXTRA_OECONF:append:class-target = " --target-list=${@get_qemu_target_list(d)}"
 EXTRA_OECONF:append:class-target:mipsarcho32 = " ${@bb.utils.contains('BBEXTENDCURR', 'multilib', '--disable-capstone', '', d)}"
@@ -41,13 +45,8 @@ do_install_ptest() {
             ${D}/${PTEST_PATH}/tests/qemu-iotests/common.env
 }
 
-PACKAGECONFIG ??= "\
-    fdt sdl kvm aio libusb vhost numa \
-    ${@bb.utils.filter('DISTRO_FEATURES', 'alsa xen', d)} \
-"
-
-PACKAGECONFIG[xkbcommon] = ",,"
-PACKAGECONFIG[libudev] = ",,"
-
 DISABLE_STATIC = ""
 
+RDEPENDS:${PN}:class-target += "bash"
+
+BBCLASSEXTEND = ""

--- a/recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc
+++ b/recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc
@@ -60,8 +60,6 @@ PROVIDES_OPENVX = ""
 PROVIDES_OPENVX:mx8-nxp-bsp = "virtual/libopenvx"
 PROVIDES_OPENVX:mx8mm-nxp-bsp = ""
 
-RPROVIDES:${PN}:imxgpu3d += "imx-gpu-viv"
-
 PE = "1"
 
 inherit fsl-eula-unpack
@@ -324,41 +322,19 @@ do_install:append:libc-musl() {
 ALLOW_EMPTY:${PN} = "1"
 
 FILES:libclc-imx += "${libdir}/libCLC${SOLIBS}"
-
 FILES:libegl-imx += "${libdir}/libEGL${REALSOLIBS} ${libdir}/libEGL${SOLIBS} "
 FILES:libegl-imx-dev += "${includedir}/EGL ${includedir}/KHR ${libdir}/pkgconfig/egl.pc"
-# libEGL.so is used by some demo apps from Freescale
-# nooelint: oelint.vars.insaneskip
-INSANE_SKIP:libegl-imx += "dev-so"
-
 FILES:libgal-imx += "${libdir}/libGAL${SOLIBS} ${libdir}/libGAL_egl${SOLIBS}"
-RDEPENDS:libgal-imx += "${@bb.utils.contains('PACKAGECONFIG', 'valgrind', 'valgrind', '', d)}"
-RPROVIDES:libgal-imx += "libgal-imx"
-RRECOMMENDS:libgal-imx += "kernel-module-imx-gpu-viv"
-# Prebuilt Vivante blob: its build-time dependencies are not expressed as recipe
-# DEPENDS, so the build-deps QA check cannot be satisfied here.
-# nooelint: oelint.vars.insaneskip
-INSANE_SKIP:libgal-imx += "build-deps"
-
 FILES:libvsc-imx += "${libdir}/libVSC${SOLIBS}"
-
 FILES:libgbm-imx += "${libdir}/libgbm*${REALSOLIBS} ${libdir}/libgbm${SOLIBS} ${libdir}/libgbm_viv${SOLIBS}"
 FILES:libgbm-imx-dev += "${libdir}/pkgconfig/gbm.pc ${includedir}/gbm.h"
-RDEPENDS:libgbm-imx:append = " libdrm"
-# libgbm ships its unversioned .so in the runtime package for dlopen consumers.
-# nooelint: oelint.vars.insaneskip
-INSANE_SKIP:libgbm-imx += "dev-so"
-
 FILES:libvulkan-imx += "\
     ${libdir}/libvulkan_VSI${REALSOLIBS} \
     ${datadir}/vulkan"
 FILES:libvulkan-imx-dev += "${includedir}/vulkan ${libdir}/libvulkan_VSI${SOLIBSDEV}"
-RPROVIDES:libvulkan-imx = "virtual-vulkan-icd"
-
 FILES:libspirv-imx += "\
     ${libdir}/libSPIRV_viv${SOLIBS} \
 "
-
 FILES:libopenvx-imx += "\
     ${libdir}/libOpenVX${REALSOLIBS} \
     ${libdir}/libOpenVXC${SOLIBS} \
@@ -367,66 +343,76 @@ FILES:libopenvx-imx += "\
     ${libdir}/libArchModelSw${SOLIBS} \
 "
 FILES:libopenvx-imx-dev += "${includedir}/VX ${libdir}/libOpenVX${SOLIBSDEV}"
-RDEPENDS:libopenvx-imx = "${OPENCL_VX_INTRINSIC_EXTENSION_PACKAGES}"
-OPENCL_VX_INTRINSIC_EXTENSION_PACKAGES = ""
-OPENCL_VX_INTRINSIC_EXTENSION_PACKAGES:mx8qm-nxp-bsp = "libclc-imx libopencl-imx-dev"
-OPENCL_VX_INTRINSIC_EXTENSION_PACKAGES:mx8mp-nxp-bsp = "libclc-imx libopencl-imx-dev"
-# The runtime package pulls -dev packages (OpenCL/VX intrinsic extensions) by
-# design; the dev-deps QA check does not fit this prebuilt driver layout.
-# nooelint: oelint.vars.insaneskip
-INSANE_SKIP:libopenvx-imx += "dev-deps"
-
 FILES:libgles1-imx += "${libdir}/libGLESv1*${REALSOLIBS} ${libdir}/libGLESv1*${SOLIBS} ${libdir}/libGLES_*${REALSOLIBS} ${libdir}/libGLES_*${SOLIBS}"
 FILES:libgles1-imx-dev += "${includedir}/GLES ${libdir}/pkgconfig/glesv1_cm.pc"
-RPROVIDES:libgles1-imx = "libgles-imx"
-RPROVIDES:libgles1-imx-dev = "libgles-imx-dev"
-# libEGL does dlopen of libGLESv1.so
-# nooelint: oelint.vars.insaneskip
-INSANE_SKIP:libgles1-imx += "dev-so"
-
 FILES:libgles2-imx += "${libdir}/libGLESv2${REALSOLIBS} ${libdir}/libGLESv2${SOLIBS}"
 FILES:libgles2-imx-dev += "${includedir}/GLES2 ${libdir}/pkgconfig/glesv2.pc"
-RDEPENDS:libgles2-imx = "libglslc-imx"
-# libEGL does dlopen of libGLESv2.so
-# nooelint: oelint.vars.insaneskip
-INSANE_SKIP:libgles2-imx += "dev-so"
-
 FILES:libgles3-imx-dev += "${includedir}/GLES3"
-# as long as there is no libgles3: ship libgles3-dev along with
-# libgles2-dev - otherwise GLES3 headers have to be added manually
-RDEPENDS:libgles2-imx-dev += "libgles3-imx-dev"
-
 FILES:libglslc-imx += "${libdir}/libGLSLC${SOLIBS}"
-
 FILES:libopencl-imx += "${libdir}/libOpenCL${REALSOLIBS} \
                         ${libdir}/libVivanteOpenCL${SOLIBS} \
                         ${libdir}/libLLVM_viv${SOLIBS} \
                         ${sysconfdir}/OpenCL/vendors/Vivante.icd"
 FILES:libopencl-imx-dev += "${includedir}/CL ${libdir}/libOpenCL${SOLIBSDEV}"
+FILES:libopenvg-imx += "${libdir}/libOpenVG*${REALSOLIBS} ${libdir}/libOpenVG*${SOLIBS}"
+FILES:libopenvg-imx-dev += "${includedir}/VG ${libdir}/pkgconfig/vg.pc"
+FILES:libvdk-imx += "${libdir}/libVDK*${REALSOLIBS}"
+FILES:libvdk-imx-dev += "${includedir}/*vdk*.h ${libdir}/libVDK${SOLIBSDEV}"
+FILES:libnn-imx += "${libdir}/libNN*${SOLIBS}"
+FILES:imx-gpu-viv-tools += "${bindir}/gmem_info"
+FILES:imx-gpu-viv-demos += "/opt"
+
+OPENCL_VX_INTRINSIC_EXTENSION_PACKAGES = ""
+OPENCL_VX_INTRINSIC_EXTENSION_PACKAGES:mx8qm-nxp-bsp = "libclc-imx libopencl-imx-dev"
+OPENCL_VX_INTRINSIC_EXTENSION_PACKAGES:mx8mp-nxp-bsp = "libclc-imx libopencl-imx-dev"
+
+RDEPENDS:libgal-imx += "${@bb.utils.contains('PACKAGECONFIG', 'valgrind', 'valgrind', '', d)}"
+RDEPENDS:libgbm-imx:append = " libdrm"
+RDEPENDS:libopenvx-imx = "${OPENCL_VX_INTRINSIC_EXTENSION_PACKAGES}"
+RDEPENDS:libgles2-imx = "libglslc-imx"
+# as long as there is no libgles3: ship libgles3-dev along with
+# libgles2-dev - otherwise GLES3 headers have to be added manually
+RDEPENDS:libgles2-imx-dev += "libgles3-imx-dev"
 RDEPENDS:libopencl-imx = "libclc-imx"
+
+RRECOMMENDS:libgal-imx += "kernel-module-imx-gpu-viv"
+
+RPROVIDES:${PN}:imxgpu3d += "imx-gpu-viv"
+RPROVIDES:libgal-imx += "libgal-imx"
+RPROVIDES:libvulkan-imx = "virtual-vulkan-icd"
+RPROVIDES:libgles1-imx = "libgles-imx"
+RPROVIDES:libgles1-imx-dev = "libgles-imx-dev"
 RPROVIDES:libopencl-imx = "virtual-opencl-icd"
 RPROVIDES:libopencl-imx:mx7-nxp-bsp = ""
 RPROVIDES:libopencl-imx:mx8mm-nxp-bsp = ""
 
-FILES:libopenvg-imx += "${libdir}/libOpenVG*${REALSOLIBS} ${libdir}/libOpenVG*${SOLIBS}"
-FILES:libopenvg-imx-dev += "${includedir}/VG ${libdir}/pkgconfig/vg.pc"
+# libEGL.so is used by some demo apps from Freescale
+# nooelint: oelint.vars.insaneskip
+INSANE_SKIP:libegl-imx += "dev-so"
+# Prebuilt Vivante blob: its build-time dependencies are not expressed as recipe
+# DEPENDS, so the build-deps QA check cannot be satisfied here.
+# nooelint: oelint.vars.insaneskip
+INSANE_SKIP:libgal-imx += "build-deps"
+# libgbm ships its unversioned .so in the runtime package for dlopen consumers.
+# nooelint: oelint.vars.insaneskip
+INSANE_SKIP:libgbm-imx += "dev-so"
+# The runtime package pulls -dev packages (OpenCL/VX intrinsic extensions) by
+# design; the dev-deps QA check does not fit this prebuilt driver layout.
+# nooelint: oelint.vars.insaneskip
+INSANE_SKIP:libopenvx-imx += "dev-deps"
+# libEGL does dlopen of libGLESv1.so
+# nooelint: oelint.vars.insaneskip
+INSANE_SKIP:libgles1-imx += "dev-so"
+# libEGL does dlopen of libGLESv2.so
+# nooelint: oelint.vars.insaneskip
+INSANE_SKIP:libgles2-imx += "dev-so"
 # libEGL does dlopen of libOpenVG.so
 # nooelint: oelint.vars.insaneskip
 INSANE_SKIP:libopenvg-imx += "dev-so"
-
-FILES:libvdk-imx += "${libdir}/libVDK*${REALSOLIBS}"
-FILES:libvdk-imx-dev += "${includedir}/*vdk*.h ${libdir}/libVDK${SOLIBSDEV}"
-
-FILES:imx-gpu-viv-tools += "${bindir}/gmem_info"
-
-FILES:imx-gpu-viv-demos += "/opt"
 # Prebuilt demo binaries under /opt carry vendor rpaths and link the -dev
 # packages; the rpaths and dev-deps QA checks do not apply to them.
 # nooelint: oelint.vars.insaneskip
 INSANE_SKIP:imx-gpu-viv-demos += "rpaths dev-deps"
-
-FILES:libnn-imx += "${libdir}/libNN*${SOLIBS}"
-
 # It will use gcompat at runtime therefore checking for these at compile time wont be useful as
 # they dont match musl/gcompat but it should run fine
 # nooelint: oelint.vars.insaneskip

--- a/recipes-graphics/mali/mali-imx.inc
+++ b/recipes-graphics/mali/mali-imx.inc
@@ -29,15 +29,13 @@ PACKAGES =+ "\
     ${PN}-libvulkan  \
     ${PN}-opencl-icd ${PN}-opencl-icd-dev"
 
+# Consolidate GLES dev packages
+PACKAGES =+ "${PN}-libgles-dev"
+
 # Since libmali.so is loaded by dlopen, include it in the main package
 FILES:${PN} += "\
     ${libdir}/libmali.so \
     ${nonarch_base_libdir}/firmware"
-FILES_SOLIBSDEV = ""
-# libmali.so is shipped in the main package for dlopen consumers (above), so the
-# dev-so QA check does not apply.
-# nooelint: oelint.vars.insaneskip
-INSANE_SKIP:${PN} = "dev-so"
 FILES:${PN}-libegl += "\
     ${libdir}/libEGL${SOLIBS}"
 FILES:${PN}-libgbm += "\
@@ -48,14 +46,10 @@ FILES:${PN}-libgles2 += "\
     ${libdir}/libGLESv2${SOLIBS}"
 FILES:${PN}-opencl-icd += "\
     ${sysconfdir}/OpenCL"
-RPROVIDES:${PN}-opencl-icd = "virtual-opencl-icd"
 FILES:${PN}-libvulkan += "\
     ${sysconfdir}/vulkan"
-RDEPENDS:${PN}-libvulkan = "vulkan-wsi-layer"
-RPROVIDES:${PN}-libvulkan = "virtual-vulkan-icd"
-
 # ${PN}-dev is deliberately curated to just malisc; the headers and dev
-# symlinks ship in the per-library -dev packages above, so the standard -dev
+# symlinks ship in the per-library -dev packages below, so the standard -dev
 # default is intentionally replaced rather than extended.
 # nooelint: oelint.var.filesoverride
 FILES:${PN}-dev = "\
@@ -69,26 +63,34 @@ FILES:${PN}-libgbm-dev += "\
     ${includedir}/gbm.h \
     ${libdir}/libgbm${SOLIBSDEV} \
     ${libdir}/pkgconfig/gbm.pc"
-
-# Consolidate GLES dev packages
-PACKAGES =+ "${PN}-libgles-dev"
 FILES:${PN}-libgles-dev += "\
     ${includedir}/GLES* \
     ${libdir}/libGLES*${SOLIBSDEV} \
     ${libdir}/pkgconfig/gles*.pc"
-DEBIAN_NOAUTONAME:${PN}-libgles-dev = "1"
-RREPLACES:${PN}-libgles-dev = "libgles-dev"
-RPROVIDES:${PN}-libgles-dev = "libgles-dev"
-RCONFLICTS:${PN}-libgles-dev = "libgles-dev"
-ALLOW_EMPTY:${PN}-libgles1-dev = "1"
-ALLOW_EMPTY:${PN}-libgles2-dev = "1"
-ALLOW_EMPTY:${PN}-libgles3-dev = "1"
+FILES:${PN}-opencl-icd-dev += "\
+    ${bindir}/mali_clcc"
+
+RDEPENDS:${PN}-libvulkan = "vulkan-wsi-layer"
 RDEPENDS:${PN}-libgles1-dev = "${PN}-libgles-dev"
 RDEPENDS:${PN}-libgles2-dev = "${PN}-libgles-dev"
 RDEPENDS:${PN}-libgles3-dev = "${PN}-libgles-dev"
 
-FILES:${PN}-opencl-icd-dev += "\
-    ${bindir}/mali_clcc"
+RPROVIDES:${PN}-opencl-icd = "virtual-opencl-icd"
+RPROVIDES:${PN}-libvulkan = "virtual-vulkan-icd"
+RPROVIDES:${PN}-libgles-dev = "libgles-dev"
+
+RCONFLICTS:${PN}-libgles-dev = "libgles-dev"
+
+FILES_SOLIBSDEV = ""
+# libmali.so is shipped in the main package for dlopen consumers (above), so the
+# dev-so QA check does not apply.
+# nooelint: oelint.vars.insaneskip
+INSANE_SKIP:${PN} = "dev-so"
+DEBIAN_NOAUTONAME:${PN}-libgles-dev = "1"
+RREPLACES:${PN}-libgles-dev = "libgles-dev"
+ALLOW_EMPTY:${PN}-libgles1-dev = "1"
+ALLOW_EMPTY:${PN}-libgles2-dev = "1"
+ALLOW_EMPTY:${PN}-libgles3-dev = "1"
 
 python __anonymous() {
 

--- a/recipes-graphics/wayland/weston_10.0.5.imx.bb
+++ b/recipes-graphics/wayland/weston_10.0.5.imx.bb
@@ -1,11 +1,11 @@
-# This recipe is for the i.MX fork of weston. For ease of
-# maintenance, the top section is a verbatim copy of an OE-core
-# recipe. The second section customizes the recipe for i.MX.
-
+# This recipe is modified for i.MX. For ease of maintenance the recipe itself
+# is a verbatim copy of a OE-core recipe, so it can be diffed against
+# upstream directly; the i.MX customization lives in the required
+# weston_10.0.5.imx.inc.
 ########### OE-core copy ##################
 # Upstream hash: 4b42fd87da290ddea098605aea3a5cce1fb432a7
 
-# Overridden in the i.MX overrides section below; kept here to preserve the
+# Overridden in the required weston_10.0.5.imx.inc; kept here to preserve the
 # verbatim OE-core copy (see header). UPSTREAM-PARITY.
 # nooelint: oelint.var.override
 SUMMARY = "Weston, a Wayland compositor"
@@ -168,61 +168,4 @@ GROUPADD_PARAM:${PN} = "--system weston-launch"
 
 ########### End of OE-core copy ###########
 
-########### i.MX overrides ################
-
-SUMMARY = "Weston, a Wayland compositor, i.MX fork"
-
-LIC_FILES_CHKSUM:remove = "file://COPYING;md5=d79ee9e66bb0f95d3386a7acae780b70"
-LIC_FILES_CHKSUM:append = " file://LICENSE;md5=d79ee9e66bb0f95d3386a7acae780b70"
-
-DEFAULT_PREFERENCE = "-1"
-
-SRC_URI:remove = "https://gitlab.freedesktop.org/wayland/weston/-/releases/${PV}/downloads/${BPN}-${PV}.tar.xz"
-SRC_URI:prepend = "${WESTON_SRC};branch=${SRCBRANCH} "
-WESTON_SRC ?= "git://github.com/nxp-imx/weston-imx.git;protocol=https"
-SRC_URI += "file://0001-Revert-protocol-no-found-wayland-scanner-with-Yocto-.patch \
-            file://0001-g2d-renderer.c-Include-sys-stat.h.patch"
-SRCBRANCH = "weston-imx-10.0.5"
-SRCREV = "5223a3c86177709d25f86a96622c0829da955a0e"
-
-# Disable OpenGL for parts with GPU support for 2D but not 3D
-REQUIRED_DISTRO_FEATURES = "opengl"
-REQUIRED_DISTRO_FEATURES:imxgpu2d = ""
-REQUIRED_DISTRO_FEATURES:imxgpu3d = "opengl"
-PACKAGECONFIG_OPENGL = "opengl"
-PACKAGECONFIG_OPENGL:imxgpu2d = ""
-PACKAGECONFIG_OPENGL:imxgpu3d = "opengl"
-
-PACKAGECONFIG_IMX_REMOVALS ?= "wayland x11"
-PACKAGECONFIG:remove = "${PACKAGECONFIG_IMX_REMOVALS}"
-PACKAGECONFIG:append = " ${@bb.utils.filter('DISTRO_FEATURES', '${PACKAGECONFIG_OPENGL}', d)}"
-
-PACKAGECONFIG:remove:imxfbdev = "kms"
-PACKAGECONFIG:append:imxfbdev = " fbdev clients"
-PACKAGECONFIG:append:imxgpu = " imxgpu"
-PACKAGECONFIG:append:imxgpu2d = " imxg2d"
-
-SIMPLECLIENTS:imxfbdev = "damage,im,egl,shm,touch,dmabuf-v4l"
-
-# Override
-PACKAGECONFIG[xwayland] = "-Dxwayland=true,-Dxwayland=false,libxcursor xwayland"
-# Weston with i.MX GPU support
-PACKAGECONFIG[imxgpu] = "-Dimxgpu=true,-Dimxgpu=false,virtual/egl"
-# Weston with i.MX G2D renderer
-PACKAGECONFIG[imxg2d] = "-Drenderer-g2d=true,-Drenderer-g2d=false,virtual/libg2d"
-# Weston with OpenGL support
-PACKAGECONFIG[opengl] = "-Dopengl=true,-Dopengl=false"
-
-PACKAGECONFIG[fbdev] = "-Dbackend-fbdev=true,-Dbackend-fbdev=false,udev mtdev libdrm"
-EXTRA_OEMESON:append:imxfbdev = " -Dbackend-default=fbdev"
-
-EXTRA_OEMESON += "-Ddeprecated-wl-shell=true"
-
-# links with imx-gpu libs which are pre-built for glibc
-# gcompat will address it during runtime
-LDFLAGS:append:imxgpu:libc-musl = " -Wl,--allow-shlib-undefined"
-
-PACKAGE_ARCH = "${MACHINE_SOCARCH}"
-COMPATIBLE_MACHINE = "(imx-nxp-bsp)"
-
-########### End of i.MX overrides #########
+require weston_10.0.5.imx.inc

--- a/recipes-graphics/wayland/weston_10.0.5.imx.bb
+++ b/recipes-graphics/wayland/weston_10.0.5.imx.bb
@@ -34,6 +34,8 @@ inherit meson pkgconfig useradd
 #
 require ${THISDIR}/required-distro-features.inc
 
+# Ordering comes from the upstream recipe at the header's Upstream hash.
+# nooelint: oelint.var.order.DEPENDS
 DEPENDS = "cairo gdk-pixbuf glib-2.0 libinput libxkbcommon pango pixman \
            virtual/egl wayland wayland-native wayland-protocols"
 
@@ -150,6 +152,8 @@ FILES:${PN} = "${bindir}/weston ${bindir}/weston-terminal ${bindir}/weston-info 
 # fork drift; suppress the append-preference warning.
 # nooelint: oelint.var.filesoverride
 FILES:libweston-${WESTON_MAJOR_VERSION} = "${libdir}/lib*${SOLIBS} ${libdir}/libweston-${WESTON_MAJOR_VERSION}/*.so"
+# Ordering comes from the upstream recipe at the header's Upstream hash.
+# nooelint: oelint.var.order.SUMMARY
 SUMMARY:libweston-${WESTON_MAJOR_VERSION} = "Helper library for implementing 'wayland window managers'."
 
 # nooelint: oelint.var.filesoverride
@@ -161,6 +165,8 @@ RDEPENDS:${PN}-xwayland += "xwayland"
 
 RDEPENDS:${PN} += "xkeyboard-config"
 RRECOMMENDS:${PN} = "weston-init liberation-fonts"
+# Ordering comes from the upstream recipe at the header's Upstream hash.
+# nooelint: oelint.var.order.RDEPENDS
 RDEPENDS:${PN}-dev += "wayland-protocols-dev"
 
 USERADD_PACKAGES = "${PN}"

--- a/recipes-graphics/wayland/weston_10.0.5.imx.inc
+++ b/recipes-graphics/wayland/weston_10.0.5.imx.inc
@@ -1,0 +1,59 @@
+# i.MX customization for weston_10.0.5.imx.bb.
+# Not a standalone recipe: required by that .bb, and must stay beside
+# it. Keeping it separate lets the .bb remain a verbatim copy of the
+# OE-core original.
+
+SUMMARY = "Weston, a Wayland compositor, i.MX fork"
+
+LIC_FILES_CHKSUM:remove = "file://COPYING;md5=d79ee9e66bb0f95d3386a7acae780b70"
+LIC_FILES_CHKSUM:append = " file://LICENSE;md5=d79ee9e66bb0f95d3386a7acae780b70"
+
+DEFAULT_PREFERENCE = "-1"
+
+SRC_URI:remove = "https://gitlab.freedesktop.org/wayland/weston/-/releases/${PV}/downloads/${BPN}-${PV}.tar.xz"
+SRC_URI:prepend = "${WESTON_SRC};branch=${SRCBRANCH} "
+WESTON_SRC ?= "git://github.com/nxp-imx/weston-imx.git;protocol=https"
+SRC_URI += "file://0001-Revert-protocol-no-found-wayland-scanner-with-Yocto-.patch \
+            file://0001-g2d-renderer.c-Include-sys-stat.h.patch"
+SRCBRANCH = "weston-imx-10.0.5"
+SRCREV = "5223a3c86177709d25f86a96622c0829da955a0e"
+
+# Disable OpenGL for parts with GPU support for 2D but not 3D
+REQUIRED_DISTRO_FEATURES = "opengl"
+REQUIRED_DISTRO_FEATURES:imxgpu2d = ""
+REQUIRED_DISTRO_FEATURES:imxgpu3d = "opengl"
+PACKAGECONFIG_OPENGL = "opengl"
+PACKAGECONFIG_OPENGL:imxgpu2d = ""
+PACKAGECONFIG_OPENGL:imxgpu3d = "opengl"
+
+PACKAGECONFIG_IMX_REMOVALS ?= "wayland x11"
+PACKAGECONFIG:remove = "${PACKAGECONFIG_IMX_REMOVALS}"
+PACKAGECONFIG:append = " ${@bb.utils.filter('DISTRO_FEATURES', '${PACKAGECONFIG_OPENGL}', d)}"
+
+PACKAGECONFIG:remove:imxfbdev = "kms"
+PACKAGECONFIG:append:imxfbdev = " fbdev clients"
+PACKAGECONFIG:append:imxgpu = " imxgpu"
+PACKAGECONFIG:append:imxgpu2d = " imxg2d"
+
+SIMPLECLIENTS:imxfbdev = "damage,im,egl,shm,touch,dmabuf-v4l"
+
+# Override
+PACKAGECONFIG[xwayland] = "-Dxwayland=true,-Dxwayland=false,libxcursor xwayland"
+# Weston with i.MX GPU support
+PACKAGECONFIG[imxgpu] = "-Dimxgpu=true,-Dimxgpu=false,virtual/egl"
+# Weston with i.MX G2D renderer
+PACKAGECONFIG[imxg2d] = "-Drenderer-g2d=true,-Drenderer-g2d=false,virtual/libg2d"
+# Weston with OpenGL support
+PACKAGECONFIG[opengl] = "-Dopengl=true,-Dopengl=false"
+
+PACKAGECONFIG[fbdev] = "-Dbackend-fbdev=true,-Dbackend-fbdev=false,udev mtdev libdrm"
+EXTRA_OEMESON:append:imxfbdev = " -Dbackend-default=fbdev"
+
+EXTRA_OEMESON += "-Ddeprecated-wl-shell=true"
+
+# links with imx-gpu libs which are pre-built for glibc
+# gcompat will address it during runtime
+LDFLAGS:append:imxgpu:libc-musl = " -Wl,--allow-shlib-undefined"
+
+PACKAGE_ARCH = "${MACHINE_SOCARCH}"
+COMPATIBLE_MACHINE = "(imx-nxp-bsp)"

--- a/recipes-graphics/wayland/weston_14.0.2.imx.bb
+++ b/recipes-graphics/wayland/weston_14.0.2.imx.bb
@@ -35,6 +35,8 @@ inherit meson pkgconfig useradd
 #
 require ${THISDIR}/required-distro-features.inc
 
+# Ordering comes from the upstream recipe at the header's Upstream hash.
+# nooelint: oelint.var.order.DEPENDS
 DEPENDS = "cairo gdk-pixbuf glib-2.0 libdisplay-info libinput libxkbcommon \
            pango pixman virtual/egl wayland wayland-native wayland-protocols"
 
@@ -150,6 +152,8 @@ FILES:${PN} = "${sysconfdir} ${bindir}/weston ${bindir}/weston-terminal ${bindir
 # fork drift; suppress the append-preference warning.
 # nooelint: oelint.var.filesoverride
 FILES:libweston-${WESTON_MAJOR_VERSION} = "${libdir}/lib*${SOLIBS} ${libdir}/libweston-${WESTON_MAJOR_VERSION}/*.so"
+# Ordering comes from the upstream recipe at the header's Upstream hash.
+# nooelint: oelint.var.order.SUMMARY
 SUMMARY:libweston-${WESTON_MAJOR_VERSION} = "Helper library for implementing 'wayland window managers'."
 
 # nooelint: oelint.var.filesoverride
@@ -161,6 +165,8 @@ RDEPENDS:${PN}-xwayland += "xwayland"
 
 RDEPENDS:${PN} += "xkeyboard-config"
 RRECOMMENDS:${PN} = "weston-init liberation-fonts"
+# Ordering comes from the upstream recipe at the header's Upstream hash.
+# nooelint: oelint.var.order.RDEPENDS
 RDEPENDS:${PN}-dev += "wayland-protocols-dev"
 
 USERADD_PACKAGES = "${PN}"

--- a/recipes-graphics/wayland/weston_14.0.2.imx.bb
+++ b/recipes-graphics/wayland/weston_14.0.2.imx.bb
@@ -1,11 +1,11 @@
-# This recipe is for the i.MX fork of weston. For ease of
-# maintenance, the top section is a verbatim copy of an OE-core
-# recipe. The second section customizes the recipe for i.MX.
-
+# This recipe is modified for i.MX. For ease of maintenance the recipe itself
+# is a verbatim copy of a OE-core recipe, so it can be diffed against
+# upstream directly; the i.MX customization lives in the required
+# weston_14.0.2.imx.inc.
 ########### OE-core copy ##################
 # Upstream hash: fc108ddb18c4986c2d24a5e730c3a7fe9c79a4d7
 
-# Overridden in the i.MX overrides section below; kept here to preserve the
+# Overridden in the required weston_14.0.2.imx.inc; kept here to preserve the
 # verbatim OE-core copy (see header). UPSTREAM-PARITY.
 # nooelint: oelint.var.override
 SUMMARY = "Weston, a Wayland compositor"
@@ -168,41 +168,4 @@ GROUPADD_PARAM:${PN} = "--system weston-launch"
 
 ########### End of OE-core copy ###########
 
-########### i.MX overrides ################
-
-SUMMARY = "Weston, a Wayland compositor, i.MX fork"
-LIC_FILES_CHKSUM:remove = "file://COPYING;md5=d79ee9e66bb0f95d3386a7acae780b70"
-LIC_FILES_CHKSUM += "file://LICENSE;md5=d79ee9e66bb0f95d3386a7acae780b70"
-
-DEFAULT_PREFERENCE = "-1"
-
-SRC_URI:remove = "https://gitlab.freedesktop.org/wayland/weston/-/releases/${PV}/downloads/${BPN}-${PV}.tar.xz"
-SRC_URI:prepend = "${WESTON_SRC};branch=${SRCBRANCH} "
-WESTON_SRC ?= "git://github.com/nxp-imx/weston-imx.git;protocol=https"
-SRCBRANCH = "weston-imx-14.0.2"
-SRCREV = "be99fd1adad7e77c8c31926b09520ade5cdaca35"
-
-PACKAGECONFIG:remove = "${PACKAGECONFIG_IMX_REMOVALS}"
-PACKAGECONFIG_IMX_REMOVALS ?= "wayland x11"
-
-PACKAGECONFIG:append = " ${PACKAGECONFIG_G2D} ${PACKAGECONFIG_PIPEWIRE}"
-PACKAGECONFIG_G2D ??= ""
-PACKAGECONFIG_G2D:imxgpu2d ??= "imxg2d"
-PACKAGECONFIG_G2D:mx93-nxp-bsp ??= "imxg2d"
-PACKAGECONFIG_G2D:mx943-nxp-bsp ??= "imxg2d"
-
-PACKAGECONFIG_PIPEWIRE ??= ""
-PACKAGECONFIG_PIPEWIRE:mx8-nxp-bsp ??= "pipewire"
-PACKAGECONFIG_PIPEWIRE:mx9-nxp-bsp ??= "pipewire"
-
-# Weston with i.MX G2D renderer
-PACKAGECONFIG[imxg2d] = "-Drenderer-g2d=true,-Drenderer-g2d=false,virtual/libg2d"
-
-# links with imx-gpu libs which are pre-built for glibc
-# gcompat will address it during runtime
-LDFLAGS:append:imxgpu:libc-musl = " -Wl,--allow-shlib-undefined"
-
-PACKAGE_ARCH = "${MACHINE_SOCARCH}"
-COMPATIBLE_MACHINE = "(imx-nxp-bsp)"
-
-########### End of i.MX overrides #########
+require weston_14.0.2.imx.inc

--- a/recipes-graphics/wayland/weston_14.0.2.imx.inc
+++ b/recipes-graphics/wayland/weston_14.0.2.imx.inc
@@ -1,0 +1,39 @@
+# i.MX customization for weston_14.0.2.imx.bb.
+# Not a standalone recipe: required by that .bb, and must stay beside
+# it. Keeping it separate lets the .bb remain a verbatim copy of the
+# OE-core original.
+
+SUMMARY = "Weston, a Wayland compositor, i.MX fork"
+LIC_FILES_CHKSUM:remove = "file://COPYING;md5=d79ee9e66bb0f95d3386a7acae780b70"
+LIC_FILES_CHKSUM += "file://LICENSE;md5=d79ee9e66bb0f95d3386a7acae780b70"
+
+DEFAULT_PREFERENCE = "-1"
+
+SRC_URI:remove = "https://gitlab.freedesktop.org/wayland/weston/-/releases/${PV}/downloads/${BPN}-${PV}.tar.xz"
+SRC_URI:prepend = "${WESTON_SRC};branch=${SRCBRANCH} "
+WESTON_SRC ?= "git://github.com/nxp-imx/weston-imx.git;protocol=https"
+SRCBRANCH = "weston-imx-14.0.2"
+SRCREV = "be99fd1adad7e77c8c31926b09520ade5cdaca35"
+
+PACKAGECONFIG:remove = "${PACKAGECONFIG_IMX_REMOVALS}"
+PACKAGECONFIG_IMX_REMOVALS ?= "wayland x11"
+
+PACKAGECONFIG:append = " ${PACKAGECONFIG_G2D} ${PACKAGECONFIG_PIPEWIRE}"
+PACKAGECONFIG_G2D ??= ""
+PACKAGECONFIG_G2D:imxgpu2d ??= "imxg2d"
+PACKAGECONFIG_G2D:mx93-nxp-bsp ??= "imxg2d"
+PACKAGECONFIG_G2D:mx943-nxp-bsp ??= "imxg2d"
+
+PACKAGECONFIG_PIPEWIRE ??= ""
+PACKAGECONFIG_PIPEWIRE:mx8-nxp-bsp ??= "pipewire"
+PACKAGECONFIG_PIPEWIRE:mx9-nxp-bsp ??= "pipewire"
+
+# Weston with i.MX G2D renderer
+PACKAGECONFIG[imxg2d] = "-Drenderer-g2d=true,-Drenderer-g2d=false,virtual/libg2d"
+
+# links with imx-gpu libs which are pre-built for glibc
+# gcompat will address it during runtime
+LDFLAGS:append:imxgpu:libc-musl = " -Wl,--allow-shlib-undefined"
+
+PACKAGE_ARCH = "${MACHINE_SOCARCH}"
+COMPATIBLE_MACHINE = "(imx-nxp-bsp)"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.28.1.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.28.1.imx.bb
@@ -1,7 +1,7 @@
-# This recipe is for the i.MX fork of gstreamer1.0-plugins-bad. For ease of
-# maintenance, the top section is a verbatim copy of an OE-core
-# recipe. The second section customizes the recipe for i.MX.
-
+# This recipe is modified for i.MX. For ease of maintenance the recipe itself
+# is a verbatim copy of a OE-core recipe, so it can be diffed against
+# upstream directly; the i.MX customization lives in the required
+# gstreamer1.0-plugins-bad_1.28.1.imx.inc.
 ########### OE-core copy ##################
 # Upstream hash: 937817e5164f8af8452aec03ae3c45cb23d63df9
 
@@ -15,8 +15,8 @@ BUGTRACKER = "https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad/-/issues"
 CVE_PRODUCT = "gst-plugins-bad"
 
 LICENSE = "GPL-2.0-or-later AND LGPL-2.1-or-later"
-# Overridden in the i.MX overrides section below; kept here to preserve the
-# verbatim OE-core copy (see header). UPSTREAM-PARITY.
+# Overridden in gstreamer1.0-plugins-bad_1.28.1.imx.inc; kept here to preserve
+# the verbatim OE-core copy (see header). UPSTREAM-PARITY.
 # nooelint: oelint.var.override
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
@@ -176,63 +176,4 @@ FILES:${PN}-voamrwbenc += "${datadir}/gstreamer-1.0/presets/GstVoAmrwbEnc.prs"
 
 ########### End of OE-core copy ###########
 
-########### i.MX overrides ################
-
-DEFAULT_PREFERENCE = "-1"
-
-LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=69333daa044cb77e486cc36129f7a770"
-
-SRC_URI:remove = "https://gstreamer.freedesktop.org/src/gst-plugins-bad/gst-plugins-bad-${PV}.tar.xz \
-                  file://0001-fix-maybe-uninitialized-warnings-when-compiling-with.patch \
-                  file://0002-avoid-including-sys-poll.h-directly.patch \
-                  file://0004-opencv-resolve-missing-opencv-data-dir-in-yocto-buil.patch \
-                  "
-SRC_URI:prepend = "${GST1.0-PLUGINS-BAD_SRC};branch=${SRCBRANCH} "
-
-# The cuda gir patch carries no Signed-off-by. It is an NXP-internal change
-# that arrived here without one, and a sign-off is a certification only its
-# author can make, so there is nothing here for us to correct.
-# nooelint: oelint.file.patchsignedoff
-SRC_URI:append:mx93-nxp-bsp = " file://0001-MMFMWK-9590-gstcuda-disable-gir-build-for-cuda-plugi.patch"
-SRC_URI:append:mx943-nxp-bsp = " file://0001-MMFMWK-9590-gstcuda-disable-gir-build-for-cuda-plugi.patch"
-
-GST1.0-PLUGINS-BAD_SRC ?= "gitsm://github.com/nxp-imx/gst-plugins-bad.git;protocol=https"
-SRCBRANCH = "MM_04.11.00_2605_L6.18.20"
-SRCREV = "ae93b57a6a238604c305ca79e25d6248b5bab5d6"
-
-inherit use-imx-headers
-
-PACKAGE_ARCH:imxpxp = "${MACHINE_SOCARCH}"
-PACKAGE_ARCH:mx8-nxp-bsp = "${MACHINE_SOCARCH}"
-
-PACKAGECONFIG_REMOVE ?= "\
-    dtls vulkan \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', '', 'gl', d)} \
-"
-PACKAGECONFIG:remove = "${PACKAGECONFIG_REMOVE}"
-PACKAGECONFIG:remove:mx93-nxp-bsp = "gl"
-PACKAGECONFIG:remove:mx943-nxp-bsp = "gl"
-PACKAGECONFIG:append:mx8-nxp-bsp = " kms"
-
-PACKAGECONFIG:append = " ${PACKAGECONFIG_G2D}"
-PACKAGECONFIG_G2D ??= ""
-PACKAGECONFIG_G2D:imxgpu2d ??= "g2d"
-
-PACKAGECONFIG[g2d] = ",,virtual/libg2d"
-
-EXTRA_OEMESON += "\
-    -Dc_args="${CFLAGS} -I${STAGING_INCDIR_IMX}" \
-"
-
-EXTRA_OEMESON:remove = "\
-    -Dkate=disabled \
-"
-
-COMPATIBLE_MACHINE = "(imx-nxp-bsp)"
-
-# The per-plugin split packages (${PN}-*, libgst*) are created dynamically by
-# PACKAGES_DYNAMIC, which OE-core sets in gstreamer1.0-plugins-packaging.inc
-# (pulled in through the required gstreamer1.0-plugins-common.inc above).
-PACKAGES_DYNAMIC = "^${PN}-.* ^libgst.*"
-
-########### End of i.MX overrides #########
+require gstreamer1.0-plugins-bad_1.28.1.imx.inc

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.28.1.imx.inc
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.28.1.imx.inc
@@ -27,9 +27,6 @@ SRCREV = "ae93b57a6a238604c305ca79e25d6248b5bab5d6"
 
 inherit use-imx-headers
 
-PACKAGE_ARCH:imxpxp = "${MACHINE_SOCARCH}"
-PACKAGE_ARCH:mx8-nxp-bsp = "${MACHINE_SOCARCH}"
-
 PACKAGECONFIG_REMOVE ?= "\
     dtls vulkan \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', '', 'gl', d)} \
@@ -44,6 +41,9 @@ PACKAGECONFIG_G2D ??= ""
 PACKAGECONFIG_G2D:imxgpu2d ??= "g2d"
 
 PACKAGECONFIG[g2d] = ",,virtual/libg2d"
+
+PACKAGE_ARCH:imxpxp = "${MACHINE_SOCARCH}"
+PACKAGE_ARCH:mx8-nxp-bsp = "${MACHINE_SOCARCH}"
 
 EXTRA_OEMESON += "\
     -Dc_args="${CFLAGS} -I${STAGING_INCDIR_IMX}" \

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.28.1.imx.inc
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.28.1.imx.inc
@@ -1,0 +1,61 @@
+# i.MX customization for gstreamer1.0-plugins-bad_1.28.1.imx.bb.
+# Not a standalone recipe: required by that .bb, and must stay beside
+# it. Keeping it separate lets the .bb remain a verbatim copy of the
+# OE-core original.
+
+DEFAULT_PREFERENCE = "-1"
+
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=69333daa044cb77e486cc36129f7a770"
+
+SRC_URI:remove = "https://gstreamer.freedesktop.org/src/gst-plugins-bad/gst-plugins-bad-${PV}.tar.xz \
+                  file://0001-fix-maybe-uninitialized-warnings-when-compiling-with.patch \
+                  file://0002-avoid-including-sys-poll.h-directly.patch \
+                  file://0004-opencv-resolve-missing-opencv-data-dir-in-yocto-buil.patch \
+                  "
+SRC_URI:prepend = "${GST1.0-PLUGINS-BAD_SRC};branch=${SRCBRANCH} "
+
+# The cuda gir patch carries no Signed-off-by. It is an NXP-internal change
+# that arrived here without one, and a sign-off is a certification only its
+# author can make, so there is nothing here for us to correct.
+# nooelint: oelint.file.patchsignedoff
+SRC_URI:append:mx93-nxp-bsp = " file://0001-MMFMWK-9590-gstcuda-disable-gir-build-for-cuda-plugi.patch"
+SRC_URI:append:mx943-nxp-bsp = " file://0001-MMFMWK-9590-gstcuda-disable-gir-build-for-cuda-plugi.patch"
+
+GST1.0-PLUGINS-BAD_SRC ?= "gitsm://github.com/nxp-imx/gst-plugins-bad.git;protocol=https"
+SRCBRANCH = "MM_04.11.00_2605_L6.18.20"
+SRCREV = "ae93b57a6a238604c305ca79e25d6248b5bab5d6"
+
+inherit use-imx-headers
+
+PACKAGE_ARCH:imxpxp = "${MACHINE_SOCARCH}"
+PACKAGE_ARCH:mx8-nxp-bsp = "${MACHINE_SOCARCH}"
+
+PACKAGECONFIG_REMOVE ?= "\
+    dtls vulkan \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', '', 'gl', d)} \
+"
+PACKAGECONFIG:remove = "${PACKAGECONFIG_REMOVE}"
+PACKAGECONFIG:remove:mx93-nxp-bsp = "gl"
+PACKAGECONFIG:remove:mx943-nxp-bsp = "gl"
+PACKAGECONFIG:append:mx8-nxp-bsp = " kms"
+
+PACKAGECONFIG:append = " ${PACKAGECONFIG_G2D}"
+PACKAGECONFIG_G2D ??= ""
+PACKAGECONFIG_G2D:imxgpu2d ??= "g2d"
+
+PACKAGECONFIG[g2d] = ",,virtual/libg2d"
+
+EXTRA_OEMESON += "\
+    -Dc_args="${CFLAGS} -I${STAGING_INCDIR_IMX}" \
+"
+
+EXTRA_OEMESON:remove = "\
+    -Dkate=disabled \
+"
+
+COMPATIBLE_MACHINE = "(imx-nxp-bsp)"
+
+# The per-plugin split packages (${PN}-*, libgst*) are created dynamically by
+# PACKAGES_DYNAMIC, which OE-core sets in gstreamer1.0-plugins-packaging.inc
+# (pulled in through the required gstreamer1.0-plugins-common.inc above).
+PACKAGES_DYNAMIC = "^${PN}-.* ^libgst.*"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.28.1.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.28.1.imx.bb
@@ -1,7 +1,7 @@
-# This recipe is for the i.MX fork of gstreamer1.0-plugins-base. For ease of
-# maintenance, the top section is a verbatim copy of an OE-core
-# recipe. The second section customizes the recipe for i.MX.
-
+# This recipe is modified for i.MX. For ease of maintenance the recipe itself
+# is a verbatim copy of a OE-core recipe, so it can be diffed against
+# upstream directly; the i.MX customization lives in the required
+# gstreamer1.0-plugins-base_1.28.1.imx.inc.
 ########### OE-core copy ##################
 # Upstream hash: 937817e5164f8af8452aec03ae3c45cb23d63df9
 
@@ -12,8 +12,8 @@ DESCRIPTION = "A well-maintained collection of GStreamer plugins and helper libr
 HOMEPAGE = "https://gstreamer.freedesktop.org/"
 BUGTRACKER = "https://gitlab.freedesktop.org/gstreamer/gst-plugins-base/-/issues"
 LICENSE = "LGPL-2.1-or-later"
-# Overridden in the i.MX overrides section below; kept here to preserve the
-# verbatim OE-core copy (see header). UPSTREAM-PARITY.
+# Overridden in gstreamer1.0-plugins-base_1.28.1.imx.inc; kept here to preserve
+# the verbatim OE-core copy (see header). UPSTREAM-PARITY.
 # nooelint: oelint.var.override
 LIC_FILES_CHKSUM = "file://COPYING;md5=69333daa044cb77e486cc36129f7a770"
 
@@ -106,53 +106,4 @@ CVE_PRODUCT += "gst-plugins-base"
 
 ########### End of OE-core copy ###########
 
-########### i.MX overrides ################
-
-DEFAULT_PREFERENCE = "-1"
-
-LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=69333daa044cb77e486cc36129f7a770"
-
-SRC_URI:remove = "\
-    https://gstreamer.freedesktop.org/src/gst-plugins-base/gst-plugins-base-${PV}.tar.xz \
-    file://0001-ENGR00312515-get-caps-from-src-pad-when-query-caps.patch \
-    file://0003-viv-fb-Make-sure-config.h-is-included.patch \
-    file://0002-ssaparse-enhance-SSA-text-lines-parsing.patch"
-SRC_URI:prepend = "${GST1.0-PLUGINS-BASE_SRC};branch=${SRCBRANCH} "
-
-# The gl gir patch carries no Signed-off-by. It is an NXP-internal change
-# that arrived here without one, and a sign-off is a certification only its
-# author can make, so there is nothing here for us to correct.
-# nooelint: oelint.file.patchsignedoff
-SRC_URI:append:mx93-nxp-bsp = " file://0001-MMFMWK-9590-gstgl-1.0-disable-gir-build-for-gl-plugi.patch"
-SRC_URI:append:mx943-nxp-bsp = " file://0001-MMFMWK-9590-gstgl-1.0-disable-gir-build-for-gl-plugi.patch"
-
-GST1.0-PLUGINS-BASE_SRC ?= "gitsm://github.com/nxp-imx/gst-plugins-base.git;protocol=https"
-SRCBRANCH = "MM_04.11.00_2605_L6.18.20"
-SRCREV = "500aeb1b0dc50198005bd60459a38b42c7359d1d"
-
-inherit use-imx-headers
-
-PACKAGECONFIG:remove = "${PACKAGECONFIG_REMOVE}"
-PACKAGECONFIG_REMOVE ?= "jpeg"
-
-PACKAGECONFIG:append = " ${PACKAGECONFIG_G2D}"
-PACKAGECONFIG_G2D ??= ""
-PACKAGECONFIG_G2D:imxgpu2d ??= "g2d"
-
-PACKAGECONFIG[g2d] = ",,virtual/libg2d"
-PACKAGECONFIG[viv-fb] = ",,virtual/libgles2"
-
-EXTRA_OEMESON += "-Dc_args="${CFLAGS} -I${STAGING_INCDIR_IMX}""
-
-# links with imx-gpu libs which are pre-built for glibc
-# gcompat will address it during runtime
-LDFLAGS:append:imxgpu:libc-musl = " -Wl,--allow-shlib-undefined"
-
-COMPATIBLE_MACHINE = "(imx-nxp-bsp)"
-
-# The per-plugin split packages (${PN}-*, libgst*) are created dynamically by
-# PACKAGES_DYNAMIC, which OE-core sets in gstreamer1.0-plugins-packaging.inc
-# (pulled in through the required gstreamer1.0-plugins-common.inc above).
-PACKAGES_DYNAMIC = "^${PN}-.* ^libgst.*"
-
-########### End of i.MX overrides #########
+require gstreamer1.0-plugins-base_1.28.1.imx.inc

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.28.1.imx.inc
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.28.1.imx.inc
@@ -1,0 +1,51 @@
+# i.MX customization for gstreamer1.0-plugins-base_1.28.1.imx.bb.
+# Not a standalone recipe: required by that .bb, and must stay beside
+# it. Keeping it separate lets the .bb remain a verbatim copy of the
+# OE-core original.
+
+DEFAULT_PREFERENCE = "-1"
+
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=69333daa044cb77e486cc36129f7a770"
+
+SRC_URI:remove = "\
+    https://gstreamer.freedesktop.org/src/gst-plugins-base/gst-plugins-base-${PV}.tar.xz \
+    file://0001-ENGR00312515-get-caps-from-src-pad-when-query-caps.patch \
+    file://0003-viv-fb-Make-sure-config.h-is-included.patch \
+    file://0002-ssaparse-enhance-SSA-text-lines-parsing.patch"
+SRC_URI:prepend = "${GST1.0-PLUGINS-BASE_SRC};branch=${SRCBRANCH} "
+
+# The gl gir patch carries no Signed-off-by. It is an NXP-internal change
+# that arrived here without one, and a sign-off is a certification only its
+# author can make, so there is nothing here for us to correct.
+# nooelint: oelint.file.patchsignedoff
+SRC_URI:append:mx93-nxp-bsp = " file://0001-MMFMWK-9590-gstgl-1.0-disable-gir-build-for-gl-plugi.patch"
+SRC_URI:append:mx943-nxp-bsp = " file://0001-MMFMWK-9590-gstgl-1.0-disable-gir-build-for-gl-plugi.patch"
+
+GST1.0-PLUGINS-BASE_SRC ?= "gitsm://github.com/nxp-imx/gst-plugins-base.git;protocol=https"
+SRCBRANCH = "MM_04.11.00_2605_L6.18.20"
+SRCREV = "500aeb1b0dc50198005bd60459a38b42c7359d1d"
+
+inherit use-imx-headers
+
+PACKAGECONFIG:remove = "${PACKAGECONFIG_REMOVE}"
+PACKAGECONFIG_REMOVE ?= "jpeg"
+
+PACKAGECONFIG:append = " ${PACKAGECONFIG_G2D}"
+PACKAGECONFIG_G2D ??= ""
+PACKAGECONFIG_G2D:imxgpu2d ??= "g2d"
+
+PACKAGECONFIG[g2d] = ",,virtual/libg2d"
+PACKAGECONFIG[viv-fb] = ",,virtual/libgles2"
+
+EXTRA_OEMESON += "-Dc_args="${CFLAGS} -I${STAGING_INCDIR_IMX}""
+
+# links with imx-gpu libs which are pre-built for glibc
+# gcompat will address it during runtime
+LDFLAGS:append:imxgpu:libc-musl = " -Wl,--allow-shlib-undefined"
+
+COMPATIBLE_MACHINE = "(imx-nxp-bsp)"
+
+# The per-plugin split packages (${PN}-*, libgst*) are created dynamically by
+# PACKAGES_DYNAMIC, which OE-core sets in gstreamer1.0-plugins-packaging.inc
+# (pulled in through the required gstreamer1.0-plugins-common.inc above).
+PACKAGES_DYNAMIC = "^${PN}-.* ^libgst.*"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.28.1.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.28.1.imx.bb
@@ -23,6 +23,8 @@ SRC_URI[sha256sum] = "b67b31313a54c6929b82969d41d3cfdf2f58db573fb5f491e6bba5d84a
 # nooelint: oelint.var.override
 S = "${UNPACKDIR}/gst-plugins-good-${PV}"
 
+# Ordering comes from the upstream recipe at the header's Upstream hash.
+# nooelint: oelint.var.order.LICENSE
 LICENSE = "LGPL-2.1-or-later"
 # Overridden in gstreamer1.0-plugins-good_1.28.1.imx.inc; kept here to preserve
 # the verbatim OE-core copy (see header). UPSTREAM-PARITY.
@@ -33,10 +35,14 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=a6f89e2100d9b6cdffcea4f398e37343 \
 DEPENDS += "gstreamer1.0-plugins-base libcap zlib"
 RPROVIDES:${PN}-pulseaudio += "${PN}-pulse"
 RPROVIDES:${PN}-soup += "${PN}-souphttpsrc"
+# Ordering comes from the upstream recipe at the header's Upstream hash.
+# nooelint: oelint.var.order.RDEPENDS
 RDEPENDS:${PN}-soup += "${MLPREFIX}${@bb.utils.contains('PACKAGECONFIG', 'soup2', 'libsoup-2.4', 'libsoup', d)}"
 
 PACKAGECONFIG_SOUP ?= "soup3"
 
+# Ordering comes from the upstream recipe at the header's Upstream hash.
+# nooelint: oelint.var.order.PACKAGECONFIG
 PACKAGECONFIG ??= "\
     ${GSTREAMER_ORC} \
     ${PACKAGECONFIG_SOUP} \

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.28.1.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.28.1.imx.bb
@@ -1,7 +1,7 @@
-# This recipe is for the i.MX fork of gstreamer1.0-plugins-good. For ease of
-# maintenance, the top section is a verbatim copy of an OE-core
-# recipe. The second section customizes the recipe for i.MX.
-
+# This recipe is modified for i.MX. For ease of maintenance the recipe itself
+# is a verbatim copy of a OE-core recipe, so it can be diffed against
+# upstream directly; the i.MX customization lives in the required
+# gstreamer1.0-plugins-good_1.28.1.imx.inc.
 ########### OE-core copy ##################
 # Upstream hash: 937817e5164f8af8452aec03ae3c45cb23d63df9
 
@@ -18,14 +18,14 @@ SRC_URI = "https://gstreamer.freedesktop.org/src/gst-plugins-good/gst-plugins-go
 
 SRC_URI[sha256sum] = "b67b31313a54c6929b82969d41d3cfdf2f58db573fb5f491e6bba5d84aea0778"
 
-# Overridden in the i.MX overrides section below; kept here to preserve the
-# verbatim OE-core copy (see header). UPSTREAM-PARITY.
+# Overridden in gstreamer1.0-plugins-good_1.28.1.imx.inc; kept here to preserve
+# the verbatim OE-core copy (see header). UPSTREAM-PARITY.
 # nooelint: oelint.var.override
 S = "${UNPACKDIR}/gst-plugins-good-${PV}"
 
 LICENSE = "LGPL-2.1-or-later"
-# Overridden in the i.MX overrides section below; kept here to preserve the
-# verbatim OE-core copy (see header). UPSTREAM-PARITY.
+# Overridden in gstreamer1.0-plugins-good_1.28.1.imx.inc; kept here to preserve
+# the verbatim OE-core copy (see header). UPSTREAM-PARITY.
 # nooelint: oelint.var.override
 LIC_FILES_CHKSUM = "file://COPYING;md5=a6f89e2100d9b6cdffcea4f398e37343 \
                     file://gst/replaygain/rganalysis.c;beginline=1;endline=23;md5=b60ebefd5b2f5a8e0cab6bfee391a5fe"
@@ -96,42 +96,4 @@ FILES:${PN}-equalizer += "${datadir}/gstreamer-1.0/presets/*.prs"
 
 ########### End of OE-core copy ###########
 
-########### i.MX overrides ################
-
-DEFAULT_PREFERENCE = "-1"
-
-LIC_FILES_CHKSUM = "\
-    file://LICENSE.txt;md5=69333daa044cb77e486cc36129f7a770 \
-    file://gst/replaygain/rganalysis.c;beginline=1;endline=23;md5=b60ebefd5b2f5a8e0cab6bfee391a5fe \
-"
-# Enable pulsesink in gstreamer
-PACKAGECONFIG:append = " pulseaudio"
-
-# fb implementation of v4l2 uses libdrm
-DEPENDS:append = " ${@bb.utils.contains('PACKAGECONFIG', 'v4l2', '${DEPENDS_V4L2}', '', d)}"
-DEPENDS_V4L2 = "${@bb.utils.contains_any('DISTRO_FEATURES', 'wayland x11', '', 'libdrm', d)}"
-
-# FIXME: imx93/943 DISTRO_FEATURES contains x11 but v4l2 implement by libdrm ?
-DEPENDS:append:mx93-nxp-bsp = " libdrm"
-DEPENDS:append:mx943-nxp-bsp = " libdrm"
-
-SRC_URI:remove = "https://gstreamer.freedesktop.org/src/gst-plugins-good/gst-plugins-good-${PV}.tar.xz \
-                  file://0001-qt-include-ext-qt-gstqtgl.h-instead-of-gst-gl-gstglf.patch \
-                  file://0001-v4l2-Define-ioctl_req_t-for-posix-linux-case.patch \
-"
-
-SRC_URI:prepend = "${GST1.0-PLUGINS-GOOD_SRC};branch=${SRCBRANCH} "
-GST1.0-PLUGINS-GOOD_SRC ?= "gitsm://github.com/nxp-imx/gst-plugins-good.git;protocol=https"
-SRCBRANCH = "MM_04.11.00_2605_L6.18.20"
-SRCREV = "59dc51ce285f65dfde65c4484eb1da8b51c18841"
-
-S = "${UNPACKDIR}/${BP}"
-
-COMPATIBLE_MACHINE = "(imx-nxp-bsp)"
-
-# The per-plugin split packages (${PN}-*, libgst*) are created dynamically by
-# PACKAGES_DYNAMIC, which OE-core sets in gstreamer1.0-plugins-packaging.inc
-# (pulled in through the required gstreamer1.0-plugins-common.inc above).
-PACKAGES_DYNAMIC = "^${PN}-.* ^libgst.*"
-
-########### End of i.MX overrides #########
+require gstreamer1.0-plugins-good_1.28.1.imx.inc

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.28.1.imx.inc
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.28.1.imx.inc
@@ -1,0 +1,40 @@
+# i.MX customization for gstreamer1.0-plugins-good_1.28.1.imx.bb.
+# Not a standalone recipe: required by that .bb, and must stay beside
+# it. Keeping it separate lets the .bb remain a verbatim copy of the
+# OE-core original.
+
+DEFAULT_PREFERENCE = "-1"
+
+LIC_FILES_CHKSUM = "\
+    file://LICENSE.txt;md5=69333daa044cb77e486cc36129f7a770 \
+    file://gst/replaygain/rganalysis.c;beginline=1;endline=23;md5=b60ebefd5b2f5a8e0cab6bfee391a5fe \
+"
+# Enable pulsesink in gstreamer
+PACKAGECONFIG:append = " pulseaudio"
+
+# fb implementation of v4l2 uses libdrm
+DEPENDS:append = " ${@bb.utils.contains('PACKAGECONFIG', 'v4l2', '${DEPENDS_V4L2}', '', d)}"
+DEPENDS_V4L2 = "${@bb.utils.contains_any('DISTRO_FEATURES', 'wayland x11', '', 'libdrm', d)}"
+
+# FIXME: imx93/943 DISTRO_FEATURES contains x11 but v4l2 implement by libdrm ?
+DEPENDS:append:mx93-nxp-bsp = " libdrm"
+DEPENDS:append:mx943-nxp-bsp = " libdrm"
+
+SRC_URI:remove = "https://gstreamer.freedesktop.org/src/gst-plugins-good/gst-plugins-good-${PV}.tar.xz \
+                  file://0001-qt-include-ext-qt-gstqtgl.h-instead-of-gst-gl-gstglf.patch \
+                  file://0001-v4l2-Define-ioctl_req_t-for-posix-linux-case.patch \
+"
+
+SRC_URI:prepend = "${GST1.0-PLUGINS-GOOD_SRC};branch=${SRCBRANCH} "
+GST1.0-PLUGINS-GOOD_SRC ?= "gitsm://github.com/nxp-imx/gst-plugins-good.git;protocol=https"
+SRCBRANCH = "MM_04.11.00_2605_L6.18.20"
+SRCREV = "59dc51ce285f65dfde65c4484eb1da8b51c18841"
+
+S = "${UNPACKDIR}/${BP}"
+
+COMPATIBLE_MACHINE = "(imx-nxp-bsp)"
+
+# The per-plugin split packages (${PN}-*, libgst*) are created dynamically by
+# PACKAGES_DYNAMIC, which OE-core sets in gstreamer1.0-plugins-packaging.inc
+# (pulled in through the required gstreamer1.0-plugins-common.inc above).
+PACKAGES_DYNAMIC = "^${PN}-.* ^libgst.*"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.28.1.imx.inc
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.28.1.imx.inc
@@ -9,9 +9,6 @@ LIC_FILES_CHKSUM = "\
     file://LICENSE.txt;md5=69333daa044cb77e486cc36129f7a770 \
     file://gst/replaygain/rganalysis.c;beginline=1;endline=23;md5=b60ebefd5b2f5a8e0cab6bfee391a5fe \
 "
-# Enable pulsesink in gstreamer
-PACKAGECONFIG:append = " pulseaudio"
-
 # fb implementation of v4l2 uses libdrm
 DEPENDS:append = " ${@bb.utils.contains('PACKAGECONFIG', 'v4l2', '${DEPENDS_V4L2}', '', d)}"
 DEPENDS_V4L2 = "${@bb.utils.contains_any('DISTRO_FEATURES', 'wayland x11', '', 'libdrm', d)}"
@@ -31,6 +28,9 @@ SRCBRANCH = "MM_04.11.00_2605_L6.18.20"
 SRCREV = "59dc51ce285f65dfde65c4484eb1da8b51c18841"
 
 S = "${UNPACKDIR}/${BP}"
+
+# Enable pulsesink in gstreamer
+PACKAGECONFIG:append = " pulseaudio"
 
 COMPATIBLE_MACHINE = "(imx-nxp-bsp)"
 

--- a/recipes-multimedia/gstreamer/gstreamer1.0_1.28.1.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0_1.28.1.imx.bb
@@ -1,7 +1,7 @@
-# This recipe is for the i.MX fork of gstreamer1.0. For ease of
-# maintenance, the top section is a verbatim copy of an OE-core
-# recipe. The second section customizes the recipe for i.MX.
-
+# This recipe is modified for i.MX. For ease of maintenance the recipe itself
+# is a verbatim copy of a OE-core recipe, so it can be diffed against
+# upstream directly; the i.MX customization lives in the required
+# gstreamer1.0_1.28.1.imx.inc.
 ########### OE-core copy ##################
 # Upstream hash: 937817e5164f8af8452aec03ae3c45cb23d63df9
 
@@ -12,8 +12,8 @@ HOMEPAGE = "http://gstreamer.freedesktop.org/"
 BUGTRACKER = "https://bugzilla.gnome.org/enter_bug.cgi?product=Gstreamer"
 SECTION = "multimedia"
 LICENSE = "LGPL-2.1-or-later"
-# Overridden in the i.MX overrides section below; kept here to preserve the
-# verbatim OE-core copy (see header). UPSTREAM-PARITY.
+# Overridden in gstreamer1.0_1.28.1.imx.inc; kept here to preserve the verbatim
+# OE-core copy (see header). UPSTREAM-PARITY.
 # nooelint: oelint.var.override
 LIC_FILES_CHKSUM = "file://COPYING;md5=69333daa044cb77e486cc36129f7a770 \
                     file://gst/gst.h;beginline=1;endline=21;md5=e059138481205ee2c6fc1c079c016d0d"
@@ -83,29 +83,4 @@ PTEST_BUILD_HOST_FILES = ""
 
 ########### End of OE-core copy ###########
 
-########### i.MX overrides ################
-
-DEFAULT_PREFERENCE = "-1"
-
-LIC_FILES_CHKSUM = "\
-    file://LICENSE.txt;md5=69333daa044cb77e486cc36129f7a770 \
-    file://gst/gst.h;beginline=1;endline=21;md5=e059138481205ee2c6fc1c079c016d0d \
-"
-
-# Use i.MX fork of GST for customizations
-SRC_URI:remove = "https://gstreamer.freedesktop.org/src/gstreamer/gstreamer-${PV}.tar.xz \
-                  file://0001-tests-respect-the-idententaion-used-in-meson.patch \
-                  file://0002-tests-add-support-for-install-the-tests.patch \
-                  file://0003-tests-use-a-dictionaries-for-environment.patch;striplevel=3 \
-                  file://0004-tests-add-helper-script-to-run-the-installed_tests.patch;striplevel=3 \
-"
-SRC_URI:prepend = "${GST1.0_SRC};branch=${SRCBRANCH} "
-GST1.0_SRC ?= "gitsm://github.com/nxp-imx/gstreamer.git;protocol=https"
-SRCBRANCH = "MM_04.11.00_2605_L6.18.20"
-SRCREV = "c95d8ba246d60779d8ffd7864f97dfa44e8b7386"
-
-PACKAGECONFIG[tests] = "-Dtests=enabled,-Dtests=disabled"
-
-COMPATIBLE_MACHINE = "(imx-nxp-bsp)"
-
-########### End of i.MX overrides #########
+require gstreamer1.0_1.28.1.imx.inc

--- a/recipes-multimedia/gstreamer/gstreamer1.0_1.28.1.imx.inc
+++ b/recipes-multimedia/gstreamer/gstreamer1.0_1.28.1.imx.inc
@@ -1,0 +1,27 @@
+# i.MX customization for gstreamer1.0_1.28.1.imx.bb.
+# Not a standalone recipe: required by that .bb, and must stay beside
+# it. Keeping it separate lets the .bb remain a verbatim copy of the
+# OE-core original.
+
+DEFAULT_PREFERENCE = "-1"
+
+LIC_FILES_CHKSUM = "\
+    file://LICENSE.txt;md5=69333daa044cb77e486cc36129f7a770 \
+    file://gst/gst.h;beginline=1;endline=21;md5=e059138481205ee2c6fc1c079c016d0d \
+"
+
+# Use i.MX fork of GST for customizations
+SRC_URI:remove = "https://gstreamer.freedesktop.org/src/gstreamer/gstreamer-${PV}.tar.xz \
+                  file://0001-tests-respect-the-idententaion-used-in-meson.patch \
+                  file://0002-tests-add-support-for-install-the-tests.patch \
+                  file://0003-tests-use-a-dictionaries-for-environment.patch;striplevel=3 \
+                  file://0004-tests-add-helper-script-to-run-the-installed_tests.patch;striplevel=3 \
+"
+SRC_URI:prepend = "${GST1.0_SRC};branch=${SRCBRANCH} "
+GST1.0_SRC ?= "gitsm://github.com/nxp-imx/gstreamer.git;protocol=https"
+SRCBRANCH = "MM_04.11.00_2605_L6.18.20"
+SRCREV = "c95d8ba246d60779d8ffd7864f97dfa44e8b7386"
+
+PACKAGECONFIG[tests] = "-Dtests=enabled,-Dtests=disabled"
+
+COMPATIBLE_MACHINE = "(imx-nxp-bsp)"

--- a/recipes-multimedia/libcamera/libcamera_0.7.1.imx.bb
+++ b/recipes-multimedia/libcamera/libcamera_0.7.1.imx.bb
@@ -29,11 +29,15 @@ SRCREV = "e2e7c015cee997b9f992376fd2c29fa2d8813e1b"
 
 PE = "1"
 
+# Ordering comes from the upstream recipe at the header's Upstream hash.
+# nooelint: oelint.var.order.DEPENDS
 DEPENDS = "chrpath-native gnutls libevent libyaml python3-jinja2-native python3-ply-native python3-pyyaml-native udev"
 DEPENDS:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'qt', 'qtbase qtbase-native', '', d)}"
 
 PACKAGES =+ "${PN}-gst ${PN}-pycamera"
 
+# Ordering comes from the upstream recipe at the header's Upstream hash.
+# nooelint: oelint.var.order.PACKAGECONFIG
 PACKAGECONFIG ??= ""
 PACKAGECONFIG[dng] = ",,tiff"
 PACKAGECONFIG[gst] = "-Dgstreamer=enabled,-Dgstreamer=disabled,gstreamer1.0 gstreamer1.0-plugins-base"
@@ -88,6 +92,8 @@ do_package_recalculate_ipa_signatures() {
     ${S}/src/ipa/ipa-sign-install.sh ${B}/src/ipa-priv-key.pem "${modules}"
 }
 
+# Ordering comes from the upstream recipe at the header's Upstream hash.
+# nooelint: oelint.var.order.FILES
 FILES:${PN} += "${libexecdir}/libcamera/v4l2-compat.so"
 # -gst/-pycamera are split packages with no default FILES, so '=' is a complete
 # definition. Kept byte-identical to meta-multimedia libcamera to avoid fork

--- a/recipes-multimedia/libcamera/libcamera_0.7.1.imx.bb
+++ b/recipes-multimedia/libcamera/libcamera_0.7.1.imx.bb
@@ -1,7 +1,7 @@
-# This recipe is for the i.MX fork of libcamera. For ease of
-# maintenance, the top section is a verbatim copy of an OE-core
-# recipe. The second section customizes the recipe for i.MX.
-
+# This recipe is modified for i.MX. For ease of maintenance the recipe itself
+# is a verbatim copy of a meta-openembedded recipe, so it can be diffed against
+# upstream directly; the i.MX customization lives in the required
+# libcamera_0.7.1.imx.inc.
 ########### meta-openembedded copy ##################
 # Upstream hash: f4b9dfa0c903bc94c344c657917a3fbb229c322f
 
@@ -21,8 +21,9 @@ SRC_URI = "\
     git://git.libcamera.org/libcamera/libcamera.git;protocol=https;branch=master;tag=v${PV} \
 "
 
-# Re-set in the i.MX overrides section below for the nxp-imx fork; kept here
-# to preserve the verbatim meta-openembedded copy (see header). UPSTREAM-PARITY.
+# Re-set in the required libcamera_0.7.1.imx.inc for the nxp-imx fork; kept
+# here to preserve the verbatim meta-openembedded copy (see header).
+# UPSTREAM-PARITY.
 # nooelint: oelint.var.override
 SRCREV = "e2e7c015cee997b9f992376fd2c29fa2d8813e1b"
 
@@ -101,25 +102,4 @@ FILES:${PN}-pycamera = "${PYTHON_SITEPACKAGES_DIR}/libcamera"
 GLIBC_64BIT_TIME_FLAGS = ""
 ########### End of meta-openembedded copy ###########
 
-########### i.MX overrides ################
-
-SRC_URI:remove = "git://git.libcamera.org/libcamera/libcamera.git;protocol=https;branch=master;tag=v${PV}"
-SRC_URI:prepend = "${LIBCAMERA_SRC};branch=${SRCBRANCH} "
-LIBCAMERA_SRC ?= "git://github.com/nxp-imx/libcamera.git;protocol=https"
-SRCBRANCH = "lf-6.18.20_2.0.0"
-SRCREV = "e2e7c015cee997b9f992376fd2c29fa2d8813e1b"
-
-PACKAGECONFIG = "gst pycamera dng"
-
-ARM_PIPELINES .= ",nxp/neo"
-
-EXTRA_OEMESON += "\
-    --python.platlibdir=${PYTHON_SITEPACKAGES_DIR} \
-"
-
-# Qt installs native tools to /usr/libexec, but this is not in PATH
-PATH:prepend = "${@bb.utils.contains('DISTRO_FEATURES', 'qt', '${STAGING_LIBEXECDIR_NATIVE}:', '', d)}"
-
-COMPATIBLE_MACHINE = "(mx95-nxp-bsp|mx8mm-nxp-bsp|mx8ulp-nxp-bsp|mx8mq-nxp-bsp)"
-
-########### End of i.MX overrides #########
+require libcamera_0.7.1.imx.inc

--- a/recipes-multimedia/libcamera/libcamera_0.7.1.imx.inc
+++ b/recipes-multimedia/libcamera/libcamera_0.7.1.imx.inc
@@ -1,0 +1,23 @@
+# i.MX customization for libcamera_0.7.1.imx.bb.
+# Not a standalone recipe: required by that .bb, and must stay beside
+# it. Keeping it separate lets the .bb remain a verbatim copy of the
+# meta-openembedded original.
+
+SRC_URI:remove = "git://git.libcamera.org/libcamera/libcamera.git;protocol=https;branch=master;tag=v${PV}"
+SRC_URI:prepend = "${LIBCAMERA_SRC};branch=${SRCBRANCH} "
+LIBCAMERA_SRC ?= "git://github.com/nxp-imx/libcamera.git;protocol=https"
+SRCBRANCH = "lf-6.18.20_2.0.0"
+SRCREV = "e2e7c015cee997b9f992376fd2c29fa2d8813e1b"
+
+PACKAGECONFIG = "gst pycamera dng"
+
+ARM_PIPELINES .= ",nxp/neo"
+
+EXTRA_OEMESON += "\
+    --python.platlibdir=${PYTHON_SITEPACKAGES_DIR} \
+"
+
+# Qt installs native tools to /usr/libexec, but this is not in PATH
+PATH:prepend = "${@bb.utils.contains('DISTRO_FEATURES', 'qt', '${STAGING_LIBEXECDIR_NATIVE}:', '', d)}"
+
+COMPATIBLE_MACHINE = "(mx95-nxp-bsp|mx8mm-nxp-bsp|mx8ulp-nxp-bsp|mx8mq-nxp-bsp)"


### PR DESCRIPTION
Reworked per review. @thochstein asked for the i.MX overrides to stay
consolidated rather than interleaved into the copied body; @otavio preferred a
version-specific `.inc`. That is what this now is — the interleaving is gone.

Each fork recipe is once again a **verbatim copy** of its upstream original.
Its i.MX customization moved to a sibling `<recipe>.inc`, `require`d at exactly
the position the old `########## i.MX overrides ##########` block occupied.

### Why `.inc` and not `.bbappend`

Both were offered. A `require` at the block's former position preserves parse
order *by construction*, so effective metadata is identical with no per-recipe
argument needed — including for the `:remove` / `:prepend` / `+=` entries and
the `inherit use-imx-headers` that live inside the moved blocks. A `.bbappend`
parses after the whole recipe and would need that argument made case by case.

### What this buys at re-sync

Checking a fork against upstream is now a plain diff:

```
diff <(git -C openembedded-core show fc108ddb:meta/recipes-graphics/wayland/weston_14.0.2.bb) \
     recipes-graphics/wayland/weston_14.0.2.imx.bb
```

Each copy still records the exact `# Upstream hash:` it was taken from.

### `oelint.var.order`, measured against `7aa40fe03`: 43 → 0

| | count | |
|---|---|---|
| structural, outside the forks | 20 | imx-gpu-viv 10, mali-imx 5, qemu-qoriq 5 |
| cleared by the split | 8 | the offending pair straddled the copy/overrides boundary |
| structural, inside an i.MX block | 2 | gst-plugins-good, gst-plugins-bad — verbatim copies untouched |
| suppressed, UPSTREAM-PARITY | 13 | present verbatim in the upstream recipe at the recorded hash |

The 13 are upstream's own ordering — confirmed present in meta-oe
`opencv_4.13.0.bb`, OE-core `weston_15.0.0.bb`, OE-core
`gstreamer1.0-plugins-good_1.28.2.bb` and meta-oe `libcamera_0.6.0.bb`. Fixing
them in place would diverge the copy, so each carries an inline directive naming
where the order comes from. `oelint.file.inlinesuppress_na` will flag any of them
the moment upstream fixes it.

Full layer: **116 → 72**, 44 removed, **0 introduced**.

### One cost worth naming

oelint analyses per file, so the split loses a little cross-file visibility:
opencv's `oelint.task.multifragments` disappears because its two
`do_install:append` fragments now sit in different files. That is a reporting
artefact, not a fix.

### Validation

Every split is a **pure relocation** — strip comments, blanks and the new
`require`, and the result is byte-identical to the base:

```
diff <(git show upstream/master:$BB | grep -v '^[[:space:]]*#' | grep -v '^[[:space:]]*$') \
     <(cat $BB $INC | grep -v '^[[:space:]]*#' | grep -v '^[[:space:]]*$' | grep -vFx "require $(basename $INC)")
```

Each recipe was then built `-c package -f` and compared through buildhistory —
opencv and the gstreamer four on imx8mp-lpddr4-evk, weston 14.0.2 and libcamera
on imx8mm-lpddr4-evk, weston 10.0.5 on imx6qdlsabresd, qemu-qoriq on ls1046ardb.
**Every delta is empty.** For opencv the expanded datastore was compared as well:
2835 variables identical, the only change being `BBINCLUDED` gaining the new
`.inc`.

### Out of scope

`gst-devtools_1.28.1.bb` and `gstreamer1.0-rtsp-server_1.28.1.bb` have i.MX
blocks but no verbatim copy to protect, and no findings. The split exists to
protect a copy; they have none.

### Note for reviewers

Validating this on a current tree needs the build fixes on
`buildfix/wayland-protocols` — `wayland-protocols` 1.47 and `vulkan-loader`
1.4.341.0 both fail `do_patch` at `master` today, independently of this series.
