### PR TITLE
gstreamer1.0-plugins-base: Fix viv-fb override so it reaches the i.MX6

### DIFF
--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.28.1.imx.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.28.1.imx.bbappend
@@ -10,5 +10,5 @@ PACKAGECONFIG_GL:use-mainline-bsp = "${@bb.utils.contains('DISTRO_FEATURES', 'op
 # does not depend on the viv-fb feature. It used to, but that was actually a bug
 # which was fixed in GStreamer 1.22.5. Since then, the direct texture support is
 # detected by Meson by checking for direct texture symbols like "glTexDirectVIV".)
-PACKAGECONFIG_GL:imxgpu2d:append:mx6-nxp-bsp = " viv-fb"
-PACKAGECONFIG_GL:imxgpu2d:append:mx7-nxp-bsp = " viv-fb"
+PACKAGECONFIG_GL:append:imxgpu2d:mx6-nxp-bsp = " viv-fb"
+PACKAGECONFIG_GL:append:imxgpu2d:mx7-nxp-bsp = " viv-fb"


### PR DESCRIPTION
`PACKAGECONFIG_GL:imxgpu2d:append:mx6-nxp-bsp` attaches the append to the
`PACKAGECONFIG_GL:imxgpu2d` scope rather than to the value BitBake selects.
`MACHINEOVERRIDES` lists `imxgpu2d` before `imxgpu3d`, so on every i.MX6/7ULP
that has a 3D GPU the `imxgpu3d` scope wins the override selection and the
`viv-fb` append is never applied.

Regression from d1c6878cf ("gstreamer: Update 6.6.3-1.0.0 to 6.6.23-2.0.0"),
which rewrote the two working lines:

```
-PACKAGECONFIG_GL:append:mx6-nxp-bsp = " viv-fb "
-PACKAGECONFIG_GL:append:mx7ulp-nxp-bsp = " viv-fb "
+PACKAGECONFIG_GL:imxgpu2d:append:mx6-nxp-bsp = " viv-fb "
+PACKAGECONFIG_GL:imxgpu2d:append:mx7-nxp-bsp = " viv-fb "
```

Effect across the family — `viv-fb` currently reaches only mx6sl:

| SoC (nxp-bsp) | GPU overrides | viv-fb before | after |
|---|---|---|---|
| mx6q, mx6dl, mx6sx | 2d + 3d | no | yes |
| mx6sl | 2d only | yes | yes |
| mx6sll/ul/ull/ulz | none | no | no |
| mx7d | none | no | no |
| mx7ulp | 2d + 3d | no | yes |

Keeping the `imxgpu2d` qualifier (rather than restoring the original
`:append:mx6-nxp-bsp`) is deliberate: it excludes the GPU-less mx6ul/mx6sll
families and mx7d, which the pre-regression form would have enabled.

### Validation

`bitbake -e gstreamer1.0-plugins-base`, imx6qdlsabresd / fslc-framebuffer:

- before: `PACKAGECONFIG_GL="gles2 egl"` (pre-expansion value from the `:imxgpu3d` line)
- after: `PACKAGECONFIG_GL="gles2 egl viv-fb"`

Buildhistory diff (baseline vs candidate, `-C configure`, no sstate reuse —
do_configure through do_package all re-ran) contains only viv-fb artefacts:

```
gstreamer1.0-plugins-base: PACKAGES: added "gstreamer1.0-plugins-base-glvivfb-typelib"
gstreamer1.0-plugins-base: FILELIST: added "/usr/lib/girepository-1.0/GstGLVivFB-1.0.typelib"
gstreamer1.0-plugins-base-dev: FILELIST: added
  /usr/include/gstreamer-1.0/gst/gl/viv-fb/gstgldisplay_viv_fb.h
  /usr/include/gstreamer-1.0/gst/gl/viv-fb/gstglviv-fb.h
  /usr/lib/pkgconfig/gstreamer-gl-viv-fb-1.0.pc
  /usr/share/gir-1.0/GstGLVivFB-1.0.gir
```

No other package, version, dependency or size changed.

Found by `oelint-adv` (`oelint.vars.overrideappend`).