### PR TITLE
oelint: Append rather than overwrite DEPENDS after an include (vars.dependsappend)

### DIFF
--- a/dynamic-layers/arm-toolchain/recipes-bsp/imx-system-manager/imx-system-manager.inc
+++ b/dynamic-layers/arm-toolchain/recipes-bsp/imx-system-manager/imx-system-manager.inc
@@ -1,6 +1,6 @@
 # Set generic compiler for system manager core
 INHIBIT_DEFAULT_DEPS = "1"
-DEPENDS = "${SM_COMPILER}"
+DEPENDS += "${SM_COMPILER}"
 DEPENDS:append:mx943-nxp-bsp = " srecord-native"
 SM_COMPILER ?= "gcc-arm-none-eabi-native"
 PROVIDES += "virtual/imx-system-manager"

--- a/recipes-graphics/wayland/weston_10.0.5.imx.bb
+++ b/recipes-graphics/wayland/weston_10.0.5.imx.bb
@@ -38,8 +38,11 @@ inherit meson pkgconfig useradd
 #
 require ${THISDIR}/required-distro-features.inc
 
-# Ordering comes from the upstream recipe at the header's Upstream hash.
-# nooelint: oelint.var.order.DEPENDS
+# Ordering and placement both come from the upstream recipe at the header's
+# Upstream hash. The '=' discards nothing: meson, pkgconfig and useradd add to
+# DEPENDS only through :append/:prepend, which BitBake applies after plain
+# assignments. UPSTREAM-PARITY.
+# nooelint: oelint.var.order.DEPENDS,oelint.vars.dependsappend
 DEPENDS = "cairo gdk-pixbuf glib-2.0 libinput libxkbcommon pango pixman \
            virtual/egl wayland wayland-native wayland-protocols"
 

--- a/recipes-graphics/wayland/weston_14.0.2.imx.bb
+++ b/recipes-graphics/wayland/weston_14.0.2.imx.bb
@@ -39,8 +39,11 @@ inherit meson pkgconfig useradd
 #
 require ${THISDIR}/required-distro-features.inc
 
-# Ordering comes from the upstream recipe at the header's Upstream hash.
-# nooelint: oelint.var.order.DEPENDS
+# Ordering and placement both come from the upstream recipe at the header's
+# Upstream hash. The '=' discards nothing: meson, pkgconfig and useradd add to
+# DEPENDS only through :append/:prepend, which BitBake applies after plain
+# assignments. UPSTREAM-PARITY.
+# nooelint: oelint.var.order.DEPENDS,oelint.vars.dependsappend
 DEPENDS = "cairo gdk-pixbuf glib-2.0 libdisplay-info libinput libxkbcommon \
            pango pixman virtual/egl wayland wayland-native wayland-protocols"
 

--- a/recipes-security/optee-imx/optee-test-fslc.inc
+++ b/recipes-security/optee-imx/optee-test-fslc.inc
@@ -12,7 +12,7 @@ inherit python3native ptest
 inherit deploy
 require optee-fslc.inc
 
-DEPENDS = "openssl optee-client optee-os-tadevkit python3-cryptography-native"
+DEPENDS += "openssl optee-client optee-os-tadevkit python3-cryptography-native"
 DEPENDS:append:toolchain-clang = " lld-native"
 
 SRC_URI = "git://github.com/OP-TEE/optee_test.git;branch=master;protocol=https \

--- a/recipes-security/optee-qoriq/optee-client.nxp.inc
+++ b/recipes-security/optee-qoriq/optee-client.nxp.inc
@@ -12,7 +12,7 @@ require recipes-security/optee-imx/optee-client-fslc.inc
 # nooelint: oelint.vars.outofcontext
 FILESEXTRAPATHS:prepend := "${THISDIR}/../optee-imx/optee-client:"
 
-DEPENDS = "util-linux-libuuid"
+DEPENDS += "util-linux-libuuid"
 
 SRC_URI:remove = "git://github.com/OP-TEE/optee_client.git;branch=master;protocol=https"
 SRC_URI:prepend = "${OPTEE_CLIENT_SRC};branch=${OPTEE_CLIENT_BRANCH} "

--- a/recipes-security/smw/smw_5.3.bb
+++ b/recipes-security/smw/smw_5.3.bb
@@ -9,7 +9,7 @@ LICENSE = "Apache-2.0 AND BSD-3-Clause AND Zlib"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=ff20c8e51b28869d9cdec70a818d163f \
                     file://${PSA_ARCH_TESTS_SRC_PATH}/LICENSE.md;md5=2a944942e1496af1886903d274dedb13"
 
