### PR TITLE
oelint: Append instead of building up an override scope (vars.overrideappend)

### DIFF
--- a/classes/qoriq_build_64bit_kernel.bbclass
+++ b/classes/qoriq_build_64bit_kernel.bbclass
@@ -1,5 +1,5 @@
 inherit features_check
-REQUIRED_DISTRO_FEATURES:e6500 += "multiarch"
+REQUIRED_DISTRO_FEATURES:append:e6500 = " multiarch"
 
 # BUILD_64BIT_KERNEL is this class's interface, not a machine override: any
 # machine that sets it gets the promotion, and in-tree only e6500.inc does.

--- a/recipes-devtools/qemu/qemu-qoriq_4.2.bb
+++ b/recipes-devtools/qemu/qemu-qoriq_4.2.bb
@@ -47,6 +47,6 @@ do_install_ptest() {
 
 DISABLE_STATIC = ""
 
-RDEPENDS:${PN}:class-target += "bash"
+RDEPENDS:${PN}:append:class-target = " bash"
 
 BBCLASSEXTEND = ""

--- a/recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc
+++ b/recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc
@@ -377,7 +377,7 @@ RDEPENDS:libopencl-imx = "libclc-imx"
 
 RRECOMMENDS:libgal-imx += "kernel-module-imx-gpu-viv"
 
-RPROVIDES:${PN}:imxgpu3d += "imx-gpu-viv"
+RPROVIDES:${PN}:append:imxgpu3d = " imx-gpu-viv"
 RPROVIDES:libgal-imx += "libgal-imx"
 RPROVIDES:libvulkan-imx = "virtual-vulkan-icd"
 RPROVIDES:libgles1-imx = "libgles-imx"


### PR DESCRIPTION
Clears every remaining `oelint.vars.overrideappend` finding in the layer. The rule
flags `VAR:<override> += "x"`, which does not extend `VAR` — it builds the
`VAR:<override>` scope up from empty. When that override is active the scope
*replaces* the base value rather than adding to it, so any contribution to `VAR`
made elsewhere is silently discarded.

Rule count: **5 -> 0**. Full scan: **63 -> 60**, three findings removed, none
introduced.

### Commits

Three structural fixes, no suppressions. Each is the same edit —
`VAR:<override> += "x"` becomes `VAR:append:<override> = " x"`:

| Commit | File | Variable |
|---|---|---|
| `imx-gpu-viv` | `imx-gpu-viv-6.inc` | `RPROVIDES:${PN}:imxgpu3d` |
| `qoriq_build_64bit_kernel` | `qoriq_build_64bit_kernel.bbclass` | `REQUIRED_DISTRO_FEATURES:e6500` |
| `qemu-qoriq` | `qemu-qoriq_4.2.bb` | `RDEPENDS:${PN}:class-target` |

In all three cases nothing sets the base variable today, so the effective value is
unchanged. `:append` is what keeps it that way if packaging, a class or a consumer
ever contributes one — which is the defect the rule is pointing at, not a style
preference.

### Fixed by hand, deliberately

`oelint-adv --fix` is broken for this rule and was not used. On `qemu-qoriq` it
rewrites `RDEPENDS:${PN}:class-target += "bash"` to
`RDEPENDS:append:class-target = " bash"` — dropping `:${PN}` and appending to the
wrong variable. It also emits `:append:append:append` elsewhere and reorders
overrides, which changes selection. Every edit here was written and reviewed
individually.

### Validation

Behaviour-preserving, and measured rather than assumed. Per recipe, on a machine
where the override is actually active:

| Recipe | Machine | `bitbake -e` | buildhistory |
|---|---|---|---|
| `imx-gpu-viv` | `imx6qdlsabresd`/`fslc-framebuffer` | same `" imx-gpu-viv"` | no changes |
| `qoriq_build_64bit_kernel` | `t2080rdb` | same `" multiarch"` | no changes (via `linux-qoriq`) |
| `qemu-qoriq` | `ls1046ardb` | same `" bash"` | no changes |

For `imx-gpu-viv`, `bitbake -e` reports `[2 operations]` on `RPROVIDES:${PN}`, both
originating from the same line — confirming no base value is being discarded.
`do_packagedata_setscene` hit from sstate, so the task hash never moved.

Scan delta taken from a full survey in both directions, not a rule-scoped one:

```
removed 3, introduced 0, unchanged 60
  classes/qoriq_build_64bit_kernel.bbclass
  recipes-devtools/qemu/qemu-qoriq_4.2.bb
  recipes-graphics/imx-gpu-viv/imx-gpu-viv-6.inc
```

The totals differ by exactly the three findings this PR targets, so nothing was
masked or traded to another rule.
