### PR TITLE
Fix oelint.vars.srcurimutualex in the i.MX fork recipes

### DIFF
--- a/recipes-graphics/wayland/weston_10.0.5.imx.bb
+++ b/recipes-graphics/wayland/weston_10.0.5.imx.bb
@@ -23,6 +23,10 @@ SRC_URI = "https://gitlab.freedesktop.org/wayland/weston/-/releases/${PV}/downlo
            file://systemd-notify.weston-start \
            "
 
+# The required .inc removes this tarball from SRC_URI and fetches the NXP git
+# fork instead, so this checksum and SRCREV never apply to the same item.
+# UPSTREAM-PARITY.
+# nooelint: oelint.vars.srcurimutualex
 SRC_URI[sha256sum] = "89646ca0d9f8d413c2767e5c3828eaa3fa149c2a105b3729a6894fa7cf1549e7"
 
 UPSTREAM_CHECK_URI = "https://wayland.freedesktop.org/releases.html"

--- a/recipes-graphics/wayland/weston_14.0.2.imx.bb
+++ b/recipes-graphics/wayland/weston_14.0.2.imx.bb
@@ -24,6 +24,10 @@ SRC_URI = "https://gitlab.freedesktop.org/wayland/weston/-/releases/${PV}/downlo
            file://0001-libweston-backend-drm-meson.build-allow-libdisplay-i.patch \
            "
 
+# The required .inc removes this tarball from SRC_URI and fetches the NXP git
+# fork instead, so this checksum and SRCREV never apply to the same item.
+# UPSTREAM-PARITY.
+# nooelint: oelint.vars.srcurimutualex
 SRC_URI[sha256sum] = "b47216b3530da76d02a3a1acbf1846a9cd41d24caa86448f9c46f78f20b6e0ac"
 
 UPSTREAM_CHECK_URI = "https://gitlab.freedesktop.org/wayland/weston/-/tags"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.28.1.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.28.1.imx.bb
@@ -27,6 +27,10 @@ SRC_URI = "https://gstreamer.freedesktop.org/src/gst-plugins-bad/gst-plugins-bad
            file://0002-avoid-including-sys-poll.h-directly.patch \
            file://0004-opencv-resolve-missing-opencv-data-dir-in-yocto-buil.patch \
            "
+# The required .inc removes this tarball from SRC_URI and fetches the NXP git
+# fork instead, so this checksum and SRCREV never apply to the same item.
+# UPSTREAM-PARITY.
+# nooelint: oelint.vars.srcurimutualex
 SRC_URI[sha256sum] = "e64e75cdafd7ff2fc7fc34e855b06b1e3ed227cc06fa378d17bbcd76780c338c"
 
 inherit gobject-introspection

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.28.1.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.28.1.imx.bb
@@ -24,6 +24,10 @@ SRC_URI = "https://gstreamer.freedesktop.org/src/gst-plugins-base/gst-plugins-ba
            file://0003-viv-fb-Make-sure-config.h-is-included.patch \
            file://0002-ssaparse-enhance-SSA-text-lines-parsing.patch \
            "
+# The required .inc removes this tarball from SRC_URI and fetches the NXP git
+# fork instead, so this checksum and SRCREV never apply to the same item.
+# UPSTREAM-PARITY.
+# nooelint: oelint.vars.srcurimutualex
 SRC_URI[sha256sum] = "edd4338b45c26a9af28c0d35aab964a024c3884ba6f520d8428df04212c8c93a"
 
 inherit gobject-introspection

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.28.1.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.28.1.imx.bb
@@ -16,6 +16,10 @@ SRC_URI = "https://gstreamer.freedesktop.org/src/gst-plugins-good/gst-plugins-go
            file://0001-qt-include-ext-qt-gstqtgl.h-instead-of-gst-gl-gstglf.patch \
            file://0001-v4l2-Define-ioctl_req_t-for-posix-linux-case.patch"
 
+# The required .inc removes this tarball from SRC_URI and fetches the NXP git
+# fork instead, so this checksum and SRCREV never apply to the same item.
+# UPSTREAM-PARITY.
+# nooelint: oelint.vars.srcurimutualex
 SRC_URI[sha256sum] = "b67b31313a54c6929b82969d41d3cfdf2f58db573fb5f491e6bba5d84aea0778"
 
 # Overridden in gstreamer1.0-plugins-good_1.28.1.imx.inc; kept here to preserve

--- a/recipes-multimedia/gstreamer/gstreamer1.0_1.28.1.imx.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0_1.28.1.imx.bb
@@ -29,6 +29,10 @@ SRC_URI = "https://gstreamer.freedesktop.org/src/gstreamer/gstreamer-${PV}.tar.x
            file://0003-tests-use-a-dictionaries-for-environment.patch;striplevel=3 \
            file://0004-tests-add-helper-script-to-run-the-installed_tests.patch;striplevel=3 \
            "
+# The required .inc removes this tarball from SRC_URI and fetches the NXP git
+# fork instead, so this checksum and SRCREV never apply to the same item.
+# UPSTREAM-PARITY.
+# nooelint: oelint.vars.srcurimutualex
 SRC_URI[sha256sum] = "4408d7930f381809e85917acc19712f173261ba85bdf20c5567b2a21b1193b61"
 
 PACKAGECONFIG ??= "\


### PR DESCRIPTION
## Summary

Clears `oelint.vars.srcurimutualex` across the i.MX fork recipes.

Every flagged recipe reports the same thing: `SRCREV` and `SRC_URI[sha256sum]` set for the
same item. The two never actually apply together — the i.MX overrides `SRC_URI:remove` the
release tarball and fetch the NXP git fork instead, so the checksum belongs to a URI that is
no longer in `SRC_URI`. oelint reports it because it does not evaluate `SRC_URI:remove`.

Note that the `.inc` split merged in #2678 does not clear this on its own: oelint parses the
`require`d `.inc` along with the `.bb`, so it still sees `SRCREV` and the checksum together.

## What changed

The unused checksum is annotated in place rather than deleted, so the copied OE-core body
stays byte-identical to upstream and remains diffable against it:

```bitbake
# The required .inc removes this tarball from SRC_URI and fetches the NXP git
# fork instead, so this checksum and SRCREV never apply to the same item.
# UPSTREAM-PARITY.
# nooelint: oelint.vars.srcurimutualex
SRC_URI[sha256sum] = "..."
```

One commit per recipe: `weston` (10.0.5 and 14.0.2 together), `gstreamer1.0`,
`gstreamer1.0-plugins-base`, `gstreamer1.0-plugins-bad`, `gstreamer1.0-plugins-good`.

## Validation

Comments only — no assignment is added, removed or changed, so generated output cannot move.
The full diff against master is six comment blocks and nothing else.

`oelint-adv` over the six recipes (each with its required `.inc`):

| | before | after |
|---|---|---|
| `oelint.vars.srcurimutualex` | 6 | 0 |
| all findings | 62 | 56 |

The rule is cleared with no collateral: the totals differ by exactly the six findings this
PR targets, so nothing else was masked or shifted.

## Note on scope

This branch originally also carried the `.inc` split for these recipes. That work landed
independently in #2678, so those commits were dropped in the rebase — upstream's versions
supersede them (identical for three recipes; for `-plugins-bad` and `-plugins-good` upstream
additionally reorders `PACKAGE_ARCH` / `PACKAGECONFIG`). What remains here is only the
parity annotation.
