### PR TITLE
oelint: Drop the redundant leading space on non-append assignments (vars.notneededspace)

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-support/opencv/opencv_4.13.0.imx.bb
+++ b/dynamic-layers/openembedded-layer/recipes-support/opencv/opencv_4.13.0.imx.bb
@@ -80,7 +80,7 @@ addtask unpack_extra after do_unpack before do_patch
 
 CMAKE_VERBOSE = "VERBOSE=1"
 
-EXTRA_OECMAKE = " \
+EXTRA_OECMAKE = "\
     -DOPENCV_EXTRA_MODULES_PATH=${S}/contrib/modules \
     -DWITH_1394=OFF \
     -DENABLE_PRECOMPILED_HEADERS=OFF \
@@ -100,7 +100,7 @@ LDFLAGS:append:riscv32 = " -Wl,--no-as-needed -latomic -Wl,--as-needed"
 EXTRA_OECMAKE:append:x86 = " -DX86=ON"
 EXTRA_OECMAKE:append:aarch64 = " -DKLEIDICV_SOURCE_PATH=${S}/3rdparty/kleidicv"
 
-PACKAGECONFIG ??= " \
+PACKAGECONFIG ??= "\
     python3 eigen jpeg png tiff v4l libv4l samples tbb \
     ${@bb.utils.contains_any('DISTRO_FEATURES', '${GTK3DISTROFEATURES}', 'gtk', '', d)}"
 PACKAGECONFIG:append:class-target = " \

--- a/dynamic-layers/qt5-layer/recipes-qt/qt5/qtbase_%.bbappend
+++ b/dynamic-layers/qt5-layer/recipes-qt/qt5/qtbase_%.bbappend
@@ -25,10 +25,10 @@ PACKAGECONFIG_GL_IMX_GPU:mx8-nxp-bsp = "gbm kms"
 PACKAGECONFIG_GL_IMX_GPU:mx95-nxp-bsp = "gbm kms"
 
 PACKAGECONFIG_GL:imxpxp = "gles2"
-PACKAGECONFIG_GL:imxgpu2d = " \
+PACKAGECONFIG_GL:imxgpu2d = "\
     ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'gl', '', d)} \
     ${PACKAGECONFIG_GL_IMX_GPU}"
-PACKAGECONFIG_GL:imxgpu3d = " \
+PACKAGECONFIG_GL:imxgpu3d = "\
     gles2 \
     ${PACKAGECONFIG_GL_IMX_GPU}"
 PACKAGECONFIG_GL:use-mainline-bsp ?= "gles2 gbm kms"

--- a/dynamic-layers/qt6-layer/recipes-qt/qt6/qtbase_%.bbappend
+++ b/dynamic-layers/qt6-layer/recipes-qt/qt6/qtbase_%.bbappend
@@ -5,7 +5,7 @@
 
 PACKAGECONFIG_GRAPHICS:imxpxp = "\
     gles2"
-PACKAGECONFIG_GRAPHICS:imxgpu2d = " \
+PACKAGECONFIG_GRAPHICS:imxgpu2d = "\
     ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'gl', '', d)} \
     ${PACKAGECONFIG_GRAPHICS_IMX_GPU}"
 PACKAGECONFIG_GRAPHICS:imxgpu3d = "\


### PR DESCRIPTION
Clears every remaining `oelint.vars.notneededspace` finding in the layer. The rule
flags a space after the opening quote of a multi-line value, as in
`VAR = " \`. Only `:append` needs that space — it is what separates the appended
text from the value it joins. On a plain `=`, a weak `??=` or a `+=` (which
inserts its own separator) there is nothing to join, so the space is noise that
lands inside the value.

Rule count: **5 -> 0**. Full scan: **48 -> 46**, two findings removed, none
introduced.

### Commits

| Commit | File | Variables |
|---|---|---|
| `qtbase` | `qtbase_%.bbappend` | `PACKAGECONFIG_GRAPHICS:imxgpu2d` |
| `qtbase` | `qtbase_%.bbappend` | `PACKAGECONFIG_GL` (both override scopes) |
| `opencv` | `opencv_4.13.0.imx.bb` | `EXTRA_OECMAKE`, `PACKAGECONFIG` |

In each file the fix follows a form the file already uses: the neighbouring
`PACKAGECONFIG_PLATFORM:imxgpu3d` in the qtbase bbappend, and `PACKAGES += "\` in
the opencv recipe, both already open without the space.

### Why opencv is edited in place

`opencv_4.13.0.imx.bb` is a verbatim meta-openembedded copy, kept that way so it
can be diffed against upstream directly, and the i.MX customization lives in the
required `opencv_4.13.0.imx.inc`. Changes to the copied body are normally avoided
for that reason.

The space is not upstream's, though. Diffed against the hash recorded in the file
header, meta-oe writes:

    EXTRA_OECMAKE = "-DOPENCV_EXTRA_MODULES_PATH=${S}/contrib/modules \

It arrived in 96a58b1e3, which reflowed these values so the first entry no longer
sits on the opening-quote line. So this is a line we introduced, and fixing it
brings the file back towards upstream rather than further from it.

`PACKAGECONFIG:append:class-target` in the same recipe keeps its space, correctly.

### Validation

A whitespace-only edit still changes the task hash, since it is taken over the
raw expanded string — so sstate does not quietly reuse the old result and each
recipe genuinely rebuilt.

- **qtbase** — each override validated on the machine that selects it, with
  `do_configure` forced: `imxgpu2d` on imx6slevk, `imxgpu3d` on
  imx8mm-lpddr4-evk. Buildhistory unchanged.
- **opencv** — imx8mm-lpddr4-evk / fslc-wayland, `bitbake opencv -C configure`.
  `do_configure`, `do_compile`, `do_install` and `do_package` all re-ran from
  scratch, and the before/after buildhistory trees are byte-identical
  (`ba0593b2`). Hash equivalence then let the downstream setscene tasks reuse
  sstate, which independently confirms `do_package` output never moved.

Both values are whitespace-split — 45 cmake arguments and 15 PACKAGECONFIG
entries — and the expanded token sets are identical either side of the change.