-DEPENDS = "\
+DEPENDS += "\
     json-c \
     optee-client \
     optee-os-tadevkit \


### PR DESCRIPTION
Clears every remaining `oelint.vars.dependsappend` finding in the layer. The rule
flags a plain `DEPENDS =` placed after an `inherit`, `include` or `require`, on
the grounds that those statements can set `DEPENDS` themselves and a later plain
assignment would silently discard what they contributed.

Rule count: **6 -> 0**. Full scan: **46 -> 40**, six findings removed, none
introduced.

### Nothing was actually being discarded

Worth stating up front, because it decides the shape of every commit here: in all
of these recipes the preceding statements contribute `DEPENDS` only through
*deferred* operators, which BitBake applies after plain assignments.

| Contributor | Form | Survives a later `DEPENDS =`? |
|---|---|---|
| `base.bbclass` (default deps) | `DEPENDS:prepend` | yes |
| `meson`, `cmake`, `pkgconfig`, `python3native`, `update-rc.d`, `useradd` | `:append` / `:prepend` | yes |
| `systemd.bbclass` | `d.appendVar` in `python __anonymous` | yes (runs post-parse) |
| `useradd.bbclass:204` | `DEPENDS += "${USERADD_DEPENDS}"` | **no** — immediate |

The one immediate contributor is `useradd`, and `USERADD_DEPENDS` is empty in
every recipe it reaches here. So these changes restore the invariant the rule
protects rather than alter behaviour — confirmed below, not assumed.

### Commits

| Commit | File(s) | Change |
|---|---|---|
| `weston` | `weston_10.0.5.imx.bb`, `weston_14.0.2.imx.bb` | parity suppression |
| `imx-system-manager` | `imx-system-manager.inc` | `=` -> `+=` |
| `optee-test-fslc` | `optee-test-fslc.inc` | `=` -> `+=` |
| `optee-client-qoriq` | `optee-client.nxp.inc` | `=` -> `+=` |
| `smw` | `smw_5.3.bb` | `=` -> `+=` |

`optee-client-qoriq` is the one with real protective value: the required
`optee-client-fslc.inc` inherits `useradd`, so its immediate
`DEPENDS += "${USERADD_DEPENDS}"` genuinely runs before the flagged line.

### Why weston is suppressed rather than fixed

Both weston recipes keep the OE-core body as a verbatim copy so it can be diffed
against upstream directly. The flagged `DEPENDS` sits inside that copy, and the
construct is upstream's own — OE-core writes it the same way at the hash each
header records:

    inherit meson pkgconfig useradd
    require ${THISDIR}/required-distro-features.inc

    DEPENDS = "libxkbcommon gdk-pixbuf pixman cairo glib-2.0"

(`weston_14.0.2.bb:27`, and `weston_10.0.2.bb:26` for the 10.0.5 fork, which
bumps only the tarball.) The recent split into `weston_<version>.imx.inc` did not
clear it, and could not have: the i.MX include never touches `DEPENDS`, so both
halves of the offending pair live in the copy.

The line already carried a parity suppression for `oelint.var.order.DEPENDS`, so
this folds into it rather than adding a second block — inline suppressions take
their ids from one directive line, and stacking a second line would disable the
first.

### Validation

Each `+=` predicts an *empty* buildhistory delta. Every recipe was built before
and after on the machine that actually selects it, and the prediction held in all
four cases.

| Recipe | Machine | `bitbake -e` DEPENDS | Buildhistory |
|---|---|---|---|
| `imx-system-manager` | imx95-19x19-verdin | identical (1 token) | empty |
| `optee-test` | imx8mp-lpddr4-evk | identical (8 tokens) | empty |
| `optee-test-qoriq` | ls1088ardb | identical (9 tokens) | — |
| `optee-client-qoriq` | ls1088ardb | identical (14 tokens) | empty |
| `smw` | imx8mp-lpddr4-evk | identical (11 tokens) | empty |

`optee-test-fslc.inc` feeds two consumer families, so both were checked: the
QorIQ side applies `DEPENDS:remove = "optee-client optee-os-tadevkit"` to the
base value, and it still strips exactly those entries. The i.MX consumer carried
the build and buildhistory comparison.

smw was rebuilt with `do_configure` forced, so the cmake-generated test manifests
are regenerated from scratch rather than incrementally; both sides then produce
byte-identical packaging.

The weston commit is comment-only, so it needs no build — the effective metadata
is byte-identical either side of it.
